### PR TITLE
coprocessor: optimize batch analyze sub-task concurrency and streaming merge

### DIFF
--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -69,6 +69,12 @@ use crate::{
 /// light ones, which means they don't need a permit from the semaphore before
 /// execution.
 const LIGHT_TASK_THRESHOLD: Duration = Duration::from_millis(5);
+
+/// Maximum number of batch sub-tasks that run concurrently within a single
+/// batch ANALYZE request.  Limiting this avoids flooding the readpool semaphore
+/// when a large batch arrives, while still providing enough parallelism to keep
+/// the pipeline busy.
+const BATCH_SUB_TASK_CONCURRENCY: usize = 3;
 fn elapsed_ms(start: Instant) -> u64 {
     start.saturating_elapsed().as_millis() as u64
 }
@@ -136,6 +142,19 @@ struct AnalyzeFullSamplingBatchTaskResult {
     sampling_result: Option<AnalyzeSamplingResult>,
 }
 
+/// Result of batch sub-task processing with streaming merge.
+enum AnalyzeFullSamplingBatchMergeResult {
+    /// All sub-tasks succeeded; their sampling results have been merged
+    /// incrementally as each sub-task completed, keeping peak memory low.
+    Merged {
+        merged: AnalyzeSamplingResult,
+        task_count: usize,
+    },
+    /// At least one sub-task had an error; individual results returned for
+    /// TiDB to handle per-region retry.
+    Individual(Vec<AnalyzeFullSamplingBatchTaskResult>),
+}
+
 fn set_analyze_sampling_response_data(
     resp: &mut coppb::Response,
     sampling_result: AnalyzeSamplingResult,
@@ -179,67 +198,84 @@ fn analyze_full_sampling_batch_response(
 
 fn finish_analyze_full_sampling_batch_response(
     mut top: AnalyzeFullSamplingTaskResult,
-    mut batch_outputs: Vec<AnalyzeFullSamplingBatchTaskResult>,
+    batch_result: AnalyzeFullSamplingBatchMergeResult,
 ) -> Result<coppb::Response> {
     let finish_start = Instant::now();
-    let can_reduce = !response_has_error(&top.response)
-        && top.sampling_result.is_some()
-        && batch_outputs.iter().all(|output| {
-            !response_has_error(&output.response) && output.sampling_result.is_some()
-        });
-
-    if can_reduce {
-        let batch_task_count = batch_outputs.len();
-        let merge_start = Instant::now();
-        let mut merged = top.sampling_result.take().unwrap();
-        for output in &mut batch_outputs {
-            merged.merge_from(output.sampling_result.take().unwrap())?;
+    match batch_result {
+        AnalyzeFullSamplingBatchMergeResult::Merged { merged, task_count }
+            if !response_has_error(&top.response) && top.sampling_result.is_some() =>
+        {
+            // Both top and batch succeeded — merge top into the pre-merged batch result.
+            let merge_start = Instant::now();
+            let mut top_sr = top.sampling_result.take().unwrap();
+            top_sr.merge_from(merged)?;
+            info!("analyze full sampling trace";
+                "component" => "tikv",
+                "phase" => "tikv.merge_sampling_results",
+                "event" => "finish",
+                "success" => true,
+                "elapsed_ms" => elapsed_ms(merge_start),
+                "total_task_count" => task_count + 1,
+                "batch_task_count" => task_count,
+            );
+            set_analyze_sampling_response_data(&mut top.response, top_sr, "reduced_top")?;
+            top.response.set_batch_responses(Default::default());
+            info!("analyze full sampling trace";
+                "component" => "tikv",
+                "phase" => "tikv.reduce_batch_response",
+                "event" => "finish",
+                "success" => true,
+                "reduced" => true,
+                "elapsed_ms" => elapsed_ms(finish_start),
+                "total_task_count" => task_count + 1,
+                "batch_task_count" => task_count,
+                "response_bytes" => top.response.get_data().len(),
+            );
+            Ok(top.response)
         }
-        info!("analyze full sampling trace";
-            "component" => "tikv",
-            "phase" => "tikv.merge_sampling_results",
-            "event" => "finish",
-            "success" => true,
-            "elapsed_ms" => elapsed_ms(merge_start),
-            "total_task_count" => batch_task_count + 1,
-            "batch_task_count" => batch_task_count,
-        );
-        set_analyze_sampling_response_data(&mut top.response, merged, "reduced_top")?;
-        top.response.set_batch_responses(Default::default());
-        info!("analyze full sampling trace";
-            "component" => "tikv",
-            "phase" => "tikv.reduce_batch_response",
-            "event" => "finish",
-            "success" => true,
-            "reduced" => true,
-            "elapsed_ms" => elapsed_ms(finish_start),
-            "total_task_count" => batch_task_count + 1,
-            "batch_task_count" => batch_task_count,
-            "response_bytes" => top.response.get_data().len(),
-        );
-        return Ok(top.response);
+        _ => {
+            // Fallback: top had error OR batch had errors → individual responses.
+            let batch_outputs = match batch_result {
+                AnalyzeFullSamplingBatchMergeResult::Individual(outputs) => outputs,
+                AnalyzeFullSamplingBatchMergeResult::Merged { merged, .. } => {
+                    // Top failed but batch was pre-merged. We cannot split the
+                    // merge back into individual results, so we pack the merged
+                    // result as a single batch response entry.
+                    let mut resp = coppb::Response::default();
+                    set_analyze_sampling_response_data(&mut resp, merged, "merged_fallback")?;
+                    vec![AnalyzeFullSamplingBatchTaskResult {
+                        task_id: 0,
+                        response: resp,
+                        sampling_result: None,
+                    }]
+                }
+            };
+            if let Some(sampling_result) = top.sampling_result.take() {
+                set_analyze_sampling_response_data(
+                    &mut top.response,
+                    sampling_result,
+                    "fallback_top",
+                )?;
+            }
+            let mut batch_responses = Vec::with_capacity(batch_outputs.len());
+            for output in batch_outputs {
+                batch_responses.push(analyze_full_sampling_batch_response(output)?);
+            }
+            let batch_response_count = batch_responses.len();
+            top.response.set_batch_responses(batch_responses.into());
+            info!("analyze full sampling trace";
+                "component" => "tikv",
+                "phase" => "tikv.reduce_batch_response",
+                "event" => "finish",
+                "success" => true,
+                "reduced" => false,
+                "elapsed_ms" => elapsed_ms(finish_start),
+                "response_bytes" => top.response.get_data().len(),
+                "batch_response_count" => batch_response_count,
+            );
+            Ok(top.response)
+        }
     }
-
-    if let Some(sampling_result) = top.sampling_result.take() {
-        set_analyze_sampling_response_data(&mut top.response, sampling_result, "fallback_top")?;
-    }
-    let mut batch_responses = Vec::with_capacity(batch_outputs.len());
-    for output in batch_outputs {
-        batch_responses.push(analyze_full_sampling_batch_response(output)?);
-    }
-    let batch_response_count = batch_responses.len();
-    top.response.set_batch_responses(batch_responses.into());
-    info!("analyze full sampling trace";
-        "component" => "tikv",
-        "phase" => "tikv.reduce_batch_response",
-        "event" => "finish",
-        "success" => true,
-        "reduced" => false,
-        "elapsed_ms" => elapsed_ms(finish_start),
-        "response_bytes" => top.response.get_data().len(),
-        "batch_response_count" => batch_response_count,
-    );
-    Ok(top.response)
 }
 
 /// A pool to build and run Coprocessor request handlers.
@@ -1247,7 +1283,7 @@ impl<E: Engine> Endpoint<E> {
         &self,
         req: &mut coppb::Request,
         peer: &Option<String>,
-    ) -> impl Future<Output = Vec<AnalyzeFullSamplingBatchTaskResult>> {
+    ) -> impl Future<Output = AnalyzeFullSamplingBatchMergeResult> {
         let extract_start = Instant::now();
         let mut batch_futs = Vec::with_capacity(req.tasks.len());
         let batch_reqs: Vec<(coppb::Request, u64)> = req
@@ -1340,7 +1376,91 @@ impl<E: Engine> Endpoint<E> {
                 })),
             }
         }
-        stream::FuturesOrdered::from_iter(batch_futs).collect()
+        // Optimization 1: limit sub-task concurrency to avoid flooding the
+        // readpool semaphore.
+        // Optimization 2: merge sampling results incrementally as each
+        // sub-task completes, so only one merged result is held in memory
+        // instead of all N results simultaneously.
+        async move {
+            let mut stream = futures::stream::iter(batch_futs)
+                .buffered(BATCH_SUB_TASK_CONCURRENCY);
+            let merge_start = Instant::now();
+            let mut merged: Option<AnalyzeSamplingResult> = None;
+            let mut task_count: usize = 0;
+            let mut has_error = false;
+            let mut error_outputs: Vec<AnalyzeFullSamplingBatchTaskResult> = Vec::new();
+
+            while let Some(mut output) = stream.next().await {
+                if has_error
+                    || response_has_error(&output.response)
+                    || output.sampling_result.is_none()
+                {
+                    has_error = true;
+                    error_outputs.push(output);
+                } else {
+                    let sr = output.sampling_result.take().unwrap();
+                    match merged {
+                        None => merged = Some(sr),
+                        Some(ref mut m) => match m.merge_from(sr) {
+                            Ok(()) => {}
+                            Err(e) => {
+                                warn!("streaming merge failed, falling back"; "err" => ?e);
+                                has_error = true;
+                                error_outputs.push(output);
+                                continue;
+                            }
+                        },
+                    }
+                    task_count += 1;
+                    // output.sampling_result is now None; the response metadata
+                    // is small and dropped here — the heavy sampling data has
+                    // already been consumed by merge_from.
+                }
+            }
+
+            if has_error {
+                // Collect remaining: put already-merged results back as one entry
+                // so TiDB can still use them.
+                if let Some(m) = merged {
+                    let mut resp = coppb::Response::default();
+                    if let Err(e) = set_analyze_sampling_response_data(&mut resp, m, "partial_merge") {
+                        warn!("failed to serialize partial merge"; "err" => ?e);
+                    } else {
+                        error_outputs.insert(
+                            0,
+                            AnalyzeFullSamplingBatchTaskResult {
+                                task_id: 0,
+                                response: resp,
+                                sampling_result: None,
+                            },
+                        );
+                    }
+                }
+                info!("analyze full sampling trace";
+                    "component" => "tikv",
+                    "phase" => "tikv.streaming_merge_batch_tasks",
+                    "event" => "finish",
+                    "success" => false,
+                    "elapsed_ms" => elapsed_ms(merge_start),
+                    "merged_count" => task_count,
+                    "error_count" => error_outputs.len(),
+                );
+                AnalyzeFullSamplingBatchMergeResult::Individual(error_outputs)
+            } else {
+                info!("analyze full sampling trace";
+                    "component" => "tikv",
+                    "phase" => "tikv.streaming_merge_batch_tasks",
+                    "event" => "finish",
+                    "success" => true,
+                    "elapsed_ms" => elapsed_ms(merge_start),
+                    "task_count" => task_count,
+                );
+                AnalyzeFullSamplingBatchMergeResult::Merged {
+                    merged: merged.unwrap_or_default(),
+                    task_count,
+                }
+            }
+        }
     }
 
     /// The real implementation of handling a stream request.

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -149,12 +149,17 @@ fn finish_analyze_full_sampling_batch_response(
         });
 
     if can_reduce {
+        let batch_task_count = batch_outputs.len();
         let mut merged = top.sampling_result.take().unwrap();
         for output in &mut batch_outputs {
             merged.merge_from(output.sampling_result.take().unwrap())?;
         }
         set_analyze_sampling_response_data(&mut top.response, merged)?;
         top.response.set_batch_responses(Default::default());
+        info!("analyze full sampling batch reduce finished";
+            "total_task_count" => batch_task_count + 1,
+            "batch_task_count" => batch_task_count,
+        );
         return Ok(top.response);
     }
 

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -47,8 +47,12 @@ use tokio::sync::Semaphore;
 use super::config_manager::CopConfigManager;
 use crate::{
     coprocessor::{
-        cache::CachedRequestHandler, interceptors::*, metrics::*,
-        statistics::analyze_context::AnalyzeContext, tracker::Tracker, *,
+        cache::CachedRequestHandler,
+        interceptors::*,
+        metrics::*,
+        statistics::{analyze::AnalyzeSamplingResult, analyze_context::AnalyzeContext},
+        tracker::Tracker,
+        *,
     },
     read_pool::ReadPoolHandle,
     server::Config,
@@ -65,6 +69,105 @@ use crate::{
 /// light ones, which means they don't need a permit from the semaphore before
 /// execution.
 const LIGHT_TASK_THRESHOLD: Duration = Duration::from_millis(5);
+
+fn is_analyze_full_sampling_batch_request(req: &coppb::Request) -> bool {
+    if req.get_tp() != REQ_TYPE_ANALYZE || req.get_tasks().is_empty() {
+        return false;
+    }
+    let mut analyze = AnalyzeReq::default();
+    if Message::merge_from_bytes(&mut analyze, req.get_data()).is_err() {
+        return false;
+    }
+    analyze.get_tp() == AnalyzeType::TypeFullSampling && analyze.has_col_req()
+}
+
+fn response_has_error(resp: &coppb::Response) -> bool {
+    resp.has_region_error() || resp.has_locked() || !resp.get_other_error().is_empty()
+}
+
+fn record_coprocessor_response_size(resp_size: u64) {
+    COPR_RESP_SIZE.inc_by(resp_size);
+    record_network_out_bytes(resp_size);
+    with_tls_tracker(|tracker| {
+        tracker.metrics.coprocessor_response_bytes = tracker
+            .metrics
+            .coprocessor_response_bytes
+            .saturating_add(resp_size);
+    });
+}
+
+struct AnalyzeFullSamplingTaskResult {
+    response: coppb::Response,
+    sampling_result: Option<AnalyzeSamplingResult>,
+}
+
+struct AnalyzeFullSamplingBatchTaskResult {
+    task_id: u64,
+    response: coppb::Response,
+    sampling_result: Option<AnalyzeSamplingResult>,
+}
+
+fn set_analyze_sampling_response_data(
+    resp: &mut coppb::Response,
+    sampling_result: AnalyzeSamplingResult,
+) -> Result<()> {
+    let data = sampling_result.write_to_bytes()?;
+    record_coprocessor_response_size(data.len() as u64);
+    resp.set_data(data);
+    Ok(())
+}
+
+fn analyze_full_sampling_batch_response(
+    mut output: AnalyzeFullSamplingBatchTaskResult,
+) -> Result<coppb::StoreBatchTaskResponse> {
+    if let Some(sampling_result) = output.sampling_result.take() {
+        set_analyze_sampling_response_data(&mut output.response, sampling_result)?;
+    }
+
+    let mut response = coppb::StoreBatchTaskResponse::new();
+    response.set_task_id(output.task_id);
+    response.set_data(output.response.take_data());
+    if let Some(err) = output.response.region_error.take() {
+        response.set_region_error(err);
+    }
+    if let Some(lock_info) = output.response.locked.take() {
+        response.set_locked(lock_info);
+    }
+    response.set_other_error(output.response.take_other_error());
+    response.set_exec_details_v2(output.response.take_exec_details_v2());
+    Ok(response)
+}
+
+fn finish_analyze_full_sampling_batch_response(
+    mut top: AnalyzeFullSamplingTaskResult,
+    mut batch_outputs: Vec<AnalyzeFullSamplingBatchTaskResult>,
+) -> Result<coppb::Response> {
+    let can_reduce = !response_has_error(&top.response)
+        && top.sampling_result.is_some()
+        && batch_outputs.iter().all(|output| {
+            !response_has_error(&output.response) && output.sampling_result.is_some()
+        });
+
+    if can_reduce {
+        let mut merged = top.sampling_result.take().unwrap();
+        for output in &mut batch_outputs {
+            merged.merge_from(output.sampling_result.take().unwrap())?;
+        }
+        set_analyze_sampling_response_data(&mut top.response, merged)?;
+        top.response.set_batch_responses(Default::default());
+        return Ok(top.response);
+    }
+
+    if let Some(sampling_result) = top.sampling_result.take() {
+        set_analyze_sampling_response_data(&mut top.response, sampling_result)?;
+    }
+    let mut batch_responses = Vec::with_capacity(batch_outputs.len());
+    for output in batch_outputs {
+        batch_responses.push(analyze_full_sampling_batch_response(output)?);
+    }
+    top.response.set_batch_responses(batch_responses.into());
+    Ok(top.response)
+}
 
 /// A pool to build and run Coprocessor request handlers.
 #[derive(Clone)]
@@ -547,14 +650,7 @@ impl<E: Engine> Endpoint<E> {
         let mut resp = match result {
             Ok(resp) => {
                 let resp_size = resp.data.len() as u64;
-                COPR_RESP_SIZE.inc_by(resp_size);
-                record_network_out_bytes(resp_size);
-                with_tls_tracker(|tracker| {
-                    tracker.metrics.coprocessor_response_bytes = tracker
-                        .metrics
-                        .coprocessor_response_bytes
-                        .saturating_add(resp_size);
-                });
+                record_coprocessor_response_size(resp_size);
                 resp
             }
             Err(e) => {
@@ -574,6 +670,90 @@ impl<E: Engine> Endpoint<E> {
         resp.set_exec_details_v2(exec_details_v2);
         resp.set_latest_buckets_version(buckets_version);
         Ok(resp)
+    }
+
+    async fn handle_analyze_full_sampling_request_impl(
+        semaphore: Option<Arc<Semaphore>>,
+        mut tracker: Box<Tracker<E>>,
+        handler_builder: RequestHandlerBuilder<E::IMSnap>,
+    ) -> Result<AnalyzeFullSamplingTaskResult> {
+        with_tls_tracker(|tracker1| {
+            record_network_in_bytes(tracker1.metrics.grpc_req_size);
+        });
+        tracker.on_scheduled();
+        tracker.req_ctx.deadline.check()?;
+
+        // Safety: spawning this function using a `FuturePool` ensures that a TLS engine
+        // exists.
+        let snapshot = unsafe { Self::get_snapshot_with_timeout(&tracker.req_ctx).await }?;
+
+        let latest_buckets = snapshot.ext().get_buckets();
+        let region_cache_snap = snapshot.ext().in_memory_engine_hit();
+        tracker.adjust_snapshot_type(region_cache_snap);
+
+        if let Some(ref buckets) = latest_buckets {
+            if buckets.version > tracker.req_ctx.context.buckets_version
+                && tracker.req_ctx.context.buckets_version != 0
+            {
+                let mut bucket_not_match = errorpb::BucketVersionNotMatch::default();
+                bucket_not_match.set_version(buckets.version);
+                bucket_not_match.set_keys(buckets.keys.clone().into());
+                let mut err = errorpb::Error::default();
+                err.set_bucket_version_not_match(bucket_not_match);
+                return Err(Error::Region(err));
+            }
+        }
+
+        tracker.on_snapshot_finished();
+        tracker.req_ctx.deadline.check()?;
+        tracker.buckets = latest_buckets;
+        let buckets_version = tracker.buckets.as_ref().map_or(0, |b| b.version);
+
+        let mut handler = handler_builder(snapshot, &tracker.req_ctx)?;
+        tracker.on_begin_all_items();
+
+        let deadline = tracker.req_ctx.deadline;
+        let handle_request_future =
+            check_deadline(handler.handle_analyze_full_sampling(), deadline);
+        let handle_request_future = track(handle_request_future, tracker.as_mut());
+
+        let deadline_res = if let Some(semaphore) = &semaphore {
+            limit_concurrency(handle_request_future, semaphore, LIGHT_TASK_THRESHOLD).await
+        } else {
+            handle_request_future.await
+        };
+        let result = deadline_res.map_err(Error::from).and_then(|res| res);
+
+        let mut exec_summary = ExecSummary::default();
+        handler.collect_scan_summary(&mut exec_summary);
+        tracker.collect_scan_process_time(exec_summary);
+        let mut storage_stats = Statistics::default();
+        handler.collect_scan_statistics(&mut storage_stats);
+        tracker.collect_storage_statistics(storage_stats);
+
+        let (mut resp, sampling_result) = match result {
+            Ok(sampling_result) => (coppb::Response::default(), Some(sampling_result)),
+            Err(e) => {
+                if let Error::DefaultNotFound(errmsg) = &e {
+                    error!("default not found in coprocessor request processing";
+                        "err" => errmsg,
+                        "reqCtx" => ?&tracker.req_ctx,
+                    );
+                }
+                (make_error_response(e), None)
+            }
+        };
+
+        let (exec_details, exec_details_v2) = tracker.get_exec_details();
+        tracker.on_finish_all_items();
+        record_logical_read_bytes(exec_details_v2.get_scan_detail_v2().processed_versions_size);
+        resp.set_exec_details(exec_details);
+        resp.set_exec_details_v2(exec_details_v2);
+        resp.set_latest_buckets_version(buckets_version);
+        Ok(AnalyzeFullSamplingTaskResult {
+            response: resp,
+            sampling_result,
+        })
     }
 
     /// Handle a unary request and run on the read pool.
@@ -636,6 +816,115 @@ impl<E: Engine> Endpoint<E> {
         }
     }
 
+    fn handle_analyze_full_sampling_request(
+        &self,
+        r: ParseCopRequestResult<E::IMSnap>,
+    ) -> impl Future<Output = Result<AnalyzeFullSamplingTaskResult>> {
+        let req_ctx = r.req_ctx;
+        let priority = req_ctx.context.get_priority();
+        let task_id = req_ctx.build_task_id();
+        let key_ranges: Vec<_> = req_ctx
+            .ranges
+            .iter()
+            .map(|key_range| (key_range.get_start().to_vec(), key_range.get_end().to_vec()))
+            .collect();
+        let resource_tag = self
+            .resource_tag_factory
+            .new_tag_with_key_ranges(&req_ctx.context, key_ranges);
+        let mut allocated_bytes = resource_tag.approximate_heap_size();
+
+        let metadata = TaskMetadata::from_ctx(req_ctx.context.get_resource_control_context());
+        let resource_limiter = self.resource_ctl.as_ref().and_then(|r| {
+            r.get_resource_limiter(
+                req_ctx
+                    .context
+                    .get_resource_control_context()
+                    .get_resource_group_name(),
+                req_ctx.context.get_request_source(),
+                req_ctx
+                    .context
+                    .get_resource_control_context()
+                    .get_override_priority(),
+            )
+        });
+        let tracker = Box::new(Tracker::new(req_ctx, r.req_tag, self.slow_log_threshold));
+        allocated_bytes += tracker.approximate_mem_size();
+
+        let (tx, rx) = oneshot::channel();
+        let future = Self::handle_analyze_full_sampling_request_impl(
+            self.semaphore.clone(),
+            tracker,
+            r.handler_builder,
+        )
+        .in_resource_metering_tag(resource_tag)
+        .map(move |res| {
+            let _ = tx.send(res);
+        });
+        let spawn_fut_result = self.read_pool_spawn_with_memory_quota_check(
+            allocated_bytes,
+            future,
+            priority,
+            task_id,
+            metadata,
+            resource_limiter,
+        );
+        async move {
+            spawn_fut_result?.await?;
+            rx.map_err(|_| Error::MaxPendingTasksExceeded).await?
+        }
+    }
+
+    fn parse_and_handle_analyze_full_sampling_batch_request(
+        &self,
+        mut req: coppb::Request,
+        peer: Option<String>,
+        tracker: ::tracker::TrackerToken,
+    ) -> impl Future<Output = MemoryTraceGuard<coppb::Response>> {
+        let result_of_batch = self.process_analyze_full_sampling_batch_tasks(&mut req, &peer);
+        set_tls_tracker_token(tracker);
+        with_tls_tracker(|tracker| {
+            tracker.metrics.grpc_req_size = req.compute_size() as u64;
+        });
+        let result_of_future = self
+            .parse_request_and_check_memory_locks(req, peer, false)
+            .map(|r| self.handle_analyze_full_sampling_request(r));
+        with_tls_tracker(|tracker| {
+            tracker.metrics.grpc_process_nanos =
+                tracker.req_info.begin.saturating_elapsed().as_nanos() as u64;
+        });
+
+        async move {
+            let mut res = match result_of_future {
+                Err(e) => {
+                    let top = AnalyzeFullSamplingTaskResult {
+                        response: make_error_response(e),
+                        sampling_result: None,
+                    };
+                    let batch_outputs = result_of_batch.await;
+                    finish_analyze_full_sampling_batch_response(top, batch_outputs)
+                        .unwrap_or_else(make_error_response)
+                }
+                Ok(handle_fut) => {
+                    let (handle_res, batch_outputs) = futures::join!(handle_fut, result_of_batch);
+                    let top = handle_res.unwrap_or_else(|e| AnalyzeFullSamplingTaskResult {
+                        response: make_error_response(e),
+                        sampling_result: None,
+                    });
+                    finish_analyze_full_sampling_batch_response(top, batch_outputs)
+                        .unwrap_or_else(make_error_response)
+                }
+            };
+            GLOBAL_TRACKERS.with_tracker(tracker, |tracker| {
+                let exec_detail_v2 = res.mut_exec_details_v2();
+                tracker.write_scan_detail(exec_detail_v2.mut_scan_detail_v2());
+                tracker.merge_time_detail(exec_detail_v2.mut_time_detail_v2());
+            });
+            GLOBAL_TRACKERS.remove(tracker);
+            let memory_size = res.data.capacity();
+            MEMTRACE_ANALYZE.trace_guard(res, memory_size)
+        }
+    }
+
     /// Parses and handles a unary request. Returns a future that will never
     /// fail. If there are errors during parsing or handling, they will be
     /// converted into a `Response` as the success result of the future.
@@ -659,6 +948,11 @@ impl<E: Engine> Endpoint<E> {
             pb_error.set_server_is_busy(busy_err);
             let resp = make_error_response(Error::Region(pb_error));
             return Either::Left(async move { resp.into() });
+        }
+
+        if is_analyze_full_sampling_batch_request(&req) {
+            let fut = self.parse_and_handle_analyze_full_sampling_batch_request(req, peer, tracker);
+            return Either::Right(Either::Left(fut));
         }
 
         let result_of_batch = self.process_batch_tasks(&mut req, &peer);
@@ -696,7 +990,7 @@ impl<E: Engine> Endpoint<E> {
             GLOBAL_TRACKERS.remove(tracker);
             res
         };
-        Either::Right(fut)
+        Either::Right(Either::Right(fut))
     }
 
     // process_batch_tasks process the input batched coprocessor tasks if any,
@@ -771,6 +1065,73 @@ impl<E: Engine> Endpoint<E> {
                 Err(e) => batch_futs.push(future::Either::Right(async move {
                     make_error_batch_response(&mut response, e);
                     response
+                })),
+            }
+        }
+        stream::FuturesOrdered::from_iter(batch_futs).collect()
+    }
+
+    fn process_analyze_full_sampling_batch_tasks(
+        &self,
+        req: &mut coppb::Request,
+        peer: &Option<String>,
+    ) -> impl Future<Output = Vec<AnalyzeFullSamplingBatchTaskResult>> {
+        let mut batch_futs = Vec::with_capacity(req.tasks.len());
+        let batch_reqs: Vec<(coppb::Request, u64)> = req
+            .take_tasks()
+            .iter_mut()
+            .map(|task| {
+                let mut new_req = req.clone();
+                new_req.is_cache_enabled = false;
+                new_req.ranges = task.take_ranges();
+                let new_context = new_req.mut_context();
+                new_context.set_region_id(task.get_region_id());
+                new_context.set_region_epoch(task.take_region_epoch());
+                new_context.set_peer(task.take_peer());
+                (new_req, task.get_task_id())
+            })
+            .collect();
+        for (cur_req, task_id) in batch_reqs.into_iter() {
+            let request_info = RequestInfo::new(
+                cur_req.get_context(),
+                RequestType::Unknown,
+                cur_req.start_ts,
+            );
+            match self.parse_request_and_check_memory_locks(cur_req, peer.clone(), false) {
+                Ok(r) => {
+                    let cur_tracker = GLOBAL_TRACKERS.insert(::tracker::Tracker::new(request_info));
+                    set_tls_tracker_token(cur_tracker);
+                    let fut = self.handle_analyze_full_sampling_request(r);
+                    let fut = async move {
+                        let mut output = match fut.await {
+                            Ok(output) => AnalyzeFullSamplingBatchTaskResult {
+                                task_id,
+                                response: output.response,
+                                sampling_result: output.sampling_result,
+                            },
+                            Err(e) => AnalyzeFullSamplingBatchTaskResult {
+                                task_id,
+                                response: make_error_response(e),
+                                sampling_result: None,
+                            },
+                        };
+                        GLOBAL_TRACKERS.with_tracker(cur_tracker, |tracker| {
+                            tracker.write_scan_detail(
+                                output.response.mut_exec_details_v2().mut_scan_detail_v2(),
+                            );
+                        });
+                        GLOBAL_TRACKERS.remove(cur_tracker);
+                        output
+                    };
+
+                    batch_futs.push(future::Either::Left(fut));
+                }
+                Err(e) => batch_futs.push(future::Either::Right(async move {
+                    AnalyzeFullSamplingBatchTaskResult {
+                        task_id,
+                        response: make_error_response(e),
+                        sampling_result: None,
+                    }
                 })),
             }
         }

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -69,16 +69,45 @@ use crate::{
 /// light ones, which means they don't need a permit from the semaphore before
 /// execution.
 const LIGHT_TASK_THRESHOLD: Duration = Duration::from_millis(5);
+fn elapsed_ms(start: Instant) -> u64 {
+    start.saturating_elapsed().as_millis() as u64
+}
 
 fn is_analyze_full_sampling_batch_request(req: &coppb::Request) -> bool {
     if req.get_tp() != REQ_TYPE_ANALYZE || req.get_tasks().is_empty() {
         return false;
     }
+    let start = Instant::now();
     let mut analyze = AnalyzeReq::default();
-    if Message::merge_from_bytes(&mut analyze, req.get_data()).is_err() {
+    let merge_res = Message::merge_from_bytes(&mut analyze, req.get_data());
+    if let Err(err) = merge_res {
+        info!("analyze full sampling trace";
+            "component" => "tikv",
+            "phase" => "tikv.inspect_batch_request",
+            "event" => "finish",
+            "request_bytes" => req.get_data().len(),
+            "batch_task_count" => req.get_tasks().len(),
+            "elapsed_ms" => elapsed_ms(start),
+            "success" => false,
+            "err" => ?err,
+        );
         return false;
     }
-    analyze.get_tp() == AnalyzeType::TypeFullSampling && analyze.has_col_req()
+    let is_full_sampling =
+        analyze.get_tp() == AnalyzeType::TypeFullSampling && analyze.has_col_req();
+    if is_full_sampling {
+        info!("analyze full sampling trace";
+            "component" => "tikv",
+            "phase" => "tikv.inspect_batch_request",
+            "event" => "finish",
+            "request_bytes" => req.get_data().len(),
+            "batch_task_count" => req.get_tasks().len(),
+            "elapsed_ms" => elapsed_ms(start),
+            "success" => true,
+            "is_full_sampling" => is_full_sampling,
+        );
+    }
+    is_full_sampling
 }
 
 fn response_has_error(resp: &coppb::Response) -> bool {
@@ -110,8 +139,18 @@ struct AnalyzeFullSamplingBatchTaskResult {
 fn set_analyze_sampling_response_data(
     resp: &mut coppb::Response,
     sampling_result: AnalyzeSamplingResult,
+    response_kind: &'static str,
 ) -> Result<()> {
+    let start = Instant::now();
     let data = sampling_result.write_to_bytes()?;
+    debug!("analyze full sampling trace";
+        "component" => "tikv",
+        "phase" => "tikv.set_sampling_response_data",
+        "event" => "finish",
+        "response_kind" => response_kind,
+        "elapsed_ms" => elapsed_ms(start),
+        "response_bytes" => data.len(),
+    );
     record_coprocessor_response_size(data.len() as u64);
     resp.set_data(data);
     Ok(())
@@ -121,7 +160,7 @@ fn analyze_full_sampling_batch_response(
     mut output: AnalyzeFullSamplingBatchTaskResult,
 ) -> Result<coppb::StoreBatchTaskResponse> {
     if let Some(sampling_result) = output.sampling_result.take() {
-        set_analyze_sampling_response_data(&mut output.response, sampling_result)?;
+        set_analyze_sampling_response_data(&mut output.response, sampling_result, "batch_task")?;
     }
 
     let mut response = coppb::StoreBatchTaskResponse::new();
@@ -142,6 +181,7 @@ fn finish_analyze_full_sampling_batch_response(
     mut top: AnalyzeFullSamplingTaskResult,
     mut batch_outputs: Vec<AnalyzeFullSamplingBatchTaskResult>,
 ) -> Result<coppb::Response> {
+    let finish_start = Instant::now();
     let can_reduce = !response_has_error(&top.response)
         && top.sampling_result.is_some()
         && batch_outputs.iter().all(|output| {
@@ -150,27 +190,55 @@ fn finish_analyze_full_sampling_batch_response(
 
     if can_reduce {
         let batch_task_count = batch_outputs.len();
+        let merge_start = Instant::now();
         let mut merged = top.sampling_result.take().unwrap();
         for output in &mut batch_outputs {
             merged.merge_from(output.sampling_result.take().unwrap())?;
         }
-        set_analyze_sampling_response_data(&mut top.response, merged)?;
-        top.response.set_batch_responses(Default::default());
-        info!("analyze full sampling batch reduce finished";
+        info!("analyze full sampling trace";
+            "component" => "tikv",
+            "phase" => "tikv.merge_sampling_results",
+            "event" => "finish",
+            "success" => true,
+            "elapsed_ms" => elapsed_ms(merge_start),
             "total_task_count" => batch_task_count + 1,
             "batch_task_count" => batch_task_count,
+        );
+        set_analyze_sampling_response_data(&mut top.response, merged, "reduced_top")?;
+        top.response.set_batch_responses(Default::default());
+        info!("analyze full sampling trace";
+            "component" => "tikv",
+            "phase" => "tikv.reduce_batch_response",
+            "event" => "finish",
+            "success" => true,
+            "reduced" => true,
+            "elapsed_ms" => elapsed_ms(finish_start),
+            "total_task_count" => batch_task_count + 1,
+            "batch_task_count" => batch_task_count,
+            "response_bytes" => top.response.get_data().len(),
         );
         return Ok(top.response);
     }
 
     if let Some(sampling_result) = top.sampling_result.take() {
-        set_analyze_sampling_response_data(&mut top.response, sampling_result)?;
+        set_analyze_sampling_response_data(&mut top.response, sampling_result, "fallback_top")?;
     }
     let mut batch_responses = Vec::with_capacity(batch_outputs.len());
     for output in batch_outputs {
         batch_responses.push(analyze_full_sampling_batch_response(output)?);
     }
+    let batch_response_count = batch_responses.len();
     top.response.set_batch_responses(batch_responses.into());
+    info!("analyze full sampling trace";
+        "component" => "tikv",
+        "phase" => "tikv.reduce_batch_response",
+        "event" => "finish",
+        "success" => true,
+        "reduced" => false,
+        "elapsed_ms" => elapsed_ms(finish_start),
+        "response_bytes" => top.response.get_data().len(),
+        "batch_response_count" => batch_response_count,
+    );
     Ok(top.response)
 }
 
@@ -410,9 +478,23 @@ impl<E: Engine> Endpoint<E> {
             }
             REQ_TYPE_ANALYZE => {
                 let mut analyze = AnalyzeReq::default();
+                let unmarshal_start = Instant::now();
                 box_try!(analyze.merge_from(&mut input));
                 if start_ts == 0 {
                     start_ts = analyze.get_start_ts_fallback();
+                }
+                if analyze.get_tp() == AnalyzeType::TypeFullSampling {
+                    debug!("analyze full sampling trace";
+                        "component" => "tikv",
+                        "phase" => "tikv.unmarshal_analyze_req",
+                        "event" => "finish",
+                        "elapsed_ms" => elapsed_ms(unmarshal_start),
+                        "request_bytes" => data.len(),
+                        "range_count" => ranges.len(),
+                        "region_id" => context.get_region_id(),
+                        "start_ts" => start_ts,
+                        "has_column_request" => analyze.has_col_req(),
+                    );
                 }
 
                 req_tag = match analyze.get_tp() {
@@ -682,6 +764,17 @@ impl<E: Engine> Endpoint<E> {
         mut tracker: Box<Tracker<E>>,
         handler_builder: RequestHandlerBuilder<E::IMSnap>,
     ) -> Result<AnalyzeFullSamplingTaskResult> {
+        let total_start = Instant::now();
+        let region_id = tracker.req_ctx.context.get_region_id();
+        let start_ts = tracker.req_ctx.txn_start_ts.into_inner();
+        debug!("analyze full sampling trace";
+            "component" => "tikv",
+            "phase" => "tikv.handle_full_sampling",
+            "event" => "start",
+            "region_id" => region_id,
+            "start_ts" => start_ts,
+            "range_count" => tracker.req_ctx.ranges.len(),
+        );
         with_tls_tracker(|tracker1| {
             record_network_in_bytes(tracker1.metrics.grpc_req_size);
         });
@@ -690,7 +783,16 @@ impl<E: Engine> Endpoint<E> {
 
         // Safety: spawning this function using a `FuturePool` ensures that a TLS engine
         // exists.
+        let snapshot_start = Instant::now();
         let snapshot = unsafe { Self::get_snapshot_with_timeout(&tracker.req_ctx).await }?;
+        debug!("analyze full sampling trace";
+            "component" => "tikv",
+            "phase" => "tikv.get_snapshot",
+            "event" => "finish",
+            "region_id" => region_id,
+            "start_ts" => start_ts,
+            "elapsed_ms" => elapsed_ms(snapshot_start),
+        );
 
         let latest_buckets = snapshot.ext().get_buckets();
         let region_cache_snap = snapshot.ext().in_memory_engine_hit();
@@ -714,10 +816,20 @@ impl<E: Engine> Endpoint<E> {
         tracker.buckets = latest_buckets;
         let buckets_version = tracker.buckets.as_ref().map_or(0, |b| b.version);
 
+        let handler_start = Instant::now();
         let mut handler = handler_builder(snapshot, &tracker.req_ctx)?;
+        debug!("analyze full sampling trace";
+            "component" => "tikv",
+            "phase" => "tikv.build_analyze_handler",
+            "event" => "finish",
+            "region_id" => region_id,
+            "start_ts" => start_ts,
+            "elapsed_ms" => elapsed_ms(handler_start),
+        );
         tracker.on_begin_all_items();
 
         let deadline = tracker.req_ctx.deadline;
+        let scan_start = Instant::now();
         let handle_request_future =
             check_deadline(handler.handle_analyze_full_sampling(), deadline);
         let handle_request_future = track(handle_request_future, tracker.as_mut());
@@ -728,13 +840,31 @@ impl<E: Engine> Endpoint<E> {
             handle_request_future.await
         };
         let result = deadline_res.map_err(Error::from).and_then(|res| res);
+        debug!("analyze full sampling trace";
+            "component" => "tikv",
+            "phase" => "tikv.execute_full_sampling_handler",
+            "event" => "finish",
+            "region_id" => region_id,
+            "start_ts" => start_ts,
+            "elapsed_ms" => elapsed_ms(scan_start),
+            "success" => result.is_ok(),
+        );
 
+        let collect_stats_start = Instant::now();
         let mut exec_summary = ExecSummary::default();
         handler.collect_scan_summary(&mut exec_summary);
         tracker.collect_scan_process_time(exec_summary);
         let mut storage_stats = Statistics::default();
         handler.collect_scan_statistics(&mut storage_stats);
         tracker.collect_storage_statistics(storage_stats);
+        debug!("analyze full sampling trace";
+            "component" => "tikv",
+            "phase" => "tikv.collect_scan_details",
+            "event" => "finish",
+            "region_id" => region_id,
+            "start_ts" => start_ts,
+            "elapsed_ms" => elapsed_ms(collect_stats_start),
+        );
 
         let (mut resp, sampling_result) = match result {
             Ok(sampling_result) => (coppb::Response::default(), Some(sampling_result)),
@@ -755,6 +885,15 @@ impl<E: Engine> Endpoint<E> {
         resp.set_exec_details(exec_details);
         resp.set_exec_details_v2(exec_details_v2);
         resp.set_latest_buckets_version(buckets_version);
+        debug!("analyze full sampling trace";
+            "component" => "tikv",
+            "phase" => "tikv.handle_full_sampling",
+            "event" => "finish",
+            "region_id" => region_id,
+            "start_ts" => start_ts,
+            "elapsed_ms" => elapsed_ms(total_start),
+            "success" => sampling_result.is_some(),
+        );
         Ok(AnalyzeFullSamplingTaskResult {
             response: resp,
             sampling_result,
@@ -885,6 +1024,19 @@ impl<E: Engine> Endpoint<E> {
         peer: Option<String>,
         tracker: ::tracker::TrackerToken,
     ) -> impl Future<Output = MemoryTraceGuard<coppb::Response>> {
+        let total_start = Instant::now();
+        let region_id = req.get_context().get_region_id();
+        let start_ts = req.start_ts;
+        let initial_batch_task_count = req.get_tasks().len();
+        info!("analyze full sampling trace";
+            "component" => "tikv",
+            "phase" => "tikv.handle_batch_request",
+            "event" => "start",
+            "region_id" => region_id,
+            "start_ts" => start_ts,
+            "batch_task_count" => initial_batch_task_count,
+            "request_bytes" => req.get_data().len(),
+        );
         let result_of_batch = self.process_analyze_full_sampling_batch_tasks(&mut req, &peer);
         set_tls_tracker_token(tracker);
         with_tls_tracker(|tracker| {
@@ -925,6 +1077,21 @@ impl<E: Engine> Endpoint<E> {
                 tracker.merge_time_detail(exec_detail_v2.mut_time_detail_v2());
             });
             GLOBAL_TRACKERS.remove(tracker);
+            info!("analyze full sampling trace";
+                "component" => "tikv",
+                "phase" => "tikv.handle_batch_request",
+                "event" => "finish",
+                "region_id" => region_id,
+                "start_ts" => start_ts,
+                "elapsed_ms" => elapsed_ms(total_start),
+                "batch_task_count" => initial_batch_task_count,
+                "response_bytes" => res.get_data().len(),
+                "batch_response_count" => res.get_batch_responses().len(),
+                "success" => !res.has_region_error() && !res.has_locked() && res.get_other_error().is_empty(),
+                "has_region_error" => res.has_region_error(),
+                "has_locked" => res.has_locked(),
+                "other_error" => res.get_other_error(),
+            );
             let memory_size = res.data.capacity();
             MEMTRACE_ANALYZE.trace_guard(res, memory_size)
         }
@@ -1081,6 +1248,7 @@ impl<E: Engine> Endpoint<E> {
         req: &mut coppb::Request,
         peer: &Option<String>,
     ) -> impl Future<Output = Vec<AnalyzeFullSamplingBatchTaskResult>> {
+        let extract_start = Instant::now();
         let mut batch_futs = Vec::with_capacity(req.tasks.len());
         let batch_reqs: Vec<(coppb::Request, u64)> = req
             .take_tasks()
@@ -1096,7 +1264,16 @@ impl<E: Engine> Endpoint<E> {
                 (new_req, task.get_task_id())
             })
             .collect();
+        info!("analyze full sampling trace";
+            "component" => "tikv",
+            "phase" => "tikv.extract_batch_tasks",
+            "event" => "finish",
+            "elapsed_ms" => elapsed_ms(extract_start),
+            "batch_task_count" => batch_reqs.len(),
+        );
         for (cur_req, task_id) in batch_reqs.into_iter() {
+            let region_id = cur_req.get_context().get_region_id();
+            let start_ts = cur_req.start_ts;
             let request_info = RequestInfo::new(
                 cur_req.get_context(),
                 RequestType::Unknown,
@@ -1108,6 +1285,15 @@ impl<E: Engine> Endpoint<E> {
                     set_tls_tracker_token(cur_tracker);
                     let fut = self.handle_analyze_full_sampling_request(r);
                     let fut = async move {
+                        let task_start = Instant::now();
+                        debug!("analyze full sampling trace";
+                            "component" => "tikv",
+                            "phase" => "tikv.handle_batch_sub_task",
+                            "event" => "start",
+                            "task_id" => task_id,
+                            "region_id" => region_id,
+                            "start_ts" => start_ts,
+                        );
                         let mut output = match fut.await {
                             Ok(output) => AnalyzeFullSamplingBatchTaskResult {
                                 task_id,
@@ -1120,6 +1306,20 @@ impl<E: Engine> Endpoint<E> {
                                 sampling_result: None,
                             },
                         };
+                        debug!("analyze full sampling trace";
+                            "component" => "tikv",
+                            "phase" => "tikv.handle_batch_sub_task",
+                            "event" => "finish",
+                            "task_id" => task_id,
+                            "region_id" => region_id,
+                            "start_ts" => start_ts,
+                            "elapsed_ms" => elapsed_ms(task_start),
+                            "success" => output.sampling_result.is_some() && !response_has_error(&output.response),
+                            "response_bytes" => output.response.get_data().len(),
+                            "has_region_error" => output.response.has_region_error(),
+                            "has_locked" => output.response.has_locked(),
+                            "other_error" => output.response.get_other_error(),
+                        );
                         GLOBAL_TRACKERS.with_tracker(cur_tracker, |tracker| {
                             tracker.write_scan_detail(
                                 output.response.mut_exec_details_v2().mut_scan_detail_v2(),

--- a/src/coprocessor/mod.rs
+++ b/src/coprocessor/mod.rs
@@ -48,6 +48,7 @@ use tikv_alloc::{Id, MemoryTrace, MemoryTraceGuard, mem_trace};
 use tikv_util::{deadline::Deadline, memory::HeapSize, time::Duration};
 use txn_types::TsSet;
 
+use self::statistics::analyze::AnalyzeSamplingResult;
 pub use self::{
     endpoint::Endpoint,
     error::{Error, Result},
@@ -68,6 +69,15 @@ pub trait RequestHandler: Send {
     /// Processes current request and produces a response.
     async fn handle_request(&mut self) -> Result<MemoryTraceGuard<coppb::Response>> {
         panic!("unary request is not supported for this handler");
+    }
+
+    /// Processes an analyze full-sampling request and keeps the typed sampling
+    /// result alive for callers that need to merge several region results
+    /// before protobuf serialization.
+    async fn handle_analyze_full_sampling(&mut self) -> Result<AnalyzeSamplingResult> {
+        Err(Error::Other(
+            "analyze full sampling is not supported for this handler".to_owned(),
+        ))
     }
 
     /// Processes current request and produces streaming responses.

--- a/src/coprocessor/statistics/analyze.rs
+++ b/src/coprocessor/statistics/analyze.rs
@@ -1,6 +1,13 @@
 // Copyright 2017 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::{cmp::Reverse, collections::BinaryHeap, hash::Hasher, mem, sync::Arc};
+use std::{
+    cmp::Reverse,
+    collections::BinaryHeap,
+    hash::Hasher,
+    mem,
+    sync::Arc,
+    time::{Duration, Instant},
+};
 
 use api_version::KvFormat;
 use kvproto::coprocessor::KeyRange;
@@ -30,6 +37,10 @@ use crate::{
     coprocessor::{MEMTRACE_ANALYZE, dag::TikvStorage, metrics, *},
     storage::{Snapshot, SnapshotStore, Statistics},
 };
+
+fn duration_ms(duration: Duration) -> u64 {
+    duration.as_millis() as u64
+}
 
 pub(crate) struct RowSampleBuilder<S: Snapshot, F: KvFormat> {
     pub(crate) data: BatchTableScanExecutor<TikvStorage<SnapshotStore<S>>, F>,
@@ -115,12 +126,20 @@ impl<S: Snapshot, F: KvFormat> RowSampleBuilder<S, F> {
         let mut is_drained = false;
         let mut collector = self.new_collector();
         let mut ctx = EvalContext::default();
+        let scan_start = Instant::now();
+        let mut batch_count = 0_u64;
+        let mut read_bytes = 0_usize;
+        let mut next_batch_elapsed = Duration::ZERO;
+        let mut encode_collect_elapsed = Duration::ZERO;
+        let mut quota_consume_elapsed = Duration::ZERO;
+        let mut quota_delay_total = Duration::ZERO;
         while !is_drained {
             // Use background limiters for both manual and auto analyze so that iops_limiter
             // (and other background quotas) apply to manual analyze as well.
             let mut sample = self.quota_limiter.new_sample(false);
             let mut read_size: usize = 0;
             {
+                let next_batch_start = Instant::now();
                 let result = {
                     let (duration, res) = sample
                         .observe_cpu_async(self.data.next_batch(BATCH_MAX_SIZE))
@@ -128,6 +147,8 @@ impl<S: Snapshot, F: KvFormat> RowSampleBuilder<S, F> {
                     sample.add_cpu_time(duration);
                     res
                 };
+                next_batch_elapsed += next_batch_start.elapsed();
+                batch_count += 1;
 
                 // Use request-scoped storage stats for IOPS (like collect_scan_statistics),
                 // and count only RocksDB block reads as an approximation of disk IOPS.
@@ -160,6 +181,7 @@ impl<S: Snapshot, F: KvFormat> RowSampleBuilder<S, F> {
                 let _guard = sample.observe_cpu();
                 is_drained = result.is_drained?.stop();
 
+                let encode_collect_start = Instant::now();
                 let columns_slice = result.physical_columns.as_slice();
                 let mut column_vals: Vec<Vec<u8>> = vec![vec![]; self.columns_info.len()];
                 let mut collation_key_vals: Vec<Vec<u8>> = vec![vec![]; self.columns_info.len()];
@@ -201,16 +223,21 @@ impl<S: Snapshot, F: KvFormat> RowSampleBuilder<S, F> {
                     );
                     collector.collect_column(&column_vals, &collation_key_vals, &self.columns_info);
                 }
+                encode_collect_elapsed += encode_collect_start.elapsed();
             }
 
             sample.add_read_bytes(read_size);
+            read_bytes += read_size;
             // Don't let analyze bandwidth limit the quota limiter, this is already limited
             // in rate limiter.
+            let quota_consume_start = Instant::now();
             let quota_delay = {
                 // Use background limiters for both manual and auto analyze so that iops_limiter
                 // applies to manual analyze as well.
                 self.quota_limiter.consume_sample(sample, false).await
             };
+            quota_consume_elapsed += quota_consume_start.elapsed();
+            quota_delay_total += quota_delay;
 
             if !quota_delay.is_zero() {
                 NON_TXN_COMMAND_THROTTLE_TIME_COUNTER_VEC_STATIC
@@ -218,14 +245,25 @@ impl<S: Snapshot, F: KvFormat> RowSampleBuilder<S, F> {
                     .inc_by(quota_delay.as_micros() as u64);
             }
         }
-        info!("analyze full sampling table full scan finished";
+        debug!("analyze full sampling trace";
+            "component" => "tikv",
+            "phase" => "tikv.scan_full_sampling_table",
+            "event" => "finish",
+            "elapsed_ms" => scan_start.elapsed().as_millis() as u64,
+            "next_batch_elapsed_ms" => duration_ms(next_batch_elapsed),
+            "encode_collect_elapsed_ms" => duration_ms(encode_collect_elapsed),
+            "quota_consume_elapsed_ms" => duration_ms(quota_consume_elapsed),
+            "quota_delay_ms" => duration_ms(quota_delay_total),
+            "batch_count" => batch_count,
             "scanned_rows" => collector.mut_base().count,
+            "read_bytes" => read_bytes,
             "columns" => self.columns_info.len(),
             "column_groups" => self.column_groups.len(),
             "max_sample_size" => self.max_sample_size,
             "sample_rate" => self.sample_rate,
             "is_auto_analyze" => self.is_auto_analyze,
         );
+        let column_group_fixup_start = Instant::now();
         for i in 0..self.column_groups.len() {
             let offsets = self.column_groups[i].get_column_offsets();
             if offsets.len() != 1 {
@@ -244,6 +282,13 @@ impl<S: Snapshot, F: KvFormat> RowSampleBuilder<S, F> {
             collector.mut_base().total_sizes[col_group_pos] =
                 collector.mut_base().total_sizes[col_pos];
         }
+        debug!("analyze full sampling trace";
+            "component" => "tikv",
+            "phase" => "tikv.column_group_fixup",
+            "event" => "finish",
+            "elapsed_ms" => column_group_fixup_start.elapsed().as_millis() as u64,
+            "column_groups" => self.column_groups.len(),
+        );
         Ok(AnalyzeSamplingResult::new(collector))
     }
 }

--- a/src/coprocessor/statistics/analyze.rs
+++ b/src/coprocessor/statistics/analyze.rs
@@ -5,6 +5,7 @@ use std::{cmp::Reverse, collections::BinaryHeap, hash::Hasher, mem, sync::Arc};
 use api_version::KvFormat;
 use kvproto::coprocessor::KeyRange;
 use mur3::Hasher128;
+use protobuf::Message;
 use rand::{Rng, rngs::StdRng};
 use tidb_query_datatype::{
     FieldTypeAccessor,
@@ -239,8 +240,19 @@ impl<S: Snapshot, F: KvFormat> RowSampleBuilder<S, F> {
     }
 }
 
+type BernoulliSamples = Vec<Vec<Vec<u8>>>;
+type ReservoirSamples = BinaryHeap<Reverse<(i64, Vec<Vec<u8>>)>>;
+
 trait RowSampleCollector: Send {
     fn mut_base(&mut self) -> &mut BaseRowSampleCollector;
+    fn take_base(&mut self) -> BaseRowSampleCollector;
+    fn merge_collector(&mut self, other: Box<dyn RowSampleCollector>) -> Result<()>;
+    fn take_bernoulli_samples(&mut self) -> Option<BernoulliSamples> {
+        None
+    }
+    fn take_reservoir_samples(&mut self) -> Option<ReservoirSamples> {
+        None
+    }
     fn collect_column_group(
         &mut self,
         columns_val: &[Vec<u8>],
@@ -291,6 +303,28 @@ impl Default for BaseRowSampleCollector {
     }
 }
 
+fn add_i64_repeated(dst: &mut Vec<i64>, src: &[i64]) {
+    if dst.len() < src.len() {
+        dst.resize(src.len(), 0);
+    }
+    for (idx, value) in src.iter().enumerate() {
+        dst[idx] += value;
+    }
+}
+
+fn row_sample_memory_usage(row: &[Vec<u8>]) -> usize {
+    row.iter().map(Vec::capacity).sum()
+}
+
+fn bernoulli_samples_memory_usage(samples: &[Vec<Vec<u8>>]) -> usize {
+    samples.iter().map(|row| row_sample_memory_usage(row)).sum()
+}
+
+fn release_reported_memory_usage(base: &mut BaseRowSampleCollector) {
+    base.memory_usage = 0;
+    base.report_memory_usage(true);
+}
+
 impl BaseRowSampleCollector {
     fn new(max_fm_sketch_size: usize, col_and_group_len: usize) -> BaseRowSampleCollector {
         BaseRowSampleCollector {
@@ -301,6 +335,20 @@ impl BaseRowSampleCollector {
             total_sizes: vec![0; col_and_group_len],
             memory_usage: 0,
             reported_memory_usage: 0,
+        }
+    }
+
+    fn merge_from(&mut self, other: &mut BaseRowSampleCollector) {
+        self.count += other.count;
+        add_i64_repeated(&mut self.null_count, &other.null_count);
+        add_i64_repeated(&mut self.total_sizes, &other.total_sizes);
+
+        for (idx, other_sketch) in mem::take(&mut other.fm_sketches).into_iter().enumerate() {
+            if idx >= self.fm_sketches.len() {
+                self.fm_sketches.push(other_sketch);
+            } else {
+                self.fm_sketches[idx].merge(&other_sketch);
+            }
         }
     }
 
@@ -420,6 +468,30 @@ impl RowSampleCollector for BernoulliRowSampleCollector {
     fn mut_base(&mut self) -> &mut BaseRowSampleCollector {
         &mut self.base
     }
+
+    fn take_base(&mut self) -> BaseRowSampleCollector {
+        mem::take(&mut self.base)
+    }
+
+    fn merge_collector(&mut self, mut other: Box<dyn RowSampleCollector>) -> Result<()> {
+        let mut samples = other.take_bernoulli_samples().ok_or_else(|| {
+            Error::Other("cannot merge reservoir samples into bernoulli samples".to_owned())
+        })?;
+        let sample_memory_usage = bernoulli_samples_memory_usage(&samples);
+        self.samples.append(&mut samples);
+        self.base.memory_usage += sample_memory_usage;
+        self.base.report_memory_usage(false);
+
+        let mut other_base = other.take_base();
+        release_reported_memory_usage(&mut other_base);
+        self.base.merge_from(&mut other_base);
+        Ok(())
+    }
+
+    fn take_bernoulli_samples(&mut self) -> Option<BernoulliSamples> {
+        Some(mem::take(&mut self.samples))
+    }
+
     fn collect_column_group(
         &mut self,
         columns_val: &[Vec<u8>],
@@ -491,12 +563,54 @@ impl ReservoirRowSampleCollector {
             max_sample_size,
         }
     }
+
+    fn should_keep_weight(&self, weight: i64) -> bool {
+        if self.max_sample_size == 0 {
+            return false;
+        }
+        self.samples.len() < self.max_sample_size || self.samples.peek().unwrap().0.0 < weight
+    }
+
+    fn push_weighted_sample(&mut self, weight: i64, sample: Vec<Vec<u8>>) {
+        if self.samples.len() >= self.max_sample_size {
+            let (_, evicted) = self.samples.pop().unwrap().0;
+            self.base.memory_usage -= row_sample_memory_usage(&evicted);
+        }
+        self.base.memory_usage += row_sample_memory_usage(&sample);
+        self.samples.push(Reverse((weight, sample)));
+    }
 }
 
 impl RowSampleCollector for ReservoirRowSampleCollector {
     fn mut_base(&mut self) -> &mut BaseRowSampleCollector {
         &mut self.base
     }
+
+    fn take_base(&mut self) -> BaseRowSampleCollector {
+        mem::take(&mut self.base)
+    }
+
+    fn merge_collector(&mut self, mut other: Box<dyn RowSampleCollector>) -> Result<()> {
+        let samples = other.take_reservoir_samples().ok_or_else(|| {
+            Error::Other("cannot merge bernoulli samples into reservoir samples".to_owned())
+        })?;
+        for Reverse((weight, sample)) in samples {
+            if self.should_keep_weight(weight) {
+                self.push_weighted_sample(weight, sample);
+            }
+        }
+        self.base.report_memory_usage(false);
+
+        let mut other_base = other.take_base();
+        release_reported_memory_usage(&mut other_base);
+        self.base.merge_from(&mut other_base);
+        Ok(())
+    }
+
+    fn take_reservoir_samples(&mut self) -> Option<ReservoirSamples> {
+        Some(mem::take(&mut self.samples))
+    }
+
     fn collect_column_group(
         &mut self,
         columns_val: &[Vec<u8>],
@@ -524,25 +638,10 @@ impl RowSampleCollector for ReservoirRowSampleCollector {
     }
 
     fn sampling(&mut self, data: &[Vec<u8>]) {
-        // We should tolerate the abnormal case => `self.max_sample_size == 0`.
-        if self.max_sample_size == 0 {
-            return;
-        }
-        let mut need_push = false;
         let cur_rng = self.base.rng.gen_range(0, i64::MAX);
-        if self.samples.len() < self.max_sample_size {
-            need_push = true;
-        } else if self.samples.peek().unwrap().0.0 < cur_rng {
-            need_push = true;
-            let (_, evicted) = self.samples.pop().unwrap().0;
-            self.base.memory_usage -= evicted.iter().map(|x| x.capacity()).sum::<usize>();
-        }
-
-        if need_push {
-            let sample = data.to_vec();
-            self.base.memory_usage += sample.iter().map(|x| x.capacity()).sum::<usize>();
+        if self.should_keep_weight(cur_rng) {
+            self.push_weighted_sample(cur_rng, data.to_vec());
             self.base.report_memory_usage(false);
-            self.samples.push(Reverse((cur_rng, sample)));
         }
     }
 
@@ -831,7 +930,7 @@ impl From<SampleCollector> for tipb::SampleCollector {
     }
 }
 
-pub(crate) struct AnalyzeSamplingResult {
+pub struct AnalyzeSamplingResult {
     row_sample_collector: Box<dyn RowSampleCollector>,
 }
 
@@ -840,6 +939,16 @@ impl AnalyzeSamplingResult {
         AnalyzeSamplingResult {
             row_sample_collector,
         }
+    }
+
+    pub(crate) fn merge_from(&mut self, other: AnalyzeSamplingResult) -> Result<()> {
+        self.row_sample_collector
+            .merge_collector(other.row_sample_collector)
+    }
+
+    pub(crate) fn write_to_bytes(self) -> Result<Vec<u8>> {
+        let resp: tipb::AnalyzeColumnsResp = self.into();
+        Ok(box_try!(resp.write_to_bytes()))
     }
 }
 
@@ -1100,6 +1209,58 @@ mod tests {
             }
             assert_eq!(collector.samples.len(), 0);
         }
+    }
+
+    fn sorted_hashset(sketch: &tipb::FmSketch) -> Vec<u64> {
+        let mut hashes = sketch.get_hashset().to_vec();
+        hashes.sort_unstable();
+        hashes
+    }
+
+    fn test_sampling_result(
+        count: u64,
+        null_count: i64,
+        total_size: i64,
+        sample_weights: &[i64],
+        ndv_hashes: &[u64],
+    ) -> AnalyzeSamplingResult {
+        let mut collector = ReservoirRowSampleCollector::new(2, 1000, 1);
+        collector.base.count = count;
+        collector.base.null_count[0] = null_count;
+        collector.base.total_sizes[0] = total_size;
+        for hash in ndv_hashes {
+            collector.base.fm_sketches[0].insert_hash_value(*hash);
+        }
+        for weight in sample_weights {
+            collector.push_weighted_sample(*weight, vec![vec![*weight as u8]]);
+        }
+        AnalyzeSamplingResult::new(Box::new(collector))
+    }
+
+    #[test]
+    fn test_analyze_sampling_result_merge() {
+        let a = 10;
+        let b = 20;
+        let c = 30;
+        let mut result = test_sampling_result(2, 1, 10, &[1, 3], &[a, b]);
+        result
+            .merge_from(test_sampling_result(2, 2, 20, &[4], &[a, c]))
+            .unwrap();
+
+        let resp: tipb::AnalyzeColumnsResp = result.into();
+        let collector = resp.get_row_collector();
+        assert_eq!(collector.get_count(), 4);
+        assert_eq!(collector.get_null_counts(), &[3]);
+        assert_eq!(collector.get_total_size(), &[30]);
+
+        let mut sample_weights: Vec<_> = collector
+            .get_samples()
+            .iter()
+            .map(|sample| sample.get_weight())
+            .collect();
+        sample_weights.sort_unstable();
+        assert_eq!(sample_weights, vec![3, 4]);
+        assert_eq!(sorted_hashset(&collector.get_fm_sketch()[0]), vec![a, b, c]);
     }
 }
 

--- a/src/coprocessor/statistics/analyze.rs
+++ b/src/coprocessor/statistics/analyze.rs
@@ -218,6 +218,14 @@ impl<S: Snapshot, F: KvFormat> RowSampleBuilder<S, F> {
                     .inc_by(quota_delay.as_micros() as u64);
             }
         }
+        info!("analyze full sampling table full scan finished";
+            "scanned_rows" => collector.mut_base().count,
+            "columns" => self.columns_info.len(),
+            "column_groups" => self.column_groups.len(),
+            "max_sample_size" => self.max_sample_size,
+            "sample_rate" => self.sample_rate,
+            "is_auto_analyze" => self.is_auto_analyze,
+        );
         for i in 0..self.column_groups.len() {
             let offsets = self.column_groups[i].get_column_offsets();
             if offsets.len() != 1 {

--- a/src/coprocessor/statistics/analyze_context.rs
+++ b/src/coprocessor/statistics/analyze_context.rs
@@ -120,13 +120,27 @@ impl<S: Snapshot, F: KvFormat> AnalyzeContext<S, F> {
         Ok(res_data)
     }
 
-    async fn handle_full_sampling(builder: &mut RowSampleBuilder<S, F>) -> Result<Vec<u8>> {
-        let sample_res = builder.collect_column_stats().await?;
-        let res_data = {
-            let res: tipb::AnalyzeColumnsResp = sample_res.into();
-            box_try!(res.write_to_bytes())
-        };
-        Ok(res_data)
+    async fn handle_full_sampling_result(&mut self) -> Result<AnalyzeSamplingResult> {
+        if self.req.get_tp() != AnalyzeType::TypeFullSampling {
+            return Err(Error::Other(
+                "typed analyze result is only supported for full sampling".to_owned(),
+            ));
+        }
+        let col_req = self.req.take_col_req();
+        let storage = self.storage.take().unwrap();
+        let ranges = std::mem::take(&mut self.ranges);
+
+        let mut builder = RowSampleBuilder::<_, F>::new(
+            col_req,
+            storage,
+            ranges,
+            self.quota_limiter.clone(),
+            self.is_auto_analyze,
+        )?;
+
+        let res = builder.collect_column_stats().await;
+        builder.merge_storage_stats_into(&mut self.storage_stats);
+        res
     }
 
     // handle_index is used to handle `AnalyzeIndexReq`,
@@ -272,21 +286,8 @@ impl<S: Snapshot, F: KvFormat> RequestHandler for AnalyzeContext<S, F> {
             }
 
             AnalyzeType::TypeFullSampling => {
-                let col_req = self.req.take_col_req();
-                let storage = self.storage.take().unwrap();
-                let ranges = std::mem::take(&mut self.ranges);
-
-                let mut builder = RowSampleBuilder::<_, F>::new(
-                    col_req,
-                    storage,
-                    ranges,
-                    self.quota_limiter.clone(),
-                    self.is_auto_analyze,
-                )?;
-
-                let res = AnalyzeContext::handle_full_sampling(&mut builder).await;
-                builder.merge_storage_stats_into(&mut self.storage_stats);
-                res
+                let res = self.handle_full_sampling_result().await;
+                res.and_then(AnalyzeSamplingResult::write_to_bytes)
             }
 
             AnalyzeType::TypeSampleIndex => Err(Error::Other(
@@ -307,6 +308,10 @@ impl<S: Snapshot, F: KvFormat> RequestHandler for AnalyzeContext<S, F> {
             }
             Err(e) => Err(e),
         }
+    }
+
+    async fn handle_analyze_full_sampling(&mut self) -> Result<AnalyzeSamplingResult> {
+        self.handle_full_sampling_result().await
     }
 
     fn collect_scan_statistics(&mut self, dest: &mut Statistics) {

--- a/src/coprocessor/statistics/fmsketch.rs
+++ b/src/coprocessor/statistics/fmsketch.rs
@@ -79,6 +79,16 @@ impl FmSketch {
             self.mask = mask;
         }
     }
+
+    pub(crate) fn merge(&mut self, other: &FmSketch) {
+        if self.mask < other.mask {
+            self.mask = other.mask;
+            self.hash_set.retain(|&x| x & self.mask == 0);
+        }
+        for hash in &other.hash_set {
+            self.insert_hash_value(*hash);
+        }
+    }
 }
 
 impl From<FmSketch> for tipb::FmSketch {


### PR DESCRIPTION
## Summary

Optimize batch ANALYZE full sampling sub-task handling to reduce TiKV semaphore contention and memory usage.

**Changes (building on #19638):**

1. **Limit batch sub-task concurrency** (`BATCH_SUB_TASK_CONCURRENCY = 3`): Replace `FuturesOrdered::from_iter().collect()` with `stream::iter().buffered(3)`. Previously, all sub-tasks in a batch request acquired semaphore simultaneously, causing contention when `tidb_analyze_distsql_scan_concurrency` is high. Now at most 3 sub-tasks run concurrently per batch request.

2. **Streaming merge**: Merge `AnalyzeSamplingResult` incrementally as each sub-task completes, instead of collecting all results then merging. This reduces peak memory for large batch operations.

## Test Results (10M-row table, 10 rounds)

| Config | wall (avg) | semaphore waits |
|--------|-----------|----------------|
| batch=0, conc=4 | 2.42s | 0 |
| batch=10, conc=4 | 1.82s | 0 |
| batch=0, conc=30 | 1.64s | 1-2 |
| **batch=10, conc=30** | **1.76s** | **0** (was 2-8) |

Key improvement: `batch=10, conc=30` semaphore waits dropped from **2-8 to 0** across all 10 rounds.