### PR TITLE
[release-8.5] topsql: backport #19378

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3690,7 +3690,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git?branch=release-8.5-20251208-v8.5.4#ca8835cfa7218cc2aff979162d997c9d79b9a466"
+source = "git+https://github.com/pingcap/kvproto.git?branch=release-8.5-20251208-v8.5.4#e9239b4f96fa02d2983512102ee405f4165dc859"
 dependencies = [
  "futures 0.3.15",
  "grpcio",

--- a/components/raftstore/src/store/worker/pd.rs
+++ b/components/raftstore/src/store/worker/pd.rs
@@ -2860,6 +2860,10 @@ mod tests {
                             cpu_time: 10,
                             read_keys: 0,
                             write_keys: 0,
+                            network_in_bytes: 0,
+                            network_out_bytes: 0,
+                            logical_read_bytes: 0,
+                            logical_write_bytes: 0,
                         },
                     );
                     records
@@ -3010,6 +3014,10 @@ mod tests {
                             cpu_time: 111,
                             read_keys: 1,
                             write_keys: 0,
+                            network_in_bytes: 0,
+                            network_out_bytes: 0,
+                            logical_read_bytes: 0,
+                            logical_write_bytes: 0,
                         },
                     );
                     records

--- a/components/raftstore/src/store/worker/split_controller.rs
+++ b/components/raftstore/src/store/worker/split_controller.rs
@@ -1446,6 +1446,10 @@ mod tests {
                     cpu_time: cpu_times[idx],
                     read_keys: 0,
                     write_keys: 0,
+                    network_in_bytes: 0,
+                    network_out_bytes: 0,
+                    logical_read_bytes: 0,
+                    logical_write_bytes: 0,
                 },
             );
         }
@@ -1922,6 +1926,10 @@ mod tests {
                     cpu_time: test_case.0,
                     read_keys: 0,
                     write_keys: 0,
+                    network_in_bytes: 0,
+                    network_out_bytes: 0,
+                    logical_read_bytes: 0,
+                    logical_write_bytes: 0,
                 },
             );
             // ["c", "d"] with (test_case.1)ms CPU time.
@@ -1931,6 +1939,10 @@ mod tests {
                     cpu_time: test_case.1,
                     read_keys: 0,
                     write_keys: 0,
+                    network_in_bytes: 0,
+                    network_out_bytes: 0,
+                    logical_read_bytes: 0,
+                    logical_write_bytes: 0,
                 },
             );
             // Multiple key ranges with (test_case.2)ms CPU time.
@@ -1940,6 +1952,10 @@ mod tests {
                     cpu_time: test_case.2,
                     read_keys: 0,
                     write_keys: 0,
+                    network_in_bytes: 0,
+                    network_out_bytes: 0,
+                    logical_read_bytes: 0,
+                    logical_write_bytes: 0,
                 },
             );
             // Empty key range with (test_case.3)ms CPU time.
@@ -1949,6 +1965,10 @@ mod tests {
                     cpu_time: test_case.3,
                     read_keys: 0,
                     write_keys: 0,
+                    network_in_bytes: 0,
+                    network_out_bytes: 0,
+                    logical_read_bytes: 0,
+                    logical_write_bytes: 0,
                 },
             );
 

--- a/components/resource_metering/src/config.rs
+++ b/components/resource_metering/src/config.rs
@@ -15,7 +15,7 @@ const MIN_PRECISION: ReadableDuration = ReadableDuration::millis(100);
 const MAX_PRECISION: ReadableDuration = ReadableDuration::hours(1);
 const MAX_MAX_RESOURCE_GROUPS: usize = 5_000;
 const MIN_REPORT_RECEIVER_INTERVAL: ReadableDuration = ReadableDuration::millis(500);
-const DEFAULT_ENABLE_NETWORK_IO_COLLECTION: bool = false;
+const DEFAULT_ENABLE_NETWORK_IO_COLLECTION: bool = true;
 
 pub static ENABLE_NETWORK_IO_COLLECTION: AtomicBool =
     AtomicBool::new(DEFAULT_ENABLE_NETWORK_IO_COLLECTION);
@@ -141,6 +141,7 @@ mod tests {
     #[test]
     fn test_config_validate() {
         let cfg = Config::default();
+        assert!(cfg.enable_network_io_collection);
         cfg.validate().unwrap(); // Empty address is allowed.
         let cfg = Config {
             receiver_address: "127.0.0.1:6666".to_string(),

--- a/components/resource_metering/src/lib.rs
+++ b/components/resource_metering/src/lib.rs
@@ -16,12 +16,13 @@ use std::{
 };
 
 pub use collector::Collector;
-pub use config::{Config, ConfigManager};
+pub use config::{Config, ConfigManager, ENABLE_NETWORK_IO_COLLECTION};
 pub use model::*;
 pub use recorder::{
     CollectorGuard, CollectorId, CollectorRegHandle,
     ConfigChangeNotifier as RecorderConfigChangeNotifier, CpuRecorder, Recorder, RecorderBuilder,
-    SummaryRecorder, init_recorder, record_read_keys, record_write_keys,
+    SummaryRecorder, init_recorder, record_logical_read_bytes, record_logical_write_bytes,
+    record_network_in_bytes, record_network_out_bytes, record_read_keys, record_write_keys,
 };
 use recorder::{LocalStorage, LocalStorageRef, STORAGE};
 pub use reporter::{
@@ -146,7 +147,10 @@ impl Drop for Guard {
                 return;
             }
             let cur_record = ls.summary_cur_record.take_and_reset();
-            if cur_record.read_keys.load(Relaxed) == 0 && cur_record.write_keys.load(Relaxed) == 0 {
+            if cur_record.read_keys.load(Relaxed) == 0
+                && cur_record.logical_read_bytes.load(Relaxed) == 0
+                && cur_record.logical_write_bytes.load(Relaxed) == 0
+            {
                 return;
             }
             let mut records = ls.summary_records.lock().unwrap();

--- a/components/resource_metering/src/model.rs
+++ b/components/resource_metering/src/model.rs
@@ -2,37 +2,200 @@
 
 use std::{
     cell::Cell,
+    hash::Hash,
     sync::{
         Arc,
-        atomic::{AtomicU32, Ordering::Relaxed},
+        atomic::{AtomicU32, AtomicU64, Ordering::Relaxed},
     },
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
 use collections::HashMap;
-use kvproto::resource_usage_agent::{GroupTagRecord, GroupTagRecordItem, ResourceUsageRecord};
+use kvproto::resource_usage_agent::{
+    GroupTagRecord, GroupTagRecordItem, RegionRecord, ResourceUsageRecord,
+};
 use tikv_util::warn;
 
 use crate::TagInfos;
 
 thread_local! {
-    static STATIC_BUF: Cell<Vec<u32>> = const {Cell::new(vec![])};
+    static STATIC_CPU_BUF: Cell<Vec<u32>> = const {Cell::new(vec![])};
+    static STATIC_NETWORK_BUF: Cell<Vec<u64>> = const {Cell::new(vec![])};
+    static STATIC_LOGICAL_IO_BUF: Cell<Vec<u64>> = const {Cell::new(vec![])};
+}
+
+/// Find the kth values in the iterator, returns (kth_cpu_time,
+/// kth_network_traffic, kth_logical_io)
+pub fn find_kth_values<'a, T: 'a>(
+    iter: impl Iterator<Item = (&'a T, &'a RawRecord)>,
+    k: usize,
+) -> (u32, u64, u64) {
+    let mut cpu_buf = STATIC_CPU_BUF.with(|b| b.take());
+    let mut network_buf = STATIC_NETWORK_BUF.with(|b| b.take());
+    let mut logical_io_buf = STATIC_LOGICAL_IO_BUF.with(|b| b.take());
+    cpu_buf.clear();
+    network_buf.clear();
+    logical_io_buf.clear();
+    for (_, record) in iter {
+        cpu_buf.push(record.cpu_time);
+        network_buf.push(record.network_in_bytes + record.network_out_bytes);
+        logical_io_buf.push(record.logical_read_bytes + record.logical_write_bytes);
+    }
+    pdqselect::select_by(&mut cpu_buf, k, |a, b| b.cmp(a));
+    let kth_cpu = cpu_buf[k];
+    STATIC_CPU_BUF.with(move |b| b.set(cpu_buf));
+
+    pdqselect::select_by(&mut network_buf, k, |a, b| b.cmp(a));
+    let kth_network = network_buf[k];
+    STATIC_NETWORK_BUF.with(move |b| b.set(network_buf));
+
+    pdqselect::select_by(&mut logical_io_buf, k, |a, b| b.cmp(a));
+    let kth_logical_io = logical_io_buf[k];
+    STATIC_LOGICAL_IO_BUF.with(move |b| b.set(logical_io_buf));
+
+    (kth_cpu, kth_network, kth_logical_io)
 }
 
 /// Find the kth cpu time in the iterator.
-pub fn find_kth_cpu_time<'a>(
-    iter: impl Iterator<Item = (&'a Arc<Vec<u8>>, &'a RawRecord)>,
+pub fn find_kth_cpu_time<'a, T: 'a>(
+    iter: impl Iterator<Item = (&'a T, &'a RawRecord)>,
     k: usize,
 ) -> u32 {
-    let mut buf = STATIC_BUF.with(|b| b.take());
+    let mut buf = STATIC_CPU_BUF.with(|b| b.take());
     buf.clear();
     for (_, record) in iter {
         buf.push(record.cpu_time);
     }
     pdqselect::select_by(&mut buf, k, |a, b| b.cmp(a));
     let kth = buf[k];
-    STATIC_BUF.with(move |b| b.set(buf));
+    STATIC_CPU_BUF.with(move |b| b.set(buf));
     kth
+}
+
+/// Get two iterators: first is the one whose cpu_time > kth_cpu,
+/// second is the one whose cpu_time <= kth_cpu.
+pub fn get_iter_for_cpu_time<'a, T: 'a>(
+    records: &'a HashMap<T, RawRecord>,
+    kth_cpu: u32,
+) -> (
+    impl Iterator<Item = (&'a T, &'a RawRecord)>,
+    impl Iterator<Item = (&'a T, &'a RawRecord)>,
+) {
+    (
+        records.iter().filter(move |(_, v)| v.cpu_time > kth_cpu),
+        records.iter().filter(move |(_, v)| v.cpu_time <= kth_cpu),
+    )
+}
+
+/// Get two iterators, first is the one whose cpu_time > kth_cpu or network_io >
+/// kth_network or logical_io > kth_logical_io, second is the one whose cpu_time
+/// <= kth_cpu and network_io <= kth_network and logical_io <= kth_logical_io.
+pub fn get_iter_for_cpu_network_io<'a, T: 'a>(
+    records: &'a HashMap<T, RawRecord>,
+    kth_cpu: u32,
+    kth_network: u64,
+    kth_logical_io: u64,
+) -> (
+    impl Iterator<Item = (&'a T, &'a RawRecord)>,
+    impl Iterator<Item = (&'a T, &'a RawRecord)>,
+) {
+    (
+        records.iter().filter(move |(_, v)| {
+            v.cpu_time > kth_cpu
+                || v.network_in_bytes + v.network_out_bytes > kth_network
+                || v.logical_read_bytes + v.logical_write_bytes > kth_logical_io
+        }),
+        records.iter().filter(move |(_, v)| {
+            v.cpu_time <= kth_cpu
+                && v.network_in_bytes + v.network_out_bytes <= kth_network
+                && v.logical_read_bytes + v.logical_write_bytes <= kth_logical_io
+        }),
+    )
+}
+
+/// Append raw_record to records[key] at timestamp ts.
+fn append_impl<T>(records: &mut HashMap<T, Record>, ts: u64, key: &T, raw_record: &RawRecord)
+where
+    T: Clone + Eq + Hash,
+{
+    let record_value = records.get_mut(key);
+    if record_value.is_none() {
+        records.insert(
+            key.clone(),
+            Record {
+                timestamps: vec![ts],
+                cpu_time_list: vec![raw_record.cpu_time],
+                read_keys_list: vec![raw_record.read_keys],
+                write_keys_list: vec![raw_record.write_keys],
+                total_cpu_time: raw_record.cpu_time,
+                logical_read_bytes_list: vec![raw_record.logical_read_bytes],
+                logical_write_bytes_list: vec![raw_record.logical_write_bytes],
+                network_in_bytes_list: vec![raw_record.network_in_bytes],
+                network_out_bytes_list: vec![raw_record.network_out_bytes],
+            },
+        );
+        return;
+    }
+    let record = record_value.unwrap();
+    record.total_cpu_time += raw_record.cpu_time;
+    if *record.timestamps.last().unwrap() == ts {
+        *record.cpu_time_list.last_mut().unwrap() += raw_record.cpu_time;
+        *record.read_keys_list.last_mut().unwrap() += raw_record.read_keys;
+        *record.write_keys_list.last_mut().unwrap() += raw_record.write_keys;
+        *record.logical_read_bytes_list.last_mut().unwrap() += raw_record.logical_read_bytes;
+        *record.logical_write_bytes_list.last_mut().unwrap() += raw_record.logical_write_bytes;
+        *record.network_in_bytes_list.last_mut().unwrap() += raw_record.network_in_bytes;
+        *record.network_out_bytes_list.last_mut().unwrap() += raw_record.network_out_bytes;
+    } else {
+        record.timestamps.push(ts);
+        record.cpu_time_list.push(raw_record.cpu_time);
+        record.read_keys_list.push(raw_record.read_keys);
+        record.write_keys_list.push(raw_record.write_keys);
+        record
+            .logical_read_bytes_list
+            .push(raw_record.logical_read_bytes);
+        record
+            .logical_write_bytes_list
+            .push(raw_record.logical_write_bytes);
+        record
+            .network_in_bytes_list
+            .push(raw_record.network_in_bytes);
+        record
+            .network_out_bytes_list
+            .push(raw_record.network_out_bytes);
+    }
+}
+
+/// Pick top n agged raw records, then append picked topN records and merge
+/// unpicked ones to others. If enable_network_io_collection is true, pick top n
+/// records by cpu_time, network_io and logical_io, otherwise, pick top n
+/// records by cpu_time only.
+pub fn handle_records_impl<'a, K, T>(
+    records: &'a mut T,
+    enable_network_io_collection: bool,
+    agg_map: &'a HashMap<K, crate::RawRecord>,
+    ts: u64,
+    n: usize,
+) where
+    T: AppendableRecords<K>,
+    K: Clone + Eq + Hash,
+{
+    if n >= agg_map.len() {
+        records.append(ts, agg_map.iter());
+        return;
+    }
+    if enable_network_io_collection {
+        let (kth_cpu, kth_network, kth_logical_io) = find_kth_values(agg_map.iter(), n);
+        let (picked_iter, unpicked_iter) =
+            get_iter_for_cpu_network_io(agg_map, kth_cpu, kth_network, kth_logical_io);
+        records.append(ts, picked_iter);
+        records.merge_other(ts, unpicked_iter);
+    } else {
+        let kth_cpu = find_kth_cpu_time(agg_map.iter(), n);
+        let (picked_iter, unpicked_iter) = get_iter_for_cpu_time(agg_map, kth_cpu);
+        records.append(ts, picked_iter);
+        records.merge_other(ts, unpicked_iter);
+    }
 }
 
 /// Raw resource statistics record.
@@ -41,6 +204,10 @@ pub struct RawRecord {
     pub cpu_time: u32, // ms
     pub read_keys: u32,
     pub write_keys: u32,
+    pub logical_read_bytes: u64,
+    pub logical_write_bytes: u64,
+    pub network_in_bytes: u64,
+    pub network_out_bytes: u64,
 }
 
 impl RawRecord {
@@ -48,11 +215,19 @@ impl RawRecord {
         self.cpu_time += other.cpu_time;
         self.read_keys += other.read_keys;
         self.write_keys += other.write_keys;
+        self.logical_read_bytes += other.logical_read_bytes;
+        self.logical_write_bytes += other.logical_write_bytes;
+        self.network_in_bytes += other.network_in_bytes;
+        self.network_out_bytes += other.network_out_bytes;
     }
 
     pub fn merge_summary(&mut self, r: &SummaryRecord) {
         self.read_keys += r.read_keys.load(Relaxed);
         self.write_keys += r.write_keys.load(Relaxed);
+        self.logical_read_bytes += r.logical_read_bytes.load(Relaxed);
+        self.logical_write_bytes += r.logical_write_bytes.load(Relaxed);
+        self.network_in_bytes += r.network_in_bytes.load(Relaxed);
+        self.network_out_bytes += r.network_out_bytes.load(Relaxed);
     }
 }
 
@@ -104,6 +279,37 @@ impl RawRecords {
         }
         raw_map
     }
+    /// Returns (RawRecord aggregated by extra tag, RawRecord aggregated by
+    /// region id). Merge these two aggregations together to save one
+    /// iteration.
+    pub fn aggregate_by_extra_tag_and_region(
+        &self,
+    ) -> (HashMap<Arc<Vec<u8>>, RawRecord>, HashMap<u64, RawRecord>) {
+        let mut raw_map: HashMap<Arc<Vec<u8>>, RawRecord> = HashMap::default();
+        let mut region_raw_map: HashMap<u64, RawRecord> = HashMap::default();
+        for (tag_info, record) in self.records.iter() {
+            let tag = &tag_info.extra_attachment;
+            if !tag.is_empty() {
+                let value = raw_map.get_mut(tag);
+                if let Some(val) = value {
+                    val.merge(record);
+                } else {
+                    raw_map.insert(tag.clone(), *record);
+                }
+            }
+
+            let region_id = tag_info.region_id;
+            if region_id != 0 {
+                let value = region_raw_map.get_mut(&region_id);
+                if let Some(val) = value {
+                    val.merge(record);
+                } else {
+                    region_raw_map.insert(region_id, *record);
+                }
+            }
+        }
+        (raw_map, region_raw_map)
+    }
 }
 
 /// Resource statistics.
@@ -115,6 +321,10 @@ pub struct Record {
     pub cpu_time_list: Vec<u32>,
     pub read_keys_list: Vec<u32>,
     pub write_keys_list: Vec<u32>,
+    pub logical_read_bytes_list: Vec<u64>,
+    pub logical_write_bytes_list: Vec<u64>,
+    pub network_in_bytes_list: Vec<u64>,
+    pub network_out_bytes_list: Vec<u64>,
     pub total_cpu_time: u32,
 }
 
@@ -127,6 +337,10 @@ impl From<Record> for Vec<GroupTagRecordItem> {
             item.set_cpu_time_ms(record.cpu_time_list[n]);
             item.set_read_keys(record.read_keys_list[n]);
             item.set_write_keys(record.write_keys_list[n]);
+            item.set_logical_read_bytes(record.logical_read_bytes_list[n]);
+            item.set_logical_write_bytes(record.logical_write_bytes_list[n]);
+            item.set_network_in_bytes(record.network_in_bytes_list[n]);
+            item.set_network_out_bytes(record.network_out_bytes_list[n]);
             items.push(item);
         }
         items
@@ -138,9 +352,23 @@ impl Record {
         self.timestamps.len() == self.cpu_time_list.len()
             && self.timestamps.len() == self.read_keys_list.len()
             && self.timestamps.len() == self.write_keys_list.len()
+            && self.timestamps.len() == self.logical_read_bytes_list.len()
+            && self.timestamps.len() == self.logical_write_bytes_list.len()
+            && self.timestamps.len() == self.network_in_bytes_list.len()
+            && self.timestamps.len() == self.network_out_bytes_list.len()
     }
 }
 
+pub trait AppendableRecords<K> {
+    /// Append picked aggregated [RawRecords].
+    fn append<'a>(&mut self, ts: u64, iter: impl Iterator<Item = (&'a K, &'a RawRecord)>)
+    where
+        K: 'a;
+    /// Merge unpicked aggregated [RawRecords].
+    fn merge_other<'a>(&mut self, ts: u64, iter: impl Iterator<Item = (&'a K, &'a RawRecord)>)
+    where
+        K: 'a;
+}
 /// Resource statistics map.
 ///
 /// This structure is used for final aggregation in the [Reporter] and also
@@ -179,6 +407,10 @@ impl From<Records> for Vec<ResourceUsageRecord> {
                     cpu_time,
                     read_keys,
                     write_keys,
+                    logical_read_bytes,
+                    logical_write_bytes,
+                    network_in_bytes,
+                    network_out_bytes,
                 },
             ) in records.others
             {
@@ -187,6 +419,10 @@ impl From<Records> for Vec<ResourceUsageRecord> {
                 item.set_cpu_time_ms(cpu_time);
                 item.set_read_keys(read_keys);
                 item.set_write_keys(write_keys);
+                item.set_logical_read_bytes(logical_read_bytes);
+                item.set_logical_write_bytes(logical_write_bytes);
+                item.set_network_in_bytes(network_in_bytes);
+                item.set_network_out_bytes(network_out_bytes);
                 items.push(item);
             }
             let mut tag_record = GroupTagRecord::new();
@@ -197,6 +433,55 @@ impl From<Records> for Vec<ResourceUsageRecord> {
         }
 
         res
+    }
+}
+
+impl AppendableRecords<Arc<Vec<u8>>> for Records {
+    fn append<'a>(
+        &mut self,
+        ts: u64,
+        iter: impl Iterator<Item = (&'a Arc<Vec<u8>>, &'a RawRecord)>,
+    ) {
+        // # Before
+        //
+        // ts: 1630464417
+        // records: | tag | cpu time |
+        //          | --- | -------- |
+        //          | t1  |  500     |
+        //          | t2  |  600     |
+        //          | t3  |  200     |
+
+        // # After
+        //
+        // t1: | ts       | ... | 1630464417 |
+        //     | cpu time | ... |    500     |
+        //     | total    | $total + 500     |
+        //
+        // t2: | ts       | ... | 1630464417 |
+        //     | cpu time | ... |    600     |
+        //     | total    | $total + 600     |
+        //
+        // t3: | ts       | ... | 1630464417 |
+        //     | cpu time | ... |    200     |
+        //     | total    | $total + 200     |
+
+        for (tag, raw_record) in iter {
+            if tag.is_empty() {
+                continue;
+            }
+            append_impl(&mut self.records, ts, tag, raw_record);
+        }
+    }
+
+    fn merge_other<'a>(
+        &mut self,
+        ts: u64,
+        iter: impl Iterator<Item = (&'a Arc<Vec<u8>>, &'a RawRecord)>,
+    ) {
+        let others = self.others.entry(ts).or_default();
+        iter.for_each(|(_, v)| {
+            others.merge(v);
+        });
     }
 }
 
@@ -234,35 +519,131 @@ impl Records {
             if tag.is_empty() {
                 continue;
             }
-            let record_value = self.records.get_mut(tag);
-            if record_value.is_none() {
-                self.records.insert(
-                    tag.clone(),
-                    Record {
-                        timestamps: vec![ts],
-                        cpu_time_list: vec![raw_record.cpu_time],
-                        read_keys_list: vec![raw_record.read_keys],
-                        write_keys_list: vec![raw_record.write_keys],
-                        total_cpu_time: raw_record.cpu_time,
-                    },
-                );
-                continue;
-            }
-            let record = record_value.unwrap();
-            record.total_cpu_time += raw_record.cpu_time;
-            if *record.timestamps.last().unwrap() == ts {
-                *record.cpu_time_list.last_mut().unwrap() += raw_record.cpu_time;
-                *record.read_keys_list.last_mut().unwrap() += raw_record.read_keys;
-                *record.write_keys_list.last_mut().unwrap() += raw_record.write_keys;
-            } else {
-                record.timestamps.push(ts);
-                record.cpu_time_list.push(raw_record.cpu_time);
-                record.read_keys_list.push(raw_record.read_keys);
-                record.write_keys_list.push(raw_record.write_keys);
-            }
+            append_impl(&mut self.records, ts, tag, raw_record);
         }
     }
 
+    /// Clear all internal data.
+    pub fn clear(&mut self) {
+        self.records.clear();
+        self.others.clear();
+    }
+
+    /// Whether `Records` is empty.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.records.is_empty() && self.others.is_empty()
+    }
+}
+
+/// Resource statistics map.
+///
+/// This structure is used for final aggregation in the [Reporter] and also
+/// for uploading to the remote side through [Client].
+///
+/// [Reporter]: crate::reporter::CpuReporter
+/// [Client]: crate::client::Client
+#[derive(Debug, Default)]
+pub struct RegionRecords {
+    pub records: HashMap<u64, Record>,
+    pub others: HashMap<u64, RawRecord>,
+}
+
+impl From<RegionRecords> for Vec<ResourceUsageRecord> {
+    fn from(records: RegionRecords) -> Vec<ResourceUsageRecord> {
+        let mut res = Vec::with_capacity(records.records.len() + 1);
+        for (key, record) in records.records {
+            if !record.valid() {
+                warn!("invalid record"); // should not happen
+                continue;
+            }
+            let items: Vec<GroupTagRecordItem> = record.into();
+            let mut region_record = RegionRecord::new();
+            region_record.set_region_id(key);
+            region_record.set_items(items.into());
+            let mut r = ResourceUsageRecord::new();
+            r.set_region_record(region_record);
+            res.push(r);
+        }
+
+        if !records.others.is_empty() {
+            let mut items = Vec::with_capacity(records.others.len());
+            for (
+                ts,
+                RawRecord {
+                    cpu_time,
+                    read_keys,
+                    write_keys,
+                    logical_read_bytes,
+                    logical_write_bytes,
+                    network_in_bytes,
+                    network_out_bytes,
+                },
+            ) in records.others
+            {
+                let mut item = GroupTagRecordItem::new();
+                item.set_timestamp_sec(ts);
+                item.set_cpu_time_ms(cpu_time);
+                item.set_read_keys(read_keys);
+                item.set_write_keys(write_keys);
+                item.set_logical_read_bytes(logical_read_bytes);
+                item.set_logical_write_bytes(logical_write_bytes);
+                item.set_network_in_bytes(network_in_bytes);
+                item.set_network_out_bytes(network_out_bytes);
+                items.push(item);
+            }
+            let mut region_record = RegionRecord::new();
+            region_record.set_items(items.into());
+            let mut r = ResourceUsageRecord::new();
+            r.set_region_record(region_record);
+            res.push(r);
+        }
+
+        res
+    }
+}
+
+impl AppendableRecords<u64> for RegionRecords {
+    fn append<'a>(&mut self, ts: u64, iter: impl Iterator<Item = (&'a u64, &'a RawRecord)>) {
+        // # Before
+        //
+        // ts: 1630464417
+        // records: | region_id | cpu time |
+        //          | --------- | -------- |
+        //          | 1         |  500     |
+        //          | 2         |  600     |
+        //          | 3         |  200     |
+
+        // # After
+        //
+        // 1:  | ts       | ... | 1630464417 |
+        //     | cpu time | ... |    500     |
+        //     | total    | $total + 500     |
+        //
+        // 2:  | ts       | ... | 1630464417 |
+        //     | cpu time | ... |    600     |
+        //     | total    | $total + 600     |
+        //
+        // 3:  | ts       | ... | 1630464417 |
+        //     | cpu time | ... |    200     |
+        //     | total    | $total + 200     |
+        for (region_id, raw_record) in iter {
+            if *region_id == 0 {
+                continue;
+            }
+            append_impl(&mut self.records, ts, region_id, raw_record);
+        }
+    }
+
+    fn merge_other<'a>(&mut self, ts: u64, iter: impl Iterator<Item = (&'a u64, &'a RawRecord)>) {
+        let others = self.others.entry(ts).or_default();
+        iter.for_each(|(_, v)| {
+            others.merge(v);
+        });
+    }
+}
+
+impl RegionRecords {
     /// Clear all internal data.
     pub fn clear(&mut self) {
         self.records.clear();
@@ -283,6 +664,19 @@ pub struct SummaryRecord {
 
     /// Number of keys that have been written.
     pub write_keys: AtomicU32,
+
+    /// Logical read bytes. TableScan executor's total read bytes recorded in
+    /// execution summary.
+    pub logical_read_bytes: AtomicU64,
+
+    /// Logical write bytes.
+    pub logical_write_bytes: AtomicU64,
+
+    /// Network input bytes.
+    pub network_in_bytes: AtomicU64,
+
+    /// Network output bytes.
+    pub network_out_bytes: AtomicU64,
 }
 
 impl Clone for SummaryRecord {
@@ -290,6 +684,10 @@ impl Clone for SummaryRecord {
         Self {
             read_keys: AtomicU32::new(self.read_keys.load(Relaxed)),
             write_keys: AtomicU32::new(self.write_keys.load(Relaxed)),
+            logical_read_bytes: AtomicU64::new(self.logical_read_bytes.load(Relaxed)),
+            logical_write_bytes: AtomicU64::new(self.logical_write_bytes.load(Relaxed)),
+            network_in_bytes: AtomicU64::new(self.network_in_bytes.load(Relaxed)),
+            network_out_bytes: AtomicU64::new(self.network_out_bytes.load(Relaxed)),
         }
     }
 }
@@ -299,6 +697,10 @@ impl SummaryRecord {
     pub fn reset(&self) {
         self.read_keys.store(0, Relaxed);
         self.write_keys.store(0, Relaxed);
+        self.logical_read_bytes.store(0, Relaxed);
+        self.logical_write_bytes.store(0, Relaxed);
+        self.network_in_bytes.store(0, Relaxed);
+        self.network_out_bytes.store(0, Relaxed);
     }
 
     /// Add two items.
@@ -307,6 +709,14 @@ impl SummaryRecord {
             .fetch_add(other.read_keys.load(Relaxed), Relaxed);
         self.write_keys
             .fetch_add(other.write_keys.load(Relaxed), Relaxed);
+        self.logical_read_bytes
+            .fetch_add(other.logical_read_bytes.load(Relaxed), Relaxed);
+        self.logical_write_bytes
+            .fetch_add(other.logical_write_bytes.load(Relaxed), Relaxed);
+        self.network_in_bytes
+            .fetch_add(other.network_in_bytes.load(Relaxed), Relaxed);
+        self.network_out_bytes
+            .fetch_add(other.network_out_bytes.load(Relaxed), Relaxed);
     }
 
     /// Gets the value and writes it to zero.
@@ -315,6 +725,10 @@ impl SummaryRecord {
         Self {
             read_keys: AtomicU32::new(self.read_keys.swap(0, Relaxed)),
             write_keys: AtomicU32::new(self.write_keys.swap(0, Relaxed)),
+            logical_read_bytes: AtomicU64::new(self.logical_read_bytes.swap(0, Relaxed)),
+            logical_write_bytes: AtomicU64::new(self.logical_write_bytes.swap(0, Relaxed)),
+            network_in_bytes: AtomicU64::new(self.network_in_bytes.swap(0, Relaxed)),
+            network_out_bytes: AtomicU64::new(self.network_out_bytes.swap(0, Relaxed)),
         }
     }
 }
@@ -331,26 +745,58 @@ mod tests {
         let record = SummaryRecord {
             read_keys: AtomicU32::new(1),
             write_keys: AtomicU32::new(2),
+            network_in_bytes: AtomicU64::new(10),
+            network_out_bytes: AtomicU64::new(20),
+            logical_read_bytes: AtomicU64::new(100),
+            logical_write_bytes: AtomicU64::new(200),
         };
         assert_eq!(record.read_keys.load(Relaxed), 1);
         assert_eq!(record.write_keys.load(Relaxed), 2);
+        assert_eq!(record.network_in_bytes.load(Relaxed), 10);
+        assert_eq!(record.network_out_bytes.load(Relaxed), 20);
+        assert_eq!(record.logical_read_bytes.load(Relaxed), 100);
+        assert_eq!(record.logical_write_bytes.load(Relaxed), 200);
         let record2 = record.clone();
         assert_eq!(record2.read_keys.load(Relaxed), 1);
         assert_eq!(record2.write_keys.load(Relaxed), 2);
+        assert_eq!(record2.network_in_bytes.load(Relaxed), 10);
+        assert_eq!(record2.network_out_bytes.load(Relaxed), 20);
+        assert_eq!(record2.logical_read_bytes.load(Relaxed), 100);
+        assert_eq!(record2.logical_write_bytes.load(Relaxed), 200);
         record.merge(&SummaryRecord {
             read_keys: AtomicU32::new(3),
             write_keys: AtomicU32::new(4),
+            network_in_bytes: AtomicU64::new(30),
+            network_out_bytes: AtomicU64::new(40),
+            logical_read_bytes: AtomicU64::new(300),
+            logical_write_bytes: AtomicU64::new(400),
         });
         assert_eq!(record.read_keys.load(Relaxed), 4);
         assert_eq!(record.write_keys.load(Relaxed), 6);
+        assert_eq!(record.network_in_bytes.load(Relaxed), 40);
+        assert_eq!(record.network_out_bytes.load(Relaxed), 60);
+        assert_eq!(record.logical_read_bytes.load(Relaxed), 400);
+        assert_eq!(record.logical_write_bytes.load(Relaxed), 600);
         let record2 = record.take_and_reset();
         assert_eq!(record.read_keys.load(Relaxed), 0);
         assert_eq!(record.write_keys.load(Relaxed), 0);
+        assert_eq!(record.network_in_bytes.load(Relaxed), 0);
+        assert_eq!(record.network_out_bytes.load(Relaxed), 0);
+        assert_eq!(record.logical_read_bytes.load(Relaxed), 0);
+        assert_eq!(record.logical_write_bytes.load(Relaxed), 0);
         assert_eq!(record2.read_keys.load(Relaxed), 4);
         assert_eq!(record2.write_keys.load(Relaxed), 6);
+        assert_eq!(record2.network_in_bytes.load(Relaxed), 40);
+        assert_eq!(record2.network_out_bytes.load(Relaxed), 60);
+        assert_eq!(record2.logical_read_bytes.load(Relaxed), 400);
+        assert_eq!(record2.logical_write_bytes.load(Relaxed), 600);
         record2.reset();
         assert_eq!(record2.read_keys.load(Relaxed), 0);
         assert_eq!(record2.write_keys.load(Relaxed), 0);
+        assert_eq!(record2.network_in_bytes.load(Relaxed), 0);
+        assert_eq!(record2.network_out_bytes.load(Relaxed), 0);
+        assert_eq!(record2.logical_read_bytes.load(Relaxed), 0);
+        assert_eq!(record2.logical_write_bytes.load(Relaxed), 0);
     }
 
     #[test]
@@ -384,6 +830,10 @@ mod tests {
                 cpu_time: 111,
                 read_keys: 222,
                 write_keys: 333,
+                network_in_bytes: 1111,
+                network_out_bytes: 2222,
+                logical_read_bytes: 3333,
+                logical_write_bytes: 4444,
             },
         );
         raw_map.insert(
@@ -392,6 +842,10 @@ mod tests {
                 cpu_time: 444,
                 read_keys: 555,
                 write_keys: 666,
+                network_in_bytes: 4444,
+                network_out_bytes: 5555,
+                logical_read_bytes: 6666,
+                logical_write_bytes: 7777,
             },
         );
         raw_map.insert(
@@ -400,6 +854,10 @@ mod tests {
                 cpu_time: 777,
                 read_keys: 888,
                 write_keys: 999,
+                network_in_bytes: 7777,
+                network_out_bytes: 8888,
+                logical_read_bytes: 9999,
+                logical_write_bytes: 11110,
             },
         );
         let raw = RawRecords {
@@ -443,6 +901,10 @@ mod tests {
                 cpu_time: 111,
                 read_keys: 222,
                 write_keys: 333,
+                network_in_bytes: 1111,
+                network_out_bytes: 2222,
+                logical_read_bytes: 3333,
+                logical_write_bytes: 4444,
             },
         );
         records.insert(
@@ -451,6 +913,10 @@ mod tests {
                 cpu_time: 444,
                 read_keys: 555,
                 write_keys: 666,
+                network_in_bytes: 4444,
+                network_out_bytes: 5555,
+                logical_read_bytes: 6666,
+                logical_write_bytes: 7777,
             },
         );
         records.insert(
@@ -459,6 +925,10 @@ mod tests {
                 cpu_time: 777,
                 read_keys: 888,
                 write_keys: 999,
+                network_in_bytes: 7777,
+                network_out_bytes: 8888,
+                logical_read_bytes: 9999,
+                logical_write_bytes: 11110,
             },
         );
         let rs = RawRecords {
@@ -469,10 +939,7 @@ mod tests {
 
         let agg_map = rs.aggregate_by_extra_tag();
         let kth = find_kth_cpu_time(agg_map.iter(), 2);
-        let (top, evicted) = (
-            agg_map.iter().filter(move |(_, v)| v.cpu_time > kth),
-            agg_map.iter().filter(move |(_, v)| v.cpu_time <= kth),
-        );
+        let (top, evicted) = get_iter_for_cpu_time(&agg_map, kth);
         let others = evicted
             .map(|(_, v)| v)
             .fold(RawRecord::default(), |mut others, r| {
@@ -483,12 +950,13 @@ mod tests {
         assert_eq!(others.cpu_time, 111);
         assert_eq!(others.read_keys, 222);
         assert_eq!(others.write_keys, 333);
+        assert_eq!(others.network_in_bytes, 1111);
+        assert_eq!(others.network_out_bytes, 2222);
+        assert_eq!(others.logical_read_bytes, 3333);
+        assert_eq!(others.logical_write_bytes, 4444);
 
         let kth = find_kth_cpu_time(agg_map.iter(), 0);
-        let (top, evicted) = (
-            agg_map.iter().filter(move |(_, v)| v.cpu_time > kth),
-            agg_map.iter().filter(move |(_, v)| v.cpu_time <= kth),
-        );
+        let (top, evicted) = get_iter_for_cpu_time(&agg_map, kth);
         // let top = top.collect::<Vec<(&Arc<TagInfos>, &RawRecord)>>();
         let others = evicted
             .map(|(_, v)| v)
@@ -500,6 +968,10 @@ mod tests {
         assert_eq!(others.cpu_time, 111 + 444 + 777);
         assert_eq!(others.read_keys, 222 + 555 + 888);
         assert_eq!(others.write_keys, 333 + 666 + 999);
+        assert_eq!(others.network_in_bytes, 1111 + 4444 + 7777);
+        assert_eq!(others.network_out_bytes, 2222 + 5555 + 8888);
+        assert_eq!(others.logical_read_bytes, 3333 + 6666 + 9999);
+        assert_eq!(others.logical_write_bytes, 4444 + 7777 + 11110);
     }
 
     // Issue: https://github.com/tikv/tikv/issues/12234
@@ -539,6 +1011,10 @@ mod tests {
                 cpu_time: 111,
                 read_keys: 111,
                 write_keys: 111,
+                network_in_bytes: 111,
+                network_out_bytes: 111,
+                logical_read_bytes: 111,
+                logical_write_bytes: 111,
             },
         );
         raw_records.records.insert(
@@ -547,6 +1023,10 @@ mod tests {
                 cpu_time: 111,
                 read_keys: 111,
                 write_keys: 111,
+                network_in_bytes: 111,
+                network_out_bytes: 111,
+                logical_read_bytes: 111,
+                logical_write_bytes: 111,
             },
         );
         raw_records.records.insert(
@@ -555,6 +1035,10 @@ mod tests {
                 cpu_time: 111,
                 read_keys: 111,
                 write_keys: 111,
+                network_in_bytes: 111,
+                network_out_bytes: 111,
+                logical_read_bytes: 111,
+                logical_write_bytes: 111,
             },
         );
 
@@ -630,6 +1114,10 @@ mod tests {
                 cpu_time: 111,
                 read_keys: 222,
                 write_keys: 333,
+                network_in_bytes: 1111,
+                network_out_bytes: 2222,
+                logical_read_bytes: 3333,
+                logical_write_bytes: 4444,
             },
         );
         records.insert(
@@ -638,6 +1126,10 @@ mod tests {
                 cpu_time: 444,
                 read_keys: 555,
                 write_keys: 666,
+                network_in_bytes: 4444,
+                network_out_bytes: 5555,
+                logical_read_bytes: 6666,
+                logical_write_bytes: 7777,
             },
         );
         records.insert(
@@ -646,30 +1138,46 @@ mod tests {
                 cpu_time: 777,
                 read_keys: 888,
                 write_keys: 999,
+                network_in_bytes: 7777,
+                network_out_bytes: 8888,
+                logical_read_bytes: 9999,
+                logical_write_bytes: 11110,
             },
         );
         records.insert(
-            tag4,
+            tag4.clone(),
             RawRecord {
                 cpu_time: 1110,
                 read_keys: 2220,
                 write_keys: 3330,
+                network_in_bytes: 11110,
+                network_out_bytes: 22220,
+                logical_read_bytes: 33330,
+                logical_write_bytes: 44440,
             },
         );
         records.insert(
-            tag5,
+            tag5.clone(),
             RawRecord {
                 cpu_time: 4440,
                 read_keys: 5550,
                 write_keys: 6660,
+                network_in_bytes: 44440,
+                network_out_bytes: 55550,
+                logical_read_bytes: 66660,
+                logical_write_bytes: 77770,
             },
         );
         records.insert(
-            tag6,
+            tag6.clone(),
             RawRecord {
                 cpu_time: 7770,
                 read_keys: 8880,
                 write_keys: 9990,
+                network_in_bytes: 77770,
+                network_out_bytes: 88880,
+                logical_read_bytes: 99990,
+                logical_write_bytes: 111110,
             },
         );
         let rs = RawRecords {
@@ -685,9 +1193,354 @@ mod tests {
             111 + 1110 + 4440
         );
         assert_eq!(
+            agg_map.get(&tag1.extra_attachment).unwrap().read_keys,
+            222 + 2220 + 5550
+        );
+        assert_eq!(
+            agg_map.get(&tag1.extra_attachment).unwrap().write_keys,
+            333 + 3330 + 6660
+        );
+        assert_eq!(
+            agg_map
+                .get(&tag1.extra_attachment)
+                .unwrap()
+                .network_in_bytes,
+            1111 + 11110 + 44440
+        );
+        assert_eq!(
+            agg_map
+                .get(&tag1.extra_attachment)
+                .unwrap()
+                .network_out_bytes,
+            2222 + 22220 + 55550
+        );
+        assert_eq!(
+            agg_map
+                .get(&tag1.extra_attachment)
+                .unwrap()
+                .logical_read_bytes,
+            3333 + 33330 + 66660
+        );
+        assert_eq!(
+            agg_map
+                .get(&tag1.extra_attachment)
+                .unwrap()
+                .logical_write_bytes,
+            4444 + 44440 + 77770
+        );
+        assert_eq!(
             agg_map.get(&tag2.extra_attachment).unwrap().cpu_time,
             444 + 7770
         );
         assert_eq!(agg_map.get(&tag3.extra_attachment).unwrap().cpu_time, 777);
+    }
+
+    #[test]
+    fn test_raw_records_agg_by_region() {
+        let tag1 = Arc::new(TagInfos {
+            store_id: 0,
+            region_id: 1,
+            peer_id: 0,
+            key_ranges: vec![],
+            extra_attachment: Arc::new(b"a".to_vec()),
+        });
+        let tag2 = Arc::new(TagInfos {
+            store_id: 0,
+            region_id: 2,
+            peer_id: 0,
+            key_ranges: vec![],
+            extra_attachment: Arc::new(b"b".to_vec()),
+        });
+        let tag3 = Arc::new(TagInfos {
+            store_id: 0,
+            region_id: 3,
+            peer_id: 0,
+            key_ranges: vec![],
+            extra_attachment: Arc::new(b"c".to_vec()),
+        });
+        // tag4's region_id is equal to tag1's
+        let tag4 = Arc::new(TagInfos {
+            store_id: 1,
+            region_id: 1,
+            peer_id: 0,
+            key_ranges: vec![],
+            extra_attachment: Arc::new(b"a".to_vec()),
+        });
+        // tag5's region_id is equal to tag1's
+        let tag5 = Arc::new(TagInfos {
+            store_id: 2,
+            region_id: 1,
+            peer_id: 0,
+            key_ranges: vec![],
+            extra_attachment: Arc::new(b"a".to_vec()),
+        });
+        // tag6's region_id is equal to tag2's
+        let tag6 = Arc::new(TagInfos {
+            store_id: 3,
+            region_id: 2,
+            peer_id: 0,
+            key_ranges: vec![],
+            extra_attachment: Arc::new(b"b".to_vec()),
+        });
+        let mut records = HashMap::default();
+        records.insert(
+            tag1.clone(),
+            RawRecord {
+                cpu_time: 111,
+                read_keys: 222,
+                write_keys: 333,
+                network_in_bytes: 1111,
+                network_out_bytes: 2222,
+                logical_read_bytes: 3333,
+                logical_write_bytes: 4444,
+            },
+        );
+        records.insert(
+            tag2.clone(),
+            RawRecord {
+                cpu_time: 444,
+                read_keys: 555,
+                write_keys: 666,
+                network_in_bytes: 4444,
+                network_out_bytes: 5555,
+                logical_read_bytes: 6666,
+                logical_write_bytes: 7777,
+            },
+        );
+        records.insert(
+            tag3.clone(),
+            RawRecord {
+                cpu_time: 777,
+                read_keys: 888,
+                write_keys: 999,
+                network_in_bytes: 7777,
+                network_out_bytes: 8888,
+                logical_read_bytes: 9999,
+                logical_write_bytes: 11110,
+            },
+        );
+        records.insert(
+            tag4.clone(),
+            RawRecord {
+                cpu_time: 1110,
+                read_keys: 2220,
+                write_keys: 3330,
+                network_in_bytes: 11110,
+                network_out_bytes: 22220,
+                logical_read_bytes: 33330,
+                logical_write_bytes: 44440,
+            },
+        );
+        records.insert(
+            tag5.clone(),
+            RawRecord {
+                cpu_time: 4440,
+                read_keys: 5550,
+                write_keys: 6660,
+                network_in_bytes: 44440,
+                network_out_bytes: 55550,
+                logical_read_bytes: 66660,
+                logical_write_bytes: 77770,
+            },
+        );
+        records.insert(
+            tag6.clone(),
+            RawRecord {
+                cpu_time: 7770,
+                read_keys: 8880,
+                write_keys: 9990,
+                network_in_bytes: 77770,
+                network_out_bytes: 88880,
+                logical_read_bytes: 99990,
+                logical_write_bytes: 111110,
+            },
+        );
+        let rs = RawRecords {
+            begin_unix_time_secs: 1,
+            duration: Duration::from_secs(1),
+            records,
+        };
+
+        let (_, agg_map) = rs.aggregate_by_extra_tag_and_region();
+        assert_eq!(agg_map.len(), 3);
+        assert_eq!(
+            agg_map.get(&tag1.region_id).unwrap().cpu_time,
+            111 + 1110 + 4440
+        );
+        assert_eq!(
+            agg_map.get(&tag1.region_id).unwrap().read_keys,
+            222 + 2220 + 5550
+        );
+        assert_eq!(
+            agg_map.get(&tag1.region_id).unwrap().write_keys,
+            333 + 3330 + 6660
+        );
+        assert_eq!(
+            agg_map.get(&tag1.region_id).unwrap().network_in_bytes,
+            1111 + 11110 + 44440
+        );
+        assert_eq!(
+            agg_map.get(&tag1.region_id).unwrap().network_out_bytes,
+            2222 + 22220 + 55550
+        );
+        assert_eq!(
+            agg_map.get(&tag1.region_id).unwrap().logical_read_bytes,
+            3333 + 33330 + 66660
+        );
+        assert_eq!(
+            agg_map.get(&tag1.region_id).unwrap().logical_write_bytes,
+            4444 + 44440 + 77770
+        );
+        assert_eq!(agg_map.get(&tag2.region_id).unwrap().cpu_time, 444 + 7770);
+        assert_eq!(agg_map.get(&tag3.region_id).unwrap().cpu_time, 777);
+    }
+
+    #[test]
+    fn test_pick_top_k_cpu_network_io() {
+        let tag1 = Arc::new(TagInfos {
+            store_id: 0,
+            region_id: 0,
+            peer_id: 0,
+            key_ranges: vec![],
+            extra_attachment: Arc::new(b"a".to_vec()),
+        });
+        let tag2 = Arc::new(TagInfos {
+            store_id: 0,
+            region_id: 0,
+            peer_id: 0,
+            key_ranges: vec![],
+            extra_attachment: Arc::new(b"b".to_vec()),
+        });
+        let tag3 = Arc::new(TagInfos {
+            store_id: 0,
+            region_id: 0,
+            peer_id: 0,
+            key_ranges: vec![],
+            extra_attachment: Arc::new(b"c".to_vec()),
+        });
+        let mut records = HashMap::default();
+        // tag1 largest network
+        records.insert(
+            tag1,
+            RawRecord {
+                cpu_time: 111,
+                read_keys: 222,
+                write_keys: 333,
+                network_in_bytes: 9999,
+                network_out_bytes: 8888,
+                logical_read_bytes: 7777,
+                logical_write_bytes: 6666,
+            },
+        );
+        // tag2 largest logical io
+        records.insert(
+            tag2,
+            RawRecord {
+                cpu_time: 444,
+                read_keys: 555,
+                write_keys: 666,
+                network_in_bytes: 7777,
+                network_out_bytes: 6666,
+                logical_read_bytes: 9999,
+                logical_write_bytes: 9999,
+            },
+        );
+        // tag3 largest cpu
+        records.insert(
+            tag3,
+            RawRecord {
+                cpu_time: 777,
+                read_keys: 888,
+                write_keys: 999,
+                network_in_bytes: 1111,
+                network_out_bytes: 2222,
+                logical_read_bytes: 3333,
+                logical_write_bytes: 4444,
+            },
+        );
+        let rs = RawRecords {
+            begin_unix_time_secs: 1,
+            duration: Duration::from_secs(1),
+            records,
+        };
+
+        let agg_map = rs.aggregate_by_extra_tag();
+        let (kth_cpu, kth_network, kth_logical_io) = find_kth_values(agg_map.iter(), 2);
+        let (top, evicted) =
+            get_iter_for_cpu_network_io(&agg_map, kth_cpu, kth_network, kth_logical_io);
+        let others = evicted
+            .map(|(_, v)| v)
+            .fold(RawRecord::default(), |mut others, r| {
+                others.merge(r);
+                others
+            });
+        assert_eq!(top.count(), 3);
+        assert_eq!(others.cpu_time, 0);
+
+        // With unpicked tags
+        let tag4 = Arc::new(TagInfos {
+            store_id: 0,
+            region_id: 0,
+            peer_id: 0,
+            key_ranges: vec![],
+            extra_attachment: Arc::new(b"d".to_vec()),
+        });
+        let tag5 = Arc::new(TagInfos {
+            store_id: 0,
+            region_id: 0,
+            peer_id: 0,
+            key_ranges: vec![],
+            extra_attachment: Arc::new(b"ad".to_vec()),
+        });
+        let mut records = rs.records.clone();
+        // tag4 won't be picked
+        records.insert(
+            tag4,
+            RawRecord {
+                cpu_time: 77,
+                read_keys: 88,
+                write_keys: 99,
+                network_in_bytes: 111,
+                network_out_bytes: 222,
+                logical_read_bytes: 333,
+                logical_write_bytes: 444,
+            },
+        );
+        // tag5 won't be picked
+        records.insert(
+            tag5,
+            RawRecord {
+                cpu_time: 66,
+                read_keys: 55,
+                write_keys: 44,
+                network_in_bytes: 11,
+                network_out_bytes: 22,
+                logical_read_bytes: 33,
+                logical_write_bytes: 44,
+            },
+        );
+        let rs = RawRecords {
+            begin_unix_time_secs: 1,
+            duration: Duration::from_secs(1),
+            records,
+        };
+        let agg_map = rs.aggregate_by_extra_tag();
+        let (kth_cpu, kth_network, kth_logical_io) = find_kth_values(agg_map.iter(), 2);
+        let (top, evicted) =
+            get_iter_for_cpu_network_io(&agg_map, kth_cpu, kth_network, kth_logical_io);
+        let others = evicted
+            .map(|(_, v)| v)
+            .fold(RawRecord::default(), |mut others, r| {
+                others.merge(r);
+                others
+            });
+        assert_eq!(top.count(), 3);
+        assert_eq!(others.cpu_time, 77 + 66);
+        assert_eq!(others.read_keys, 88 + 55);
+        assert_eq!(others.write_keys, 99 + 44);
+        assert_eq!(others.network_in_bytes, 111 + 11);
+        assert_eq!(others.network_out_bytes, 222 + 22);
+        assert_eq!(others.logical_read_bytes, 333 + 33);
+        assert_eq!(others.logical_write_bytes, 444 + 44);
     }
 }

--- a/components/resource_metering/src/recorder/mod.rs
+++ b/components/resource_metering/src/recorder/mod.rs
@@ -2,7 +2,7 @@
 
 use std::{
     fmt::{self, Display, Formatter},
-    sync::Arc,
+    sync::{Arc, atomic::Ordering::Relaxed},
     time::Duration,
 };
 
@@ -15,8 +15,10 @@ use tikv_util::{
 };
 
 use self::{collector_reg::CollectorReg, sub_recorder::SubRecorder};
-use crate::{Config, RawRecords, ResourceTagFactory, collector::Collector};
-
+use crate::{
+    Config, RawRecords, ResourceTagFactory, collector::Collector,
+    config::ENABLE_NETWORK_IO_COLLECTION,
+};
 mod collector_reg;
 mod localstorage;
 mod sub_recorder;
@@ -26,7 +28,10 @@ pub use self::{
     localstorage::{LocalStorage, LocalStorageRef, STORAGE},
     sub_recorder::{
         cpu::CpuRecorder,
-        summary::{SummaryRecorder, record_read_keys, record_write_keys},
+        summary::{
+            SummaryRecorder, record_logical_read_bytes, record_logical_write_bytes,
+            record_network_in_bytes, record_network_out_bytes, record_read_keys, record_write_keys,
+        },
     },
 };
 
@@ -123,6 +128,7 @@ impl Recorder {
 
     fn handle_config_change(&mut self, config: Config) {
         self.precision_ms = config.precision.as_millis();
+        ENABLE_NETWORK_IO_COLLECTION.store(config.enable_network_io_collection, Relaxed);
     }
 
     fn tick(&mut self) {
@@ -295,12 +301,15 @@ impl ConfigChangeNotifier {
 /// This function is intended to simplify external use.
 pub fn init_recorder(
     precision_ms: u64,
+    enable_network_io_collection: bool,
 ) -> (
     ConfigChangeNotifier,
     CollectorRegHandle,
     ResourceTagFactory,
     Box<LazyWorker<Task>>,
 ) {
+    // initialize the global flag for network io collection
+    ENABLE_NETWORK_IO_COLLECTION.store(enable_network_io_collection, Relaxed);
     let recorder = RecorderBuilder::default()
         .precision_ms(precision_ms)
         .add_sub_recorder(Box::<CpuRecorder>::default())

--- a/components/resource_metering/src/recorder/sub_recorder/summary.rs
+++ b/components/resource_metering/src/recorder/sub_recorder/summary.rs
@@ -6,7 +6,7 @@ use collections::HashMap;
 use tikv_util::sys::thread::Pid;
 
 use crate::{
-    RawRecords,
+    ENABLE_NETWORK_IO_COLLECTION, RawRecords,
     recorder::{
         SubRecorder,
         localstorage::{LocalStorage, STORAGE},
@@ -30,6 +30,58 @@ pub fn record_write_keys(count: u32) {
             .summary_cur_record
             .write_keys
             .fetch_add(count, Relaxed);
+    })
+}
+
+/// Records how many bytes have been received in the current context.
+pub fn record_network_in_bytes(bytes: u64) {
+    if !ENABLE_NETWORK_IO_COLLECTION.load(Relaxed) {
+        return;
+    }
+    STORAGE.with(|s| {
+        s.borrow()
+            .summary_cur_record
+            .network_in_bytes
+            .fetch_add(bytes, Relaxed);
+    })
+}
+
+/// Records how many bytes have been sent in the current context.
+pub fn record_network_out_bytes(bytes: u64) {
+    if !ENABLE_NETWORK_IO_COLLECTION.load(Relaxed) {
+        return;
+    }
+    STORAGE.with(|s| {
+        s.borrow()
+            .summary_cur_record
+            .network_out_bytes
+            .fetch_add(bytes, Relaxed);
+    })
+}
+
+/// Records how many bytes have been read in the current context.
+pub fn record_logical_read_bytes(bytes: u64) {
+    if !ENABLE_NETWORK_IO_COLLECTION.load(Relaxed) {
+        return;
+    }
+    STORAGE.with(|s| {
+        s.borrow()
+            .summary_cur_record
+            .logical_read_bytes
+            .fetch_add(bytes, Relaxed);
+    })
+}
+
+/// Records how many bytes have been written in the current context.
+pub fn record_logical_write_bytes(bytes: u64) {
+    if !ENABLE_NETWORK_IO_COLLECTION.load(Relaxed) {
+        return;
+    }
+    STORAGE.with(|s| {
+        s.borrow()
+            .summary_cur_record
+            .logical_write_bytes
+            .fetch_add(bytes, Relaxed);
     })
 }
 

--- a/components/resource_metering/src/reporter/mod.rs
+++ b/components/resource_metering/src/reporter/mod.rs
@@ -14,6 +14,7 @@ use std::{
 use collections::HashMap;
 use kvproto::resource_usage_agent::ResourceUsageRecord;
 use tikv_util::{
+    info,
     time::Duration,
     warn,
     worker::{Builder as WorkerBuilder, LazyWorker, Runnable, RunnableWithTimer, Scheduler},
@@ -163,7 +164,7 @@ impl Reporter {
             return;
         }
 
-        warn!("upload region record");
+        info!("upload region record");
         // Whether endpoint exists or not, records should be taken in order to reset.
         let region_records = std::mem::take(&mut self.region_records);
         let report_data: Arc<Vec<ResourceUsageRecord>> = Arc::new(region_records.into());

--- a/components/resource_metering/src/reporter/mod.rs
+++ b/components/resource_metering/src/reporter/mod.rs
@@ -20,7 +20,7 @@ use tikv_util::{
 };
 
 use crate::{
-    Config, DataSink, RawRecords, Records, find_kth_cpu_time,
+    Config, DataSink, RawRecords, Records, RegionRecords, handle_records_impl,
     recorder::{CollectorGuard, CollectorRegHandle},
     reporter::{
         collector_impl::CollectorImpl,
@@ -47,6 +47,7 @@ pub struct Reporter {
 
     data_sinks: HashMap<DataSinkId, Box<dyn DataSink>>,
     records: Records,
+    region_records: RegionRecords,
 }
 
 impl Runnable for Reporter {
@@ -89,27 +90,21 @@ impl Reporter {
 
             data_sinks: HashMap::default(),
             records: Records::default(),
+            region_records: RegionRecords::default(),
         }
     }
 
     fn handle_records(&mut self, records: Arc<RawRecords>) {
         let ts = records.begin_unix_time_secs;
-        let agg_map = records.aggregate_by_extra_tag();
-        if self.config.max_resource_groups >= agg_map.len() {
-            self.records.append(ts, agg_map.iter());
-            return;
+        let n = self.config.max_resource_groups;
+        if self.config.enable_network_io_collection {
+            let (agg_tag_map, agg_region_map) = records.aggregate_by_extra_tag_and_region();
+            handle_records_impl(&mut self.records, true, &agg_tag_map, ts, n);
+            handle_records_impl(&mut self.region_records, true, &agg_region_map, ts, n);
+        } else {
+            let agg_map = records.aggregate_by_extra_tag();
+            handle_records_impl(&mut self.records, false, &agg_map, ts, n);
         }
-
-        let kth = find_kth_cpu_time(agg_map.iter(), self.config.max_resource_groups);
-        self.records
-            .append(ts, agg_map.iter().filter(move |(_, v)| v.cpu_time > kth));
-        let others = self.records.others.entry(ts).or_default();
-        agg_map
-            .iter()
-            .filter(move |(_, v)| v.cpu_time <= kth)
-            .for_each(|(_, v)| {
-                others.merge(v);
-            });
     }
 
     fn handle_config_change(&mut self, config: Config) {
@@ -140,7 +135,7 @@ impl Reporter {
         }
     }
 
-    fn upload(&mut self) {
+    fn upload_grouptag_record(&mut self) {
         // When either of records.records and records.others is not empty, we
         // will report it. Only when the cpu_time of all tags is equal, and the
         // number of tags exceeds the max_resource_group limit, will records.records
@@ -156,17 +151,37 @@ impl Reporter {
         // Whether endpoint exists or not, records should be taken in order to reset.
         let records = std::mem::take(&mut self.records);
         let report_data: Arc<Vec<ResourceUsageRecord>> = Arc::new(records.into());
-
         for data_sink in self.data_sinks.values_mut() {
             if let Err(err) = data_sink.try_send(report_data.clone()) {
-                warn!("failed to send data to datasink"; "error" => ?err);
+                warn!("failed to send data to datasink"; "group_by" => "tag", "error" => ?err);
             }
         }
     }
 
+    fn upload_region_record(&mut self) {
+        if !self.config.enable_network_io_collection || self.region_records.is_empty() {
+            return;
+        }
+
+        warn!("upload region record");
+        // Whether endpoint exists or not, records should be taken in order to reset.
+        let region_records = std::mem::take(&mut self.region_records);
+        let report_data: Arc<Vec<ResourceUsageRecord>> = Arc::new(region_records.into());
+        for data_sink in self.data_sinks.values_mut() {
+            if let Err(err) = data_sink.try_send(report_data.clone()) {
+                warn!("failed to send data to datasink"; "group_by" => "region" ,"error" => ?err);
+            }
+        }
+    }
+
+    fn upload(&mut self) {
+        self.upload_grouptag_record();
+        self.upload_region_record();
+    }
     fn reset(&mut self) {
         self.collector.take();
         self.records.clear();
+        self.region_records.clear();
     }
 }
 
@@ -255,11 +270,15 @@ mod tests {
     #[derive(Default, Clone)]
     struct MockDataSink {
         op_count: Arc<AtomicUsize>,
+        region_op_count: Arc<AtomicUsize>,
     }
 
     impl DataSink for MockDataSink {
         fn try_send(&mut self, _records: Arc<Vec<ResourceUsageRecord>>) -> Result<()> {
             self.op_count.fetch_add(1, SeqCst);
+            if !_records.is_empty() && _records[0].has_region_record() {
+                self.region_op_count.fetch_add(1, SeqCst);
+            }
             Ok(())
         }
     }
@@ -280,6 +299,7 @@ mod tests {
             report_receiver_interval: ReadableDuration::minutes(2),
             max_resource_groups: 3000,
             precision: ReadableDuration::secs(2),
+            enable_network_io_collection: false,
         }));
         assert_eq!(r.get_interval(), Duration::from_secs(120));
         let mut records = HashMap::default();
@@ -295,6 +315,10 @@ mod tests {
                 cpu_time: 1,
                 read_keys: 2,
                 write_keys: 3,
+                network_in_bytes: 4,
+                network_out_bytes: 5,
+                logical_read_bytes: 6,
+                logical_write_bytes: 7,
             },
         );
         r.run(Task::Records(Arc::new(RawRecords {
@@ -341,6 +365,10 @@ mod tests {
                 cpu_time: 1,
                 read_keys: 2,
                 write_keys: 3,
+                network_in_bytes: 4,
+                network_out_bytes: 5,
+                logical_read_bytes: 6,
+                logical_write_bytes: 7,
             },
         );
 
@@ -371,5 +399,54 @@ mod tests {
         assert_eq!(ds3.op_count.load(SeqCst), 2);
 
         r.shutdown();
+    }
+
+    #[test]
+    fn test_reporter_region_data() {
+        let scheduler = LazyWorker::new("test-worker").scheduler();
+        let collector_reg_handle = CollectorRegHandle::new_for_test();
+        let mut r = Reporter::new(Config::default(), collector_reg_handle, scheduler);
+
+        let client = MockDataSink::default();
+        r.run(Task::DataSinkReg(DataSinkReg::Register {
+            id: DataSinkId(1),
+            data_sink: Box::new(client.clone()),
+        }));
+        r.run(Task::ConfigChange(Config {
+            receiver_address: "abc".to_string(),
+            report_receiver_interval: ReadableDuration::minutes(2),
+            max_resource_groups: 3000,
+            precision: ReadableDuration::secs(2),
+            enable_network_io_collection: true,
+        }));
+        assert_eq!(r.get_interval(), Duration::from_secs(120));
+        let mut records = HashMap::default();
+        records.insert(
+            Arc::new(TagInfos {
+                store_id: 0,
+                region_id: 1,
+                peer_id: 0,
+                key_ranges: vec![],
+                extra_attachment: Arc::new(b"12345".to_vec()),
+            }),
+            RawRecord {
+                cpu_time: 1,
+                read_keys: 2,
+                write_keys: 3,
+                network_in_bytes: 4,
+                network_out_bytes: 5,
+                logical_read_bytes: 6,
+                logical_write_bytes: 7,
+            },
+        );
+        r.run(Task::Records(Arc::new(RawRecords {
+            begin_unix_time_secs: 123,
+            duration: Duration::default(),
+            records,
+        })));
+        r.on_timeout();
+        r.shutdown();
+        assert_eq!(client.op_count.load(SeqCst), 2);
+        assert_eq!(client.region_op_count.load(SeqCst), 1);
     }
 }

--- a/components/resource_metering/src/reporter/pubsub.rs
+++ b/components/resource_metering/src/reporter/pubsub.rs
@@ -54,7 +54,7 @@ impl ResourceMeteringPubSub for PubSubService {
         // The reporter calls `tx.try_send` roughly every minute. If the the gRPC
         // stream sender does not send data out over the network in time, it discards
         // the incoming records to prevent memory overflow.
-        let (tx, mut rx) = channel(1);
+        let (tx, mut rx) = channel(2);
 
         let data_sink = DataSinkImpl { tx };
         let handle = self.data_sink_reg_handle.register(Box::new(data_sink));

--- a/components/resource_metering/tests/recorder_test.rs
+++ b/components/resource_metering/tests/recorder_test.rs
@@ -179,7 +179,7 @@ mod tests {
 
     #[test]
     fn test_cpu_recorder_heavy_single_thread() {
-        let (_, collector_reg_handle, resource_tag_factory, worker) = init_recorder(1000);
+        let (_, collector_reg_handle, resource_tag_factory, worker) = init_recorder(1000, false);
 
         let collector = DummyCollector::default();
         let _handle = collector_reg_handle.register(Box::new(collector.clone()), false);
@@ -198,7 +198,7 @@ mod tests {
 
     #[test]
     fn test_cpu_recorder_sleep_single_thread() {
-        let (_, collector_reg_handle, resource_tag_factory, worker) = init_recorder(1000);
+        let (_, collector_reg_handle, resource_tag_factory, worker) = init_recorder(1000, false);
 
         let collector = DummyCollector::default();
         let _handle = collector_reg_handle.register(Box::new(collector.clone()), false);
@@ -217,7 +217,7 @@ mod tests {
 
     #[test]
     fn test_cpu_recorder_hybrid_single_thread() {
-        let (_, collector_reg_handle, resource_tag_factory, worker) = init_recorder(1000);
+        let (_, collector_reg_handle, resource_tag_factory, worker) = init_recorder(1000, false);
 
         // Hybrid workload with 1 thread
         let collector = DummyCollector::default();
@@ -245,7 +245,7 @@ mod tests {
 
     #[test]
     fn test_cpu_recorder_heavy_multiple_threads() {
-        let (_, collector_reg_handle, resource_tag_factory, worker) = init_recorder(1000);
+        let (_, collector_reg_handle, resource_tag_factory, worker) = init_recorder(1000, false);
 
         // Heavy CPU with 3 threads
         let collector = DummyCollector::default();
@@ -277,7 +277,7 @@ mod tests {
 
     #[test]
     fn test_cpu_recorder_hybrid_multiple_threads() {
-        let (_, collector_reg_handle, resource_tag_factory, worker) = init_recorder(1000);
+        let (_, collector_reg_handle, resource_tag_factory, worker) = init_recorder(1000, false);
 
         // Hybrid workload with 3 threads
         let collector = DummyCollector::default();

--- a/components/resource_metering/tests/summary_test.rs
+++ b/components/resource_metering/tests/summary_test.rs
@@ -48,7 +48,7 @@ fn test_summary() {
     };
 
     let (_, collector_reg_handle, resource_tag_factory, mut recorder_worker) =
-        init_recorder(cfg.precision.as_millis());
+        init_recorder(cfg.precision.as_millis(), cfg.enable_network_io_collection);
     let (_, data_sink_reg_handle, mut reporter_worker) = init_reporter(cfg, collector_reg_handle);
 
     let data_sink = MockDataSink::default();

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -647,6 +647,10 @@ where
         let (recorder_notifier, collector_reg_handle, resource_tag_factory, recorder_worker) =
             resource_metering::init_recorder(
                 self.core.config.resource_metering.precision.as_millis(),
+                self.core
+                    .config
+                    .resource_metering
+                    .enable_network_io_collection,
             );
         self.core.to_stop.push(recorder_worker);
         let (reporter_notifier, data_sink_reg_handle, reporter_worker) =

--- a/components/server/src/server2.rs
+++ b/components/server/src/server2.rs
@@ -523,6 +523,10 @@ where
         let (recorder_notifier, collector_reg_handle, resource_tag_factory, recorder_worker) =
             resource_metering::init_recorder(
                 self.core.config.resource_metering.precision.as_millis(),
+                self.core
+                    .config
+                    .resource_metering
+                    .enable_network_io_collection,
             );
         self.core.to_stop.push(recorder_worker);
         let (reporter_notifier, data_sink_reg_handle, reporter_worker) =

--- a/components/test_raftstore-v2/src/server.rs
+++ b/components/test_raftstore-v2/src/server.rs
@@ -762,7 +762,10 @@ impl<EK: KvEngine> ServerCluster<EK> {
         cfg: &resource_metering::Config,
     ) -> (ResourceTagFactory, CollectorRegHandle, Box<dyn FnOnce()>) {
         let (_, collector_reg_handle, resource_tag_factory, recorder_worker) =
-            resource_metering::init_recorder(cfg.precision.as_millis());
+            resource_metering::init_recorder(
+                cfg.precision.as_millis(),
+                cfg.enable_network_io_collection,
+            );
         let (_, data_sink_reg_handle, reporter_worker) =
             resource_metering::init_reporter(cfg.clone(), collector_reg_handle.clone());
         let (_, single_target_worker) = resource_metering::init_single_target(

--- a/components/test_raftstore/src/server.rs
+++ b/components/test_raftstore/src/server.rs
@@ -254,7 +254,10 @@ impl ServerCluster {
         cfg: &resource_metering::Config,
     ) -> (ResourceTagFactory, CollectorRegHandle, Box<dyn FnOnce()>) {
         let (_, collector_reg_handle, resource_tag_factory, recorder_worker) =
-            resource_metering::init_recorder(cfg.precision.as_millis());
+            resource_metering::init_recorder(
+                cfg.precision.as_millis(),
+                cfg.enable_network_io_collection,
+            );
         let (_, data_sink_reg_handle, reporter_worker) =
             resource_metering::init_reporter(cfg.clone(), collector_reg_handle.clone());
         let (_, single_target_worker) = resource_metering::init_single_target(

--- a/components/tracker/src/lib.rs
+++ b/components/tracker/src/lib.rs
@@ -182,4 +182,7 @@ pub struct RequestMetrics {
     pub apply_thread_wait_nanos: u64,
     pub apply_write_wal_nanos: u64,
     pub apply_write_memtable_nanos: u64,
+
+    // recorded outside the read_pool thread, accessed inside the read_pool thread for topsql usage
+    pub grpc_req_size: u64,
 }

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -21,7 +21,10 @@ use kvproto::{coprocessor as coppb, errorpb, kvrpcpb, kvrpcpb::CommandPri};
 use online_config::ConfigManager;
 use protobuf::{CodedInputStream, Message};
 use resource_control::{ResourceGroupManager, ResourceLimiter, TaskMetadata};
-use resource_metering::{FutureExt, ResourceTagFactory, StreamExt};
+use resource_metering::{
+    FutureExt, ResourceTagFactory, StreamExt, record_logical_read_bytes, record_network_in_bytes,
+    record_network_out_bytes,
+};
 use tidb_query_common::execute_stats::ExecSummary;
 use tikv_alloc::trace::MemoryTraceGuard;
 use tikv_kv::SnapshotExt;
@@ -430,6 +433,9 @@ impl<E: Engine> Endpoint<E> {
         mut tracker: Box<Tracker<E>>,
         handler_builder: RequestHandlerBuilder<E::IMSnap>,
     ) -> Result<MemoryTraceGuard<coppb::Response>> {
+        with_tls_tracker(|tracker1| {
+            record_network_in_bytes(tracker1.metrics.grpc_req_size);
+        });
         // When this function is being executed, it may be queued for a long time, so
         // that deadline may exceed.
         tracker.on_scheduled();
@@ -497,10 +503,12 @@ impl<E: Engine> Endpoint<E> {
         tracker.collect_storage_statistics(storage_stats);
         let (exec_details, exec_details_v2) = tracker.get_exec_details();
         tracker.on_finish_all_items();
-
+        record_logical_read_bytes(exec_details_v2.get_scan_detail_v2().processed_versions_size);
         let mut resp = match result {
             Ok(resp) => {
-                COPR_RESP_SIZE.inc_by(resp.data.len() as u64);
+                let resp_size = resp.data.len() as u64;
+                COPR_RESP_SIZE.inc_by(resp_size);
+                record_network_out_bytes(resp_size);
                 resp
             }
             Err(e) => make_error_response(e).into(),
@@ -554,7 +562,7 @@ impl<E: Engine> Endpoint<E> {
         let future =
             Self::handle_unary_request_impl(self.semaphore.clone(), tracker, handler_builder)
                 .in_resource_metering_tag(resource_tag)
-                .map(|res| {
+                .map(move |res| {
                     let _ = tx.send(res);
                 });
         let res = self.read_pool_spawn_with_memory_quota_check(
@@ -599,6 +607,9 @@ impl<E: Engine> Endpoint<E> {
         )));
         let result_of_batch = self.process_batch_tasks(&mut req, &peer);
         set_tls_tracker_token(tracker);
+        with_tls_tracker(|tracker| {
+            tracker.metrics.grpc_req_size = req.compute_size() as u64;
+        });
         let result_of_future = self
             .parse_request_and_check_memory_locks(req, peer, false)
             .map(|(handler_builder, req_ctx)| self.handle_unary_request(req_ctx, handler_builder));
@@ -727,6 +738,9 @@ impl<E: Engine> Endpoint<E> {
                 None
             };
 
+            with_tls_tracker(|tracker| {
+                record_network_in_bytes(tracker.metrics.grpc_req_size);
+            });
             // When this function is being executed, it may be queued for a long time, so that
             // deadline may exceed.
             tracker.on_scheduled();
@@ -771,7 +785,10 @@ impl<E: Engine> Endpoint<E> {
                     },
                     Ok((None, _)) => break,
                     Ok((Some(mut resp), finished)) => {
-                        COPR_RESP_SIZE.inc_by(resp.data.len() as u64);
+                        let resp_size = resp.data.len() as u64;
+                        COPR_RESP_SIZE.inc_by(resp_size);
+                        record_network_out_bytes(resp_size);
+                        record_logical_read_bytes(exec_details_v2.get_scan_detail_v2().processed_versions_size);
                         resp.set_exec_details(exec_details);
                         resp.set_exec_details_v2(exec_details_v2);
                         yield resp;
@@ -854,6 +871,15 @@ impl<E: Engine> Endpoint<E> {
         req: coppb::Request,
         peer: Option<String>,
     ) -> impl futures::stream::Stream<Item = coppb::Response> {
+        let tracker = GLOBAL_TRACKERS.insert(::tracker::Tracker::new(RequestInfo::new(
+            req.get_context(),
+            RequestType::Unknown,
+            req.start_ts,
+        )));
+        set_tls_tracker_token(tracker);
+        with_tls_tracker(|tracker| {
+            tracker.metrics.grpc_req_size = req.compute_size() as u64;
+        });
         let result_of_stream = self
             .parse_request_and_check_memory_locks(req, peer, true)
             .and_then(|(handler_builder, req_ctx)| {

--- a/src/server/service/batch.rs
+++ b/src/server/service/batch.rs
@@ -3,6 +3,7 @@
 // #[PerformanceCriticalPath]
 use api_version::KvFormat;
 use kvproto::kvrpcpb::*;
+use protobuf::Message;
 use tikv_util::{
     future::poll_future_notify,
     mpsc::future::{Sender, WakePolicy},
@@ -65,6 +66,9 @@ impl ReqBatcher {
             RequestType::KvBatchGetCommand,
             req.get_version(),
         )));
+        GLOBAL_TRACKERS.with_tracker(tracker, |the_tracker| {
+            the_tracker.metrics.grpc_req_size = req.compute_size() as u64;
+        });
         self.gets.push(req);
         self.get_ids.push(id);
         self.get_trackers.push(tracker);

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -24,7 +24,7 @@ use grpcio::{
 };
 use health_controller::HealthController;
 use kvproto::{coprocessor::*, kvrpcpb::*, mpp::*, raft_serverpb::*, tikvpb::*};
-use protobuf::RepeatedField;
+use protobuf::{Message, RepeatedField};
 use raft::eraftpb::MessageType;
 use raftstore::{
     Error as RaftStoreError, Result as RaftStoreResult,
@@ -44,7 +44,9 @@ use tikv_util::{
     time::Instant,
     worker::Scheduler,
 };
-use tracker::{GLOBAL_TRACKERS, RequestInfo, RequestType, Tracker, set_tls_tracker_token};
+use tracker::{
+    GLOBAL_TRACKERS, RequestInfo, RequestType, Tracker, set_tls_tracker_token, with_tls_tracker,
+};
 use txn_types::{self, Key};
 
 use super::batch::{BatcherBuilder, ReqBatcher};
@@ -1557,6 +1559,9 @@ fn future_get<E: Engine, L: LockManager, F: KvFormat>(
         req.get_version(),
     )));
     set_tls_tracker_token(tracker);
+    with_tls_tracker(|tracker| {
+        tracker.metrics.grpc_req_size = req.compute_size() as u64;
+    });
     let start = Instant::now();
     let v = storage.get(
         req.take_context(),
@@ -1628,6 +1633,9 @@ fn future_scan<E: Engine, L: LockManager, F: KvFormat>(
         req.get_version(),
     )));
     set_tls_tracker_token(tracker);
+    with_tls_tracker(|tracker| {
+        tracker.metrics.grpc_req_size = req.compute_size() as u64;
+    });
     let end_key = Key::from_raw_maybe_unbounded(req.get_end_key());
 
     let v = storage.scan(
@@ -1677,6 +1685,9 @@ fn future_batch_get<E: Engine, L: LockManager, F: KvFormat>(
     )));
     set_tls_tracker_token(tracker);
     let start = Instant::now();
+    with_tls_tracker(|tracker| {
+        tracker.metrics.grpc_req_size = req.compute_size() as u64;
+    });
     let keys = req.get_keys().iter().map(|x| Key::from_raw(x)).collect();
     let v = storage.batch_get(req.take_context(), keys, req.get_version().into());
 
@@ -1726,6 +1737,9 @@ fn future_buffer_batch_get<E: Engine, L: LockManager, F: KvFormat>(
         req.get_version(),
     )));
     set_tls_tracker_token(tracker);
+    with_tls_tracker(|tracker| {
+        tracker.metrics.grpc_req_size = req.compute_size() as u64;
+    });
     let start = Instant::now();
     let keys = req.get_keys().iter().map(|x| Key::from_raw(x)).collect();
     let v = storage.buffer_batch_get(req.take_context(), keys, req.get_version().into());
@@ -1770,6 +1784,9 @@ fn future_scan_lock<E: Engine, L: LockManager, F: KvFormat>(
         req.get_max_version(),
     )));
     set_tls_tracker_token(tracker);
+    with_tls_tracker(|tracker| {
+        tracker.metrics.grpc_req_size = req.compute_size() as u64;
+    });
     let start_key = Key::from_raw_maybe_unbounded(req.get_start_key());
     let end_key = Key::from_raw_maybe_unbounded(req.get_end_key());
 
@@ -2333,6 +2350,9 @@ macro_rules! txn_command_future {
                 0,
             )));
             set_tls_tracker_token($tracker);
+            with_tls_tracker(|tracker| {
+                tracker.metrics.grpc_req_size = $req.compute_size() as u64;
+            });
             let (cb, f) = paired_future_callback();
             let res = storage.sched_txn_command($req.into(), cb);
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -956,9 +956,9 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
                                         buckets.as_ref(),
                                     );
                                     statistics.add(&stat);
-                                    let value_size = v.as_ref().map_or(0, |v| {
-                                        v.as_ref().map_or(0, |v1| v1.value.len()) as u64
-                                    });
+                                    let value_size = v
+                                        .as_ref()
+                                        .map_or(0, |v| v.as_ref().map_or(0, |v1| v1.len()) as u64);
                                     record_network_out_bytes(value_size);
                                     record_logical_read_bytes(statistics.processed_size as u64);
                                     consumer.consume(
@@ -1336,8 +1336,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
                                     .get(CMD)
                                     .observe(kv_pairs.len() as f64);
                                 record_network_out_bytes(kv_pairs.iter().fold(0u64, |acc, r| {
-                                    acc + r.as_ref().map_or(0, |(k, v)| k.len() + v.value.len())
-                                        as u64
+                                    acc + r.as_ref().map_or(0, |(k, v)| k.len() + v.len()) as u64
                                 }));
                                 kv_pairs
                             });

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -90,10 +90,14 @@ use kvproto::{
     pdpb::QueryKind,
 };
 use pd_client::FeatureGate;
+use protobuf::Message;
 use raftstore::store::{ReadStats, TxnExt, WriteStats, util::build_key_range};
 use rand::prelude::*;
 use resource_control::{ResourceController, ResourceGroupManager, ResourceLimiter, TaskMetadata};
-use resource_metering::{FutureExt, ResourceTagFactory};
+use resource_metering::{
+    FutureExt, ResourceTagFactory, record_logical_read_bytes, record_network_in_bytes,
+    record_network_out_bytes,
+};
 use tikv_kv::{OnAppliedCb, SnapshotExt};
 use tikv_util::{
     deadline::Deadline,
@@ -646,6 +650,9 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
                     false,
                     QueryKind::Get,
                 );
+                with_tls_tracker(|tracker| {
+                    record_network_in_bytes(tracker.metrics.grpc_req_size);
+                });
 
                 KV_COMMAND_COUNTER_VEC_STATIC.get(CMD).inc();
                 SCHED_COMMANDS_PRI_COUNTER_VEC_STATIC
@@ -718,12 +725,13 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
                         now.saturating_duration_since(command_duration),
                     ));
 
-                    let read_bytes = key.len()
-                        + result
-                            .as_ref()
-                            .unwrap_or(&None)
-                            .as_ref()
-                            .map_or(0, |v| v.len());
+                    let result_len = result
+                        .as_ref()
+                        .unwrap_or(&None)
+                        .as_ref()
+                        .map_or(0, |v| v.len());
+                    record_network_out_bytes(result_len as u64);
+                    let read_bytes = key.len() + result_len;
                     sample.add_read_bytes(read_bytes);
                     let quota_delay = quota_limiter.consume_sample(sample, true).await;
                     if !quota_delay.is_zero() {
@@ -751,6 +759,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
                         tracker.metrics.read_pool_schedule_wait_nanos =
                             schedule_wait_time.as_nanos() as u64;
                     });
+                    record_logical_read_bytes(statistics.processed_size as u64);
                     Ok((
                         result?,
                         KvGetStatistics {
@@ -848,6 +857,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
                         false,
                         QueryKind::Get,
                     );
+                    record_network_in_bytes(req.get_key().len() as u64);
 
                     Self::check_api_version(api_version, ctx.api_version, CMD, [key.as_encoded()])?;
 
@@ -946,6 +956,11 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
                                         buckets.as_ref(),
                                     );
                                     statistics.add(&stat);
+                                    let value_size = v.as_ref().map_or(0, |v| {
+                                        v.as_ref().map_or(0, |v1| v1.value.len()) as u64
+                                    });
+                                    record_network_out_bytes(value_size);
+                                    record_logical_read_bytes(statistics.processed_size as u64);
                                     consumer.consume(
                                         id,
                                         v.map_err(|e| Error::from(txn::Error::from(e)))
@@ -1037,6 +1052,9 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
                     key_ranges,
                     QueryKind::Get,
                 );
+                with_tls_tracker(|tracker| {
+                    record_network_in_bytes(tracker.metrics.grpc_req_size);
+                });
 
                 KV_COMMAND_COUNTER_VEC_STATIC.get(CMD).inc();
                 SCHED_COMMANDS_PRI_COUNTER_VEC_STATIC
@@ -1120,6 +1138,12 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
                                 pair.map(|r| r.map_err(|e| Error::from(TxnError::from(e))))
                             })
                             .collect();
+                        record_network_out_bytes(
+                            result.iter().fold(0u64, |acc, r| {
+                                acc + r.as_ref().map_or(0, |(k, v)| k.len() + v.len()) as u64
+                            })
+                        );
+                        record_logical_read_bytes(reader.statistics.processed_size as u64);
                         (result, reader.statistics)
                     });
                     metrics::tls_collect_scan_details(CMD, &stats);
@@ -1231,6 +1255,9 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
                     key_ranges,
                     QueryKind::Get,
                 );
+                with_tls_tracker(|tracker| {
+                    record_network_in_bytes(tracker.metrics.grpc_req_size);
+                });
 
                 KV_COMMAND_COUNTER_VEC_STATIC.get(CMD).inc();
                 SCHED_COMMANDS_PRI_COUNTER_VEC_STATIC
@@ -1308,6 +1335,10 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
                                 KV_COMMAND_KEYREAD_HISTOGRAM_STATIC
                                     .get(CMD)
                                     .observe(kv_pairs.len() as f64);
+                                record_network_out_bytes(kv_pairs.iter().fold(0u64, |acc, r| {
+                                    acc + r.as_ref().map_or(0, |(k, v)| k.len() + v.value.len())
+                                        as u64
+                                }));
                                 kv_pairs
                             });
                         (result, stats)
@@ -1353,6 +1384,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
                         wait_wall_time_ns: duration_to_ms(wait_wall_time),
                         process_wall_time_ns: duration_to_ms(process_wall_time),
                     };
+                    record_logical_read_bytes(stats.processed_size as u64);
                     Ok((
                         result?,
                         KvGetStatistics {
@@ -1428,6 +1460,9 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
                         reverse_scan,
                         QueryKind::Scan,
                     );
+                    with_tls_tracker(|tracker| {
+                        record_network_in_bytes(tracker.metrics.grpc_req_size);
+                    });
                 }
                 KV_COMMAND_COUNTER_VEC_STATIC.get(CMD).inc();
                 SCHED_COMMANDS_PRI_COUNTER_VEC_STATIC
@@ -1543,6 +1578,10 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
                         KV_COMMAND_KEYREAD_HISTOGRAM_STATIC
                             .get(CMD)
                             .observe(results.len() as f64);
+                        record_network_out_bytes(results.iter().fold(0u64, |acc, r| {
+                            acc + r.as_ref().map_or(0, |(k, v)| k.len() + v.len()) as u64
+                        }));
+                        record_logical_read_bytes(statistics.processed_size as u64);
                         results
                             .into_iter()
                             .map(|x| x.map_err(Error::from))
@@ -1609,6 +1648,9 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
                         false,
                         QueryKind::Scan,
                     );
+                    with_tls_tracker(|tracker| {
+                        record_network_in_bytes(tracker.metrics.grpc_req_size);
+                    });
                 }
 
                 KV_COMMAND_COUNTER_VEC_STATIC.get(CMD).inc();
@@ -1704,7 +1746,10 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
                     SCHED_HISTOGRAM_VEC_STATIC.get(CMD).observe(duration_to_sec(
                         now.saturating_duration_since(command_duration),
                     ));
-
+                    record_network_out_bytes(
+                        locks.iter().map(|l| l.compute_size()).sum::<u32>() as u64
+                    );
+                    record_logical_read_bytes(statistics.processed_size as u64);
                     Ok(locks)
                 })
             }

--- a/src/storage/txn/commands/acquire_pessimistic_lock.rs
+++ b/src/storage/txn/commands/acquire_pessimistic_lock.rs
@@ -2,6 +2,7 @@
 
 // #[PerformanceCriticalPath]
 use kvproto::kvrpcpb::ExtraOp;
+use resource_metering::record_network_out_bytes;
 use tikv_kv::Modify;
 use txn_types::{Key, OldValues, TimeStamp, TxnExtra, insert_old_value_if_resolved};
 
@@ -175,6 +176,7 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for AcquirePessimisticLock 
 
         let rows = if res.is_ok() { total_keys } else { 0 };
 
+        record_network_out_bytes(res.as_ref().map_or(0, |v| v.estimate_resp_size()));
         let pr = ProcessResult::PessimisticLockRes { res };
 
         let to_be_write = make_write_data(modifies, old_values);

--- a/src/storage/txn/commands/check_secondary_locks.rs
+++ b/src/storage/txn/commands/check_secondary_locks.rs
@@ -1,6 +1,8 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
 // #[PerformanceCriticalPath]
+use protobuf::Message;
+use resource_metering::record_network_out_bytes;
 use txn_types::{Key, Lock, WriteType};
 
 use crate::storage::{
@@ -158,7 +160,7 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for CheckSecondaryLocks {
         );
         let mut released_locks = ReleasedLocks::new();
         let mut result = SecondaryLocksStatus::Locked(Vec::new());
-
+        let mut result_size: u64 = 0;
         for key in self.keys {
             let mut released_lock = None;
             let mut mismatch_lock = None;
@@ -195,7 +197,9 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for CheckSecondaryLocks {
             released_locks.push(released_lock);
             match status {
                 SecondaryLockStatus::Locked(lock) => {
-                    result.push(lock.into_lock_info(key.to_raw()?));
+                    let lock_info = lock.into_lock_info(key.to_raw()?);
+                    result_size += lock_info.compute_size() as u64;
+                    result.push(lock_info);
                 }
                 SecondaryLockStatus::Committed(commit_ts) => {
                     result = SecondaryLocksStatus::Committed(commit_ts);
@@ -208,6 +212,7 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for CheckSecondaryLocks {
             }
         }
 
+        record_network_out_bytes(result_size);
         let write_result_known_txn_status =
             if let SecondaryLocksStatus::Committed(commit_ts) = &result {
                 vec![(self.start_ts, *commit_ts)]

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -48,7 +48,10 @@ use parking_lot::{Mutex, MutexGuard, RwLockWriteGuard};
 use pd_client::{Feature, FeatureGate};
 use raftstore::store::TxnExt;
 use resource_control::{ResourceController, ResourceGroupManager, TaskMetadata};
-use resource_metering::{FutureExt, ResourceTagFactory};
+use resource_metering::{
+    FutureExt, ResourceTagFactory, record_logical_read_bytes, record_logical_write_bytes,
+    record_network_in_bytes,
+};
 use smallvec::{SmallVec, smallvec};
 use tikv_kv::{Modify, Snapshot, SnapshotExt, WriteData, WriteEvent};
 use tikv_util::{
@@ -319,7 +322,6 @@ impl<L: LockManager> TxnSchedulerInner<L> {
 
     fn dequeue_task_context(&self, cid: u64) -> TaskContext {
         let tctx = self.get_task_slot(cid).remove(&cid).unwrap();
-
         let running_write_bytes = self
             .running_write_bytes
             .fetch_sub(tctx.write_bytes, Ordering::AcqRel) as i64;
@@ -1227,9 +1229,15 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
             }
 
             fail_point!("scheduler_process");
+            GLOBAL_TRACKERS.with_tracker(task.tracker_token(), |tracker| {
+                record_network_in_bytes(tracker.metrics.grpc_req_size);
+            });
+
             if task.cmd().readonly() {
                 self.process_read(snapshot, task, &mut sched_details);
+                record_logical_read_bytes(sched_details.stat.processed_size as u64);
             } else {
+                record_logical_write_bytes(task.cmd().write_bytes() as u64);
                 self.process_write(snapshot, task, &mut sched_details).await;
             };
             tls_collect_scan_details(tag.get_str(), &sched_details.stat);

--- a/src/storage/types.rs
+++ b/src/storage/types.rs
@@ -397,6 +397,33 @@ impl PessimisticLockResults {
             _ => unreachable!(),
         }
     }
+
+    pub fn estimate_resp_size(&self) -> u64 {
+        AsRef::<Vec<PessimisticLockKeyResult>>::as_ref(&self.0)
+            .iter()
+            .map(|res| {
+                match res {
+                    PessimisticLockKeyResult::Empty => 1,
+                    PessimisticLockKeyResult::Value(v) => v.as_ref().map_or(0, |v| v.len() as u64),
+                    PessimisticLockKeyResult::Existence(_) => {
+                        2 // type + bool
+                    }
+                    PessimisticLockKeyResult::LockedWithConflict {
+                        value,
+                        conflict_ts: _,
+                    } => {
+                        10 + value.as_ref().map_or(0, |v| v.len() as u64) // 10 stands for type + bool + conflict_ts
+                    }
+                    PessimisticLockKeyResult::Waiting => {
+                        1 // for test only 
+                    }
+                    PessimisticLockKeyResult::Failed(_) => {
+                        1 // type, ignoring error message
+                    }
+                }
+            })
+            .sum::<u64>()
+    }
 }
 
 #[derive(Debug, PartialEq)]

--- a/tests/integrations/resource_metering/test_pubsub.rs
+++ b/tests/integrations/resource_metering/test_pubsub.rs
@@ -12,6 +12,7 @@ pub fn test_basic() {
     let mut test_suite = TestSuite::new(resource_metering::Config {
         report_receiver_interval: ReadableDuration::secs(3),
         precision: ReadableDuration::secs(1),
+        enable_network_io_collection: false,
         ..Default::default()
     });
 
@@ -34,6 +35,7 @@ pub fn test_multiple_subscribers() {
     let mut test_suite = TestSuite::new(resource_metering::Config {
         report_receiver_interval: ReadableDuration::secs(3),
         precision: ReadableDuration::secs(1),
+        enable_network_io_collection: false,
         ..Default::default()
     });
 

--- a/tests/integrations/resource_metering/test_read_keys.rs
+++ b/tests/integrations/resource_metering/test_read_keys.rs
@@ -157,7 +157,10 @@ fn test_read_keys_coprocessor() {
     cfg.report_receiver_interval = ReadableDuration::millis(400);
 
     let (_, collector_reg_handle, resource_tag_factory, recorder_worker) =
-        resource_metering::init_recorder(cfg.precision.as_millis());
+        resource_metering::init_recorder(
+            cfg.precision.as_millis(),
+            cfg.enable_network_io_collection,
+        );
     let (_, data_sink_reg_handle, reporter_worker) =
         resource_metering::init_reporter(cfg, collector_reg_handle);
 

--- a/tests/integrations/resource_metering/test_read_keys.rs
+++ b/tests/integrations/resource_metering/test_read_keys.rs
@@ -113,6 +113,7 @@ fn new_cluster(port: u16, env: Arc<Environment>) -> (Cluster<ServerCluster>, Tik
         cluster.cfg.resource_metering.receiver_address = format!("127.0.0.1:{}", port);
         cluster.cfg.resource_metering.precision = ReadableDuration::millis(100);
         cluster.cfg.resource_metering.report_receiver_interval = ReadableDuration::millis(400);
+        cluster.cfg.resource_metering.enable_network_io_collection = false;
     });
     let channel =
         ChannelBuilder::new(env).connect(&cluster.sim.rl().get_addr(leader.get_store_id()));
@@ -155,6 +156,7 @@ fn test_read_keys_coprocessor() {
     let mut cfg = resource_metering::Config::default();
     cfg.precision = ReadableDuration::millis(100);
     cfg.report_receiver_interval = ReadableDuration::millis(400);
+    cfg.enable_network_io_collection = false;
 
     let (_, collector_reg_handle, resource_tag_factory, recorder_worker) =
         resource_metering::init_recorder(

--- a/tests/integrations/resource_metering/test_receiver.rs
+++ b/tests/integrations/resource_metering/test_receiver.rs
@@ -15,6 +15,7 @@ pub fn test_alter_receiver_address() {
         report_receiver_interval: ReadableDuration::secs(3),
         max_resource_groups: 5000,
         precision: ReadableDuration::secs(1),
+        enable_network_io_collection: false,
     });
     test_suite.start_receiver_at(port);
 
@@ -51,6 +52,7 @@ pub fn test_receiver_blocking() {
         report_receiver_interval: ReadableDuration::secs(3),
         max_resource_groups: 5000,
         precision: ReadableDuration::secs(1),
+        enable_network_io_collection: false,
     });
     test_suite.start_receiver_at(port);
 
@@ -89,6 +91,7 @@ pub fn test_receiver_shutdown() {
         report_receiver_interval: ReadableDuration::secs(3),
         max_resource_groups: 5000,
         precision: ReadableDuration::secs(1),
+        enable_network_io_collection: false,
     });
     test_suite.start_receiver_at(port);
 

--- a/tests/integrations/resource_metering/test_suite/mod.rs
+++ b/tests/integrations/resource_metering/test_suite/mod.rs
@@ -55,7 +55,10 @@ impl TestSuite {
         let cfg_controller = ConfigController::new(tikv_cfg);
 
         let (recorder_notifier, collector_reg_handle, resource_tag_factory, recorder_worker) =
-            resource_metering::init_recorder(cfg.precision.as_millis());
+            resource_metering::init_recorder(
+                cfg.precision.as_millis(),
+                cfg.enable_network_io_collection,
+            );
         let (reporter_notifier, data_sink_reg_handle, reporter_worker) =
             resource_metering::init_reporter(cfg.clone(), collector_reg_handle);
         let env = Arc::new(Environment::new(2));
@@ -155,6 +158,13 @@ impl TestSuite {
         let precision = precision.into();
         self.cfg_controller
             .update_config("resource-metering.precision", &precision)
+            .unwrap();
+    }
+
+    pub fn cfg_enable_network_io_collection(&self, flag: impl Into<String>) {
+        let flag = flag.into();
+        self.cfg_controller
+            .update_config("resource-metering.enable-network-io-collection", &flag)
             .unwrap();
     }
 


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: Ref #18815

What's Changed:

```commit-message
Backport tikv/tikv#19378 to release-8.5-20251208-v8.5.4.

This backport contains TopSQL network/logical IO accounting changes:
1. Cherry-picked from commit 4a1f0ec33664504998559b7f80bc07b2ed933fa2.
2. Collect network_in, network_out, logical_read, logical_write execution info and record them in TopSQL.
3. Exclude grpc wait metrics related changes as requested.
4. Update kvproto lockfile rev to include pingcap/kvproto#1471
   (commit e9239b4f96fa02d2983512102ee405f4165dc859 on branch
   release-8.5-20251208-v8.5.4) for the new network/logical fields.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note

```release-note
Collect network and logical io info for topsql in release-8.5.
```
