### PR TITLE
read_pool: notify pool size change upon AutoAdjust

### DIFF
--- a/src/read_pool.rs
+++ b/src/read_pool.rs
@@ -1612,4 +1612,59 @@ mod tests {
         let _ = block_tx.send(());
         thread::sleep(Duration::from_millis(300));
     }
+
+    #[test]
+    fn test_auto_adjust_disable_notifies_pool_size_change() {
+        use std::sync::mpsc::sync_channel;
+
+        let config = UnifiedReadPoolConfig {
+            min_thread_count: 2,
+            max_thread_count: 8,
+            max_tasks_per_worker: 10,
+            ..Default::default()
+        };
+
+        let engine = TestEngineBuilder::new().build().unwrap();
+        let pool = build_yatp_read_pool(
+            &config,
+            DummyReporter,
+            engine,
+            None,
+            None,
+            CleanupMethod::InPlace,
+            false,
+        );
+        let handle = pool.handle();
+
+        let (tx, rx) = sync_channel(10);
+
+        let core_thread_count = 2;
+        let max_thread_count = 8;
+
+        let mut runner = ReadPoolConfigRunner {
+            interval: READ_POOL_THREAD_CHECK_DURATION,
+            sender: tx,
+            handle,
+            cpu_time_tracker: ReadPoolCpuTimeTracker::new("test"),
+            process_stats: tikv_util::sys::cpu_time::ProcessStat::cur_proc_stat().unwrap(),
+            min_thread_count: core_thread_count,
+            core_thread_count,
+            max_thread_count,
+            cur_thread_count: core_thread_count,
+            auto_adjust: true,
+            cpu_threshold: READ_POOL_THREAD_HIGH_THRESHOLD,
+        };
+
+        runner.cur_thread_count = 5;
+        runner.run(Task::AutoAdjust(false));
+
+        match rx.recv_timeout(Duration::from_millis(100)) {
+            Ok(size) => assert_eq!(size, core_thread_count),
+            Err(_) => {
+                panic!("No pool size change notification received when auto-adjust was disabled.")
+            }
+        }
+
+        assert_eq!(runner.cur_thread_count, core_thread_count);
+    }
 }

--- a/src/read_pool.rs
+++ b/src/read_pool.rs
@@ -1639,15 +1639,19 @@ mod tests {
 
         let (tx, rx) = sync_channel(10);
 
-        let core_thread_count = 2;
-        let max_thread_count = 8;
+        let core_thread_count = config.max_thread_count;
+        let max_thread_count = config.max_thread_count;
+        let process_stats = match tikv_util::sys::cpu_time::ProcessStat::cur_proc_stat() {
+            Ok(process_stats) => process_stats,
+            Err(_) => return,
+        };
 
         let mut runner = ReadPoolConfigRunner {
             interval: READ_POOL_THREAD_CHECK_DURATION,
             sender: tx,
             handle,
             cpu_time_tracker: ReadPoolCpuTimeTracker::new("test"),
-            process_stats: tikv_util::sys::cpu_time::ProcessStat::cur_proc_stat().unwrap(),
+            process_stats,
             min_thread_count: core_thread_count,
             core_thread_count,
             max_thread_count,

--- a/src/read_pool.rs
+++ b/src/read_pool.rs
@@ -778,6 +778,7 @@ impl Runnable for ReadPoolConfigRunner {
                 if !s && self.cur_thread_count != self.core_thread_count {
                     self.handle.scale_pool_size(self.core_thread_count);
                     self.cur_thread_count = self.core_thread_count;
+                    self.notify_pool_size_change(self.cur_thread_count);
                 }
             }
             Task::MaxTasksPerWorker(s) => {


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: Close #19632

What's Changed:

```commit-message
When auto-adjust is disabled and the pool size is reset to core_thread_count,
notify listeners of the pool size change. Previously, the notification was
missing, causing components that rely on pool size change notifications to
operate with a stale pool size value.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note

```release-note
Fix a bug where pool size change was not notified to listeners when auto-adjust was disabled in the unified read pool.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Listeners now reliably receive a notification with the restored core thread count when auto-adjust is disabled and the pool is scaled back.

* **Tests**
  * Added a unit test that verifies a notification is emitted with the core thread count after disabling auto-adjust and reducing the pool, and confirms the runner's thread count is restored.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tikv/tikv/pull/19633?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->