### PR TITLE
raftstore: rate-limit `failed to send extra message` WARN and add failure counter

### DIFF
--- a/components/raftstore/src/lib.rs
+++ b/components/raftstore/src/lib.rs
@@ -5,7 +5,7 @@
 #![feature(box_patterns)]
 #![feature(type_alias_impl_trait)]
 #![feature(impl_trait_in_assoc_type)]
-#![recursion_limit = "256"]
+#![recursion_limit = "400"]
 // `Instant` does not implement the "Ord" trait.
 // So type `TtlRange` can't derive Ord trait directly.
 #![allow(clippy::derive_ord_xor_partial_ord)]

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -3075,9 +3075,7 @@ where
 
             let mut extra = ExtraMessage::default();
             extra.set_type(ExtraMessageType::MsgHibernateRequest);
-            self.fsm
-                .peer
-                .send_extra_message(extra, &mut self.ctx.trans, peer);
+            self.fsm.peer.send_extra_message(extra, self.ctx, peer);
         }
         false
     }
@@ -3097,9 +3095,7 @@ where
         self.on_check_peer_complete_apply_logs();
         let mut extra = ExtraMessage::default();
         extra.set_type(ExtraMessageType::MsgHibernateResponse);
-        self.fsm
-            .peer
-            .send_extra_message(extra, &mut self.ctx.trans, from);
+        self.fsm.peer.send_extra_message(extra, self.ctx, from);
     }
 
     fn on_hibernate_response(&mut self, from: &metapb::Peer) {
@@ -3158,9 +3154,7 @@ where
         report.set_from_region_id(self.region_id());
         report.set_from_region_epoch(self.region().get_region_epoch().clone());
         report.set_trimmed(true);
-        self.fsm
-            .peer
-            .send_extra_message(resp, &mut self.ctx.trans, from);
+        self.fsm.peer.send_extra_message(resp, self.ctx, from);
         debug!(
             "peer responses availability info to leader";
             "region_id" => self.region().get_id(),
@@ -3187,9 +3181,7 @@ where
         let mut resp = ExtraMessage::default();
         resp.set_type(ExtraMessageType::MsgVoterReplicatedIndexResponse);
         resp.index = voter_replicated_idx;
-        self.fsm
-            .peer
-            .send_extra_message(resp, &mut self.ctx.trans, from);
+        self.fsm.peer.send_extra_message(resp, self.ctx, from);
         debug!(
             "leader responses voter_replicated_index to witness";
             "region_id" => self.region().get_id(),
@@ -6488,9 +6480,7 @@ where
             let leader_id = self.fsm.peer.leader_id();
             let leader = self.fsm.peer.get_peer_from_cache(leader_id);
             if let Some(leader) = leader {
-                self.fsm
-                    .peer
-                    .send_extra_message(msg, &mut self.ctx.trans, &leader);
+                self.fsm.peer.send_extra_message(msg, self.ctx, &leader);
             }
         }
         self.register_pull_voter_replicated_index_tick();
@@ -6783,9 +6773,11 @@ where
         );
         let keys = region_buckets.meta.keys.clone();
         let version = region_buckets.meta.version;
-        let mut store_meta = self.ctx.store_meta.lock().unwrap();
-        if let Some(reader) = store_meta.readers.get_mut(&self.fsm.region_id()) {
-            reader.update(ReadProgress::region_buckets(region_buckets.meta.clone()));
+        {
+            let mut store_meta = self.ctx.store_meta.lock().unwrap();
+            if let Some(reader) = store_meta.readers.get_mut(&self.fsm.region_id()) {
+                reader.update(ReadProgress::region_buckets(region_buckets.meta.clone()));
+            }
         }
 
         // Notify followers to refresh their buckets version
@@ -6801,9 +6793,7 @@ where
                 refresh_buckets.set_version(version);
                 refresh_buckets.set_keys(keys.clone().into());
                 extra_msg.set_refresh_buckets(refresh_buckets);
-                self.fsm
-                    .peer
-                    .send_extra_message(extra_msg, &mut self.ctx.trans, &p);
+                self.fsm.peer.send_extra_message(extra_msg, self.ctx, &p);
             }
         }
         // test purpose
@@ -6973,9 +6963,7 @@ where
                 Some(peer) => {
                     let mut msg = ExtraMessage::default();
                     msg.set_type(ExtraMessageType::MsgAvailabilityRequest);
-                    self.fsm
-                        .peer
-                        .send_extra_message(msg, &mut self.ctx.trans, &peer);
+                    self.fsm.peer.send_extra_message(msg, self.ctx, &peer);
                     debug!(
                         "check peer availability";
                         "target_peer_id" => *peer_id,

--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -548,6 +548,65 @@ impl Clone for PeerTickBatch {
     }
 }
 
+const EXTRA_MESSAGE_FULL_LOG_INTERVAL: Duration = Duration::from_secs(1);
+
+#[derive(Clone, Copy, Hash, PartialEq, Eq)]
+struct ExtraMessageFullLogKey {
+    target_store_id: u64,
+    msg_type: ExtraMessageType,
+}
+
+struct ExtraMessageFullLogState {
+    last_log_time: Instant,
+    suppressed_count: u64,
+}
+
+#[derive(Default)]
+pub struct ExtraMessageFullLogLimiter {
+    states: HashMap<ExtraMessageFullLogKey, ExtraMessageFullLogState>,
+}
+
+impl ExtraMessageFullLogLimiter {
+    pub fn record(&mut self, target_store_id: u64, msg_type: ExtraMessageType) -> Option<u64> {
+        self.record_at(target_store_id, msg_type, Instant::now())
+    }
+
+    fn record_at(
+        &mut self,
+        target_store_id: u64,
+        msg_type: ExtraMessageType,
+        now: Instant,
+    ) -> Option<u64> {
+        let key = ExtraMessageFullLogKey {
+            target_store_id,
+            msg_type,
+        };
+        match self.states.entry(key) {
+            HashMapEntry::Vacant(entry) => {
+                entry.insert(ExtraMessageFullLogState {
+                    last_log_time: now,
+                    suppressed_count: 0,
+                });
+                Some(0)
+            }
+            HashMapEntry::Occupied(mut entry) => {
+                let state = entry.get_mut();
+                if now.saturating_duration_since(state.last_log_time)
+                    < EXTRA_MESSAGE_FULL_LOG_INTERVAL
+                {
+                    state.suppressed_count = state.suppressed_count.saturating_add(1);
+                    return None;
+                }
+
+                let suppressed_count = state.suppressed_count;
+                state.last_log_time = now;
+                state.suppressed_count = 0;
+                Some(suppressed_count)
+            }
+        }
+    }
+}
+
 pub struct PollContext<EK, ER, T>
 where
     EK: KvEngine,
@@ -618,6 +677,7 @@ where
     pub gc_safe_point: Arc<AtomicU64>,
 
     pub process_stat: Option<ProcessStat>,
+    pub extra_message_full_log_limiter: ExtraMessageFullLogLimiter,
 }
 
 impl<EK, ER, T> PollContext<EK, ER, T>
@@ -1568,6 +1628,7 @@ where
             pending_latency_inspect: vec![],
             gc_safe_point: self.gc_safe_point.clone(),
             process_stat: None,
+            extra_message_full_log_limiter: ExtraMessageFullLogLimiter::default(),
         };
         ctx.update_ticks_timeout();
         let tag = format!("[store {}]", ctx.store.get_id());
@@ -3450,10 +3511,64 @@ impl<EK: KvEngine, ER: RaftEngine, T: Transport> StoreFsmDelegate<'_, EK, ER, T>
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeMap;
+    use std::{collections::BTreeMap, time::Duration};
 
     use engine_rocks::{RangeOffsets, RangeProperties, RocksCompactedEvent};
     use engine_traits::CompactedEvent;
+    use kvproto::raft_serverpb::ExtraMessageType;
+
+    use super::ExtraMessageFullLogLimiter;
+
+    #[test]
+    fn test_extra_message_full_log_limiter() {
+        let mut limiter = ExtraMessageFullLogLimiter::default();
+        let now = std::time::Instant::now();
+
+        assert_eq!(
+            limiter.record_at(2, ExtraMessageType::MsgHibernateRequest, now),
+            Some(0)
+        );
+        assert_eq!(
+            limiter.record_at(
+                2,
+                ExtraMessageType::MsgHibernateRequest,
+                now + Duration::from_millis(500)
+            ),
+            None
+        );
+        assert_eq!(
+            limiter.record_at(
+                2,
+                ExtraMessageType::MsgHibernateRequest,
+                now + Duration::from_secs(1)
+            ),
+            Some(1)
+        );
+        assert_eq!(
+            limiter.record_at(
+                2,
+                ExtraMessageType::MsgHibernateRequest,
+                now + Duration::from_millis(1500)
+            ),
+            None
+        );
+        assert_eq!(
+            limiter.record_at(
+                3,
+                ExtraMessageType::MsgHibernateRequest,
+                now + Duration::from_millis(1500)
+            ),
+            Some(0)
+        );
+        assert_eq!(
+            limiter.record_at(
+                2,
+                ExtraMessageType::MsgHibernateResponse,
+                now + Duration::from_millis(1500)
+            ),
+            Some(0)
+        );
+    }
 
     #[test]
     fn test_calc_region_declined_bytes() {

--- a/components/raftstore/src/store/metrics.rs
+++ b/components/raftstore/src/store/metrics.rs
@@ -604,6 +604,13 @@ lazy_static! {
             &["type"]
         ).unwrap();
 
+    pub static ref STORE_EXTRA_MESSAGE_SEND_FAILURE_COUNTER_VEC: IntCounterVec =
+        register_int_counter_vec!(
+            "tikv_raftstore_extra_message_send_failure_total",
+            "Total number of failed raftstore extra message sends.",
+            &["type", "reason"]
+        ).unwrap();
+
     pub static ref STORE_SNAPSHOT_TRAFFIC_GAUGE_VEC: IntGaugeVec =
         register_int_gauge_vec!(
             "tikv_raftstore_snapshot_traffic_total",

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -79,7 +79,7 @@ use super::{
     worker::BucketStatsInfo,
 };
 use crate::{
-    Error, Result,
+    DiscardReason, Error, Result,
     coprocessor::{
         CoprocessorHost, RegionChangeEvent, RegionChangeReason, RoleChange,
         TransferLeaderCustomContext,
@@ -117,6 +117,42 @@ const MIN_BCAST_WAKE_UP_INTERVAL: u64 = 1_000;
 const REGION_READ_PROGRESS_CAP: usize = 128;
 
 const SNAP_GEN_PRECHECK_FEATURE: Feature = Feature::require(8, 2, 0);
+
+fn extra_message_type_label(msg_type: ExtraMessageType) -> &'static str {
+    match msg_type {
+        ExtraMessageType::MsgRegionWakeUp => "region_wake_up",
+        ExtraMessageType::MsgWantRollbackMerge => "want_rollback_merge",
+        ExtraMessageType::MsgCheckStalePeer => "check_stale_peer",
+        ExtraMessageType::MsgCheckStalePeerResponse => "check_stale_peer_response",
+        ExtraMessageType::MsgHibernateRequest => "hibernate_request",
+        ExtraMessageType::MsgHibernateResponse => "hibernate_response",
+        ExtraMessageType::MsgRejectRaftLogCausedByMemoryUsage => {
+            "reject_raft_log_caused_by_memory_usage"
+        }
+        ExtraMessageType::MsgAvailabilityRequest => "availability_request",
+        ExtraMessageType::MsgAvailabilityResponse => "availability_response",
+        ExtraMessageType::MsgVoterReplicatedIndexRequest => "voter_replicated_index_request",
+        ExtraMessageType::MsgVoterReplicatedIndexResponse => "voter_replicated_index_response",
+        ExtraMessageType::MsgGcPeerRequest => "gc_peer_request",
+        ExtraMessageType::MsgGcPeerResponse => "gc_peer_response",
+        ExtraMessageType::MsgFlushMemtable => "flush_memtable",
+        ExtraMessageType::MsgRefreshBuckets => "refresh_buckets",
+        ExtraMessageType::MsgSnapGenPrecheckRequest => "snap_gen_precheck_request",
+        ExtraMessageType::MsgSnapGenPrecheckResponse => "snap_gen_precheck_response",
+        ExtraMessageType::MsgPreLoadRegionRequest => "pre_load_region_request",
+        ExtraMessageType::MsgPreLoadRegionResponse => "pre_load_region_response",
+    }
+}
+
+fn extra_message_send_failure_reason(err: &Error) -> &'static str {
+    match err {
+        Error::Transport(DiscardReason::Full) => "full",
+        Error::Transport(DiscardReason::Disconnected) => "disconnected",
+        Error::Transport(DiscardReason::Paused) => "paused",
+        Error::Transport(DiscardReason::Filtered) => "filtered",
+        _ => "other",
+    }
+}
 
 #[doc(hidden)]
 pub const MAX_COMMITTED_SIZE_PER_READY: u64 = 16 * 1024 * 1024;
@@ -2813,7 +2849,7 @@ where
             let mut msg = ExtraMessage::default();
             msg.set_type(ExtraMessageType::MsgAvailabilityResponse);
             msg.wait_data = false;
-            self.send_extra_message(msg, &mut ctx.trans, &leader);
+            self.send_extra_message(msg, ctx, &leader);
             info!(
                 "notify leader the peer is available";
                 "region_id" => self.region().get_id(),
@@ -5901,7 +5937,7 @@ where
     pub fn send_extra_message<T: Transport>(
         &self,
         msg: ExtraMessage,
-        trans: &mut T,
+        ctx: &mut PollContext<EK, ER, T>,
         to: &metapb::Peer,
     ) {
         let mut send_msg = self.prepare_raft_message();
@@ -5914,15 +5950,39 @@ where
         );
         send_msg.set_extra_msg(msg);
         send_msg.set_to_peer(to.clone());
-        if let Err(e) = trans.send(send_msg) {
-            warn!(
-                "failed to send extra message";
-                "err" => ?e,
-                "type" => ?ty,
-                "region_id" => self.region_id,
-                "peer_id" => self.peer.get_id(),
-                "target" => ?to,
-            );
+        if let Err(e) = ctx.trans.send(send_msg) {
+            STORE_EXTRA_MESSAGE_SEND_FAILURE_COUNTER_VEC
+                .with_label_values(&[
+                    extra_message_type_label(ty),
+                    extra_message_send_failure_reason(&e),
+                ])
+                .inc();
+            if matches!(&e, Error::Transport(DiscardReason::Full)) {
+                if let Some(suppressed_count) = ctx
+                    .extra_message_full_log_limiter
+                    .record(to.get_store_id(), ty)
+                {
+                    warn!(
+                        "failed to send extra message";
+                        "err" => ?e,
+                        "type" => ?ty,
+                        "region_id" => self.region_id,
+                        "peer_id" => self.peer.get_id(),
+                        "target" => ?to,
+                        "target_store_id" => to.get_store_id(),
+                        "suppressed_count" => suppressed_count,
+                    );
+                }
+            } else {
+                warn!(
+                    "failed to send extra message";
+                    "err" => ?e,
+                    "type" => ?ty,
+                    "region_id" => self.region_id,
+                    "peer_id" => self.peer.get_id(),
+                    "target" => ?to,
+                );
+            }
         }
     }
 
@@ -5997,7 +6057,7 @@ where
     ) {
         let mut msg = ExtraMessage::default();
         msg.set_type(ExtraMessageType::MsgRegionWakeUp);
-        self.send_extra_message(msg, &mut ctx.trans, peer);
+        self.send_extra_message(msg, ctx, peer);
     }
 
     pub fn bcast_check_stale_peer_message<T: Transport>(
@@ -6022,7 +6082,7 @@ where
             }
             let mut extra_msg = ExtraMessage::default();
             extra_msg.set_type(ExtraMessageType::MsgCheckStalePeer);
-            self.send_extra_message(extra_msg, &mut ctx.trans, peer);
+            self.send_extra_message(extra_msg, ctx, peer);
         }
     }
 
@@ -6044,7 +6104,7 @@ where
     ) {
         let mut extra_msg = ExtraMessage::default();
         extra_msg.set_type(ExtraMessageType::MsgSnapGenPrecheckRequest);
-        self.send_extra_message(extra_msg, &mut ctx.trans, to_peer);
+        self.send_extra_message(extra_msg, ctx, to_peer);
     }
 
     pub fn send_snap_gen_precheck_response<T: Transport>(
@@ -6056,7 +6116,7 @@ where
         let mut extra_msg = ExtraMessage::default();
         extra_msg.set_type(ExtraMessageType::MsgSnapGenPrecheckResponse);
         extra_msg.set_snap_gen_precheck_passed(passed);
-        self.send_extra_message(extra_msg, &mut ctx.trans, to_peer);
+        self.send_extra_message(extra_msg, ctx, to_peer);
     }
 
     pub fn send_want_rollback_merge<T: Transport>(
@@ -6079,7 +6139,7 @@ where
         let mut extra_msg = ExtraMessage::default();
         extra_msg.set_type(ExtraMessageType::MsgWantRollbackMerge);
         extra_msg.set_index(premerge_commit);
-        self.send_extra_message(extra_msg, &mut ctx.trans, &to_peer);
+        self.send_extra_message(extra_msg, ctx, &to_peer);
     }
 
     pub fn require_updating_max_ts(&self, pd_scheduler: &Scheduler<PdTask<EK>>) {

--- a/metrics/grafana/tikv_details.dashboard.py
+++ b/metrics/grafana/tikv_details.dashboard.py
@@ -2680,6 +2680,20 @@ def RaftMessage() -> RowPanel:
                     ),
                 ],
             ),
+            graph_panel(
+                title="Extra message send failures",
+                description="The rate of failed raftstore extra message sends by message type and failure reason",
+                yaxes=yaxes(left_format=UNITS.OPS_PER_SEC),
+                targets=[
+                    target(
+                        expr=expr_sum_rate(
+                            "tikv_raftstore_extra_message_send_failure_total",
+                            by_labels=["type", "reason"],
+                        ),
+                        additional_groupby=True,
+                    ),
+                ],
+            ),
         ]
     )
     layout.row(

--- a/metrics/grafana/tikv_details.json
+++ b/metrics/grafana/tikv_details.json
@@ -27687,7 +27687,7 @@
           },
           "gridPos": {
             "h": 7,
-            "w": 12,
+            "w": 8,
             "x": 0,
             "y": 14
           },
@@ -27820,8 +27820,8 @@
           },
           "gridPos": {
             "h": 7,
-            "w": 12,
-            "x": 12,
+            "w": 8,
+            "x": 8,
             "y": 14
           },
           "height": null,
@@ -27943,6 +27943,139 @@
           }
         },
         {
+          "aliasColors": {},
+          "bars": false,
+          "cacheTimeout": null,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "The rate of failed raftstore extra message sends by message type and failure reason",
+          "editable": true,
+          "error": false,
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              }
+            }
+          },
+          "fill": 1,
+          "fillGradient": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 16,
+            "y": 14
+          },
+          "height": null,
+          "hideTimeOverride": false,
+          "id": 201,
+          "interval": null,
+          "isNew": true,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": null,
+            "sort": "max",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "maxDataPoints": null,
+          "maxPerRow": null,
+          "minSpan": null,
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true,
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "repeatDirection": null,
+          "seriesOverrides": [],
+          "span": null,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "sum(rate(\n    tikv_raftstore_extra_message_send_failure_total\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (type, reason, $additional_groupby) ",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{type}}-{{reason}} {{$additional_groupby}}",
+              "metric": "",
+              "query": "sum(rate(\n    tikv_raftstore_extra_message_send_failure_total\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (type, reason, $additional_groupby) ",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Extra message send failures",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "transformations": [],
+          "transparent": false,
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "ops",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": 0
+          }
+        },
+        {
           "cacheTimeout": null,
           "cards": {
             "cardPadding": null,
@@ -27981,7 +28114,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 201,
+          "id": 202,
           "interval": null,
           "legend": {
             "show": false
@@ -28079,7 +28212,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 202,
+          "id": 203,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -28287,7 +28420,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 203,
+          "id": 204,
           "interval": null,
           "legend": {
             "show": false
@@ -28385,7 +28518,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 204,
+          "id": 205,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -28589,7 +28722,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 205,
+      "id": 206,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -28628,7 +28761,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 206,
+          "id": 207,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -28761,7 +28894,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 207,
+          "id": 208,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -28894,7 +29027,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 208,
+          "id": 209,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -29027,7 +29160,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 209,
+          "id": 210,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -29160,7 +29293,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 210,
+          "id": 211,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -29293,7 +29426,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 211,
+          "id": 212,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -29456,7 +29589,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 212,
+          "id": 213,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -29619,7 +29752,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 213,
+          "id": 214,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -29820,7 +29953,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 214,
+          "id": 215,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -30021,7 +30154,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 215,
+          "id": 216,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -30157,7 +30290,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 216,
+      "id": 217,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -30196,7 +30329,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 217,
+          "id": 218,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -30344,7 +30477,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 218,
+          "id": 219,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -30492,7 +30625,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 219,
+          "id": 220,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -30625,7 +30758,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 220,
+          "id": 221,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -30758,7 +30891,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 221,
+          "id": 222,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -30891,7 +31024,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 222,
+          "id": 223,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -31024,7 +31157,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 223,
+          "id": 224,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -31157,7 +31290,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 224,
+          "id": 225,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -31290,7 +31423,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 225,
+          "id": 226,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -31467,7 +31600,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 226,
+      "id": 227,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -31506,7 +31639,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 227,
+          "id": 228,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -31669,7 +31802,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 228,
+          "id": 229,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -31870,7 +32003,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 229,
+          "id": 230,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -32018,7 +32151,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 230,
+          "id": 231,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -32181,7 +32314,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 231,
+          "id": 232,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -32382,7 +32515,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 232,
+          "id": 233,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -32560,7 +32693,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 233,
+          "id": 234,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -32723,7 +32856,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 234,
+          "id": 235,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -32886,7 +33019,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 235,
+          "id": 236,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -33019,7 +33152,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 236,
+          "id": 237,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -33223,7 +33356,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 237,
+      "id": 238,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -33262,7 +33395,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 238,
+          "id": 239,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -33455,7 +33588,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 239,
+          "id": 240,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -33633,7 +33766,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 240,
+          "id": 241,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -33841,7 +33974,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 241,
+          "id": 242,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -34019,7 +34152,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 242,
+          "id": 243,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -34182,7 +34315,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 243,
+          "id": 244,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -34360,7 +34493,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 244,
+          "id": 245,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -34493,7 +34626,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 245,
+          "id": 246,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -34671,7 +34804,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 246,
+          "id": 247,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -34844,7 +34977,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 247,
+          "id": 248,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -35022,7 +35155,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 248,
+          "id": 249,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -35155,7 +35288,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 249,
+          "id": 250,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -35333,7 +35466,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 250,
+          "id": 251,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -35511,7 +35644,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 251,
+          "id": 252,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -35689,7 +35822,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 252,
+          "id": 253,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -35822,7 +35955,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 253,
+          "id": 254,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -35955,7 +36088,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 254,
+          "id": 255,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -36088,7 +36221,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 255,
+          "id": 256,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -36311,7 +36444,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 256,
+          "id": 257,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -36504,7 +36637,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 257,
+          "id": 258,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -36667,7 +36800,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 258,
+          "id": 259,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -36860,7 +36993,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 259,
+          "id": 260,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -37008,7 +37141,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 260,
+          "id": 261,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -37141,7 +37274,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 261,
+          "id": 262,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -37289,7 +37422,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 262,
+          "id": 263,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -37467,7 +37600,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 263,
+          "id": 264,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -37630,7 +37763,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 264,
+          "id": 265,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -37808,7 +37941,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 265,
+          "id": 266,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -37941,7 +38074,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 266,
+          "id": 267,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -38074,7 +38207,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 267,
+          "id": 268,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -38207,7 +38340,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 268,
+          "id": 269,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -38340,7 +38473,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 269,
+          "id": 270,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -38473,7 +38606,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 270,
+          "id": 271,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -38613,7 +38746,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 271,
+          "id": 272,
           "interval": null,
           "legend": {
             "show": false
@@ -38711,7 +38844,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 272,
+          "id": 273,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -38912,7 +39045,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 273,
+          "id": 274,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -39045,7 +39178,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 274,
+          "id": 275,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -39193,7 +39326,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 275,
+          "id": 276,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -39326,7 +39459,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 276,
+          "id": 277,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -39504,7 +39637,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 277,
+          "id": 278,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -39637,7 +39770,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 278,
+          "id": 279,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -39773,7 +39906,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 279,
+      "id": 280,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -39812,7 +39945,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 280,
+          "id": 281,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -39960,7 +40093,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 281,
+          "id": 282,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -40108,7 +40241,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 282,
+          "id": 283,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -40241,7 +40374,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 283,
+          "id": 284,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -40374,7 +40507,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 284,
+          "id": 285,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -40552,7 +40685,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 285,
+          "id": 286,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -40730,7 +40863,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 286,
+          "id": 287,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -40908,7 +41041,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 287,
+          "id": 288,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -41041,7 +41174,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 288,
+          "id": 289,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -41219,7 +41352,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 289,
+          "id": 290,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -41352,7 +41485,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 290,
+          "id": 291,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -41515,7 +41648,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 291,
+          "id": 292,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -41693,7 +41826,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 292,
+          "id": 293,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -41871,7 +42004,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 293,
+          "id": 294,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -42049,7 +42182,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 294,
+          "id": 295,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -42182,7 +42315,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 295,
+          "id": 296,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -42360,7 +42493,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 296,
+          "id": 297,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -42493,7 +42626,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 297,
+          "id": 298,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -42671,7 +42804,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 298,
+          "id": 299,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -42804,7 +42937,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 299,
+          "id": 300,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -42937,7 +43070,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 300,
+          "id": 301,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -43115,7 +43248,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 301,
+          "id": 302,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -43293,7 +43426,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 302,
+          "id": 303,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -43426,7 +43559,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 303,
+          "id": 304,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -43604,7 +43737,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 304,
+          "id": 305,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -43737,7 +43870,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 305,
+          "id": 306,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -43915,7 +44048,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 306,
+          "id": 307,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -44051,7 +44184,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 307,
+      "id": 308,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -44090,7 +44223,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 308,
+          "id": 309,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -44223,7 +44356,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 309,
+          "id": 310,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -44371,7 +44504,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 310,
+          "id": 311,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -44572,7 +44705,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 311,
+          "id": 312,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -44705,7 +44838,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 312,
+          "id": 313,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -44838,7 +44971,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 313,
+          "id": 314,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -44971,7 +45104,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 314,
+          "id": 315,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -45104,7 +45237,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 315,
+          "id": 316,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -45237,7 +45370,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 316,
+          "id": 317,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -45377,7 +45510,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 317,
+          "id": 318,
           "interval": null,
           "legend": {
             "show": false
@@ -45482,7 +45615,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 318,
+          "id": 319,
           "interval": null,
           "legend": {
             "show": false
@@ -45580,7 +45713,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 319,
+          "id": 320,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -45720,7 +45853,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 320,
+          "id": 321,
           "interval": null,
           "legend": {
             "show": false
@@ -45818,7 +45951,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 321,
+          "id": 322,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -45951,7 +46084,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 322,
+          "id": 323,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -46091,7 +46224,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 323,
+          "id": 324,
           "interval": null,
           "legend": {
             "show": false
@@ -46189,7 +46322,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 324,
+          "id": 325,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -46397,7 +46530,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 325,
+          "id": 326,
           "interval": null,
           "legend": {
             "show": false
@@ -46495,7 +46628,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 326,
+          "id": 327,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -46696,7 +46829,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 327,
+          "id": 328,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -46904,7 +47037,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 328,
+          "id": 329,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -47082,7 +47215,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 329,
+          "id": 330,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -47215,7 +47348,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 330,
+          "id": 331,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -47348,7 +47481,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 331,
+          "id": 332,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -47481,7 +47614,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 332,
+          "id": 333,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -47621,7 +47754,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 333,
+          "id": 334,
           "interval": null,
           "legend": {
             "show": false
@@ -47726,7 +47859,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 334,
+          "id": 335,
           "interval": null,
           "legend": {
             "show": false
@@ -47831,7 +47964,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 335,
+          "id": 336,
           "interval": null,
           "legend": {
             "show": false
@@ -47936,7 +48069,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 336,
+          "id": 337,
           "interval": null,
           "legend": {
             "show": false
@@ -48037,7 +48170,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 337,
+      "id": 338,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -48076,7 +48209,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 338,
+          "id": 339,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -48224,7 +48357,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 339,
+          "id": 340,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -48364,7 +48497,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 340,
+          "id": 341,
           "interval": null,
           "legend": {
             "show": false
@@ -48462,7 +48595,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 341,
+          "id": 342,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -48595,7 +48728,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 342,
+          "id": 343,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -48728,7 +48861,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 343,
+          "id": 344,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -48906,7 +49039,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 344,
+          "id": 345,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -49069,7 +49202,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 345,
+          "id": 346,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -49217,7 +49350,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 346,
+          "id": 347,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -49350,7 +49483,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 347,
+          "id": 348,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -49486,7 +49619,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 348,
+      "id": 349,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -49525,7 +49658,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 349,
+          "id": 350,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -49673,7 +49806,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 350,
+          "id": 351,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -49806,7 +49939,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 351,
+          "id": 352,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -49939,7 +50072,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 352,
+          "id": 353,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -50072,7 +50205,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 353,
+          "id": 354,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -50205,7 +50338,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 354,
+          "id": 355,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -50360,7 +50493,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 355,
+          "id": 356,
           "interval": null,
           "legend": {
             "show": false
@@ -50465,7 +50598,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 356,
+          "id": 357,
           "interval": null,
           "legend": {
             "show": false
@@ -50566,7 +50699,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 357,
+      "id": 358,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -50605,7 +50738,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 358,
+          "id": 359,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -50738,7 +50871,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 359,
+          "id": 360,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -50871,7 +51004,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 360,
+          "id": 361,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -51011,7 +51144,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 361,
+          "id": 362,
           "interval": null,
           "legend": {
             "show": false
@@ -51109,7 +51242,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 362,
+          "id": 363,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -51242,7 +51375,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 363,
+          "id": 364,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -51443,7 +51576,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 364,
+          "id": 365,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -51644,7 +51777,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 365,
+          "id": 366,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -51848,7 +51981,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 366,
+      "id": 367,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -51887,7 +52020,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 367,
+          "id": 368,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -52035,7 +52168,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 368,
+          "id": 369,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -52236,7 +52369,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 369,
+          "id": 370,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -52437,7 +52570,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 370,
+          "id": 371,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -52638,7 +52771,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 371,
+          "id": 372,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -52839,7 +52972,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 372,
+          "id": 373,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -52972,7 +53105,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 373,
+          "id": 374,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -53105,7 +53238,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 374,
+          "id": 375,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -53238,7 +53371,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 375,
+          "id": 376,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -53371,7 +53504,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 376,
+          "id": 377,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -53572,7 +53705,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 377,
+          "id": 378,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -53780,7 +53913,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 378,
+          "id": 379,
           "interval": null,
           "legend": {
             "show": false
@@ -53881,7 +54014,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 379,
+      "id": 380,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -53927,7 +54060,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 380,
+          "id": 381,
           "interval": null,
           "legend": {
             "show": false
@@ -54025,7 +54158,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 381,
+          "id": 382,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -54226,7 +54359,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 382,
+          "id": 383,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -54359,7 +54492,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 383,
+          "id": 384,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -54492,7 +54625,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 384,
+          "id": 385,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -54625,7 +54758,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 385,
+          "id": 386,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -54826,7 +54959,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 386,
+          "id": 387,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -54959,7 +55092,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 387,
+          "id": 388,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -55092,7 +55225,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 388,
+          "id": 389,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -55228,7 +55361,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 389,
+      "id": 390,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -55267,7 +55400,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 390,
+          "id": 391,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -55468,7 +55601,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 391,
+          "id": 392,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -55669,7 +55802,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 392,
+          "id": 393,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -55870,7 +56003,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 393,
+          "id": 394,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -56071,7 +56204,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 394,
+          "id": 395,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -56204,7 +56337,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 395,
+          "id": 396,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -56337,7 +56470,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 396,
+          "id": 397,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -56470,7 +56603,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 397,
+          "id": 398,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -56603,7 +56736,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 398,
+          "id": 399,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -56736,7 +56869,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 399,
+          "id": 400,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -56876,7 +57009,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 400,
+          "id": 401,
           "interval": null,
           "legend": {
             "show": false
@@ -56974,7 +57107,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 401,
+          "id": 402,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -57182,7 +57315,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 402,
+          "id": 403,
           "interval": null,
           "legend": {
             "show": false
@@ -57280,7 +57413,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 403,
+          "id": 404,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -57481,7 +57614,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 404,
+          "id": 405,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -57617,7 +57750,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 405,
+      "id": 406,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -57656,7 +57789,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 406,
+          "id": 407,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -57789,7 +57922,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 407,
+          "id": 408,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -57922,7 +58055,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 408,
+          "id": 409,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -58062,7 +58195,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 409,
+          "id": 410,
           "interval": null,
           "legend": {
             "show": false
@@ -58160,7 +58293,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 410,
+          "id": 411,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -58293,7 +58426,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 411,
+          "id": 412,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -58494,7 +58627,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 412,
+          "id": 413,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -58695,7 +58828,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 413,
+          "id": 414,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -58899,7 +59032,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 414,
+      "id": 415,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -58938,7 +59071,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 415,
+          "id": 416,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -59116,7 +59249,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 416,
+          "id": 417,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -59317,7 +59450,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 417,
+          "id": 418,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -59450,7 +59583,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 418,
+          "id": 419,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -59583,7 +59716,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 419,
+          "id": 420,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -59716,7 +59849,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 420,
+          "id": 421,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -59849,7 +59982,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 421,
+          "id": 422,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -59982,7 +60115,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 422,
+          "id": 423,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -60111,7 +60244,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 423,
+          "id": 424,
           "interval": null,
           "links": [],
           "maxDataPoints": 100,
@@ -60186,7 +60319,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 424,
+          "id": 425,
           "interval": null,
           "links": [],
           "maxDataPoints": 100,
@@ -60265,7 +60398,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 425,
+          "id": 426,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -60518,7 +60651,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 426,
+          "id": 427,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -60651,7 +60784,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 427,
+          "id": 428,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -60784,7 +60917,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 428,
+          "id": 429,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -60985,7 +61118,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 429,
+          "id": 430,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -61133,7 +61266,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 430,
+          "id": 431,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -61334,7 +61467,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 431,
+          "id": 432,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -61535,7 +61668,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 432,
+          "id": 433,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -61736,7 +61869,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 433,
+          "id": 434,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -61940,7 +62073,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 434,
+      "id": 435,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -61979,7 +62112,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 435,
+          "id": 436,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -62127,7 +62260,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 436,
+          "id": 437,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -62260,7 +62393,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 437,
+          "id": 438,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -62461,7 +62594,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 438,
+          "id": 439,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -62609,7 +62742,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 439,
+          "id": 440,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -62810,7 +62943,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 440,
+          "id": 441,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -62943,7 +63076,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 441,
+          "id": 442,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -63076,7 +63209,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 442,
+          "id": 443,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -63209,7 +63342,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 443,
+          "id": 444,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -63342,7 +63475,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 444,
+          "id": 445,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -63482,7 +63615,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 445,
+          "id": 446,
           "interval": null,
           "legend": {
             "show": false
@@ -63580,7 +63713,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 446,
+          "id": 447,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -63784,7 +63917,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 447,
+      "id": 448,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -63823,7 +63956,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 448,
+          "id": 449,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -63956,7 +64089,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 449,
+          "id": 450,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -64089,7 +64222,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 450,
+          "id": 451,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -64222,7 +64355,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 451,
+          "id": 452,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -64358,7 +64491,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 452,
+      "id": 453,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -64397,7 +64530,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 453,
+          "id": 454,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -64530,7 +64663,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 454,
+          "id": 455,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -64663,7 +64796,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 455,
+          "id": 456,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -64811,7 +64944,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 456,
+          "id": 457,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -64944,7 +65077,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 457,
+          "id": 458,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -65077,7 +65210,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 458,
+          "id": 459,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -65210,7 +65343,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 459,
+          "id": 460,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -65346,7 +65479,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 460,
+      "id": 461,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -65385,7 +65518,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 461,
+          "id": 462,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -65518,7 +65651,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 462,
+          "id": 463,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -65651,7 +65784,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 463,
+          "id": 464,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -65784,7 +65917,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 464,
+          "id": 465,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -65917,7 +66050,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 465,
+          "id": 466,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -66050,7 +66183,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 466,
+          "id": 467,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -66183,7 +66316,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 467,
+          "id": 468,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -66319,7 +66452,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 468,
+      "id": 469,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -66358,7 +66491,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 469,
+          "id": 470,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -66491,7 +66624,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 470,
+          "id": 471,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -66639,7 +66772,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 471,
+          "id": 472,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -66787,7 +66920,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 472,
+          "id": 473,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -66950,7 +67083,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 473,
+          "id": 474,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -67083,7 +67216,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 474,
+          "id": 475,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -67216,7 +67349,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 475,
+          "id": 476,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -67379,7 +67512,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 476,
+          "id": 477,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -67527,7 +67660,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 477,
+          "id": 478,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -67663,7 +67796,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 478,
+      "id": 479,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -67702,7 +67835,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 479,
+          "id": 480,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -67835,7 +67968,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 480,
+          "id": 481,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -67968,7 +68101,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 481,
+          "id": 482,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -68101,7 +68234,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 482,
+          "id": 483,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -68234,7 +68367,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 483,
+          "id": 484,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -68367,7 +68500,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 484,
+          "id": 485,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -68500,7 +68633,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 485,
+          "id": 486,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -68633,7 +68766,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 486,
+          "id": 487,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -68766,7 +68899,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 487,
+          "id": 488,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -68906,7 +69039,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 488,
+          "id": 489,
           "interval": null,
           "legend": {
             "show": false
@@ -69004,7 +69137,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 489,
+          "id": 490,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -69137,7 +69270,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 490,
+          "id": 491,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -69285,7 +69418,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 491,
+          "id": 492,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -69433,7 +69566,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 492,
+          "id": 493,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -69573,7 +69706,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 493,
+          "id": 494,
           "interval": null,
           "legend": {
             "show": false
@@ -69671,7 +69804,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 494,
+          "id": 495,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -69804,7 +69937,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 495,
+          "id": 496,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -69940,7 +70073,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 496,
+      "id": 497,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -69979,7 +70112,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 497,
+          "id": 498,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -70112,7 +70245,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 498,
+          "id": 499,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -70275,7 +70408,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 499,
+          "id": 500,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -70423,7 +70556,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 500,
+          "id": 501,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -70556,7 +70689,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 501,
+          "id": 502,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -70696,7 +70829,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 502,
+          "id": 503,
           "interval": null,
           "legend": {
             "show": false
@@ -70801,7 +70934,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 503,
+          "id": 504,
           "interval": null,
           "legend": {
             "show": false
@@ -70906,7 +71039,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 504,
+          "id": 505,
           "interval": null,
           "legend": {
             "show": false
@@ -71004,7 +71137,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 505,
+          "id": 506,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -71144,7 +71277,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 506,
+          "id": 507,
           "interval": null,
           "legend": {
             "show": false
@@ -71249,7 +71382,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 507,
+          "id": 508,
           "interval": null,
           "legend": {
             "show": false
@@ -71354,7 +71487,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 508,
+          "id": 509,
           "interval": null,
           "legend": {
             "show": false
@@ -71452,7 +71585,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 509,
+          "id": 510,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -71585,7 +71718,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 510,
+          "id": 511,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -71718,7 +71851,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 511,
+          "id": 512,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -71858,7 +71991,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 512,
+          "id": 513,
           "interval": null,
           "legend": {
             "show": false
@@ -71956,7 +72089,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 513,
+          "id": 514,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -72092,7 +72225,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 514,
+      "id": 515,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -72131,7 +72264,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 515,
+          "id": 516,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -72294,7 +72427,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 516,
+          "id": 517,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -72427,7 +72560,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 517,
+          "id": 518,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -72567,7 +72700,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 518,
+          "id": 519,
           "interval": null,
           "legend": {
             "show": false
@@ -72672,7 +72805,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 519,
+          "id": 520,
           "interval": null,
           "legend": {
             "show": false
@@ -72770,7 +72903,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 520,
+          "id": 521,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -72925,7 +73058,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 521,
+          "id": 522,
           "interval": null,
           "legend": {
             "show": false
@@ -73030,7 +73163,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 522,
+          "id": 523,
           "interval": null,
           "legend": {
             "show": false
@@ -73135,7 +73268,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 523,
+          "id": 524,
           "interval": null,
           "legend": {
             "show": false
@@ -73233,7 +73366,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 524,
+          "id": 525,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -73403,7 +73536,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 525,
+          "id": 526,
           "interval": null,
           "legend": {
             "show": false
@@ -73501,7 +73634,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 526,
+          "id": 527,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -73702,7 +73835,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 527,
+          "id": 528,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -73903,7 +74036,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 528,
+          "id": 529,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -74036,7 +74169,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 529,
+          "id": 530,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -74199,7 +74332,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 530,
+          "id": 531,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -74332,7 +74465,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 531,
+          "id": 532,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -74465,7 +74598,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 532,
+          "id": 533,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -74666,7 +74799,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 533,
+          "id": 534,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -74799,7 +74932,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 534,
+          "id": 535,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -74939,7 +75072,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 535,
+          "id": 536,
           "interval": null,
           "legend": {
             "show": false
@@ -75044,7 +75177,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 536,
+          "id": 537,
           "interval": null,
           "legend": {
             "show": false
@@ -75149,7 +75282,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 537,
+          "id": 538,
           "interval": null,
           "legend": {
             "show": false
@@ -75254,7 +75387,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 538,
+          "id": 539,
           "interval": null,
           "legend": {
             "show": false
@@ -75359,7 +75492,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 539,
+          "id": 540,
           "interval": null,
           "legend": {
             "show": false
@@ -75464,7 +75597,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 540,
+          "id": 541,
           "interval": null,
           "legend": {
             "show": false
@@ -75569,7 +75702,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 541,
+          "id": 542,
           "interval": null,
           "legend": {
             "show": false
@@ -75667,7 +75800,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 542,
+          "id": 543,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -75815,7 +75948,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 543,
+          "id": 544,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -75948,7 +76081,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 544,
+          "id": 545,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -76081,7 +76214,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 545,
+          "id": 546,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -76229,7 +76362,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 546,
+          "id": 547,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -76365,7 +76498,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 547,
+      "id": 548,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -76416,7 +76549,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 548,
+          "id": 549,
           "interval": null,
           "links": [],
           "maxDataPoints": 100,
@@ -76512,7 +76645,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 549,
+          "id": 550,
           "interval": null,
           "links": [],
           "maxDataPoints": 100,
@@ -76587,7 +76720,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 550,
+          "id": 551,
           "interval": null,
           "links": [],
           "maxDataPoints": 100,
@@ -76662,7 +76795,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 551,
+          "id": 552,
           "interval": null,
           "links": [],
           "maxDataPoints": 100,
@@ -76737,7 +76870,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 552,
+          "id": 553,
           "interval": null,
           "links": [],
           "maxDataPoints": 100,
@@ -76812,7 +76945,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 553,
+          "id": 554,
           "interval": null,
           "links": [],
           "maxDataPoints": 100,
@@ -76887,7 +77020,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 554,
+          "id": 555,
           "interval": null,
           "links": [],
           "maxDataPoints": 100,
@@ -76962,7 +77095,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 555,
+          "id": 556,
           "interval": null,
           "links": [],
           "maxDataPoints": 100,
@@ -77041,7 +77174,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 556,
+          "id": 557,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -77174,7 +77307,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 557,
+          "id": 558,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -77307,7 +77440,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 558,
+          "id": 559,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -77440,7 +77573,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 559,
+          "id": 560,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -77573,7 +77706,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 560,
+          "id": 561,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -77706,7 +77839,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 561,
+          "id": 562,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -77854,7 +77987,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 562,
+          "id": 563,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -77987,7 +78120,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 563,
+          "id": 564,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -78120,7 +78253,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 564,
+          "id": 565,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -78286,7 +78419,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 565,
+          "id": 566,
           "interval": null,
           "legend": {
             "show": false
@@ -78391,7 +78524,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 566,
+          "id": 567,
           "interval": null,
           "legend": {
             "show": false
@@ -78496,7 +78629,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 567,
+          "id": 568,
           "interval": null,
           "legend": {
             "show": false
@@ -78601,7 +78734,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 568,
+          "id": 569,
           "interval": null,
           "legend": {
             "show": false
@@ -78706,7 +78839,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 569,
+          "id": 570,
           "interval": null,
           "legend": {
             "show": false
@@ -78811,7 +78944,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 570,
+          "id": 571,
           "interval": null,
           "legend": {
             "show": false
@@ -78916,7 +79049,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 571,
+          "id": 572,
           "interval": null,
           "legend": {
             "show": false
@@ -79021,7 +79154,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 572,
+          "id": 573,
           "interval": null,
           "legend": {
             "show": false
@@ -79119,7 +79252,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 573,
+          "id": 574,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -79252,7 +79385,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 574,
+          "id": 575,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -79385,7 +79518,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 575,
+          "id": 576,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -79518,7 +79651,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 576,
+          "id": 577,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -79651,7 +79784,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 577,
+          "id": 578,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -79784,7 +79917,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 578,
+          "id": 579,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -79917,7 +80050,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 579,
+          "id": 580,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -80050,7 +80183,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 580,
+          "id": 581,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -80183,7 +80316,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 581,
+          "id": 582,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -80316,7 +80449,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 582,
+          "id": 583,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -80456,7 +80589,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 583,
+          "id": 584,
           "interval": null,
           "legend": {
             "show": false
@@ -80561,7 +80694,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 584,
+          "id": 585,
           "interval": null,
           "legend": {
             "show": false
@@ -80659,7 +80792,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 585,
+          "id": 586,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -80792,7 +80925,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 586,
+          "id": 587,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -80925,7 +81058,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 587,
+          "id": 588,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -81058,7 +81191,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 588,
+          "id": 589,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -81191,7 +81324,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 589,
+          "id": 590,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -81324,7 +81457,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 590,
+          "id": 591,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -81457,7 +81590,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 591,
+          "id": 592,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -81590,7 +81723,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 592,
+          "id": 593,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -81723,7 +81856,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 593,
+          "id": 594,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -81856,7 +81989,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 594,
+          "id": 595,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -81992,7 +82125,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 595,
+      "id": 596,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -82031,7 +82164,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 596,
+          "id": 597,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -82179,7 +82312,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 597,
+          "id": 598,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -82312,7 +82445,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 598,
+          "id": 599,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -82445,7 +82578,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 599,
+          "id": 600,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -82581,7 +82714,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 600,
+      "id": 601,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -82620,7 +82753,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 601,
+          "id": 602,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -82753,7 +82886,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 602,
+          "id": 603,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -82886,7 +83019,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 603,
+          "id": 604,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -83019,7 +83152,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 604,
+          "id": 605,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -83152,7 +83285,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 605,
+          "id": 606,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -83285,7 +83418,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 606,
+          "id": 607,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -83421,7 +83554,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 607,
+      "id": 608,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -83460,7 +83593,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 608,
+          "id": 609,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -83593,7 +83726,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 609,
+          "id": 610,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -83726,7 +83859,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 610,
+          "id": 611,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -83889,7 +84022,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 611,
+          "id": 612,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -84025,7 +84158,1226 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 612,
+      "id": 613,
+      "interval": null,
+      "links": [],
+      "maxDataPoints": 100,
+      "maxPerRow": null,
+      "minSpan": null,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "cacheTimeout": null,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "Historical baseline and current CPU utilization % per resource group (100% = 1 core).",
+          "editable": true,
+          "error": false,
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              }
+            }
+          },
+          "fill": 1,
+          "fillGradient": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 0
+          },
+          "height": null,
+          "hideTimeOverride": false,
+          "id": 614,
+          "interval": null,
+          "isNew": true,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": null,
+            "sort": "max",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "maxDataPoints": null,
+          "maxPerRow": null,
+          "minSpan": null,
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true,
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "repeatDirection": null,
+          "seriesOverrides": [],
+          "span": null,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "sum((\n    tikv_resource_control_group_ru_historical_rate\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    \n)) by (resource_group)  > 0",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "historical-{{resource_group}}",
+              "metric": "",
+              "query": "sum((\n    tikv_resource_control_group_ru_historical_rate\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    \n)) by (resource_group)  > 0",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            },
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "sum((\n    tikv_resource_control_group_ru_current_rate\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    \n)) by (resource_group)  > 0",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "current-{{resource_group}}",
+              "metric": "",
+              "query": "sum((\n    tikv_resource_control_group_ru_current_rate\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    \n)) by (resource_group)  > 0",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "CPU Utilization % per Resource Group",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "transformations": [],
+          "transparent": false,
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "percent",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": 0
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "cacheTimeout": null,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "Total resource utilization percentage of background tasks.",
+          "editable": true,
+          "error": false,
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              }
+            }
+          },
+          "fill": 1,
+          "fillGradient": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 0
+          },
+          "height": null,
+          "hideTimeOverride": false,
+          "id": 615,
+          "interval": null,
+          "isNew": true,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": null,
+            "sort": "max",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "maxDataPoints": null,
+          "maxPerRow": null,
+          "minSpan": null,
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true,
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "repeatDirection": null,
+          "seriesOverrides": [],
+          "span": null,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "sum((\n    tikv_resource_control_bg_resource_utilization\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    \n)) by (type)  > 0",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{type}}",
+              "metric": "",
+              "query": "sum((\n    tikv_resource_control_bg_resource_utilization\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    \n)) by (type)  > 0",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Background Resource Utilization",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "transformations": [],
+          "transparent": false,
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "percent",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": 0
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "cacheTimeout": null,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "Current rate limit per resource group (0 = unlimited, hidden).",
+          "editable": true,
+          "error": false,
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              }
+            }
+          },
+          "fill": 1,
+          "fillGradient": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 7
+          },
+          "height": null,
+          "hideTimeOverride": false,
+          "id": 616,
+          "interval": null,
+          "isNew": true,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": null,
+            "sort": "max",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "maxDataPoints": null,
+          "maxPerRow": null,
+          "minSpan": null,
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true,
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "repeatDirection": null,
+          "seriesOverrides": [],
+          "span": null,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "sum((\n    tikv_resource_control_group_quota_limit\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    \n)) by (resource_group, type)  > 0",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{resource_group}}-{{type}}",
+              "metric": "",
+              "query": "sum((\n    tikv_resource_control_group_quota_limit\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    \n)) by (resource_group, type)  > 0",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Resource Group Quota Limit",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "transformations": [],
+          "transparent": false,
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "none",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": 0
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "cacheTimeout": null,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "Current quota limit for background resource groups.",
+          "editable": true,
+          "error": false,
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              }
+            }
+          },
+          "fill": 1,
+          "fillGradient": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 7
+          },
+          "height": null,
+          "hideTimeOverride": false,
+          "id": 617,
+          "interval": null,
+          "isNew": true,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": null,
+            "sort": "max",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "maxDataPoints": null,
+          "maxPerRow": null,
+          "minSpan": null,
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true,
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "repeatDirection": null,
+          "seriesOverrides": [],
+          "span": null,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "sum((\n    tikv_resource_control_background_quota_limiter\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    \n)) by (resource_group, type)  > 0",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{resource_group}}-{{type}}",
+              "metric": "",
+              "query": "sum((\n    tikv_resource_control_background_quota_limiter\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    \n)) by (resource_group, type)  > 0",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Background Quota Limit",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "transformations": [],
+          "transparent": false,
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "none",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": 0
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "cacheTimeout": null,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "Rate of deprioritized (phase 1), delayed, and rejected requests.",
+          "editable": true,
+          "error": false,
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              }
+            }
+          },
+          "fill": 1,
+          "fillGradient": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 14
+          },
+          "height": null,
+          "hideTimeOverride": false,
+          "id": 618,
+          "interval": null,
+          "isNew": true,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": null,
+            "sort": "max",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "maxDataPoints": null,
+          "maxPerRow": null,
+          "minSpan": null,
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true,
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "repeatDirection": null,
+          "seriesOverrides": [],
+          "span": null,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "sum(rate(\n    tikv_resource_control_two_phase_throttled_requests_total\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (resource_group)  > 0",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "deprioritized-{{resource_group}}",
+              "metric": "",
+              "query": "sum(rate(\n    tikv_resource_control_two_phase_throttled_requests_total\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (resource_group)  > 0",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            },
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "sum(rate(\n    tikv_resource_control_admission_delayed_requests_total\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (resource_group, is_background)  > 0",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "delayed-{{resource_group}}-{{is_background}}",
+              "metric": "",
+              "query": "sum(rate(\n    tikv_resource_control_admission_delayed_requests_total\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (resource_group, is_background)  > 0",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            },
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "sum(rate(\n    tikv_resource_control_admission_rejected_requests_total\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (resource_group, is_background)  > 0",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "rejected-{{resource_group}}-{{is_background}}",
+              "metric": "",
+              "query": "sum(rate(\n    tikv_resource_control_admission_rejected_requests_total\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (resource_group, is_background)  > 0",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Deprioritized / Delayed / Rejected Requests",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "transformations": [],
+          "transparent": false,
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "ops",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": 0
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "cacheTimeout": null,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "Number of requests currently sitting in admission control delay.",
+          "editable": true,
+          "error": false,
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              }
+            }
+          },
+          "fill": 1,
+          "fillGradient": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 14
+          },
+          "height": null,
+          "hideTimeOverride": false,
+          "id": 619,
+          "interval": null,
+          "isNew": true,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": null,
+            "sort": "max",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "maxDataPoints": null,
+          "maxPerRow": null,
+          "minSpan": null,
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true,
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "repeatDirection": null,
+          "seriesOverrides": [],
+          "span": null,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "sum((\n    tikv_resource_control_admission_currently_delayed\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    \n)) by (instance)  > 0",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{instance}}",
+              "metric": "",
+              "query": "sum((\n    tikv_resource_control_admission_currently_delayed\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    \n)) by (instance)  > 0",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Currently Delayed Requests",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "transformations": [],
+          "transparent": false,
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "none",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": 0
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "cacheTimeout": null,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "Delay duration imposed by foreground admission control.",
+          "editable": true,
+          "error": false,
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              }
+            }
+          },
+          "fill": 1,
+          "fillGradient": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 21
+          },
+          "height": null,
+          "hideTimeOverride": false,
+          "id": 620,
+          "interval": null,
+          "isNew": true,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": null,
+            "sort": "max",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "maxDataPoints": null,
+          "maxPerRow": null,
+          "minSpan": null,
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true,
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "repeatDirection": null,
+          "seriesOverrides": [
+            {
+              "alias": "/^count/",
+              "bars": false,
+              "dashLength": 1,
+              "dashes": true,
+              "fill": 2,
+              "fillBelowTo": null,
+              "lines": true,
+              "spaceLength": 1,
+              "transform": "negative-Y",
+              "yaxis": 2,
+              "zindex": -3
+            },
+            {
+              "alias": "/^avg/",
+              "bars": false,
+              "fill": 7,
+              "fillBelowTo": null,
+              "lines": true,
+              "yaxis": 1,
+              "zindex": 0
+            }
+          ],
+          "span": null,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "histogram_quantile(0.9999,(\n    sum(rate(\n    tikv_resource_control_admission_delay_duration_seconds_bucket\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",is_background=\"false\"}\n    [$__rate_interval]\n)) by (resource_group, le, $additional_groupby) \n    \n    \n))  ",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "99.99%-{{resource_group}} {{$additional_groupby}}",
+              "metric": "",
+              "query": "histogram_quantile(0.9999,(\n    sum(rate(\n    tikv_resource_control_admission_delay_duration_seconds_bucket\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",is_background=\"false\"}\n    [$__rate_interval]\n)) by (resource_group, le, $additional_groupby) \n    \n    \n))  ",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            },
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "histogram_quantile(0.99,(\n    sum(rate(\n    tikv_resource_control_admission_delay_duration_seconds_bucket\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",is_background=\"false\"}\n    [$__rate_interval]\n)) by (resource_group, le, $additional_groupby) \n    \n    \n))  ",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "99%-{{resource_group}} {{$additional_groupby}}",
+              "metric": "",
+              "query": "histogram_quantile(0.99,(\n    sum(rate(\n    tikv_resource_control_admission_delay_duration_seconds_bucket\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",is_background=\"false\"}\n    [$__rate_interval]\n)) by (resource_group, le, $additional_groupby) \n    \n    \n))  ",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            },
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "(sum(rate(\n    tikv_resource_control_admission_delay_duration_seconds_sum\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",is_background=\"false\"}\n    [$__rate_interval]\n)) by (resource_group, $additional_groupby)  / sum(rate(\n    tikv_resource_control_admission_delay_duration_seconds_count\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",is_background=\"false\"}\n    [$__rate_interval]\n)) by (resource_group, $additional_groupby) )",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "avg-{{resource_group}} {{$additional_groupby}}",
+              "metric": "",
+              "query": "(sum(rate(\n    tikv_resource_control_admission_delay_duration_seconds_sum\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",is_background=\"false\"}\n    [$__rate_interval]\n)) by (resource_group, $additional_groupby)  / sum(rate(\n    tikv_resource_control_admission_delay_duration_seconds_count\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",is_background=\"false\"}\n    [$__rate_interval]\n)) by (resource_group, $additional_groupby) )",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            },
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "sum(rate(\n    tikv_resource_control_admission_delay_duration_seconds_count\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",is_background=\"false\"}\n    [$__rate_interval]\n)) by (resource_group, $additional_groupby) ",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "count-{{resource_group}} {{$additional_groupby}}",
+              "metric": "",
+              "query": "sum(rate(\n    tikv_resource_control_admission_delay_duration_seconds_count\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",is_background=\"false\"}\n    [$__rate_interval]\n)) by (resource_group, $additional_groupby) ",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Admission Delay Duration",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "transformations": [],
+          "transparent": false,
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "s",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": 0
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "cacheTimeout": null,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "Total wait duration of background tasks per resource group.",
+          "editable": true,
+          "error": false,
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              }
+            }
+          },
+          "fill": 1,
+          "fillGradient": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 21
+          },
+          "height": null,
+          "hideTimeOverride": false,
+          "id": 621,
+          "interval": null,
+          "isNew": true,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": null,
+            "sort": "max",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "maxDataPoints": null,
+          "maxPerRow": null,
+          "minSpan": null,
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true,
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "repeatDirection": null,
+          "seriesOverrides": [],
+          "span": null,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "sum(rate(\n    tikv_resource_control_background_task_wait_duration\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (resource_group)  > 0",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{resource_group}}",
+              "metric": "",
+              "query": "sum(rate(\n    tikv_resource_control_background_task_wait_duration\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (resource_group)  > 0",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Background Task Wait Duration",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "transformations": [],
+          "transparent": false,
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "\u00b5s",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": 0
+          }
+        }
+      ],
+      "repeat": null,
+      "repeatDirection": null,
+      "span": null,
+      "targets": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Load Shedding",
+      "transformations": [],
+      "transparent": false,
+      "type": "row"
+    },
+    {
+      "cacheTimeout": null,
+      "collapsed": true,
+      "datasource": null,
+      "description": null,
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          }
+        }
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "height": null,
+      "hideTimeOverride": false,
+      "id": 622,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -84064,7 +85416,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 613,
+          "id": 623,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -84265,7 +85617,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 614,
+          "id": 624,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -84401,7 +85753,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 615,
+      "id": 625,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -84440,7 +85792,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 616,
+          "id": 626,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -84573,7 +85925,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 617,
+          "id": 627,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -84706,7 +86058,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 618,
+          "id": 628,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -84839,7 +86191,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 619,
+          "id": 629,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -84972,7 +86324,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 620,
+          "id": 630,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -85120,7 +86472,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 621,
+          "id": 631,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -85324,7 +86676,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 622,
+      "id": 632,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -85363,7 +86715,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 623,
+          "id": 633,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -85496,7 +86848,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 624,
+          "id": 634,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -85629,7 +86981,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 625,
+          "id": 635,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -85762,7 +87114,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 626,
+          "id": 636,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -85895,7 +87247,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 627,
+          "id": 637,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -86092,7 +87444,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 628,
+          "id": 638,
           "interval": null,
           "links": [],
           "maxDataPoints": 100,
@@ -86174,7 +87526,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 629,
+      "id": 639,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -86243,7 +87595,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 630,
+          "id": 640,
           "interval": null,
           "links": [],
           "mappings": [],
@@ -86360,7 +87712,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 631,
+          "id": 641,
           "interval": null,
           "links": [],
           "mappings": [],
@@ -86477,7 +87829,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 632,
+          "id": 642,
           "interval": null,
           "links": [],
           "mappings": [],
@@ -86594,7 +87946,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 633,
+          "id": 643,
           "interval": null,
           "links": [],
           "mappings": [],

--- a/metrics/grafana/tikv_details.json.sha256
+++ b/metrics/grafana/tikv_details.json.sha256
@@ -1,1 +1,1 @@
-684959591f8de0842dc35fec550c3722852db60080b8df197087f4c18493c384  ./metrics/grafana/tikv_details.json
+052ba3e8ace04be4223f89d1efe57e37416911cb2fa4735ff93a3968da7e6e41  ./metrics/grafana/tikv_details.json


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: Close #19644

What's Changed:

- Add a per-poll `ExtraMessageFullLogLimiter` keyed by `(target_store_id, ExtraMessageType)`. When `Transport::send` of an ExtraMessage fails with `Transport(Full)`, emit the standard `failed to send extra message` WARN at most once per second per key; failures suppressed during the window are summed into a `suppressed_count` field that is included on the next emitted WARN. The WARN now also carries `target_store_id` for direct identification of the saturated peer.
- Failures with other transport reasons (`Disconnected`, `Paused`, `Filtered`) keep the original per-failure WARN behavior.
- Add `tikv_raftstore_extra_message_send_failure_total` (counter, labels `type` and `reason`). It is incremented on every failed `send_extra_message`, regardless of whether the WARN was emitted or suppressed, so failure rate stays observable through metrics.
- Change `Peer::send_extra_message` to take `&mut PollContext` instead of `&mut Transport` so the limiter can be reached from inside the method; update all call sites accordingly. In `on_refresh_region_buckets`, shorten the `store_meta` lock scope so the guard is dropped before the subsequent `send_extra_message` calls (required by the new borrow shape).

```commit-message
raftstore: rate-limit `failed to send extra message` WARN and add failure counter

When the transport channel toward a target store is full, every region/peer
that tries to broadcast an ExtraMessage (e.g. MsgHibernateRequest) to that
store today emits one WARN. Under cluster-wide back-pressure this single
log line can reach thousands of lines per second.

Introduce a per-poll ExtraMessageFullLogLimiter keyed by (target_store_id,
ExtraMessageType). On Transport(Full) failures we emit at most one WARN per
key per second, with a suppressed_count summarizing the failures hidden
during the window; non-Full failures keep the original WARN behavior. The
WARN now also carries target_store_id so the saturated store is identifiable
at a glance.

Add tikv_raftstore_extra_message_send_failure_total (labels: type, reason)
incremented on every failure regardless of whether the WARN was emitted, so
failure rate stays observable through metrics.

send_extra_message now takes &mut PollContext instead of &mut Transport so
the limiter can be reached from inside; all call sites and one store_meta
lock scope are updated accordingly.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [x] Need to cherry-pick to the release branch

### Check List

Tests

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note

```release-note
Deduplicate the raftstore `failed to send extra message` WARN log when the transport channel toward a target store is full: at most one line per second per `(target store, message type)`, with a `suppressed_count` field summarizing hidden failures. Failures with other reasons remain logged per occurrence. Add `tikv_raftstore_extra_message_send_failure_total` counter (labels `type`, `reason`) for failure observability.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Rate-limited repeated “full log” extra-message emissions to reduce noisy bursts.
  * Added a Prometheus counter for extra-message send failures (by message type and failure reason) and added a Grafana panel to visualize them.

* **Refactor**
  * Improved extra-message sending handling for consistent discard limiting and clearer failure tracking across leader- and follower-driven flows.

* **Tests**
  * Added unit tests validating the “full log” emission limiter behavior across time windows and message types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->