### PR TITLE
backup-stream: fix initial range scan deadlock

### DIFF
--- a/components/backup-stream/src/endpoint.rs
+++ b/components/backup-stream/src/endpoint.rs
@@ -640,12 +640,10 @@ where
     /// initialize a range: it simply scan the regions with leader role and send
     /// them to [`initialize_region`].
     pub async fn initialize_range(&self, start_key: Vec<u8>, end_key: Vec<u8>) -> Result<()> {
-        // Generally we will be very very fast to consume.
-        // Directly clone the initial data loader to the background thread looks a
-        // little heavier than creating a new channel. TODO: Perhaps we need a
-        // handle to the `InitialDataLoader`. Making it a `Runnable` worker might be a
-        // good idea.
-        let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+        // Generally we will be very very fast to consume. However `region-collector`
+        // might be blocked then deadlocking happens, see #19615. Making it unbounded to
+        // avoid that.
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
         self.regions
             .seek_region(
                 &start_key,
@@ -656,7 +654,7 @@ where
                         .filter(|r| r.role == StateRole::Leader)
                         .take_while(|r| r.region.start_key < end_key)
                         .try_for_each(|r| {
-                            tx.blocking_send(ObserveOp::Start {
+                            tx.send(ObserveOp::Start {
                                 region: r.region.clone(),
                             })
                         });

--- a/components/backup-stream/src/subscription_manager.rs
+++ b/components/backup-stream/src/subscription_manager.rs
@@ -281,6 +281,14 @@ impl ScanPoolHandle {
 /// The default channel size.
 const MESSAGE_BUFFER_SIZE: usize = 32768;
 
+fn message_buffer_size() -> usize {
+    fail::fail_point!("log_backup_region_operator_buffer_size", |v| {
+        v.and_then(|x| x.parse::<usize>().ok())
+            .unwrap_or(MESSAGE_BUFFER_SIZE)
+    });
+    MESSAGE_BUFFER_SIZE
+}
+
 /// The operator for region subscription.
 /// It make a queue for operations over the `SubscriptionTracer`, generally,
 /// we should only modify the `SubscriptionTracer` itself (i.e. insert records,
@@ -344,7 +352,7 @@ where
         HInit: CdcHandle<E> + Sync + 'static,
         HChkLd: CdcHandle<E> + 'static,
     {
-        let (tx, rx) = channel(MESSAGE_BUFFER_SIZE);
+        let (tx, rx) = channel(message_buffer_size());
         let scan_pool_handle = spawn_executors(initial_loader.clone(), scan_pool_size);
         let op = Self {
             regions,

--- a/components/backup-stream/tests/failpoints/mod.rs
+++ b/components/backup-stream/tests/failpoints/mod.rs
@@ -131,6 +131,41 @@ mod all {
         let c = suite.global_checkpoint();
         assert!(c > commit_ts.into_inner(), "{} vs {}", c, commit_ts);
     }
+
+    #[test]
+    fn initial_region_scan_does_not_deadlock_when_operator_queue_fills() {
+        defer! {{
+            fail::remove("log_backup_region_operator_buffer_size");
+        }}
+        fail::cfg("log_backup_region_operator_buffer_size", "return(2)").unwrap();
+
+        let mut suite = SuiteBuilder::new_named("initial_region_scan_no_deadlock")
+            .nodes(1)
+            .build();
+        // This is the #19615 pattern scaled down: more leader regions than the
+        // subscription operator queue can hold. Without a nonblocking handoff
+        // from the region collector, registration waits forever here.
+        for i in 1..=8 {
+            suite.must_split(&make_split_key_at_record(1, i * 10));
+        }
+
+        let task = "initial_region_scan_no_deadlock";
+        let cli = suite.get_meta_cli();
+        block_on(cli.insert_task_with_range(
+            &suite.simple_task(task),
+            &[(&make_table_key(1, b""), &make_table_key(2, b""))],
+        ))
+        .unwrap();
+
+        assert!(
+            suite.wait_with_router_timeout(
+                move |r| r.get_task_handler(task).is_ok(),
+                Duration::from_secs(30),
+            ),
+            "log backup task registration did not finish; region initialization may be deadlocked"
+        );
+        suite.cluster.shutdown();
+    }
     #[test]
     fn region_failure() {
         defer! {{

--- a/components/backup-stream/tests/suite.rs
+++ b/components/backup-stream/tests/suite.rs
@@ -1,5 +1,10 @@
 // Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
 
+// This file will be included to two files.
+// Some of functions might just be used by one of them,
+// which triggers dead_code warning.
+#![allow(dead_code)]
+
 use std::{
     collections::{HashMap, HashSet},
     fmt::Display,

--- a/components/backup-stream/tests/suite.rs
+++ b/components/backup-stream/tests/suite.rs
@@ -5,7 +5,7 @@ use std::{
     fmt::Display,
     path::{Path, PathBuf},
     sync::Arc,
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use async_compression::futures::write::ZstdDecoder;
@@ -955,8 +955,56 @@ impl Suite {
             .for_each(|rx| rx.recv().unwrap())
     }
 
+    pub fn wait_with_timeout(
+        &self,
+        cond: impl FnMut(&mut TestEndpoint) -> bool + Send + 'static + Clone,
+        timeout: Duration,
+    ) -> bool {
+        let deadline = Instant::now() + timeout;
+        let rxs = self
+            .endpoints
+            .iter()
+            .map({
+                move |(_, wkr)| {
+                    let (tx, rx) = std::sync::mpsc::channel();
+                    let mut cond = cond.clone();
+                    wkr.scheduler()
+                        .schedule(Task::Sync(
+                            Box::new(move || tx.send(()).unwrap()),
+                            Box::new(move |this| {
+                                let ep = this
+                                    .downcast_mut::<TestEndpoint>()
+                                    .expect("`Sync` with wrong type");
+                                cond(ep)
+                            }),
+                        ))
+                        .unwrap();
+                    rx
+                }
+            })
+            .collect::<Vec<_>>();
+
+        for rx in rxs {
+            let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
+                return false;
+            };
+            if rx.recv_timeout(remaining).is_err() {
+                return false;
+            }
+        }
+        true
+    }
+
     pub fn wait_with_router(&self, mut cond: impl FnMut(&Router) -> bool + Send + 'static + Clone) {
         self.wait_with(move |ep| cond(&ep.range_router))
+    }
+
+    pub fn wait_with_router_timeout(
+        &self,
+        mut cond: impl FnMut(&Router) -> bool + Send + 'static + Clone,
+        timeout: Duration,
+    ) -> bool {
+        self.wait_with_timeout(move |ep| cond(&ep.range_router), timeout)
     }
 
     pub fn wait_for_flush(&self) {


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: Close #19615

What's Changed:

```commit-message
backup-stream: fix initial range scan deadlock

When log backup initializes a range with many regions, the region collector
runs the seek-region callback on its own worker thread. The old callback used a
bounded channel with blocking_send. Once the subscription operator queue filled,
range initialization could stop draining that channel while the operator loop was
waiting for find_region_by_id on the same region collector worker, causing a
deadlock.

Use an unbounded local handoff channel in initialize_range so the region
collector callback does not block while emitting initial ObserveOp::Start
messages. Add a failpoint-backed regression test that scales the operator queue
down and verifies task registration completes when the queue fills.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [x] Need to cherry-pick to the release branch

### Check List

Tests

- [ ] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Manual test:

- `make clippy`
- `cargo test -p backup-stream --test failpoints --features failpoints initial_region_scan_does_not_deadlock_when_operator_queue_fills -- --nocapture`
- Reverted the fix locally and confirmed the regression test failed with `log backup task registration did not finish; region initialization may be deadlocked`.
- Ran `tiup playground nightly` with the local TiKV binary, created 33967 regions, and confirmed `br log start` succeeded and TiKV finished registering backup stream ranges.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note

```release-note
Fix a log backup task startup hang when initializing more than 32768 regions.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a potential deadlock in backup-region scanning to prevent backup tasks from hanging and improve reliability.
  * Improved internal message buffering to better handle high-volume concurrent operations without blocking.

* **Tests**
  * Added integration tests simulating high-load region scans to validate deadlock fixes.
  * Enhanced test utilities with timeout-aware wait helpers for faster, deterministic failure detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->