### PR TITLE
raftstore: relax load base split thresholds and improve observability

### DIFF
--- a/components/raftstore/src/store/metrics.rs
+++ b/components/raftstore/src/store/metrics.rs
@@ -256,6 +256,18 @@ make_static_metric! {
         no_uncross_key,
         // Split info for the top hot CPU region has been collected, ready to split.
         ready_to_split_cpu_top,
+        // Normal split-key selection failed.
+        normal_key_failed,
+        // CPU fallback is skipped because the unified read pool is not busy.
+        cpu_fallback_unified_not_busy,
+        // CPU fallback is skipped because the region CPU is not hot enough.
+        cpu_fallback_region_not_busy,
+        // CPU fallback is blocked because gRPC poll threads are busy.
+        cpu_fallback_grpc_busy,
+        // Load-base split admin command succeeds.
+        split_success,
+        // Load-base split admin command fails.
+        split_failed,
         // Hottest key range for the top hot CPU region could not be found.
         empty_hottest_key_range,
         // The top hot CPU region could not be split.
@@ -809,6 +821,13 @@ lazy_static! {
         "Histogram of query balance",
         &["type"],
         linear_buckets(0.0, 0.05, 20).unwrap()
+    ).unwrap();
+
+    pub static ref LOAD_BASE_SPLIT_REGION_LOAD_VEC: HistogramVec = register_histogram_vec!(
+        "tikv_load_base_split_region_load",
+        "Histogram of region load observed before load-fit filtering when load base split evaluates regions on this TiKV. The type label is cpu_millicores, qps, or bytes_kib.",
+        &["type"],
+        exponential_buckets(1.0, 2.0, 28).unwrap()
     ).unwrap();
 
     pub static ref LOAD_BASE_SPLIT_DURATION_HISTOGRAM : Histogram = register_histogram!(

--- a/components/raftstore/src/store/worker/pd.rs
+++ b/components/raftstore/src/store/worker/pd.rs
@@ -146,6 +146,7 @@ where
         right_derive: bool,
         share_source_region_size: bool,
         callback: Callback<EK::Snapshot>,
+        split_reason: pdpb::SplitReason,
     },
     AskBatchSplit {
         region: metapb::Region,
@@ -1079,9 +1080,11 @@ where
         share_source_region_size: bool,
         callback: Callback<EK::Snapshot>,
         task: String,
+        split_reason: pdpb::SplitReason,
     ) {
         let router = self.router.clone();
         let resp = self.pd_client.ask_split(region.clone());
+        let is_load_split = split_reason == pdpb::SplitReason::Load;
         let f = async move {
             match resp.await {
                 Ok(mut resp) => {
@@ -1102,7 +1105,12 @@ where
                     );
                     let region_id = region.get_id();
                     let epoch = region.take_region_epoch();
-                    send_admin_request(
+                    let callback = if is_load_split {
+                        Self::load_base_split_callback(callback)
+                    } else {
+                        callback
+                    };
+                    if !send_admin_request(
                         &router,
                         region_id,
                         epoch,
@@ -1110,13 +1118,19 @@ where
                         req,
                         callback,
                         Default::default(),
-                    );
+                    ) && is_load_split
+                    {
+                        LOAD_BASE_SPLIT_EVENT.split_failed.inc();
+                    }
                 }
                 Err(e) => {
                     warn!("failed to ask split";
                     "region_id" => region.get_id(),
                     "err" => ?e,
                     "task"=>task);
+                    if is_load_split {
+                        LOAD_BASE_SPLIT_EVENT.split_failed.inc();
+                    }
                 }
             }
         };
@@ -1148,6 +1162,7 @@ where
         if reason != pdpb::SplitReason::Admin && split_validator.is_disabled(region.get_id()) {
             return;
         }
+        let is_load_split = reason == pdpb::SplitReason::Load;
         let resp = pd_client.ask_batch_split(region.clone(), split_keys.len(), reason);
         let f = async move {
             match resp.await {
@@ -1168,7 +1183,12 @@ where
                     );
                     let region_id = region.get_id();
                     let epoch = region.take_region_epoch();
-                    send_admin_request(
+                    let callback = if is_load_split {
+                        Self::load_base_split_callback(callback)
+                    } else {
+                        callback
+                    };
+                    if !send_admin_request(
                         &router,
                         region_id,
                         epoch,
@@ -1176,7 +1196,10 @@ where
                         req,
                         callback,
                         Default::default(),
-                    );
+                    ) && is_load_split
+                    {
+                        LOAD_BASE_SPLIT_EVENT.split_failed.inc();
+                    }
                 }
                 // When rolling update, there might be some old version tikvs that don't support
                 // batch split in cluster. In this situation, PD version check would refuse
@@ -1195,6 +1218,7 @@ where
                         right_derive,
                         share_source_region_size,
                         callback,
+                        split_reason: reason,
                     };
                     if let Err(ScheduleError::Stopped(t)) = scheduler.schedule(task) {
                         error!(
@@ -1203,7 +1227,14 @@ where
                             "peer_id" =>  peer_id
                         );
                         match t {
-                            Task::AskSplit { callback, .. } => {
+                            Task::AskSplit {
+                                callback,
+                                split_reason,
+                                ..
+                            } => {
+                                if split_reason == pdpb::SplitReason::Load {
+                                    LOAD_BASE_SPLIT_EVENT.split_failed.inc();
+                                }
                                 callback.invoke_with_response(new_error(box_err!(
                                     "failed to split: Stopped"
                                 )));
@@ -1218,6 +1249,9 @@ where
                         "region_id" => region.get_id(),
                         "err" => ?e,
                     );
+                    if is_load_split {
+                        LOAD_BASE_SPLIT_EVENT.split_failed.inc();
+                    }
                 }
             }
         };
@@ -1264,6 +1298,17 @@ where
             }
         };
         self.remote.spawn(f);
+    }
+
+    fn load_base_split_callback(callback: Callback<EK::Snapshot>) -> Callback<EK::Snapshot> {
+        Callback::write(Box::new(move |resp| {
+            if resp.response.get_header().has_error() {
+                LOAD_BASE_SPLIT_EVENT.split_failed.inc();
+            } else {
+                LOAD_BASE_SPLIT_EVENT.split_success.inc();
+            }
+            callback.invoke_with_response(resp.response);
+        }))
     }
 
     fn handle_store_heartbeat(
@@ -2236,6 +2281,7 @@ where
                 right_derive,
                 share_source_region_size,
                 callback,
+                split_reason,
             } => self.handle_ask_split(
                 region,
                 split_key,
@@ -2244,6 +2290,7 @@ where
                 share_source_region_size,
                 callback,
                 String::from("ask_split"),
+                split_reason,
             ),
             Task::AskBatchSplit {
                 region,
@@ -2597,7 +2644,8 @@ fn send_admin_request<EK, ER>(
     request: AdminRequest,
     callback: Callback<EK::Snapshot>,
     extra_opts: RaftCmdExtraOpts,
-) where
+) -> bool
+where
     EK: KvEngine,
     ER: RaftEngine,
 {
@@ -2615,7 +2663,9 @@ fn send_admin_request<EK, ER>(
             "send request failed";
             "region_id" => region_id, "cmd_type" => ?cmd_type, "err" => ?e,
         );
+        return false;
     }
+    true
 }
 
 /// Sends a raft message to destroy the specified stale Peer

--- a/components/raftstore/src/store/worker/split_config.rs
+++ b/components/raftstore/src/store/worker/split_config.rs
@@ -22,7 +22,7 @@ pub const DEFAULT_BIG_REGION_BYTE_THRESHOLD: usize = 100 * 1024 * 1024;
 // We get balance score by
 // abs(sample.left-sample.right)/(sample.right+sample.left). It will be used to
 // measure left and right balance
-const DEFAULT_SPLIT_BALANCE_SCORE: f64 = 0.25;
+const DEFAULT_SPLIT_BALANCE_SCORE: f64 = 0.8;
 // We get contained score by
 // sample.contained/(sample.right+sample.left+sample.contained). It will be used
 // to avoid to split regions requested by range.
@@ -39,14 +39,14 @@ const DEFAULT_SPLIT_CONTAINED_SCORE: f64 = 0.5;
 // `REGION_CPU_OVERLOAD_THRESHOLD_RATIO` are exceeded to prevent from increasing
 // the gRPC poll CPU usage.
 const DEFAULT_GRPC_THREAD_CPU_OVERLOAD_THRESHOLD_RATIO: f64 = 0.5;
-// When the Unified Read Poll thread CPU usage is higher than Unified Read Poll
+// When the Unified Read Pool thread CPU usage is higher than Unified Read Pool
 // thread count *
 // `DEFAULT_UNIFIED_READ_POOL_THREAD_CPU_OVERLOAD_THRESHOLD_RATIO`,
 // the CPU-based split will try to check and record the top hot CPU region.
-const DEFAULT_UNIFIED_READ_POOL_THREAD_CPU_OVERLOAD_THRESHOLD_RATIO: f64 = 0.8;
-// When the Unified Read Poll is hot and the region's CPU usage reaches
+const DEFAULT_UNIFIED_READ_POOL_THREAD_CPU_OVERLOAD_THRESHOLD_RATIO: f64 = 0.4;
+// When the Unified Read Pool is hot and the region's CPU usage reaches
 // `REGION_CPU_OVERLOAD_THRESHOLD_RATIO` as a percentage of the Unified Read
-// Poll, it will be added into the hot region list and may be split later as the
+// Pool, it will be added into the hot region list and may be split later as the
 // top hot CPU region.
 pub const REGION_CPU_OVERLOAD_THRESHOLD_RATIO: f64 = 0.25;
 pub const BIG_REGION_CPU_OVERLOAD_THRESHOLD_RATIO: f64 = 0.75;

--- a/components/raftstore/src/store/worker/split_controller.rs
+++ b/components/raftstore/src/store/worker/split_controller.rs
@@ -229,6 +229,8 @@ impl Samples {
             LOAD_BASE_SPLIT_SAMPLE_VEC
                 .with_label_values(&["balance_score"])
                 .observe(balance_score);
+            let contained_score = sample.contained as f64 / evaluated_key_num;
+            let final_score = balance_score + contained_score;
             if balance_score >= split_balance_score {
                 LOAD_BASE_SPLIT_EVENT.no_balance_key.inc();
                 continue;
@@ -237,7 +239,6 @@ impl Samples {
             // The contained score is the ratio of a sample key that are contained in the
             // requested key. The larger the contained score, the more RPCs the
             // cluster will receive after this splitting.
-            let contained_score = sample.contained as f64 / evaluated_key_num;
             LOAD_BASE_SPLIT_SAMPLE_VEC
                 .with_label_values(&["contained_score"])
                 .observe(contained_score);
@@ -249,7 +250,6 @@ impl Samples {
             // We try to find a split key that has the smallest balance score and the
             // smallest contained score to make the splitting keep the load
             // balanced while not increasing too many RPCs.
-            let final_score = balance_score + contained_score;
             if final_score < best_score {
                 best_index = index as i32;
                 best_score = final_score;
@@ -794,6 +794,11 @@ impl AutoSplitController {
 
         // Start to record the read stats info.
         let mut split_infos = vec![];
+        let region_cpu_histogram =
+            LOAD_BASE_SPLIT_REGION_LOAD_VEC.with_label_values(&["cpu_millicores"]);
+        let region_qps_histogram = LOAD_BASE_SPLIT_REGION_LOAD_VEC.with_label_values(&["qps"]);
+        let region_bytes_histogram =
+            LOAD_BASE_SPLIT_REGION_LOAD_VEC.with_label_values(&["bytes_kib"]);
         for (region_id, region_infos) in region_infos_map {
             if split_validator.is_disabled(region_id) {
                 continue;
@@ -804,10 +809,15 @@ impl AutoSplitController {
             let byte = region_infos
                 .iter()
                 .fold(0, |flow, region_info| flow + region_info.flow.read_bytes);
-            let (cpu_usage, hottest_key_range) = region_cpu_map
-                .get(&region_id)
-                .map(|(cpu_usage, key_range)| (*cpu_usage, key_range.clone()))
-                .unwrap_or((0.0, None));
+            region_qps_histogram.observe(qps as f64);
+            region_bytes_histogram.observe(byte as f64 / 1024.0);
+            let (cpu_usage, hottest_key_range) =
+                if let Some((cpu_usage, key_range)) = region_cpu_map.get(&region_id) {
+                    region_cpu_histogram.observe(cpu_usage * 1000.0);
+                    (*cpu_usage, key_range.clone())
+                } else {
+                    (0.0, None)
+                };
             let is_region_busy = self.is_region_busy(unified_read_pool_thread_usage, cpu_usage);
             debug!("load base split params";
                 "region_id" => region_id,
@@ -875,9 +885,19 @@ impl AutoSplitController {
                     ));
                     LOAD_BASE_SPLIT_EVENT.ready_to_split.inc();
                     self.recorders.remove(&region_id);
-                } else if is_unified_read_pool_busy && is_region_busy {
-                    LOAD_BASE_SPLIT_EVENT.cpu_load_fit.inc();
-                    top_cpu_usage.push(region_id);
+                } else {
+                    LOAD_BASE_SPLIT_EVENT.normal_key_failed.inc();
+                    if !is_unified_read_pool_busy {
+                        LOAD_BASE_SPLIT_EVENT.cpu_fallback_unified_not_busy.inc();
+                    } else if !is_region_busy {
+                        LOAD_BASE_SPLIT_EVENT.cpu_fallback_region_not_busy.inc();
+                    } else {
+                        LOAD_BASE_SPLIT_EVENT.cpu_load_fit.inc();
+                        if is_grpc_poll_busy {
+                            LOAD_BASE_SPLIT_EVENT.cpu_fallback_grpc_busy.inc();
+                        }
+                        top_cpu_usage.push(region_id);
+                    }
                 }
             } else {
                 LOAD_BASE_SPLIT_EVENT.not_ready_to_split.inc();

--- a/metrics/grafana/tikv_details.dashboard.py
+++ b/metrics/grafana/tikv_details.dashboard.py
@@ -2759,6 +2759,96 @@ def RaftAdmin() -> RowPanel:
     layout.row(
         [
             graph_panel(
+                title="Observed region CPU for load-base split",
+                description=(
+                    "Per-region CPU observed before load-fit filtering when "
+                    "load-base split evaluates regions. Unit follows other CPU "
+                    "panels: 100% means one CPU core. This is pre-load-fit "
+                    "decision input; use the tail distribution to tune split "
+                    "thresholds. Use additional_groupby=instance only when "
+                    "drilling into a specific TiKV; keep it as none for large "
+                    "clusters."
+                ),
+                yaxes=yaxes(left_format=UNITS.PERCENT_UNIT),
+                targets=[
+                    target(
+                        expr=expr_operator(
+                            expr_histogram_quantile(
+                                0.9999,
+                                "tikv_load_base_split_region_load",
+                                label_selectors=['type="cpu_millicores"'],
+                            ),
+                            "/",
+                            "1000",
+                        ),
+                        legend_format="99.99%",
+                        additional_groupby=True,
+                    ),
+                    target(
+                        expr=expr_operator(
+                            expr_histogram_quantile(
+                                0.99,
+                                "tikv_load_base_split_region_load",
+                                label_selectors=['type="cpu_millicores"'],
+                            ),
+                            "/",
+                            "1000",
+                        ),
+                        legend_format="99%",
+                        additional_groupby=True,
+                    ),
+                    target(
+                        expr=expr_operator(
+                            expr_histogram_avg(
+                                "tikv_load_base_split_region_load",
+                                label_selectors=['type="cpu_millicores"'],
+                                by_labels=[],
+                            ),
+                            "/",
+                            "1000",
+                        ),
+                        legend_format="avg",
+                        additional_groupby=True,
+                    ),
+                ],
+            ),
+            graph_panel_histogram_quantiles(
+                title="Observed region QPS for load-base split",
+                description=(
+                    "Per-region QPS observed before load-fit filtering when "
+                    "load-base split evaluates regions. This is pre-load-fit "
+                    "decision input; use the tail distribution to tune split "
+                    "thresholds. Use additional_groupby=instance only when "
+                    "drilling into a specific TiKV; keep it as none for large "
+                    "clusters."
+                ),
+                yaxes=yaxes(left_format=UNITS.REQUESTS_PER_SEC),
+                metric="tikv_load_base_split_region_load",
+                label_selectors=['type="qps"'],
+                hide_count=True,
+                additional_groupby=True,
+            ),
+            graph_panel_histogram_quantiles(
+                title="Observed region read bytes for load-base split",
+                description=(
+                    "Per-region read bytes observed before load-fit filtering "
+                    "when load-base split evaluates regions. Unit: KiB. This is "
+                    "pre-load-fit decision input; use the tail distribution to "
+                    "tune split thresholds. Use additional_groupby=instance only "
+                    "when drilling into a specific TiKV; keep it as none for "
+                    "large clusters."
+                ),
+                yaxes=yaxes(left_format=UNITS.KIBI_BYTES),
+                metric="tikv_load_base_split_region_load",
+                label_selectors=['type="bytes_kib"'],
+                hide_count=True,
+                additional_groupby=True,
+            ),
+        ]
+    )
+    layout.row(
+        [
+            graph_panel(
                 title="Peer in Flashback State",
                 targets=[
                     target(

--- a/metrics/grafana/tikv_details.json
+++ b/metrics/grafana/tikv_details.json
@@ -28649,6 +28649,571 @@
           "bars": false,
           "cacheTimeout": null,
           "datasource": "${DS_TEST-CLUSTER}",
+          "description": "Per-region CPU observed before load-fit filtering when load-base split evaluates regions. Unit follows other CPU panels: 100% means one CPU core. This is pre-load-fit decision input; use the tail distribution to tune split thresholds. Use additional_groupby=instance only when drilling into a specific TiKV; keep it as none for large clusters.",
+          "editable": true,
+          "error": false,
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              }
+            }
+          },
+          "fill": 1,
+          "fillGradient": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 0,
+            "y": 21
+          },
+          "height": null,
+          "hideTimeOverride": false,
+          "id": 207,
+          "interval": null,
+          "isNew": true,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": null,
+            "sort": "max",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "maxDataPoints": null,
+          "maxPerRow": null,
+          "minSpan": null,
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true,
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "repeatDirection": null,
+          "seriesOverrides": [],
+          "span": null,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "(histogram_quantile(0.9999,(\n    sum(rate(\n    tikv_load_base_split_region_load_bucket\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"cpu_millicores\"}\n    [$__rate_interval]\n)) by (le, $additional_groupby) \n    \n    \n))   / 1000)",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "99.99% {{$additional_groupby}}",
+              "metric": "",
+              "query": "(histogram_quantile(0.9999,(\n    sum(rate(\n    tikv_load_base_split_region_load_bucket\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"cpu_millicores\"}\n    [$__rate_interval]\n)) by (le, $additional_groupby) \n    \n    \n))   / 1000)",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            },
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "(histogram_quantile(0.99,(\n    sum(rate(\n    tikv_load_base_split_region_load_bucket\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"cpu_millicores\"}\n    [$__rate_interval]\n)) by (le, $additional_groupby) \n    \n    \n))   / 1000)",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "99% {{$additional_groupby}}",
+              "metric": "",
+              "query": "(histogram_quantile(0.99,(\n    sum(rate(\n    tikv_load_base_split_region_load_bucket\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"cpu_millicores\"}\n    [$__rate_interval]\n)) by (le, $additional_groupby) \n    \n    \n))   / 1000)",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            },
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "((sum(rate(\n    tikv_load_base_split_region_load_sum\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"cpu_millicores\"}\n    [$__rate_interval]\n)) by ($additional_groupby)  / sum(rate(\n    tikv_load_base_split_region_load_count\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"cpu_millicores\"}\n    [$__rate_interval]\n)) by ($additional_groupby) ) / 1000)",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "avg {{$additional_groupby}}",
+              "metric": "",
+              "query": "((sum(rate(\n    tikv_load_base_split_region_load_sum\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"cpu_millicores\"}\n    [$__rate_interval]\n)) by ($additional_groupby)  / sum(rate(\n    tikv_load_base_split_region_load_count\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"cpu_millicores\"}\n    [$__rate_interval]\n)) by ($additional_groupby) ) / 1000)",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Observed region CPU for load-base split",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "transformations": [],
+          "transparent": false,
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "percentunit",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": 0
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "cacheTimeout": null,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "Per-region QPS observed before load-fit filtering when load-base split evaluates regions. This is pre-load-fit decision input; use the tail distribution to tune split thresholds. Use additional_groupby=instance only when drilling into a specific TiKV; keep it as none for large clusters.",
+          "editable": true,
+          "error": false,
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              }
+            }
+          },
+          "fill": 1,
+          "fillGradient": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 8,
+            "y": 21
+          },
+          "height": null,
+          "hideTimeOverride": false,
+          "id": 208,
+          "interval": null,
+          "isNew": true,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": null,
+            "sort": "max",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "maxDataPoints": null,
+          "maxPerRow": null,
+          "minSpan": null,
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true,
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "repeatDirection": null,
+          "seriesOverrides": [
+            {
+              "alias": "/^count/",
+              "bars": false,
+              "dashLength": 1,
+              "dashes": true,
+              "fill": 2,
+              "fillBelowTo": null,
+              "lines": true,
+              "spaceLength": 1,
+              "transform": "negative-Y",
+              "yaxis": 2,
+              "zindex": -3
+            },
+            {
+              "alias": "/^avg/",
+              "bars": false,
+              "fill": 7,
+              "fillBelowTo": null,
+              "lines": true,
+              "yaxis": 1,
+              "zindex": 0
+            }
+          ],
+          "span": null,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "histogram_quantile(0.9999,(\n    sum(rate(\n    tikv_load_base_split_region_load_bucket\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"qps\"}\n    [$__rate_interval]\n)) by (le, $additional_groupby) \n    \n    \n))  ",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "99.99% {{$additional_groupby}}",
+              "metric": "",
+              "query": "histogram_quantile(0.9999,(\n    sum(rate(\n    tikv_load_base_split_region_load_bucket\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"qps\"}\n    [$__rate_interval]\n)) by (le, $additional_groupby) \n    \n    \n))  ",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            },
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "histogram_quantile(0.99,(\n    sum(rate(\n    tikv_load_base_split_region_load_bucket\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"qps\"}\n    [$__rate_interval]\n)) by (le, $additional_groupby) \n    \n    \n))  ",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "99% {{$additional_groupby}}",
+              "metric": "",
+              "query": "histogram_quantile(0.99,(\n    sum(rate(\n    tikv_load_base_split_region_load_bucket\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"qps\"}\n    [$__rate_interval]\n)) by (le, $additional_groupby) \n    \n    \n))  ",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            },
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "(sum(rate(\n    tikv_load_base_split_region_load_sum\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"qps\"}\n    [$__rate_interval]\n)) by ($additional_groupby)  / sum(rate(\n    tikv_load_base_split_region_load_count\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"qps\"}\n    [$__rate_interval]\n)) by ($additional_groupby) )",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "avg {{$additional_groupby}}",
+              "metric": "",
+              "query": "(sum(rate(\n    tikv_load_base_split_region_load_sum\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"qps\"}\n    [$__rate_interval]\n)) by ($additional_groupby)  / sum(rate(\n    tikv_load_base_split_region_load_count\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"qps\"}\n    [$__rate_interval]\n)) by ($additional_groupby) )",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            },
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "sum(rate(\n    tikv_load_base_split_region_load_count\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"qps\"}\n    [$__rate_interval]\n)) by ($additional_groupby) ",
+              "format": "time_series",
+              "hide": true,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "count {{$additional_groupby}}",
+              "metric": "",
+              "query": "sum(rate(\n    tikv_load_base_split_region_load_count\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"qps\"}\n    [$__rate_interval]\n)) by ($additional_groupby) ",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Observed region QPS for load-base split",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "transformations": [],
+          "transparent": false,
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "reqps",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": 0
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "cacheTimeout": null,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "Per-region read bytes observed before load-fit filtering when load-base split evaluates regions. Unit: KiB. This is pre-load-fit decision input; use the tail distribution to tune split thresholds. Use additional_groupby=instance only when drilling into a specific TiKV; keep it as none for large clusters.",
+          "editable": true,
+          "error": false,
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              }
+            }
+          },
+          "fill": 1,
+          "fillGradient": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 16,
+            "y": 21
+          },
+          "height": null,
+          "hideTimeOverride": false,
+          "id": 209,
+          "interval": null,
+          "isNew": true,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": null,
+            "sort": "max",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "maxDataPoints": null,
+          "maxPerRow": null,
+          "minSpan": null,
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true,
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "repeatDirection": null,
+          "seriesOverrides": [
+            {
+              "alias": "/^count/",
+              "bars": false,
+              "dashLength": 1,
+              "dashes": true,
+              "fill": 2,
+              "fillBelowTo": null,
+              "lines": true,
+              "spaceLength": 1,
+              "transform": "negative-Y",
+              "yaxis": 2,
+              "zindex": -3
+            },
+            {
+              "alias": "/^avg/",
+              "bars": false,
+              "fill": 7,
+              "fillBelowTo": null,
+              "lines": true,
+              "yaxis": 1,
+              "zindex": 0
+            }
+          ],
+          "span": null,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "histogram_quantile(0.9999,(\n    sum(rate(\n    tikv_load_base_split_region_load_bucket\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"bytes_kib\"}\n    [$__rate_interval]\n)) by (le, $additional_groupby) \n    \n    \n))  ",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "99.99% {{$additional_groupby}}",
+              "metric": "",
+              "query": "histogram_quantile(0.9999,(\n    sum(rate(\n    tikv_load_base_split_region_load_bucket\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"bytes_kib\"}\n    [$__rate_interval]\n)) by (le, $additional_groupby) \n    \n    \n))  ",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            },
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "histogram_quantile(0.99,(\n    sum(rate(\n    tikv_load_base_split_region_load_bucket\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"bytes_kib\"}\n    [$__rate_interval]\n)) by (le, $additional_groupby) \n    \n    \n))  ",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "99% {{$additional_groupby}}",
+              "metric": "",
+              "query": "histogram_quantile(0.99,(\n    sum(rate(\n    tikv_load_base_split_region_load_bucket\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"bytes_kib\"}\n    [$__rate_interval]\n)) by (le, $additional_groupby) \n    \n    \n))  ",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            },
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "(sum(rate(\n    tikv_load_base_split_region_load_sum\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"bytes_kib\"}\n    [$__rate_interval]\n)) by ($additional_groupby)  / sum(rate(\n    tikv_load_base_split_region_load_count\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"bytes_kib\"}\n    [$__rate_interval]\n)) by ($additional_groupby) )",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "avg {{$additional_groupby}}",
+              "metric": "",
+              "query": "(sum(rate(\n    tikv_load_base_split_region_load_sum\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"bytes_kib\"}\n    [$__rate_interval]\n)) by ($additional_groupby)  / sum(rate(\n    tikv_load_base_split_region_load_count\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"bytes_kib\"}\n    [$__rate_interval]\n)) by ($additional_groupby) )",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            },
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "sum(rate(\n    tikv_load_base_split_region_load_count\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"bytes_kib\"}\n    [$__rate_interval]\n)) by ($additional_groupby) ",
+              "format": "time_series",
+              "hide": true,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "count {{$additional_groupby}}",
+              "metric": "",
+              "query": "sum(rate(\n    tikv_load_base_split_region_load_count\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",type=\"bytes_kib\"}\n    [$__rate_interval]\n)) by ($additional_groupby) ",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Observed region read bytes for load-base split",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "transformations": [],
+          "transparent": false,
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "kbytes",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": 0
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "cacheTimeout": null,
+          "datasource": "${DS_TEST-CLUSTER}",
           "description": null,
           "editable": true,
           "error": false,
@@ -28672,11 +29237,11 @@
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 21
+            "y": 28
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 207,
+          "id": 210,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -28812,7 +29377,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 208,
+      "id": 211,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -28851,7 +29416,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 209,
+          "id": 212,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -28999,7 +29564,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 210,
+          "id": 213,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -29147,7 +29712,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 211,
+          "id": 214,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -29280,7 +29845,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 212,
+          "id": 215,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -29413,7 +29978,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 213,
+          "id": 216,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -29546,7 +30111,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 214,
+          "id": 217,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -29679,7 +30244,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 215,
+          "id": 218,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -29812,7 +30377,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 216,
+          "id": 219,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -29945,7 +30510,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 217,
+          "id": 220,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -30122,7 +30687,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 218,
+      "id": 221,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -30161,7 +30726,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 219,
+          "id": 222,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -30324,7 +30889,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 220,
+          "id": 223,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -30525,7 +31090,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 221,
+          "id": 224,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -30673,7 +31238,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 222,
+          "id": 225,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -30836,7 +31401,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 223,
+          "id": 226,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -31037,7 +31602,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 224,
+          "id": 227,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -31215,7 +31780,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 225,
+          "id": 228,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -31378,7 +31943,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 226,
+          "id": 229,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -31541,7 +32106,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 227,
+          "id": 230,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -31674,7 +32239,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 228,
+          "id": 231,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -31878,7 +32443,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 229,
+      "id": 232,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -31917,7 +32482,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 230,
+          "id": 233,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -32110,7 +32675,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 231,
+          "id": 234,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -32288,7 +32853,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 232,
+          "id": 235,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -32496,7 +33061,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 233,
+          "id": 236,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -32674,7 +33239,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 234,
+          "id": 237,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -32837,7 +33402,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 235,
+          "id": 238,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -33015,7 +33580,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 236,
+          "id": 239,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -33148,7 +33713,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 237,
+          "id": 240,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -33326,7 +33891,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 238,
+          "id": 241,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -33459,7 +34024,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 239,
+          "id": 242,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -33637,7 +34202,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 240,
+          "id": 243,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -33770,7 +34335,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 241,
+          "id": 244,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -33948,7 +34513,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 242,
+          "id": 245,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -34126,7 +34691,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 243,
+          "id": 246,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -34304,7 +34869,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 244,
+          "id": 247,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -34437,7 +35002,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 245,
+          "id": 248,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -34570,7 +35135,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 246,
+          "id": 249,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -34703,7 +35268,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 247,
+          "id": 250,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -34926,7 +35491,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 248,
+          "id": 251,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -35119,7 +35684,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 249,
+          "id": 252,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -35282,7 +35847,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 250,
+          "id": 253,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -35475,7 +36040,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 251,
+          "id": 254,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -35623,7 +36188,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 252,
+          "id": 255,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -35756,7 +36321,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 253,
+          "id": 256,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -35904,7 +36469,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 254,
+          "id": 257,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -36082,7 +36647,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 255,
+          "id": 258,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -36245,7 +36810,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 256,
+          "id": 259,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -36423,7 +36988,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 257,
+          "id": 260,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -36556,7 +37121,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 258,
+          "id": 261,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -36689,7 +37254,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 259,
+          "id": 262,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -36822,7 +37387,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 260,
+          "id": 263,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -36955,7 +37520,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 261,
+          "id": 264,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -37088,7 +37653,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 262,
+          "id": 265,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -37228,7 +37793,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 263,
+          "id": 266,
           "interval": null,
           "legend": {
             "show": false
@@ -37326,7 +37891,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 264,
+          "id": 267,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -37527,7 +38092,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 265,
+          "id": 268,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -37660,7 +38225,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 266,
+          "id": 269,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -37793,7 +38358,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 267,
+          "id": 270,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -37971,7 +38536,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 268,
+          "id": 271,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -38104,7 +38669,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 269,
+          "id": 272,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -38240,7 +38805,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 270,
+      "id": 273,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -38279,7 +38844,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 271,
+          "id": 274,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -38427,7 +38992,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 272,
+          "id": 275,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -38575,7 +39140,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 273,
+          "id": 276,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -38708,7 +39273,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 274,
+          "id": 277,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -38841,7 +39406,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 275,
+          "id": 278,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -39019,7 +39584,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 276,
+          "id": 279,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -39197,7 +39762,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 277,
+          "id": 280,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -39375,7 +39940,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 278,
+          "id": 281,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -39508,7 +40073,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 279,
+          "id": 282,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -39686,7 +40251,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 280,
+          "id": 283,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -39819,7 +40384,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 281,
+          "id": 284,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -39982,7 +40547,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 282,
+          "id": 285,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -40160,7 +40725,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 283,
+          "id": 286,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -40338,7 +40903,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 284,
+          "id": 287,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -40516,7 +41081,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 285,
+          "id": 288,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -40649,7 +41214,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 286,
+          "id": 289,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -40827,7 +41392,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 287,
+          "id": 290,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -40960,7 +41525,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 288,
+          "id": 291,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -41138,7 +41703,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 289,
+          "id": 292,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -41271,7 +41836,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 290,
+          "id": 293,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -41404,7 +41969,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 291,
+          "id": 294,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -41582,7 +42147,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 292,
+          "id": 295,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -41760,7 +42325,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 293,
+          "id": 296,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -41893,7 +42458,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 294,
+          "id": 297,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -42071,7 +42636,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 295,
+          "id": 298,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -42204,7 +42769,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 296,
+          "id": 299,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -42382,7 +42947,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 297,
+          "id": 300,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -42518,7 +43083,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 298,
+      "id": 301,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -42557,7 +43122,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 299,
+          "id": 302,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -42690,7 +43255,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 300,
+          "id": 303,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -42838,7 +43403,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 301,
+          "id": 304,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -43039,7 +43604,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 302,
+          "id": 305,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -43172,7 +43737,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 303,
+          "id": 306,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -43305,7 +43870,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 304,
+          "id": 307,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -43438,7 +44003,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 305,
+          "id": 308,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -43571,7 +44136,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 306,
+          "id": 309,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -43704,7 +44269,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 307,
+          "id": 310,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -43844,7 +44409,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 308,
+          "id": 311,
           "interval": null,
           "legend": {
             "show": false
@@ -43949,7 +44514,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 309,
+          "id": 312,
           "interval": null,
           "legend": {
             "show": false
@@ -44047,7 +44612,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 310,
+          "id": 313,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -44187,7 +44752,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 311,
+          "id": 314,
           "interval": null,
           "legend": {
             "show": false
@@ -44285,7 +44850,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 312,
+          "id": 315,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -44418,7 +44983,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 313,
+          "id": 316,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -44558,7 +45123,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 314,
+          "id": 317,
           "interval": null,
           "legend": {
             "show": false
@@ -44656,7 +45221,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 315,
+          "id": 318,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -44864,7 +45429,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 316,
+          "id": 319,
           "interval": null,
           "legend": {
             "show": false
@@ -44962,7 +45527,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 317,
+          "id": 320,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -45163,7 +45728,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 318,
+          "id": 321,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -45371,7 +45936,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 319,
+          "id": 322,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -45549,7 +46114,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 320,
+          "id": 323,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -45682,7 +46247,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 321,
+          "id": 324,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -45815,7 +46380,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 322,
+          "id": 325,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -45948,7 +46513,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 323,
+          "id": 326,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -46088,7 +46653,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 324,
+          "id": 327,
           "interval": null,
           "legend": {
             "show": false
@@ -46193,7 +46758,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 325,
+          "id": 328,
           "interval": null,
           "legend": {
             "show": false
@@ -46298,7 +46863,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 326,
+          "id": 329,
           "interval": null,
           "legend": {
             "show": false
@@ -46403,7 +46968,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 327,
+          "id": 330,
           "interval": null,
           "legend": {
             "show": false
@@ -46504,7 +47069,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 328,
+      "id": 331,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -46543,7 +47108,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 329,
+          "id": 332,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -46691,7 +47256,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 330,
+          "id": 333,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -46831,7 +47396,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 331,
+          "id": 334,
           "interval": null,
           "legend": {
             "show": false
@@ -46929,7 +47494,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 332,
+          "id": 335,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -47062,7 +47627,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 333,
+          "id": 336,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -47195,7 +47760,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 334,
+          "id": 337,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -47373,7 +47938,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 335,
+          "id": 338,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -47536,7 +48101,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 336,
+          "id": 339,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -47684,7 +48249,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 337,
+          "id": 340,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -47817,7 +48382,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 338,
+          "id": 341,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -47953,7 +48518,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 339,
+      "id": 342,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -47992,7 +48557,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 340,
+          "id": 343,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -48140,7 +48705,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 341,
+          "id": 344,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -48273,7 +48838,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 342,
+          "id": 345,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -48406,7 +48971,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 343,
+          "id": 346,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -48539,7 +49104,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 344,
+          "id": 347,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -48672,7 +49237,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 345,
+          "id": 348,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -48827,7 +49392,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 346,
+          "id": 349,
           "interval": null,
           "legend": {
             "show": false
@@ -48932,7 +49497,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 347,
+          "id": 350,
           "interval": null,
           "legend": {
             "show": false
@@ -49033,7 +49598,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 348,
+      "id": 351,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -49072,7 +49637,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 349,
+          "id": 352,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -49205,7 +49770,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 350,
+          "id": 353,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -49338,7 +49903,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 351,
+          "id": 354,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -49478,7 +50043,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 352,
+          "id": 355,
           "interval": null,
           "legend": {
             "show": false
@@ -49576,7 +50141,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 353,
+          "id": 356,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -49709,7 +50274,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 354,
+          "id": 357,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -49910,7 +50475,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 355,
+          "id": 358,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -50111,7 +50676,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 356,
+          "id": 359,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -50315,7 +50880,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 357,
+      "id": 360,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -50354,7 +50919,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 358,
+          "id": 361,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -50502,7 +51067,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 359,
+          "id": 362,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -50703,7 +51268,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 360,
+          "id": 363,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -50904,7 +51469,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 361,
+          "id": 364,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -51105,7 +51670,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 362,
+          "id": 365,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -51306,7 +51871,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 363,
+          "id": 366,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -51439,7 +52004,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 364,
+          "id": 367,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -51572,7 +52137,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 365,
+          "id": 368,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -51705,7 +52270,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 366,
+          "id": 369,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -51838,7 +52403,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 367,
+          "id": 370,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -52039,7 +52604,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 368,
+          "id": 371,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -52247,7 +52812,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 369,
+          "id": 372,
           "interval": null,
           "legend": {
             "show": false
@@ -52348,7 +52913,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 370,
+      "id": 373,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -52394,7 +52959,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 371,
+          "id": 374,
           "interval": null,
           "legend": {
             "show": false
@@ -52492,7 +53057,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 372,
+          "id": 375,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -52693,7 +53258,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 373,
+          "id": 376,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -52826,7 +53391,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 374,
+          "id": 377,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -52959,7 +53524,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 375,
+          "id": 378,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -53092,7 +53657,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 376,
+          "id": 379,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -53293,7 +53858,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 377,
+          "id": 380,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -53426,7 +53991,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 378,
+          "id": 381,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -53559,7 +54124,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 379,
+          "id": 382,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -53695,7 +54260,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 380,
+      "id": 383,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -53734,7 +54299,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 381,
+          "id": 384,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -53935,7 +54500,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 382,
+          "id": 385,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -54136,7 +54701,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 383,
+          "id": 386,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -54337,7 +54902,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 384,
+          "id": 387,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -54538,7 +55103,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 385,
+          "id": 388,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -54671,7 +55236,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 386,
+          "id": 389,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -54804,7 +55369,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 387,
+          "id": 390,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -54937,7 +55502,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 388,
+          "id": 391,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -55070,7 +55635,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 389,
+          "id": 392,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -55203,7 +55768,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 390,
+          "id": 393,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -55343,7 +55908,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 391,
+          "id": 394,
           "interval": null,
           "legend": {
             "show": false
@@ -55441,7 +56006,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 392,
+          "id": 395,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -55649,7 +56214,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 393,
+          "id": 396,
           "interval": null,
           "legend": {
             "show": false
@@ -55747,7 +56312,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 394,
+          "id": 397,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -55948,7 +56513,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 395,
+          "id": 398,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -56084,7 +56649,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 396,
+      "id": 399,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -56123,7 +56688,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 397,
+          "id": 400,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -56256,7 +56821,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 398,
+          "id": 401,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -56389,7 +56954,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 399,
+          "id": 402,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -56529,7 +57094,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 400,
+          "id": 403,
           "interval": null,
           "legend": {
             "show": false
@@ -56627,7 +57192,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 401,
+          "id": 404,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -56760,7 +57325,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 402,
+          "id": 405,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -56961,7 +57526,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 403,
+          "id": 406,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -57162,7 +57727,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 404,
+          "id": 407,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -57366,7 +57931,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 405,
+      "id": 408,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -57405,7 +57970,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 406,
+          "id": 409,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -57583,7 +58148,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 407,
+          "id": 410,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -57784,7 +58349,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 408,
+          "id": 411,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -57917,7 +58482,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 409,
+          "id": 412,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -58050,7 +58615,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 410,
+          "id": 413,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -58183,7 +58748,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 411,
+          "id": 414,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -58316,7 +58881,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 412,
+          "id": 415,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -58449,7 +59014,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 413,
+          "id": 416,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -58578,7 +59143,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 414,
+          "id": 417,
           "interval": null,
           "links": [],
           "maxDataPoints": 100,
@@ -58653,7 +59218,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 415,
+          "id": 418,
           "interval": null,
           "links": [],
           "maxDataPoints": 100,
@@ -58732,7 +59297,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 416,
+          "id": 419,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -58985,7 +59550,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 417,
+          "id": 420,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -59118,7 +59683,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 418,
+          "id": 421,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -59251,7 +59816,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 419,
+          "id": 422,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -59452,7 +60017,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 420,
+          "id": 423,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -59600,7 +60165,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 421,
+          "id": 424,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -59801,7 +60366,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 422,
+          "id": 425,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -60002,7 +60567,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 423,
+          "id": 426,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -60203,7 +60768,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 424,
+          "id": 427,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -60407,7 +60972,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 425,
+      "id": 428,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -60446,7 +61011,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 426,
+          "id": 429,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -60594,7 +61159,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 427,
+          "id": 430,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -60727,7 +61292,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 428,
+          "id": 431,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -60928,7 +61493,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 429,
+          "id": 432,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -61076,7 +61641,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 430,
+          "id": 433,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -61277,7 +61842,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 431,
+          "id": 434,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -61410,7 +61975,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 432,
+          "id": 435,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -61543,7 +62108,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 433,
+          "id": 436,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -61676,7 +62241,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 434,
+          "id": 437,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -61809,7 +62374,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 435,
+          "id": 438,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -61949,7 +62514,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 436,
+          "id": 439,
           "interval": null,
           "legend": {
             "show": false
@@ -62047,7 +62612,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 437,
+          "id": 440,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -62251,7 +62816,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 438,
+      "id": 441,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -62290,7 +62855,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 439,
+          "id": 442,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -62423,7 +62988,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 440,
+          "id": 443,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -62556,7 +63121,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 441,
+          "id": 444,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -62689,7 +63254,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 442,
+          "id": 445,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -62825,7 +63390,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 443,
+      "id": 446,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -62864,7 +63429,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 444,
+          "id": 447,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -62997,7 +63562,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 445,
+          "id": 448,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -63130,7 +63695,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 446,
+          "id": 449,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -63278,7 +63843,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 447,
+          "id": 450,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -63411,7 +63976,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 448,
+          "id": 451,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -63544,7 +64109,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 449,
+          "id": 452,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -63677,7 +64242,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 450,
+          "id": 453,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -63813,7 +64378,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 451,
+      "id": 454,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -63852,7 +64417,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 452,
+          "id": 455,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -63985,7 +64550,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 453,
+          "id": 456,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -64118,7 +64683,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 454,
+          "id": 457,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -64251,7 +64816,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 455,
+          "id": 458,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -64384,7 +64949,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 456,
+          "id": 459,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -64517,7 +65082,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 457,
+          "id": 460,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -64650,7 +65215,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 458,
+          "id": 461,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -64786,7 +65351,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 459,
+      "id": 462,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -64825,7 +65390,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 460,
+          "id": 463,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -64958,7 +65523,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 461,
+          "id": 464,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -65091,7 +65656,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 462,
+          "id": 465,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -65239,7 +65804,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 463,
+          "id": 466,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -65402,7 +65967,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 464,
+          "id": 467,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -65535,7 +66100,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 465,
+          "id": 468,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -65668,7 +66233,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 466,
+          "id": 469,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -65831,7 +66396,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 467,
+          "id": 470,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -65979,7 +66544,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 468,
+          "id": 471,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -66115,7 +66680,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 469,
+      "id": 472,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -66154,7 +66719,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 470,
+          "id": 473,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -66287,7 +66852,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 471,
+          "id": 474,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -66420,7 +66985,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 472,
+          "id": 475,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -66553,7 +67118,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 473,
+          "id": 476,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -66686,7 +67251,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 474,
+          "id": 477,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -66819,7 +67384,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 475,
+          "id": 478,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -66952,7 +67517,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 476,
+          "id": 479,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -67085,7 +67650,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 477,
+          "id": 480,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -67218,7 +67783,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 478,
+          "id": 481,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -67358,7 +67923,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 479,
+          "id": 482,
           "interval": null,
           "legend": {
             "show": false
@@ -67456,7 +68021,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 480,
+          "id": 483,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -67589,7 +68154,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 481,
+          "id": 484,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -67737,7 +68302,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 482,
+          "id": 485,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -67885,7 +68450,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 483,
+          "id": 486,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -68025,7 +68590,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 484,
+          "id": 487,
           "interval": null,
           "legend": {
             "show": false
@@ -68123,7 +68688,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 485,
+          "id": 488,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -68256,7 +68821,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 486,
+          "id": 489,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -68392,7 +68957,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 487,
+      "id": 490,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -68431,7 +68996,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 488,
+          "id": 491,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -68564,7 +69129,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 489,
+          "id": 492,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -68727,7 +69292,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 490,
+          "id": 493,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -68875,7 +69440,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 491,
+          "id": 494,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -69008,7 +69573,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 492,
+          "id": 495,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -69148,7 +69713,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 493,
+          "id": 496,
           "interval": null,
           "legend": {
             "show": false
@@ -69253,7 +69818,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 494,
+          "id": 497,
           "interval": null,
           "legend": {
             "show": false
@@ -69358,7 +69923,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 495,
+          "id": 498,
           "interval": null,
           "legend": {
             "show": false
@@ -69456,7 +70021,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 496,
+          "id": 499,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -69596,7 +70161,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 497,
+          "id": 500,
           "interval": null,
           "legend": {
             "show": false
@@ -69701,7 +70266,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 498,
+          "id": 501,
           "interval": null,
           "legend": {
             "show": false
@@ -69806,7 +70371,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 499,
+          "id": 502,
           "interval": null,
           "legend": {
             "show": false
@@ -69904,7 +70469,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 500,
+          "id": 503,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -70037,7 +70602,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 501,
+          "id": 504,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -70170,7 +70735,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 502,
+          "id": 505,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -70310,7 +70875,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 503,
+          "id": 506,
           "interval": null,
           "legend": {
             "show": false
@@ -70408,7 +70973,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 504,
+          "id": 507,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -70544,7 +71109,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 505,
+      "id": 508,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -70583,7 +71148,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 506,
+          "id": 509,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -70746,7 +71311,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 507,
+          "id": 510,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -70879,7 +71444,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 508,
+          "id": 511,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -71019,7 +71584,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 509,
+          "id": 512,
           "interval": null,
           "legend": {
             "show": false
@@ -71124,7 +71689,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 510,
+          "id": 513,
           "interval": null,
           "legend": {
             "show": false
@@ -71222,7 +71787,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 511,
+          "id": 514,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -71377,7 +71942,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 512,
+          "id": 515,
           "interval": null,
           "legend": {
             "show": false
@@ -71482,7 +72047,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 513,
+          "id": 516,
           "interval": null,
           "legend": {
             "show": false
@@ -71587,7 +72152,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 514,
+          "id": 517,
           "interval": null,
           "legend": {
             "show": false
@@ -71685,7 +72250,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 515,
+          "id": 518,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -71855,7 +72420,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 516,
+          "id": 519,
           "interval": null,
           "legend": {
             "show": false
@@ -71953,7 +72518,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 517,
+          "id": 520,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -72154,7 +72719,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 518,
+          "id": 521,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -72355,7 +72920,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 519,
+          "id": 522,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -72488,7 +73053,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 520,
+          "id": 523,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -72651,7 +73216,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 521,
+          "id": 524,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -72784,7 +73349,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 522,
+          "id": 525,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -72917,7 +73482,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 523,
+          "id": 526,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -73118,7 +73683,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 524,
+          "id": 527,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -73251,7 +73816,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 525,
+          "id": 528,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -73391,7 +73956,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 526,
+          "id": 529,
           "interval": null,
           "legend": {
             "show": false
@@ -73496,7 +74061,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 527,
+          "id": 530,
           "interval": null,
           "legend": {
             "show": false
@@ -73601,7 +74166,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 528,
+          "id": 531,
           "interval": null,
           "legend": {
             "show": false
@@ -73706,7 +74271,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 529,
+          "id": 532,
           "interval": null,
           "legend": {
             "show": false
@@ -73811,7 +74376,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 530,
+          "id": 533,
           "interval": null,
           "legend": {
             "show": false
@@ -73916,7 +74481,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 531,
+          "id": 534,
           "interval": null,
           "legend": {
             "show": false
@@ -74021,7 +74586,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 532,
+          "id": 535,
           "interval": null,
           "legend": {
             "show": false
@@ -74119,7 +74684,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 533,
+          "id": 536,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -74267,7 +74832,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 534,
+          "id": 537,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -74400,7 +74965,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 535,
+          "id": 538,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -74533,7 +75098,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 536,
+          "id": 539,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -74681,7 +75246,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 537,
+          "id": 540,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -74817,7 +75382,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 538,
+      "id": 541,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -74868,7 +75433,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 539,
+          "id": 542,
           "interval": null,
           "links": [],
           "maxDataPoints": 100,
@@ -74964,7 +75529,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 540,
+          "id": 543,
           "interval": null,
           "links": [],
           "maxDataPoints": 100,
@@ -75039,7 +75604,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 541,
+          "id": 544,
           "interval": null,
           "links": [],
           "maxDataPoints": 100,
@@ -75114,7 +75679,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 542,
+          "id": 545,
           "interval": null,
           "links": [],
           "maxDataPoints": 100,
@@ -75189,7 +75754,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 543,
+          "id": 546,
           "interval": null,
           "links": [],
           "maxDataPoints": 100,
@@ -75264,7 +75829,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 544,
+          "id": 547,
           "interval": null,
           "links": [],
           "maxDataPoints": 100,
@@ -75339,7 +75904,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 545,
+          "id": 548,
           "interval": null,
           "links": [],
           "maxDataPoints": 100,
@@ -75414,7 +75979,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 546,
+          "id": 549,
           "interval": null,
           "links": [],
           "maxDataPoints": 100,
@@ -75493,7 +76058,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 547,
+          "id": 550,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -75626,7 +76191,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 548,
+          "id": 551,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -75759,7 +76324,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 549,
+          "id": 552,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -75892,7 +76457,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 550,
+          "id": 553,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -76025,7 +76590,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 551,
+          "id": 554,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -76158,7 +76723,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 552,
+          "id": 555,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -76306,7 +76871,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 553,
+          "id": 556,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -76439,7 +77004,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 554,
+          "id": 557,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -76572,7 +77137,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 555,
+          "id": 558,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -76738,7 +77303,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 556,
+          "id": 559,
           "interval": null,
           "legend": {
             "show": false
@@ -76843,7 +77408,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 557,
+          "id": 560,
           "interval": null,
           "legend": {
             "show": false
@@ -76948,7 +77513,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 558,
+          "id": 561,
           "interval": null,
           "legend": {
             "show": false
@@ -77053,7 +77618,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 559,
+          "id": 562,
           "interval": null,
           "legend": {
             "show": false
@@ -77158,7 +77723,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 560,
+          "id": 563,
           "interval": null,
           "legend": {
             "show": false
@@ -77263,7 +77828,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 561,
+          "id": 564,
           "interval": null,
           "legend": {
             "show": false
@@ -77368,7 +77933,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 562,
+          "id": 565,
           "interval": null,
           "legend": {
             "show": false
@@ -77473,7 +78038,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 563,
+          "id": 566,
           "interval": null,
           "legend": {
             "show": false
@@ -77571,7 +78136,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 564,
+          "id": 567,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -77704,7 +78269,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 565,
+          "id": 568,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -77837,7 +78402,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 566,
+          "id": 569,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -77970,7 +78535,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 567,
+          "id": 570,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -78103,7 +78668,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 568,
+          "id": 571,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -78236,7 +78801,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 569,
+          "id": 572,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -78369,7 +78934,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 570,
+          "id": 573,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -78502,7 +79067,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 571,
+          "id": 574,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -78642,7 +79207,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 572,
+          "id": 575,
           "interval": null,
           "legend": {
             "show": false
@@ -78747,7 +79312,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 573,
+          "id": 576,
           "interval": null,
           "legend": {
             "show": false
@@ -78845,7 +79410,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 574,
+          "id": 577,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -78978,7 +79543,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 575,
+          "id": 578,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -79111,7 +79676,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 576,
+          "id": 579,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -79244,7 +79809,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 577,
+          "id": 580,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -79377,7 +79942,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 578,
+          "id": 581,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -79510,7 +80075,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 579,
+          "id": 582,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -79646,7 +80211,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 580,
+      "id": 583,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -79685,7 +80250,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 581,
+          "id": 584,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -79833,7 +80398,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 582,
+          "id": 585,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -79966,7 +80531,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 583,
+          "id": 586,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -80099,7 +80664,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 584,
+          "id": 587,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -80235,7 +80800,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 585,
+      "id": 588,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -80274,7 +80839,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 586,
+          "id": 589,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -80407,7 +80972,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 587,
+          "id": 590,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -80540,7 +81105,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 588,
+          "id": 591,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -80673,7 +81238,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 589,
+          "id": 592,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -80806,7 +81371,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 590,
+          "id": 593,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -80939,7 +81504,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 591,
+          "id": 594,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -81075,7 +81640,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 592,
+      "id": 595,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -81114,7 +81679,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 593,
+          "id": 596,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -81247,7 +81812,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 594,
+          "id": 597,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -81383,7 +81948,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 595,
+      "id": 598,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -81422,7 +81987,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 596,
+          "id": 599,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -81623,7 +82188,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 597,
+          "id": 600,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -81759,7 +82324,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 598,
+      "id": 601,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -81798,7 +82363,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 599,
+          "id": 602,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -81931,7 +82496,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 600,
+          "id": 603,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -82064,7 +82629,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 601,
+          "id": 604,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -82197,7 +82762,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 602,
+          "id": 605,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -82330,7 +82895,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 603,
+          "id": 606,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -82478,7 +83043,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 604,
+          "id": 607,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -82682,7 +83247,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 605,
+      "id": 608,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -82721,7 +83286,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 606,
+          "id": 609,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -82854,7 +83419,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 607,
+          "id": 610,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -82987,7 +83552,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 608,
+          "id": 611,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -83120,7 +83685,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 609,
+          "id": 612,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -83253,7 +83818,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 610,
+          "id": 613,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -83450,7 +84015,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 611,
+          "id": 614,
           "interval": null,
           "links": [],
           "maxDataPoints": 100,

--- a/metrics/grafana/tikv_details.json.sha256
+++ b/metrics/grafana/tikv_details.json.sha256
@@ -1,1 +1,1 @@
-255d36bd582b388385c70c68790c90257d2f1e92d9d550ab159ea3a6d1a3234c  ./metrics/grafana/tikv_details.json
+2d2e48cbb50d3394e5ec96b0252629446f59c84482cab43da579a14b421c9174  ./metrics/grafana/tikv_details.json


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: ref #18932

What's Changed:

```commit-message
Cherry-pick #19576 to release-8.5.

This relaxes load-based split thresholds and adds observability for split-key selection, CPU fallback decisions, observed per-region load, and load split admin command success/failure.
```

### Backport notes

Cherry-picked from `ccc66d65e430057c2a28e1bef1bcd983693bad41` (#19576) onto current `release-8.5`.

Conflicts:

- `metrics/grafana/tikv_details.json`
- `metrics/grafana/tikv_details.json.sha256`

Resolution:

- Code files merged automatically.
- Kept the source dashboard change in `metrics/grafana/tikv_details.dashboard.py`.
- Regenerated `metrics/grafana/tikv_details.json` and checksum from the dashboard source with the pinned generator dependencies (`grafanalib==0.7.0`, `black==23.11.0`, `isort==5.13.2`).
- No non-cherry-pick dashboard helper changes are included. Final PR size is `+2519/-1775` across 7 files.

Line-count note:

- #19600 and this PR have the same source dashboard change (`metrics/grafana/tikv_details.dashboard.py`: `+90`).
- The raw JSON diff is larger on current `release-8.5` because generated Grafana panel ids are renumbered after inserting 3 panels in the `Raft Admin` row.
- After normalizing every `"id": N` to `"id": 0`, #19600 and this PR both reduce to the same `metrics/grafana/tikv_details.json` diff: `+566/-1`.
- Raw JSON diff comparison: #19600 `+1376/-811` (`+810/-810` id churn), this PR `+2319/-1754` (`+1753/-1753` id churn).

Validation:

- `make check`: not available on this `release-8.5` Makefile (`No rule to make target 'check'`). Used `cargo check --all` instead: passed.
- `make release`: passed.
- `make clippy`: passed.
- `make format`: passed in a temporary normal clone. In the linked worktree, `cargo fmt --all -- --check` and `cargo sort -w -c .` both passed.
- `env EXTRA_CARGO_ARGS='store::worker::split_controller::tests::test_recorder' make test_with_nextest`: exited 0. Note: this machine does not have `cargo nextest`, so the script emitted `no such command: nextest` before continuing through the test/bin-check path.
- `./scripts/check-dashboards`, JSON parsing, and dashboard sha256 verification passed.
- Local TiUP/Grafana validation passed; see PR comment for details.

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests

- [x] Unit test
- [ ] Integration test
- [x] Manual test (validation commands above)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note

```release-note
Relax load-based split thresholds and add observability for split-key and CPU fallback decisions.
```
