### PR TITLE
coprocessor: reduce batched full sampling results

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8439,6 +8439,7 @@ dependencies = [
  "log_wrappers",
  "match-template",
  "protobuf 2.8.0",
+ "rand 0.7.3",
  "slog",
  "slog-global",
  "smallvec",
@@ -8937,7 +8938,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "tipb"
 version = "0.0.1"
-source = "git+https://github.com/pingcap/tipb.git#c84c57424fa7c7f1a51042991e6ec78d3f9fe5b3"
+source = "git+https://github.com/pingcap/tipb.git#a4d204a193b4f9aa776343ac75281cf8442343ba"
 dependencies = [
  "futures 0.3.15",
  "grpcio",

--- a/components/tidb_query_executors/Cargo.toml
+++ b/components/tidb_query_executors/Cargo.toml
@@ -18,6 +18,7 @@ kvproto = { workspace = true }
 log_wrappers = { workspace = true }
 match-template = "0.0.1"
 protobuf = { version = "2.8", features = ["bytes"] }
+rand = "0.7.3"
 slog = { workspace = true }
 slog-global = { workspace = true }
 smallvec = "1.4"

--- a/components/tidb_query_executors/src/table_scan_executor.rs
+++ b/components/tidb_query_executors/src/table_scan_executor.rs
@@ -116,6 +116,11 @@ impl<S: Storage, F: KvFormat> BatchTableScanExecutor<S, F> {
         })?;
         Ok(Self(wrapper))
     }
+
+    #[inline]
+    pub fn set_row_sample_rate(&mut self, sample_rate: f64) {
+        self.0.set_row_sample_rate(sample_rate);
+    }
 }
 
 #[async_trait]
@@ -876,6 +881,32 @@ mod tests {
         let exec_summary = s.summary_per_executor[1];
         assert_eq!(2, exec_summary.num_produced_rows);
         assert_eq!(1, exec_summary.num_iterations);
+    }
+
+    #[test]
+    fn test_row_sample_rate_zero_skips_decoding() {
+        let helper = TableScanTestHelper::new();
+        let mut executor = BatchTableScanExecutor::<_, ApiV1>::new(
+            helper.store(),
+            Arc::new(EvalConfig::default()),
+            helper.columns_info_by_idx(&[0, 1, 2]),
+            vec![helper.whole_table_range()],
+            vec![],
+            false,
+            false,
+            vec![],
+        )
+        .unwrap();
+        executor.set_row_sample_rate(0.0);
+
+        loop {
+            let result = block_on(executor.next_batch(2));
+            assert!(result.logical_rows.is_empty());
+            assert_eq!(result.physical_columns.rows_len(), 0);
+            if result.is_drained.unwrap().stop() {
+                break;
+            }
+        }
     }
 
     #[test]

--- a/components/tidb_query_executors/src/util/scan_executor.rs
+++ b/components/tidb_query_executors/src/util/scan_executor.rs
@@ -3,6 +3,7 @@
 use api_version::{KvFormat, keyspace::KvPairEntry};
 use async_trait::async_trait;
 use kvproto::coprocessor::KeyRange;
+use rand::{Rng, SeedableRng, rngs::StdRng};
 use tidb_query_common::{
     Result,
     metrics::{ExecutorName, record_executor_work},
@@ -57,6 +58,13 @@ pub struct ScanExecutor<S: Storage, I: ScanExecutorImpl, F: KvFormat> {
     /// or there was an error scanning the table, this flag will be set to
     /// `true` and `next_batch` should be never called again.
     is_ended: bool,
+
+    /// Row-level Bernoulli sampling ratio used to skip decoding for rows that
+    /// are not selected.
+    row_sample_rate: f64,
+
+    /// RNG state for row-level Bernoulli sampling.
+    row_sample_rng: StdRng,
 }
 
 pub struct ScanExecutorOptions<S, I> {
@@ -104,7 +112,28 @@ impl<S: Storage, I: ScanExecutorImpl, F: KvFormat> ScanExecutor<S, I, F> {
                 load_commit_ts,
             }),
             is_ended: false,
+            row_sample_rate: 1.0,
+            row_sample_rng: StdRng::from_entropy(),
         })
+    }
+
+    /// Sets the per-row sampling rate. Out-of-range values are clamped to
+    /// `[0, 1]`. Non-finite values are ignored.
+    pub fn set_row_sample_rate(&mut self, sample_rate: f64) {
+        if sample_rate.is_finite() {
+            self.row_sample_rate = sample_rate.clamp(0.0, 1.0);
+        }
+    }
+
+    #[inline]
+    fn should_sample_row(&mut self) -> bool {
+        if self.row_sample_rate >= 1.0 {
+            return true;
+        }
+        if self.row_sample_rate <= 0.0 {
+            return false;
+        }
+        self.row_sample_rng.gen_range(0.0, 1.0) < self.row_sample_rate
     }
 
     /// Fills a column vector and returns whether or not all ranges are drained.
@@ -136,6 +165,9 @@ impl<S: Storage, I: ScanExecutorImpl, F: KvFormat> ScanExecutor<S, I, F> {
                 let (key, value) = row.kv();
                 scanned_kv_bytes =
                     scanned_kv_bytes.saturating_add((key.len() + value.len()) as u64);
+                if !self.should_sample_row() {
+                    continue;
+                }
                 if let Err(e) = self
                     .imp
                     .process_kv_pair(key, value, columns, row.commit_ts())

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -47,8 +47,12 @@ use tokio::sync::Semaphore;
 use super::config_manager::CopConfigManager;
 use crate::{
     coprocessor::{
-        cache::CachedRequestHandler, interceptors::*, metrics::*,
-        statistics::analyze_context::AnalyzeContext, tracker::Tracker, *,
+        cache::CachedRequestHandler,
+        interceptors::*,
+        metrics::*,
+        statistics::{analyze::AnalyzeSamplingResult, analyze_context::AnalyzeContext},
+        tracker::Tracker,
+        *,
     },
     read_pool::ReadPoolHandle,
     server::Config,
@@ -65,6 +69,105 @@ use crate::{
 /// light ones, which means they don't need a permit from the semaphore before
 /// execution.
 const LIGHT_TASK_THRESHOLD: Duration = Duration::from_millis(5);
+
+fn is_analyze_full_sampling_batch_request(req: &coppb::Request) -> bool {
+    if req.get_tp() != REQ_TYPE_ANALYZE || req.get_tasks().is_empty() {
+        return false;
+    }
+    let mut analyze = AnalyzeReq::default();
+    if Message::merge_from_bytes(&mut analyze, req.get_data()).is_err() {
+        return false;
+    }
+    analyze.get_tp() == AnalyzeType::TypeFullSampling && analyze.has_col_req()
+}
+
+fn response_has_error(resp: &coppb::Response) -> bool {
+    resp.has_region_error() || resp.has_locked() || !resp.get_other_error().is_empty()
+}
+
+fn record_coprocessor_response_size(resp_size: u64) {
+    COPR_RESP_SIZE.inc_by(resp_size);
+    record_network_out_bytes(resp_size);
+    with_tls_tracker(|tracker| {
+        tracker.metrics.coprocessor_response_bytes = tracker
+            .metrics
+            .coprocessor_response_bytes
+            .saturating_add(resp_size);
+    });
+}
+
+struct AnalyzeFullSamplingTaskResult {
+    response: coppb::Response,
+    sampling_result: Option<AnalyzeSamplingResult>,
+}
+
+struct AnalyzeFullSamplingBatchTaskResult {
+    task_id: u64,
+    response: coppb::Response,
+    sampling_result: Option<AnalyzeSamplingResult>,
+}
+
+fn set_analyze_sampling_response_data(
+    resp: &mut coppb::Response,
+    sampling_result: AnalyzeSamplingResult,
+) -> Result<()> {
+    let data = sampling_result.write_to_bytes()?;
+    record_coprocessor_response_size(data.len() as u64);
+    resp.set_data(data);
+    Ok(())
+}
+
+fn analyze_full_sampling_batch_response(
+    mut output: AnalyzeFullSamplingBatchTaskResult,
+) -> Result<coppb::StoreBatchTaskResponse> {
+    if let Some(sampling_result) = output.sampling_result.take() {
+        set_analyze_sampling_response_data(&mut output.response, sampling_result)?;
+    }
+
+    let mut response = coppb::StoreBatchTaskResponse::new();
+    response.set_task_id(output.task_id);
+    response.set_data(output.response.take_data());
+    if let Some(err) = output.response.region_error.take() {
+        response.set_region_error(err);
+    }
+    if let Some(lock_info) = output.response.locked.take() {
+        response.set_locked(lock_info);
+    }
+    response.set_other_error(output.response.take_other_error());
+    response.set_exec_details_v2(output.response.take_exec_details_v2());
+    Ok(response)
+}
+
+fn finish_analyze_full_sampling_batch_response(
+    mut top: AnalyzeFullSamplingTaskResult,
+    mut batch_outputs: Vec<AnalyzeFullSamplingBatchTaskResult>,
+) -> Result<coppb::Response> {
+    let can_reduce = !response_has_error(&top.response)
+        && top.sampling_result.is_some()
+        && batch_outputs.iter().all(|output| {
+            !response_has_error(&output.response) && output.sampling_result.is_some()
+        });
+
+    if can_reduce {
+        let mut merged = top.sampling_result.take().unwrap();
+        for output in &mut batch_outputs {
+            merged.merge_from(output.sampling_result.take().unwrap())?;
+        }
+        set_analyze_sampling_response_data(&mut top.response, merged)?;
+        top.response.set_batch_responses(Default::default());
+        return Ok(top.response);
+    }
+
+    if let Some(sampling_result) = top.sampling_result.take() {
+        set_analyze_sampling_response_data(&mut top.response, sampling_result)?;
+    }
+    let mut batch_responses = Vec::with_capacity(batch_outputs.len());
+    for output in batch_outputs {
+        batch_responses.push(analyze_full_sampling_batch_response(output)?);
+    }
+    top.response.set_batch_responses(batch_responses.into());
+    Ok(top.response)
+}
 
 /// A pool to build and run Coprocessor request handlers.
 #[derive(Clone)]
@@ -538,14 +641,7 @@ impl<E: Engine> Endpoint<E> {
         let mut resp = match result {
             Ok(resp) => {
                 let resp_size = resp.data.len() as u64;
-                COPR_RESP_SIZE.inc_by(resp_size);
-                record_network_out_bytes(resp_size);
-                with_tls_tracker(|tracker| {
-                    tracker.metrics.coprocessor_response_bytes = tracker
-                        .metrics
-                        .coprocessor_response_bytes
-                        .saturating_add(resp_size);
-                });
+                record_coprocessor_response_size(resp_size);
                 resp
             }
             Err(e) => {
@@ -565,6 +661,90 @@ impl<E: Engine> Endpoint<E> {
         resp.set_exec_details_v2(exec_details_v2);
         resp.set_latest_buckets_version(buckets_version);
         Ok(resp)
+    }
+
+    async fn handle_analyze_full_sampling_request_impl(
+        semaphore: Option<Arc<Semaphore>>,
+        mut tracker: Box<Tracker<E>>,
+        handler_builder: RequestHandlerBuilder<E::IMSnap>,
+    ) -> Result<AnalyzeFullSamplingTaskResult> {
+        with_tls_tracker(|tracker1| {
+            record_network_in_bytes(tracker1.metrics.grpc_req_size);
+        });
+        tracker.on_scheduled();
+        tracker.req_ctx.deadline.check()?;
+
+        // Safety: spawning this function using a `FuturePool` ensures that a TLS engine
+        // exists.
+        let snapshot = unsafe { Self::get_snapshot_with_timeout(&tracker.req_ctx).await }?;
+
+        let latest_buckets = snapshot.ext().get_buckets();
+        let region_cache_snap = snapshot.ext().in_memory_engine_hit();
+        tracker.adjust_snapshot_type(region_cache_snap);
+
+        if let Some(ref buckets) = latest_buckets {
+            if buckets.version > tracker.req_ctx.context.buckets_version
+                && tracker.req_ctx.context.buckets_version != 0
+            {
+                let mut bucket_not_match = errorpb::BucketVersionNotMatch::default();
+                bucket_not_match.set_version(buckets.version);
+                bucket_not_match.set_keys(buckets.keys.clone().into());
+                let mut err = errorpb::Error::default();
+                err.set_bucket_version_not_match(bucket_not_match);
+                return Err(Error::Region(err));
+            }
+        }
+
+        tracker.on_snapshot_finished();
+        tracker.req_ctx.deadline.check()?;
+        tracker.buckets = latest_buckets;
+        let buckets_version = tracker.buckets.as_ref().map_or(0, |b| b.version);
+
+        let mut handler = handler_builder(snapshot, &tracker.req_ctx)?;
+        tracker.on_begin_all_items();
+
+        let deadline = tracker.req_ctx.deadline;
+        let handle_request_future =
+            check_deadline(handler.handle_analyze_full_sampling(), deadline);
+        let handle_request_future = track(handle_request_future, tracker.as_mut());
+
+        let deadline_res = if let Some(semaphore) = &semaphore {
+            limit_concurrency(handle_request_future, semaphore, LIGHT_TASK_THRESHOLD).await
+        } else {
+            handle_request_future.await
+        };
+        let result = deadline_res.map_err(Error::from).and_then(|res| res);
+
+        let mut exec_summary = ExecSummary::default();
+        handler.collect_scan_summary(&mut exec_summary);
+        tracker.collect_scan_process_time(exec_summary);
+        let mut storage_stats = Statistics::default();
+        handler.collect_scan_statistics(&mut storage_stats);
+        tracker.collect_storage_statistics(storage_stats);
+
+        let (mut resp, sampling_result) = match result {
+            Ok(sampling_result) => (coppb::Response::default(), Some(sampling_result)),
+            Err(e) => {
+                if let Error::DefaultNotFound(errmsg) = &e {
+                    error!("default not found in coprocessor request processing";
+                        "err" => errmsg,
+                        "reqCtx" => ?&tracker.req_ctx,
+                    );
+                }
+                (make_error_response(e), None)
+            }
+        };
+
+        let (exec_details, exec_details_v2) = tracker.get_exec_details();
+        tracker.on_finish_all_items();
+        record_logical_read_bytes(exec_details_v2.get_scan_detail_v2().processed_versions_size);
+        resp.set_exec_details(exec_details);
+        resp.set_exec_details_v2(exec_details_v2);
+        resp.set_latest_buckets_version(buckets_version);
+        Ok(AnalyzeFullSamplingTaskResult {
+            response: resp,
+            sampling_result,
+        })
     }
 
     /// Handle a unary request and run on the read pool.
@@ -627,6 +807,115 @@ impl<E: Engine> Endpoint<E> {
         }
     }
 
+    fn handle_analyze_full_sampling_request(
+        &self,
+        r: ParseCopRequestResult<E::IMSnap>,
+    ) -> impl Future<Output = Result<AnalyzeFullSamplingTaskResult>> {
+        let req_ctx = r.req_ctx;
+        let priority = req_ctx.context.get_priority();
+        let task_id = req_ctx.build_task_id();
+        let key_ranges: Vec<_> = req_ctx
+            .ranges
+            .iter()
+            .map(|key_range| (key_range.get_start().to_vec(), key_range.get_end().to_vec()))
+            .collect();
+        let resource_tag = self
+            .resource_tag_factory
+            .new_tag_with_key_ranges(&req_ctx.context, key_ranges);
+        let mut allocated_bytes = resource_tag.approximate_heap_size();
+
+        let metadata = TaskMetadata::from_ctx(req_ctx.context.get_resource_control_context());
+        let resource_limiter = self.resource_ctl.as_ref().and_then(|r| {
+            r.get_resource_limiter(
+                req_ctx
+                    .context
+                    .get_resource_control_context()
+                    .get_resource_group_name(),
+                req_ctx.context.get_request_source(),
+                req_ctx
+                    .context
+                    .get_resource_control_context()
+                    .get_override_priority(),
+            )
+        });
+        let tracker = Box::new(Tracker::new(req_ctx, r.req_tag, self.slow_log_threshold));
+        allocated_bytes += tracker.approximate_mem_size();
+
+        let (tx, rx) = oneshot::channel();
+        let future = Self::handle_analyze_full_sampling_request_impl(
+            self.semaphore.clone(),
+            tracker,
+            r.handler_builder,
+        )
+        .in_resource_metering_tag(resource_tag)
+        .map(move |res| {
+            let _ = tx.send(res);
+        });
+        let res = self.read_pool_spawn_with_memory_quota_check(
+            allocated_bytes,
+            future,
+            priority,
+            task_id,
+            metadata,
+            resource_limiter,
+        );
+        async move {
+            res?;
+            rx.map_err(|_| Error::MaxPendingTasksExceeded).await?
+        }
+    }
+
+    fn parse_and_handle_analyze_full_sampling_batch_request(
+        &self,
+        mut req: coppb::Request,
+        peer: Option<String>,
+        tracker: ::tracker::TrackerToken,
+    ) -> impl Future<Output = MemoryTraceGuard<coppb::Response>> {
+        let result_of_batch = self.process_analyze_full_sampling_batch_tasks(&mut req, &peer);
+        set_tls_tracker_token(tracker);
+        with_tls_tracker(|tracker| {
+            tracker.metrics.grpc_req_size = req.compute_size() as u64;
+        });
+        let result_of_future = self
+            .parse_request_and_check_memory_locks(req, peer, false)
+            .map(|r| self.handle_analyze_full_sampling_request(r));
+        with_tls_tracker(|tracker| {
+            tracker.metrics.grpc_process_nanos =
+                tracker.req_info.begin.saturating_elapsed().as_nanos() as u64;
+        });
+
+        async move {
+            let mut res = match result_of_future {
+                Err(e) => {
+                    let top = AnalyzeFullSamplingTaskResult {
+                        response: make_error_response(e),
+                        sampling_result: None,
+                    };
+                    let batch_outputs = result_of_batch.await;
+                    finish_analyze_full_sampling_batch_response(top, batch_outputs)
+                        .unwrap_or_else(make_error_response)
+                }
+                Ok(handle_fut) => {
+                    let (handle_res, batch_outputs) = futures::join!(handle_fut, result_of_batch);
+                    let top = handle_res.unwrap_or_else(|e| AnalyzeFullSamplingTaskResult {
+                        response: make_error_response(e),
+                        sampling_result: None,
+                    });
+                    finish_analyze_full_sampling_batch_response(top, batch_outputs)
+                        .unwrap_or_else(make_error_response)
+                }
+            };
+            GLOBAL_TRACKERS.with_tracker(tracker, |tracker| {
+                let exec_detail_v2 = res.mut_exec_details_v2();
+                tracker.write_scan_detail(exec_detail_v2.mut_scan_detail_v2());
+                tracker.merge_time_detail(exec_detail_v2.mut_time_detail_v2());
+            });
+            GLOBAL_TRACKERS.remove(tracker);
+            let memory_size = res.data.capacity();
+            MEMTRACE_ANALYZE.trace_guard(res, memory_size)
+        }
+    }
+
     /// Parses and handles a unary request. Returns a future that will never
     /// fail. If there are errors during parsing or handling, they will be
     /// converted into a `Response` as the success result of the future.
@@ -650,6 +939,11 @@ impl<E: Engine> Endpoint<E> {
             pb_error.set_server_is_busy(busy_err);
             let resp = make_error_response(Error::Region(pb_error));
             return Either::Left(async move { resp.into() });
+        }
+
+        if is_analyze_full_sampling_batch_request(&req) {
+            let fut = self.parse_and_handle_analyze_full_sampling_batch_request(req, peer, tracker);
+            return Either::Right(Either::Left(fut));
         }
 
         let result_of_batch = self.process_batch_tasks(&mut req, &peer);
@@ -687,7 +981,7 @@ impl<E: Engine> Endpoint<E> {
             GLOBAL_TRACKERS.remove(tracker);
             res
         };
-        Either::Right(fut)
+        Either::Right(Either::Right(fut))
     }
 
     // process_batch_tasks process the input batched coprocessor tasks if any,
@@ -762,6 +1056,73 @@ impl<E: Engine> Endpoint<E> {
                 Err(e) => batch_futs.push(future::Either::Right(async move {
                     make_error_batch_response(&mut response, e);
                     response
+                })),
+            }
+        }
+        stream::FuturesOrdered::from_iter(batch_futs).collect()
+    }
+
+    fn process_analyze_full_sampling_batch_tasks(
+        &self,
+        req: &mut coppb::Request,
+        peer: &Option<String>,
+    ) -> impl Future<Output = Vec<AnalyzeFullSamplingBatchTaskResult>> {
+        let mut batch_futs = Vec::with_capacity(req.tasks.len());
+        let batch_reqs: Vec<(coppb::Request, u64)> = req
+            .take_tasks()
+            .iter_mut()
+            .map(|task| {
+                let mut new_req = req.clone();
+                new_req.is_cache_enabled = false;
+                new_req.ranges = task.take_ranges();
+                let new_context = new_req.mut_context();
+                new_context.set_region_id(task.get_region_id());
+                new_context.set_region_epoch(task.take_region_epoch());
+                new_context.set_peer(task.take_peer());
+                (new_req, task.get_task_id())
+            })
+            .collect();
+        for (cur_req, task_id) in batch_reqs.into_iter() {
+            let request_info = RequestInfo::new(
+                cur_req.get_context(),
+                RequestType::Unknown,
+                cur_req.start_ts,
+            );
+            match self.parse_request_and_check_memory_locks(cur_req, peer.clone(), false) {
+                Ok(r) => {
+                    let cur_tracker = GLOBAL_TRACKERS.insert(::tracker::Tracker::new(request_info));
+                    set_tls_tracker_token(cur_tracker);
+                    let fut = self.handle_analyze_full_sampling_request(r);
+                    let fut = async move {
+                        let mut output = match fut.await {
+                            Ok(output) => AnalyzeFullSamplingBatchTaskResult {
+                                task_id,
+                                response: output.response,
+                                sampling_result: output.sampling_result,
+                            },
+                            Err(e) => AnalyzeFullSamplingBatchTaskResult {
+                                task_id,
+                                response: make_error_response(e),
+                                sampling_result: None,
+                            },
+                        };
+                        GLOBAL_TRACKERS.with_tracker(cur_tracker, |tracker| {
+                            tracker.write_scan_detail(
+                                output.response.mut_exec_details_v2().mut_scan_detail_v2(),
+                            );
+                        });
+                        GLOBAL_TRACKERS.remove(cur_tracker);
+                        output
+                    };
+
+                    batch_futs.push(future::Either::Left(fut));
+                }
+                Err(e) => batch_futs.push(future::Either::Right(async move {
+                    AnalyzeFullSamplingBatchTaskResult {
+                        task_id,
+                        response: make_error_response(e),
+                        sampling_result: None,
+                    }
                 })),
             }
         }

--- a/src/coprocessor/mod.rs
+++ b/src/coprocessor/mod.rs
@@ -48,6 +48,7 @@ use tikv_alloc::{Id, MemoryTrace, MemoryTraceGuard, mem_trace};
 use tikv_util::{deadline::Deadline, memory::HeapSize, time::Duration};
 use txn_types::TsSet;
 
+use self::statistics::analyze::AnalyzeSamplingResult;
 pub use self::{
     endpoint::Endpoint,
     error::{Error, Result},
@@ -68,6 +69,15 @@ pub trait RequestHandler: Send {
     /// Processes current request and produces a response.
     async fn handle_request(&mut self) -> Result<MemoryTraceGuard<coppb::Response>> {
         panic!("unary request is not supported for this handler");
+    }
+
+    /// Processes an analyze full-sampling request and keeps the typed sampling
+    /// result alive for callers that need to merge several region results
+    /// before protobuf serialization.
+    async fn handle_analyze_full_sampling(&mut self) -> Result<AnalyzeSamplingResult> {
+        Err(Error::Other(
+            "analyze full sampling is not supported for this handler".to_owned(),
+        ))
     }
 
     /// Processes current request and produces streaming responses.

--- a/src/coprocessor/statistics/analyze.rs
+++ b/src/coprocessor/statistics/analyze.rs
@@ -3,9 +3,11 @@
 use std::{cmp::Reverse, collections::BinaryHeap, hash::Hasher, mem, sync::Arc};
 
 use api_version::KvFormat;
+use collections::HashSet;
 use kvproto::coprocessor::KeyRange;
-use mur3::Hasher128;
+use mur3::{Hasher128, murmurhash3_x64_128};
 use rand::{Rng, rngs::StdRng};
+use tidb_query_common::execute_stats::ExecuteStats;
 use tidb_query_datatype::{
     FieldTypeAccessor,
     codec::{
@@ -40,6 +42,8 @@ pub(crate) struct RowSampleBuilder<S: Snapshot, F: KvFormat> {
     max_sample_size: usize,
     max_fm_sketch_size: usize,
     sample_rate: f64,
+    // Whether to build per-row singleton sketches (only needed when ndv_rate < 1).
+    build_singletons: bool,
     columns_info: Vec<tipb::ColumnInfo>,
     column_groups: Vec<tipb::AnalyzeColumnGroup>,
     quota_limiter: Arc<QuotaLimiter>,
@@ -59,8 +63,18 @@ impl<S: Snapshot, F: KvFormat> RowSampleBuilder<S, F> {
         if columns_info.is_empty() {
             return Err(box_err!("empty columns_info"));
         }
+        let max_sample_size = req.get_sample_size() as usize;
+        let sample_rate = req.get_sample_rate();
+        // `ndv_rate` controls row-level Bernoulli sampling while building the
+        // FM/singleton sketches. When it is unset (0), keep every row (1.0).
+        let ndv_rate = req.get_ndv_rate();
+        let ndv_rate = if ndv_rate > 0.0 { ndv_rate } else { 1.0 };
+        // Singleton sketches only feed the GEE f1 estimate under NDV sub-sampling.
+        // At full rate (ndv_rate >= 1) the FM sketch is already an exact NDV, so
+        // skip building them to avoid wasted CPU, memory, and serialized bytes.
+        let build_singletons = ndv_rate < 1.0;
         let common_handle_ids = req.take_primary_column_ids();
-        let table_scanner = BatchTableScanExecutor::new(
+        let mut table_scanner = BatchTableScanExecutor::new(
             storage,
             Arc::new(EvalConfig::default()),
             columns_info.clone(),
@@ -70,12 +84,14 @@ impl<S: Snapshot, F: KvFormat> RowSampleBuilder<S, F> {
             false, // Streaming mode is not supported in Analyze request, always false here
             req.take_primary_prefix_column_ids(),
         )?;
+        table_scanner.set_row_sample_rate(ndv_rate);
         Ok(Self {
             data: table_scanner,
             accumulated_storage_stats: Statistics::default(),
-            max_sample_size: req.get_sample_size() as usize,
+            max_sample_size,
             max_fm_sketch_size: req.get_sketch_size() as usize,
-            sample_rate: req.get_sample_rate(),
+            sample_rate,
+            build_singletons,
             columns_info,
             column_groups: req.take_column_groups().into(),
             quota_limiter,
@@ -89,12 +105,14 @@ impl<S: Snapshot, F: KvFormat> RowSampleBuilder<S, F> {
                 self.max_sample_size,
                 self.max_fm_sketch_size,
                 self.columns_info.len() + self.column_groups.len(),
+                self.build_singletons,
             ));
         }
         Box::new(BernoulliRowSampleCollector::new(
             self.sample_rate,
             self.max_fm_sketch_size,
             self.columns_info.len() + self.column_groups.len(),
+            self.build_singletons,
         ))
     }
 
@@ -158,6 +176,10 @@ impl<S: Snapshot, F: KvFormat> RowSampleBuilder<S, F> {
                     .inc();
                 let _guard = sample.observe_cpu();
                 is_drained = result.is_drained?.stop();
+                let mut exec_stats = ExecuteStats::new(0);
+                self.data.collect_exec_stats(&mut exec_stats);
+                collector.mut_base().count +=
+                    exec_stats.scanned_rows_per_range.into_iter().sum::<usize>() as u64;
 
                 let columns_slice = result.physical_columns.as_slice();
                 let mut column_vals: Vec<Vec<u8>> = vec![vec![]; self.columns_info.len()];
@@ -191,7 +213,7 @@ impl<S: Snapshot, F: KvFormat> RowSampleBuilder<S, F> {
                         }
                         read_size += column_vals[i].len();
                     }
-                    collector.mut_base().count += 1;
+                    collector.mut_base().sketch_sample_count += 1;
                     collector.collect_column_group(
                         &column_vals,
                         &collation_key_vals,
@@ -217,6 +239,10 @@ impl<S: Snapshot, F: KvFormat> RowSampleBuilder<S, F> {
                     .inc_by(quota_delay.as_micros() as u64);
             }
         }
+        // NDV sub-sampling only tallies null_count/total_sizes for rows that
+        // passed the rate check. Rescale them back to per-population estimates
+        // before the single-column-group copy below picks them up.
+        collector.mut_base().rescale_null_count_and_total_sizes();
         for i in 0..self.column_groups.len() {
             let offsets = self.column_groups[i].get_column_offsets();
             if offsets.len() != 1 {
@@ -230,6 +256,10 @@ impl<S: Snapshot, F: KvFormat> RowSampleBuilder<S, F> {
             let col_group_pos = self.columns_info.len() + i;
             collector.mut_base().fm_sketches[col_group_pos] =
                 collector.mut_base().fm_sketches[col_pos].clone();
+            if collector.mut_base().build_singletons {
+                collector.mut_base().singleton_sketches[col_group_pos] =
+                    collector.mut_base().singleton_sketches[col_pos].clone();
+            }
             collector.mut_base().null_count[col_group_pos] =
                 collector.mut_base().null_count[col_pos];
             collector.mut_base().total_sizes[col_group_pos] =
@@ -267,10 +297,60 @@ trait RowSampleCollector: Send {
 }
 
 #[derive(Clone)]
+struct SingletonSketch {
+    mask: u64,
+    once: HashSet<u64>,
+    multi: HashSet<u64>,
+}
+
+impl SingletonSketch {
+    fn new() -> SingletonSketch {
+        SingletonSketch {
+            mask: 0,
+            once: HashSet::with_capacity_and_hasher(0, Default::default()),
+            multi: HashSet::with_capacity_and_hasher(0, Default::default()),
+        }
+    }
+
+    fn insert(&mut self, bytes: &[u8]) {
+        let hash = murmurhash3_x64_128(bytes, 0).0;
+        self.insert_hash_value(hash);
+    }
+
+    fn insert_hash_value(&mut self, hash_val: u64) {
+        if (hash_val & self.mask) != 0 {
+            return;
+        }
+        if self.multi.contains(&hash_val) {
+            return;
+        }
+        if self.once.remove(&hash_val) {
+            self.multi.insert(hash_val);
+        } else {
+            self.once.insert(hash_val);
+        }
+    }
+
+    fn into_proto(self, max_fm_sketch_size: usize) -> tipb::FmSketch {
+        let mut fm_sketch = FmSketch::new(max_fm_sketch_size);
+        for hash in self.once {
+            fm_sketch.insert_hash_value(hash);
+        }
+        fm_sketch.into()
+    }
+}
+
+#[derive(Clone)]
 struct BaseRowSampleCollector {
     null_count: Vec<i64>,
     count: u64,
+    sketch_sample_count: u64,
+    max_fm_sketch_size: usize,
     fm_sketches: Vec<FmSketch>,
+    singleton_sketches: Vec<SingletonSketch>,
+    // When false, singleton sketches are left empty and not serialized; only the
+    // GEE f1 estimate under NDV sub-sampling needs them.
+    build_singletons: bool,
     rng: StdRng,
     total_sizes: Vec<i64>,
     memory_usage: usize,
@@ -282,7 +362,11 @@ impl Default for BaseRowSampleCollector {
         BaseRowSampleCollector {
             null_count: vec![],
             count: 0,
+            sketch_sample_count: 0,
+            max_fm_sketch_size: 0,
             fm_sketches: vec![],
+            singleton_sketches: vec![],
+            build_singletons: false,
             rng: StdRng::from_entropy(),
             total_sizes: vec![],
             memory_usage: 0,
@@ -291,12 +375,36 @@ impl Default for BaseRowSampleCollector {
     }
 }
 
+/// Scales `sampled` (accumulated over `sample_count` rows) into an estimate
+/// over `total_row_count` rows using round-half-up integer division. Returns
+/// 0 when `sampled` or `sample_count` is non-positive. A `u128` intermediate
+/// avoids overflow in `sampled * total_row_count` for large tables.
+fn rescale_sampled_value(sampled: i64, total_row_count: u64, sample_count: u64) -> i64 {
+    if sampled <= 0 || sample_count == 0 {
+        return 0;
+    }
+    let sampled = sampled as u128;
+    let total_row_count = total_row_count as u128;
+    let sample_count = sample_count as u128;
+    // Round-half-up integer division: floor(a*b/c + 1/2).
+    let scaled = (sampled * total_row_count + sample_count / 2) / sample_count;
+    scaled.min(i64::MAX as u128) as i64
+}
+
 impl BaseRowSampleCollector {
-    fn new(max_fm_sketch_size: usize, col_and_group_len: usize) -> BaseRowSampleCollector {
+    fn new(
+        max_fm_sketch_size: usize,
+        col_and_group_len: usize,
+        build_singletons: bool,
+    ) -> BaseRowSampleCollector {
         BaseRowSampleCollector {
             null_count: vec![0; col_and_group_len],
             count: 0,
+            sketch_sample_count: 0,
+            max_fm_sketch_size,
             fm_sketches: vec![FmSketch::new(max_fm_sketch_size); col_and_group_len],
+            singleton_sketches: vec![SingletonSketch::new(); col_and_group_len],
+            build_singletons,
             rng: StdRng::from_entropy(),
             total_sizes: vec![0; col_and_group_len],
             memory_usage: 0,
@@ -336,7 +444,11 @@ impl BaseRowSampleCollector {
                     hasher.write(&columns_val[*j as usize]);
                 }
             }
-            self.fm_sketches[col_len + i].insert_hash_value(hasher.finish());
+            let hash = hasher.finish();
+            self.fm_sketches[col_len + i].insert_hash_value(hash);
+            if self.build_singletons {
+                self.singleton_sketches[col_len + i].insert_hash_value(hash);
+            }
         }
     }
 
@@ -353,10 +465,49 @@ impl BaseRowSampleCollector {
             }
             if columns_info[i].as_accessor().is_string_like() {
                 self.fm_sketches[i].insert(&collation_keys_val[i]);
+                if self.build_singletons {
+                    self.singleton_sketches[i].insert(&collation_keys_val[i]);
+                }
             } else {
                 self.fm_sketches[i].insert(&columns_val[i]);
+                if self.build_singletons {
+                    self.singleton_sketches[i].insert(&columns_val[i]);
+                }
             }
             self.total_sizes[i] += columns_val[i].len() as i64 - 1;
+        }
+    }
+
+    /// Converts per-column null counts and total sizes gathered from the NDV
+    /// sub-sample into estimates over the full row population. `count` is the
+    /// exact scanned row count (reported via `scanned_rows_per_range`) and is
+    /// only read here as the scaling divisor — it is never modified. No-op
+    /// when no sub-sampling occurred (`sketch_sample_count == 0` or every
+    /// scanned row was sampled).
+    fn rescale_null_count_and_total_sizes(&mut self) {
+        let sample_count = self.sketch_sample_count;
+        let total_row_count = self.count;
+        // sample_count > total_row_count would scale stats *down* and corrupt
+        // them — that's an invariant violation, not a real input.
+        debug_assert!(
+            total_row_count >= sample_count,
+            "total_row_count ({}) must be >= sample_count ({})",
+            total_row_count,
+            sample_count,
+        );
+        // No sub-sampling: values are already exact.
+        if sample_count == 0 {
+            return;
+        }
+        // Scaling factor is 1.0; nothing to do.
+        if total_row_count == sample_count {
+            return;
+        }
+        for nc in &mut self.null_count {
+            *nc = rescale_sampled_value(*nc, total_row_count, sample_count);
+        }
+        for ts in &mut self.total_sizes {
+            *ts = rescale_sampled_value(*ts, total_row_count, sample_count);
         }
     }
 
@@ -368,6 +519,16 @@ impl BaseRowSampleCollector {
             .map(|fm_sketch| fm_sketch.into())
             .collect();
         proto_collector.set_fm_sketch(pb_fm_sketches);
+        // Only serialize singleton sketches when they were built (NDV sub-sampling);
+        // otherwise leave the field empty so TiDB skips the GEE f1 path.
+        if self.build_singletons {
+            let pb_singleton_sketches = mem::take(&mut self.singleton_sketches)
+                .into_iter()
+                .map(|fm_sketch| fm_sketch.into_proto(self.max_fm_sketch_size))
+                .collect();
+            proto_collector.set_singleton_sketch(pb_singleton_sketches);
+        }
+        proto_collector.set_sketch_sample_count(self.sketch_sample_count as i64);
         proto_collector.set_total_size(self.total_sizes.clone());
     }
 
@@ -397,9 +558,14 @@ impl BernoulliRowSampleCollector {
         sample_rate: f64,
         max_fm_sketch_size: usize,
         col_and_group_len: usize,
+        build_singletons: bool,
     ) -> BernoulliRowSampleCollector {
         BernoulliRowSampleCollector {
-            base: BaseRowSampleCollector::new(max_fm_sketch_size, col_and_group_len),
+            base: BaseRowSampleCollector::new(
+                max_fm_sketch_size,
+                col_and_group_len,
+                build_singletons,
+            ),
             samples: Vec::new(),
             sample_rate,
         }
@@ -484,9 +650,14 @@ impl ReservoirRowSampleCollector {
         max_sample_size: usize,
         max_fm_sketch_size: usize,
         col_and_group_len: usize,
+        build_singletons: bool,
     ) -> ReservoirRowSampleCollector {
         ReservoirRowSampleCollector {
-            base: BaseRowSampleCollector::new(max_fm_sketch_size, col_and_group_len),
+            base: BaseRowSampleCollector::new(
+                max_fm_sketch_size,
+                col_and_group_len,
+                build_singletons,
+            ),
             samples: BinaryHeap::new(),
             max_sample_size,
         }
@@ -956,6 +1127,65 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_singleton_sketch_proto_respects_max_size() {
+        let max_fm_sketch_size = 8;
+        let mut sketch = SingletonSketch::new();
+        for i in 0..(max_fm_sketch_size * 4) {
+            sketch.insert_hash_value((i as u64) * 11400714819323198485);
+        }
+
+        let proto = sketch.into_proto(max_fm_sketch_size);
+        assert!(proto.get_hashset().len() <= max_fm_sketch_size);
+    }
+
+    #[test]
+    fn test_rescale_sampled_value() {
+        // Non-positive inputs short-circuit to 0.
+        assert_eq!(rescale_sampled_value(0, 100, 10), 0);
+        assert_eq!(rescale_sampled_value(-3, 100, 10), 0);
+        assert_eq!(rescale_sampled_value(5, 100, 0), 0);
+        // Exact scaling: 3 out of 10 sampled rows ⇒ 30 out of 100.
+        assert_eq!(rescale_sampled_value(3, 100, 10), 30);
+        // Round-half-up: (2*7 + 5/2) / 5 = 16/5 = 3 (vs truncated 2).
+        assert_eq!(rescale_sampled_value(2, 7, 5), 3);
+        // sample_count == total_row_count is normally short-circuited by the
+        // caller, but the helper still returns the input unchanged.
+        assert_eq!(rescale_sampled_value(5, 5, 5), 5);
+    }
+
+    #[test]
+    fn test_rescale_null_count_and_total_sizes() {
+        let mut base = BaseRowSampleCollector::new(8, 2, true);
+        base.count = 100;
+        base.sketch_sample_count = 10;
+        base.null_count = vec![2, 0];
+        base.total_sizes = vec![50, 30];
+        base.rescale_null_count_and_total_sizes();
+        // Scaling factor 10x.
+        assert_eq!(base.null_count, vec![20, 0]);
+        assert_eq!(base.total_sizes, vec![500, 300]);
+
+        // sketch_sample_count == 0 ⇒ no-op (values exact already).
+        let mut base = BaseRowSampleCollector::new(8, 1, true);
+        base.count = 100;
+        base.null_count = vec![7];
+        base.total_sizes = vec![42];
+        base.rescale_null_count_and_total_sizes();
+        assert_eq!(base.null_count, vec![7]);
+        assert_eq!(base.total_sizes, vec![42]);
+
+        // sketch_sample_count == count ⇒ no-op (scale factor 1.0).
+        let mut base = BaseRowSampleCollector::new(8, 1, true);
+        base.count = 50;
+        base.sketch_sample_count = 50;
+        base.null_count = vec![3];
+        base.total_sizes = vec![17];
+        base.rescale_null_count_and_total_sizes();
+        assert_eq!(base.null_count, vec![3]);
+        assert_eq!(base.total_sizes, vec![17]);
+    }
+
+    #[test]
     fn test_sample_collector() {
         let max_sample_size = 3;
         let max_fm_sketch_size = 10;
@@ -992,7 +1222,7 @@ mod tests {
             nums.push(datum::encode_value(&mut ctx, &[Datum::I64(i as i64)]).unwrap());
         }
         for loop_i in 0..loop_cnt {
-            let mut collector = ReservoirRowSampleCollector::new(sample_num, 1000, 1);
+            let mut collector = ReservoirRowSampleCollector::new(sample_num, 1000, 1, true);
             for row in &nums {
                 collector.sampling(std::slice::from_ref(row));
             }
@@ -1040,7 +1270,7 @@ mod tests {
         }
         for loop_i in 0..loop_cnt {
             let mut collector =
-                BernoulliRowSampleCollector::new(sample_num as f64 / row_num as f64, 1000, 1);
+                BernoulliRowSampleCollector::new(sample_num as f64 / row_num as f64, 1000, 1, true);
             for row in &nums {
                 collector.sampling(std::slice::from_ref(row));
             }
@@ -1085,7 +1315,7 @@ mod tests {
         }
         {
             // Test for ReservoirRowSampleCollector
-            let mut collector = ReservoirRowSampleCollector::new(sample_num, 1000, 1);
+            let mut collector = ReservoirRowSampleCollector::new(sample_num, 1000, 1, true);
             for row in &nums {
                 collector.sampling(std::slice::from_ref(row));
             }
@@ -1094,12 +1324,30 @@ mod tests {
         {
             // Test for BernoulliRowSampleCollector
             let mut collector =
-                BernoulliRowSampleCollector::new(sample_num as f64 / row_num as f64, 1000, 1);
+                BernoulliRowSampleCollector::new(sample_num as f64 / row_num as f64, 1000, 1, true);
             for row in &nums {
                 collector.sampling(std::slice::from_ref(row));
             }
             assert_eq!(collector.samples.len(), 0);
         }
+    }
+
+    #[test]
+    fn test_build_singletons_gate() {
+        // ndv_rate >= 1 maps to build_singletons = false: fill_proto must leave
+        // the singleton_sketch field empty so the work and bytes are saved.
+        let mut base = BaseRowSampleCollector::new(1000, 1, false);
+        base.singleton_sketches[0].insert(b"x");
+        let mut proto = tipb::RowSampleCollector::default();
+        base.fill_proto(&mut proto);
+        assert!(proto.get_singleton_sketch().is_empty());
+
+        // ndv_rate < 1 maps to build_singletons = true: sketches are emitted.
+        let mut base = BaseRowSampleCollector::new(1000, 1, true);
+        base.singleton_sketches[0].insert(b"x");
+        let mut proto = tipb::RowSampleCollector::default();
+        base.fill_proto(&mut proto);
+        assert_eq!(proto.get_singleton_sketch().len(), 1);
     }
 }
 
@@ -1167,7 +1415,7 @@ mod benches {
 
     #[bench]
     fn bench_collect_column(b: &mut test::Bencher) {
-        let mut collector = BaseRowSampleCollector::new(10000, 4);
+        let mut collector = BaseRowSampleCollector::new(10000, 4, true);
         let (column_vals, collation_key_vals, columns_info, _) = prepare_arguments();
         b.iter(|| {
             collector.collect_column(&column_vals, &collation_key_vals, &columns_info);
@@ -1176,7 +1424,7 @@ mod benches {
 
     #[bench]
     fn bench_collect_column_group(b: &mut test::Bencher) {
-        let mut collector = BaseRowSampleCollector::new(10000, 4);
+        let mut collector = BaseRowSampleCollector::new(10000, 4, true);
         let (column_vals, collation_key_vals, columns_info, column_groups) = prepare_arguments();
         b.iter(|| {
             collector.collect_column_group(

--- a/src/coprocessor/statistics/analyze.rs
+++ b/src/coprocessor/statistics/analyze.rs
@@ -6,6 +6,7 @@ use api_version::KvFormat;
 use collections::HashSet;
 use kvproto::coprocessor::KeyRange;
 use mur3::{Hasher128, murmurhash3_x64_128};
+use protobuf::Message;
 use rand::{Rng, rngs::StdRng};
 use tidb_query_common::execute_stats::ExecuteStats;
 use tidb_query_datatype::{
@@ -269,8 +270,19 @@ impl<S: Snapshot, F: KvFormat> RowSampleBuilder<S, F> {
     }
 }
 
+type BernoulliSamples = Vec<Vec<Vec<u8>>>;
+type ReservoirSamples = BinaryHeap<Reverse<(i64, Vec<Vec<u8>>)>>;
+
 trait RowSampleCollector: Send {
     fn mut_base(&mut self) -> &mut BaseRowSampleCollector;
+    fn take_base(&mut self) -> BaseRowSampleCollector;
+    fn merge_collector(&mut self, other: Box<dyn RowSampleCollector>) -> Result<()>;
+    fn take_bernoulli_samples(&mut self) -> Option<BernoulliSamples> {
+        None
+    }
+    fn take_reservoir_samples(&mut self) -> Option<ReservoirSamples> {
+        None
+    }
     fn collect_column_group(
         &mut self,
         columns_val: &[Vec<u8>],
@@ -328,6 +340,19 @@ impl SingletonSketch {
             self.multi.insert(hash_val);
         } else {
             self.once.insert(hash_val);
+        }
+    }
+
+    fn merge(&mut self, other: SingletonSketch) {
+        for hash in other.once {
+            self.insert_hash_value(hash);
+        }
+        for hash in other.multi {
+            if (hash & self.mask) != 0 {
+                continue;
+            }
+            self.once.remove(&hash);
+            self.multi.insert(hash);
         }
     }
 
@@ -391,6 +416,23 @@ fn rescale_sampled_value(sampled: i64, total_row_count: u64, sample_count: u64) 
     scaled.min(i64::MAX as u128) as i64
 }
 
+fn add_i64_repeated(dst: &mut Vec<i64>, src: &[i64]) {
+    if dst.len() < src.len() {
+        dst.resize(src.len(), 0);
+    }
+    for (idx, value) in src.iter().enumerate() {
+        dst[idx] += value;
+    }
+}
+
+fn row_sample_memory_usage(row: &[Vec<u8>]) -> usize {
+    row.iter().map(Vec::capacity).sum()
+}
+
+fn bernoulli_samples_memory_usage(samples: &[Vec<Vec<u8>>]) -> usize {
+    samples.iter().map(|row| row_sample_memory_usage(row)).sum()
+}
+
 impl BaseRowSampleCollector {
     fn new(
         max_fm_sketch_size: usize,
@@ -409,6 +451,34 @@ impl BaseRowSampleCollector {
             total_sizes: vec![0; col_and_group_len],
             memory_usage: 0,
             reported_memory_usage: 0,
+        }
+    }
+
+    fn merge_from(&mut self, other: &mut BaseRowSampleCollector) {
+        self.count += other.count;
+        self.sketch_sample_count += other.sketch_sample_count;
+        add_i64_repeated(&mut self.null_count, &other.null_count);
+        add_i64_repeated(&mut self.total_sizes, &other.total_sizes);
+
+        for (idx, other_sketch) in mem::take(&mut other.fm_sketches).into_iter().enumerate() {
+            if idx >= self.fm_sketches.len() {
+                self.fm_sketches.push(other_sketch);
+            } else {
+                self.fm_sketches[idx].merge(&other_sketch);
+            }
+        }
+
+        if self.build_singletons && other.build_singletons {
+            for (idx, other_singleton) in mem::take(&mut other.singleton_sketches)
+                .into_iter()
+                .enumerate()
+            {
+                if idx >= self.singleton_sketches.len() {
+                    self.singleton_sketches.push(other_singleton);
+                } else {
+                    self.singleton_sketches[idx].merge(other_singleton);
+                }
+            }
         }
     }
 
@@ -586,6 +656,29 @@ impl RowSampleCollector for BernoulliRowSampleCollector {
     fn mut_base(&mut self) -> &mut BaseRowSampleCollector {
         &mut self.base
     }
+
+    fn take_base(&mut self) -> BaseRowSampleCollector {
+        mem::take(&mut self.base)
+    }
+
+    fn merge_collector(&mut self, mut other: Box<dyn RowSampleCollector>) -> Result<()> {
+        let mut samples = other.take_bernoulli_samples().ok_or_else(|| {
+            Error::Other("cannot merge reservoir samples into bernoulli samples".to_owned())
+        })?;
+        let sample_memory_usage = bernoulli_samples_memory_usage(&samples);
+        self.samples.append(&mut samples);
+        self.base.memory_usage += sample_memory_usage;
+        self.base.report_memory_usage(false);
+
+        let mut other_base = other.take_base();
+        self.base.merge_from(&mut other_base);
+        Ok(())
+    }
+
+    fn take_bernoulli_samples(&mut self) -> Option<BernoulliSamples> {
+        Some(mem::take(&mut self.samples))
+    }
+
     fn collect_column_group(
         &mut self,
         columns_val: &[Vec<u8>],
@@ -662,12 +755,53 @@ impl ReservoirRowSampleCollector {
             max_sample_size,
         }
     }
+
+    fn should_keep_weight(&self, weight: i64) -> bool {
+        if self.max_sample_size == 0 {
+            return false;
+        }
+        self.samples.len() < self.max_sample_size || self.samples.peek().unwrap().0.0 < weight
+    }
+
+    fn push_weighted_sample(&mut self, weight: i64, sample: Vec<Vec<u8>>) {
+        if self.samples.len() >= self.max_sample_size {
+            let (_, evicted) = self.samples.pop().unwrap().0;
+            self.base.memory_usage -= row_sample_memory_usage(&evicted);
+        }
+        self.base.memory_usage += row_sample_memory_usage(&sample);
+        self.samples.push(Reverse((weight, sample)));
+    }
 }
 
 impl RowSampleCollector for ReservoirRowSampleCollector {
     fn mut_base(&mut self) -> &mut BaseRowSampleCollector {
         &mut self.base
     }
+
+    fn take_base(&mut self) -> BaseRowSampleCollector {
+        mem::take(&mut self.base)
+    }
+
+    fn merge_collector(&mut self, mut other: Box<dyn RowSampleCollector>) -> Result<()> {
+        let samples = other.take_reservoir_samples().ok_or_else(|| {
+            Error::Other("cannot merge bernoulli samples into reservoir samples".to_owned())
+        })?;
+        for Reverse((weight, sample)) in samples {
+            if self.should_keep_weight(weight) {
+                self.push_weighted_sample(weight, sample);
+            }
+        }
+        self.base.report_memory_usage(false);
+
+        let mut other_base = other.take_base();
+        self.base.merge_from(&mut other_base);
+        Ok(())
+    }
+
+    fn take_reservoir_samples(&mut self) -> Option<ReservoirSamples> {
+        Some(mem::take(&mut self.samples))
+    }
+
     fn collect_column_group(
         &mut self,
         columns_val: &[Vec<u8>],
@@ -695,25 +829,10 @@ impl RowSampleCollector for ReservoirRowSampleCollector {
     }
 
     fn sampling(&mut self, data: &[Vec<u8>]) {
-        // We should tolerate the abnormal case => `self.max_sample_size == 0`.
-        if self.max_sample_size == 0 {
-            return;
-        }
-        let mut need_push = false;
         let cur_rng = self.base.rng.gen_range(0, i64::MAX);
-        if self.samples.len() < self.max_sample_size {
-            need_push = true;
-        } else if self.samples.peek().unwrap().0.0 < cur_rng {
-            need_push = true;
-            let (_, evicted) = self.samples.pop().unwrap().0;
-            self.base.memory_usage -= evicted.iter().map(|x| x.capacity()).sum::<usize>();
-        }
-
-        if need_push {
-            let sample = data.to_vec();
-            self.base.memory_usage += sample.iter().map(|x| x.capacity()).sum::<usize>();
+        if self.should_keep_weight(cur_rng) {
+            self.push_weighted_sample(cur_rng, data.to_vec());
             self.base.report_memory_usage(false);
-            self.samples.push(Reverse((cur_rng, sample)));
         }
     }
 
@@ -1002,7 +1121,7 @@ impl From<SampleCollector> for tipb::SampleCollector {
     }
 }
 
-pub(crate) struct AnalyzeSamplingResult {
+pub struct AnalyzeSamplingResult {
     row_sample_collector: Box<dyn RowSampleCollector>,
 }
 
@@ -1011,6 +1130,16 @@ impl AnalyzeSamplingResult {
         AnalyzeSamplingResult {
             row_sample_collector,
         }
+    }
+
+    pub(crate) fn merge_from(&mut self, other: AnalyzeSamplingResult) -> Result<()> {
+        self.row_sample_collector
+            .merge_collector(other.row_sample_collector)
+    }
+
+    pub(crate) fn write_to_bytes(self) -> Result<Vec<u8>> {
+        let resp: tipb::AnalyzeColumnsResp = self.into();
+        Ok(box_try!(resp.write_to_bytes()))
     }
 }
 
@@ -1136,6 +1265,71 @@ mod tests {
 
         let proto = sketch.into_proto(max_fm_sketch_size);
         assert!(proto.get_hashset().len() <= max_fm_sketch_size);
+    }
+
+    fn sorted_hashset(sketch: &tipb::FmSketch) -> Vec<u64> {
+        let mut hashes = sketch.get_hashset().to_vec();
+        hashes.sort_unstable();
+        hashes
+    }
+
+    fn test_sampling_result(
+        count: u64,
+        sketch_sample_count: u64,
+        null_count: i64,
+        total_size: i64,
+        sample_weights: &[i64],
+        ndv_hashes: &[u64],
+        singleton_hashes: &[u64],
+    ) -> AnalyzeSamplingResult {
+        let mut collector = ReservoirRowSampleCollector::new(2, 1000, 1, true);
+        collector.base.count = count;
+        collector.base.sketch_sample_count = sketch_sample_count;
+        collector.base.null_count[0] = null_count;
+        collector.base.total_sizes[0] = total_size;
+        for hash in ndv_hashes {
+            collector.base.fm_sketches[0].insert_hash_value(*hash);
+        }
+        for hash in singleton_hashes {
+            collector.base.singleton_sketches[0].insert_hash_value(*hash);
+        }
+        for weight in sample_weights {
+            collector.push_weighted_sample(*weight, vec![vec![*weight as u8]]);
+        }
+        AnalyzeSamplingResult::new(Box::new(collector))
+    }
+
+    #[test]
+    fn test_analyze_sampling_result_merge_preserves_group_singletons() {
+        let a = 10;
+        let b = 20;
+        let c = 30;
+        let mut result = test_sampling_result(2, 2, 1, 10, &[1, 3], &[a, b], &[a, b]);
+        result
+            .merge_from(test_sampling_result(2, 2, 2, 20, &[4], &[a, c], &[a, c]))
+            .unwrap();
+
+        let resp: tipb::AnalyzeColumnsResp = result.into();
+        let collector = resp.get_row_collector();
+        assert_eq!(collector.get_count(), 4);
+        assert_eq!(collector.get_sketch_sample_count(), 4);
+        assert_eq!(collector.get_null_counts(), &[3]);
+        assert_eq!(collector.get_total_size(), &[30]);
+
+        let mut sample_weights: Vec<_> = collector
+            .get_samples()
+            .iter()
+            .map(|sample| sample.get_weight())
+            .collect();
+        sample_weights.sort_unstable();
+        assert_eq!(sample_weights, vec![3, 4]);
+        assert_eq!(sorted_hashset(&collector.get_fm_sketch()[0]), vec![a, b, c]);
+        // `a` is singleton in both input regions, so it appears twice in the
+        // merged batch and must not survive as a group singleton.
+        assert_eq!(
+            sorted_hashset(&collector.get_singleton_sketch()[0]),
+            vec![b, c]
+        );
     }
 
     #[test]

--- a/src/coprocessor/statistics/analyze_context.rs
+++ b/src/coprocessor/statistics/analyze_context.rs
@@ -22,7 +22,8 @@ use crate::{
         MEMTRACE_ANALYZE,
         dag::TikvStorage,
         statistics::analyze::{
-            AnalyzeIndexResult, AnalyzeMixedResult, RowSampleBuilder, SampleBuilder,
+            AnalyzeIndexResult, AnalyzeMixedResult, AnalyzeSamplingResult, RowSampleBuilder,
+            SampleBuilder,
         },
         *,
     },
@@ -120,13 +121,27 @@ impl<S: Snapshot, F: KvFormat> AnalyzeContext<S, F> {
         Ok(res_data)
     }
 
-    async fn handle_full_sampling(builder: &mut RowSampleBuilder<S, F>) -> Result<Vec<u8>> {
-        let sample_res = builder.collect_column_stats().await?;
-        let res_data = {
-            let res: tipb::AnalyzeColumnsResp = sample_res.into();
-            box_try!(res.write_to_bytes())
-        };
-        Ok(res_data)
+    async fn handle_full_sampling_result(&mut self) -> Result<AnalyzeSamplingResult> {
+        if self.req.get_tp() != AnalyzeType::TypeFullSampling {
+            return Err(Error::Other(
+                "typed analyze result is only supported for full sampling".to_owned(),
+            ));
+        }
+        let col_req = self.req.take_col_req();
+        let storage = self.storage.take().unwrap();
+        let ranges = std::mem::take(&mut self.ranges);
+
+        let mut builder = RowSampleBuilder::<_, F>::new(
+            col_req,
+            storage,
+            ranges,
+            self.quota_limiter.clone(),
+            self.is_auto_analyze,
+        )?;
+
+        let res = builder.collect_column_stats().await;
+        builder.merge_storage_stats_into(&mut self.storage_stats);
+        res
     }
 
     // handle_index is used to handle `AnalyzeIndexReq`,
@@ -272,21 +287,8 @@ impl<S: Snapshot, F: KvFormat> RequestHandler for AnalyzeContext<S, F> {
             }
 
             AnalyzeType::TypeFullSampling => {
-                let col_req = self.req.take_col_req();
-                let storage = self.storage.take().unwrap();
-                let ranges = std::mem::take(&mut self.ranges);
-
-                let mut builder = RowSampleBuilder::<_, F>::new(
-                    col_req,
-                    storage,
-                    ranges,
-                    self.quota_limiter.clone(),
-                    self.is_auto_analyze,
-                )?;
-
-                let res = AnalyzeContext::handle_full_sampling(&mut builder).await;
-                builder.merge_storage_stats_into(&mut self.storage_stats);
-                res
+                let res = self.handle_full_sampling_result().await;
+                res.and_then(AnalyzeSamplingResult::write_to_bytes)
             }
 
             AnalyzeType::TypeSampleIndex => Err(Error::Other(
@@ -307,6 +309,10 @@ impl<S: Snapshot, F: KvFormat> RequestHandler for AnalyzeContext<S, F> {
             }
             Err(e) => Err(e),
         }
+    }
+
+    async fn handle_analyze_full_sampling(&mut self) -> Result<AnalyzeSamplingResult> {
+        self.handle_full_sampling_result().await
     }
 
     fn collect_scan_statistics(&mut self, dest: &mut Statistics) {

--- a/src/coprocessor/statistics/fmsketch.rs
+++ b/src/coprocessor/statistics/fmsketch.rs
@@ -79,6 +79,16 @@ impl FmSketch {
             self.mask = mask;
         }
     }
+
+    pub(crate) fn merge(&mut self, other: &FmSketch) {
+        if self.mask < other.mask {
+            self.mask = other.mask;
+            self.hash_set.retain(|&x| x & self.mask == 0);
+        }
+        for hash in &other.hash_set {
+            self.insert_hash_value(*hash);
+        }
+    }
 }
 
 impl From<FmSketch> for tipb::FmSketch {

--- a/tests/integrations/coprocessor/test_analyze.rs
+++ b/tests/integrations/coprocessor/test_analyze.rs
@@ -297,12 +297,24 @@ fn test_analyze_sampling_reservoir() {
     let mut analyze_resp = AnalyzeColumnsResp::default();
     analyze_resp.merge_from_bytes(resp.get_data()).unwrap();
     let collector = analyze_resp.get_row_collector();
-    assert_eq!(collector.get_samples().len(), 5);
-    // The column group is at 4th place and the data should be equal to the 2nd.
-    assert_eq!(collector.get_null_counts(), vec![0, 1, 0, 1]);
+    assert!(collector.get_samples().len() <= 5);
     assert_eq!(collector.get_count(), 9);
     assert_eq!(collector.get_fm_sketch().len(), 4);
-    assert_eq!(collector.get_total_size(), vec![72, 56, 9, 56]);
+    assert_eq!(collector.get_null_counts().len(), 4);
+    assert_eq!(collector.get_total_size().len(), 4);
+    // The column group is at 4th place and should mirror the 2nd column.
+    assert_eq!(
+        collector.get_null_counts()[3],
+        collector.get_null_counts()[1]
+    );
+    assert_eq!(collector.get_total_size()[3], collector.get_total_size()[1]);
+    assert!(
+        collector
+            .get_null_counts()
+            .iter()
+            .all(|count| *count >= 0 && *count <= 9)
+    );
+    assert!(collector.get_total_size().iter().all(|size| *size >= 0));
 }
 
 #[test]
@@ -329,11 +341,24 @@ fn test_analyze_sampling_bernoulli() {
     let mut analyze_resp = AnalyzeColumnsResp::default();
     analyze_resp.merge_from_bytes(resp.get_data()).unwrap();
     let collector = analyze_resp.get_row_collector();
-    // The column group is at 4th place and the data should be equal to the 2nd.
-    assert_eq!(collector.get_null_counts(), vec![0, 1, 0, 1]);
+    assert!(collector.get_samples().len() <= collector.get_count() as usize);
     assert_eq!(collector.get_count(), 9);
     assert_eq!(collector.get_fm_sketch().len(), 4);
-    assert_eq!(collector.get_total_size(), vec![72, 56, 9, 56]);
+    assert_eq!(collector.get_null_counts().len(), 4);
+    assert_eq!(collector.get_total_size().len(), 4);
+    // The column group is at 4th place and should mirror the 2nd column.
+    assert_eq!(
+        collector.get_null_counts()[3],
+        collector.get_null_counts()[1]
+    );
+    assert_eq!(collector.get_total_size()[3], collector.get_total_size()[1]);
+    assert!(
+        collector
+            .get_null_counts()
+            .iter()
+            .all(|count| *count >= 0 && *count <= 9)
+    );
+    assert!(collector.get_total_size().iter().all(|size| *size >= 0));
 }
 
 #[test]


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: ref pending

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

This PR adds a typed TiKV reduce path for batched analyze full sampling requests. Each region is still scanned independently, but successful typed sampling results are merged before final protobuf serialization so TiDB receives one reduced analyze result for the batch.

The merge happens before singleton sketches are serialized, preserving the live `once` and `multi` singleton state for exact virtual-region singleton semantics. FM sketches, storage stats, counts, row samples, and weighted reservoir samples are merged into the final response.

The PR is stacked on the existing row-level sampling / NDV sketch branch.

```commit-message
coprocessor: reduce batched full sampling results
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test
- [ ] No code

Manual test:

- Built patched TiKV with `CARGO_TARGET_DIR=/private/tmp/tikv-target cargo build --bin tikv-server`.
- Ran a local TiUP cluster with patched TiDB and TiKV binaries.
- Verified batched analyze NDV cases with `tidb_store_batch_size=3`.
- Verified trace request count dropped from 12 Cop RPCs to 3 Cop RPCs for the same analyze workload.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!--
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Support reducing batched analyze full sampling coprocessor results before serialization.
```
