### PR TITLE
cloud/aws: retry S3 SlowDown returned as HTTP 200

### DIFF
--- a/components/cloud/aws/src/kms.rs
+++ b/components/cloud/aws/src/kms.rs
@@ -12,11 +12,11 @@ use aws_sdk_kms::{
     types::DataKeySpec,
 };
 use aws_sdk_s3::config::HttpClient;
+use aws_smithy_types::error::metadata::ProvideErrorMetadata;
 use cloud::{
     error::{Error, KmsError, OtherError, Result},
     kms::{Config, CryptographyType, DataKeyPair, EncryptedKey, KeyId, KmsProvider, PlainKey},
 };
-use aws_smithy_types::error::metadata::ProvideErrorMetadata;
 use futures::executor::block_on;
 
 use crate::util::{self, SdkError, is_retryable};

--- a/components/cloud/aws/src/kms.rs
+++ b/components/cloud/aws/src/kms.rs
@@ -16,6 +16,7 @@ use cloud::{
     error::{Error, KmsError, OtherError, Result},
     kms::{Config, CryptographyType, DataKeyPair, EncryptedKey, KeyId, KmsProvider, PlainKey},
 };
+use aws_smithy_types::error::metadata::ProvideErrorMetadata;
 use futures::executor::block_on;
 
 use crate::util::{self, SdkError, is_retryable};
@@ -175,7 +176,9 @@ fn classify_decrypt_error(err: SdkError<DecryptError>) -> Error {
     }
 }
 
-fn classify_error<E: std::error::Error + Send + Sync + 'static>(err: SdkError<E>) -> Error {
+fn classify_error<E: std::error::Error + ProvideErrorMetadata + Send + Sync + 'static>(
+    err: SdkError<E>,
+) -> Error {
     match &err {
         SdkError::DispatchFailure(dispatch_failure) => {
             let maybe_credentials_err = dispatch_failure

--- a/components/cloud/aws/src/s3.rs
+++ b/components/cloud/aws/src/s3.rs
@@ -41,6 +41,8 @@ use tikv_util::{
 use tokio::time::{sleep, timeout};
 use tokio_util::io::ReaderStream;
 
+use aws_smithy_types::error::metadata::ProvideErrorMetadata;
+
 use crate::util::{self, SdkError, retry_and_count};
 
 const CONNECTION_TIMEOUT: Duration = Duration::from_secs(900);
@@ -402,7 +404,7 @@ impl RetryError for UploadError {
     }
 }
 
-impl<T: 'static + StdError> From<SdkError<T>> for UploadError {
+impl<T: 'static + StdError + ProvideErrorMetadata> From<SdkError<T>> for UploadError {
     fn from(err: SdkError<T>) -> Self {
         let msg = format!("{:?}", err);
         Self::Sdk {

--- a/components/cloud/aws/src/s3.rs
+++ b/components/cloud/aws/src/s3.rs
@@ -15,6 +15,7 @@ use aws_sdk_s3::{
     operation::get_object::GetObjectError,
     types::{CompletedMultipartUpload, CompletedPart},
 };
+use aws_smithy_types::error::metadata::ProvideErrorMetadata;
 use bytes::Bytes;
 use cloud::{
     blob::{
@@ -40,8 +41,6 @@ use tikv_util::{
 };
 use tokio::time::{sleep, timeout};
 use tokio_util::io::ReaderStream;
-
-use aws_smithy_types::error::metadata::ProvideErrorMetadata;
 
 use crate::util::{self, SdkError, retry_and_count};
 

--- a/components/cloud/aws/src/util.rs
+++ b/components/cloud/aws/src/util.rs
@@ -11,10 +11,10 @@ use aws_config::{
     provider_config::ProviderConfig,
 };
 use aws_credential_types::provider::{ProvideCredentials, error::CredentialsError};
-use aws_smithy_types::error::metadata::ProvideErrorMetadata;
 use aws_sdk_kms::config::SharedHttpClient;
 use aws_sdk_s3::config::HttpClient;
 use aws_smithy_runtime::client::http::hyper_014::HyperClientBuilder;
+use aws_smithy_types::error::metadata::ProvideErrorMetadata;
 use cloud::metrics;
 use futures::{Future, TryFutureExt};
 use hyper::Client;
@@ -77,8 +77,7 @@ pub fn is_retryable<T: ProvideErrorMetadata>(error: &SdkError<T>) -> bool {
         }
         SdkError::ServiceError(service_err) => {
             let code = service_err.raw().status();
-            if code.is_server_error()
-                || code.as_u16() == http::StatusCode::REQUEST_TIMEOUT.as_u16()
+            if code.is_server_error() || code.as_u16() == http::StatusCode::REQUEST_TIMEOUT.as_u16()
             {
                 return true;
             }
@@ -320,8 +319,7 @@ mod tests {
         // the XML body. Verify all three throttling codes are retryable at
         // status 200.
         for code in &["SlowDown", "RequestThrottled", "RequestTimeout"] {
-            let response =
-                HttpResponse::new(StatusCode::try_from(200).unwrap(), SdkBody::empty());
+            let response = HttpResponse::new(StatusCode::try_from(200).unwrap(), SdkBody::empty());
             let err = SdkError::service_error(TestError::with_code(code), response);
             assert!(
                 is_retryable(&err),

--- a/components/cloud/aws/src/util.rs
+++ b/components/cloud/aws/src/util.rs
@@ -11,6 +11,7 @@ use aws_config::{
     provider_config::ProviderConfig,
 };
 use aws_credential_types::provider::{ProvideCredentials, error::CredentialsError};
+use aws_smithy_types::error::metadata::ProvideErrorMetadata;
 use aws_sdk_kms::config::SharedHttpClient;
 use aws_sdk_s3::config::HttpClient;
 use aws_smithy_runtime::client::http::hyper_014::HyperClientBuilder;
@@ -66,7 +67,7 @@ pub fn new_credentials_provider(http: impl HttpClient + 'static) -> DefaultCrede
     }
 }
 
-pub fn is_retryable<T>(error: &SdkError<T>) -> bool {
+pub fn is_retryable<T: ProvideErrorMetadata>(error: &SdkError<T>) -> bool {
     match error {
         SdkError::TimeoutError(_) => true,
         SdkError::DispatchFailure(_) => true,
@@ -76,7 +77,19 @@ pub fn is_retryable<T>(error: &SdkError<T>) -> bool {
         }
         SdkError::ServiceError(service_err) => {
             let code = service_err.raw().status();
-            code.is_server_error() || code.as_u16() == http::StatusCode::REQUEST_TIMEOUT.as_u16()
+            if code.is_server_error()
+                || code.as_u16() == http::StatusCode::REQUEST_TIMEOUT.as_u16()
+            {
+                return true;
+            }
+            // S3 can return throttling errors (e.g. SlowDown) as HTTP 200 with
+            // an error code embedded in the XML response body. The SDK detects
+            // this via body_is_error() and routes it through the error path,
+            // producing a ServiceError with raw status 200 but a parsed code.
+            matches!(
+                service_err.err().code(),
+                Some("SlowDown") | Some("RequestThrottled") | Some("RequestTimeout")
+            )
         }
         _ => false,
     }
@@ -204,87 +217,138 @@ impl ProvideCredentials for DefaultCredentialsProvider {
 #[cfg(test)]
 mod tests {
     use aws_smithy_runtime_api::http::StatusCode;
-    use aws_smithy_types::body::SdkBody;
+    use aws_smithy_types::{body::SdkBody, error::ErrorMetadata};
 
     #[allow(unused_imports)]
     use super::*;
 
+    // Minimal error type that satisfies ProvideErrorMetadata for unit tests.
+    #[derive(Debug)]
+    struct TestError {
+        meta: ErrorMetadata,
+    }
+
+    impl TestError {
+        fn with_code(code: &'static str) -> Self {
+            Self {
+                meta: ErrorMetadata::builder().code(code).build(),
+            }
+        }
+
+        fn no_code() -> Self {
+            Self {
+                meta: ErrorMetadata::builder().build(),
+            }
+        }
+    }
+
+    impl std::fmt::Display for TestError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{:?}", self.meta)
+        }
+    }
+
+    impl std::error::Error for TestError {}
+
+    impl ProvideErrorMetadata for TestError {
+        fn meta(&self) -> &ErrorMetadata {
+            &self.meta
+        }
+    }
+
     #[test]
     fn test_is_retryable_response_error_5xx() {
-        // Test that ResponseError with 5xx status codes are retryable
         let response = HttpResponse::new(StatusCode::try_from(503).unwrap(), SdkBody::empty());
-        let err = SdkError::<(), _>::response_error("service unavailable", response);
+        let err = SdkError::<TestError, _>::response_error("service unavailable", response);
         assert!(is_retryable(&err));
 
         let response = HttpResponse::new(StatusCode::try_from(500).unwrap(), SdkBody::empty());
-        let err = SdkError::<(), _>::response_error("internal server error", response);
+        let err = SdkError::<TestError, _>::response_error("internal server error", response);
         assert!(is_retryable(&err));
     }
 
     #[test]
     fn test_is_retryable_response_error_4xx() {
-        // Test that ResponseError with 4xx status codes are not retryable
         let response = HttpResponse::new(StatusCode::try_from(404).unwrap(), SdkBody::empty());
-        let err = SdkError::<(), _>::response_error("not found", response);
+        let err = SdkError::<TestError, _>::response_error("not found", response);
         assert!(!is_retryable(&err));
 
         let response = HttpResponse::new(StatusCode::try_from(400).unwrap(), SdkBody::empty());
-        let err = SdkError::<(), _>::response_error("bad request", response);
+        let err = SdkError::<TestError, _>::response_error("bad request", response);
         assert!(!is_retryable(&err));
     }
 
     #[test]
     fn test_is_retryable_response_error_408() {
-        // Test that ResponseError with 408 Request Timeout is retryable
         let response = HttpResponse::new(StatusCode::try_from(408).unwrap(), SdkBody::empty());
-        let err = SdkError::<(), _>::response_error("request timeout", response);
+        let err = SdkError::<TestError, _>::response_error("request timeout", response);
         assert!(is_retryable(&err));
     }
 
     #[test]
     fn test_is_retryable_service_error_5xx() {
-        // Test that ServiceError with 5xx status codes are retryable (e.g., S3
-        // SlowDown)
         let response = HttpResponse::new(StatusCode::try_from(503).unwrap(), SdkBody::empty());
-        let err = SdkError::<(), _>::service_error((), response);
+        let err = SdkError::service_error(TestError::no_code(), response);
         assert!(is_retryable(&err));
 
         let response = HttpResponse::new(StatusCode::try_from(500).unwrap(), SdkBody::empty());
-        let err = SdkError::<(), _>::service_error((), response);
+        let err = SdkError::service_error(TestError::no_code(), response);
         assert!(is_retryable(&err));
     }
 
     #[test]
     fn test_is_retryable_service_error_4xx() {
-        // Test that ServiceError with 4xx status codes are not retryable
         let response = HttpResponse::new(StatusCode::try_from(404).unwrap(), SdkBody::empty());
-        let err = SdkError::<(), _>::service_error((), response);
+        let err = SdkError::service_error(TestError::no_code(), response);
         assert!(!is_retryable(&err));
 
         let response = HttpResponse::new(StatusCode::try_from(403).unwrap(), SdkBody::empty());
-        let err = SdkError::<(), _>::service_error((), response);
+        let err = SdkError::service_error(TestError::no_code(), response);
         assert!(!is_retryable(&err));
     }
 
     #[test]
     fn test_is_retryable_service_error_408() {
-        // Test that ServiceError with 408 Request Timeout is retryable
         let response = HttpResponse::new(StatusCode::try_from(408).unwrap(), SdkBody::empty());
-        let err = SdkError::<(), _>::service_error((), response);
+        let err = SdkError::service_error(TestError::no_code(), response);
         assert!(is_retryable(&err));
     }
 
     #[test]
+    fn test_is_retryable_service_error_slowdown_http_200() {
+        // S3 SlowDown / throttling can arrive as HTTP 200 with the error code in
+        // the XML body. Verify all three throttling codes are retryable at
+        // status 200.
+        for code in &["SlowDown", "RequestThrottled", "RequestTimeout"] {
+            let response =
+                HttpResponse::new(StatusCode::try_from(200).unwrap(), SdkBody::empty());
+            let err = SdkError::service_error(TestError::with_code(code), response);
+            assert!(
+                is_retryable(&err),
+                "expected HTTP 200 ServiceError with code={} to be retryable",
+                code
+            );
+        }
+    }
+
+    #[test]
+    fn test_is_retryable_service_error_other_200() {
+        // A 200 ServiceError with an unrelated code must not be retried.
+        let response = HttpResponse::new(StatusCode::try_from(200).unwrap(), SdkBody::empty());
+        let err = SdkError::service_error(TestError::with_code("NoSuchKey"), response);
+        assert!(!is_retryable(&err));
+    }
+
+    #[test]
     fn test_is_retryable_timeout_error() {
-        // Test that TimeoutError is retryable
-        let err = SdkError::<(), HttpResponse>::timeout_error("operation timed out");
+        let err = SdkError::<TestError, HttpResponse>::timeout_error("operation timed out");
         assert!(is_retryable(&err));
     }
 
     #[test]
     fn test_is_retryable_construction_failure() {
-        // Test that ConstructionFailure is not retryable
-        let err = SdkError::<(), HttpResponse>::construction_failure("failed to build request");
+        let err =
+            SdkError::<TestError, HttpResponse>::construction_failure("failed to build request");
         assert!(!is_retryable(&err));
     }
 


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: ref #19196

PR #19197 added a `ServiceError` arm to `is_retryable` so that S3 5xx
SlowDown responses are retried. However, S3 can also return throttling
errors as **HTTP 200** with the error code embedded in the XML response
body (the "streaming commit" path). The AWS SDK detects this via
`body_is_error()` and produces a `SdkError::ServiceError` with
`raw.status() == 200` and parsed code `"SlowDown"`. Because
`is_retryable` only checked the HTTP status code, the 200-status case
was still treated as non-retryable, causing backup failures when S3
throttles under load:

```
[ERROR] [endpoint.rs:259] ["backup save file failed"]
[err="... ServiceError { source: Unhandled { source: ErrorMetadata {
  code: Some("SlowDown"), message: Some("Please reduce your request rate.") } },
  raw: Response { status: StatusCode(200), ... } }"]
```

**Fix:** tighten `is_retryable<T>` to require `T: ProvideErrorMetadata`
and fall through from the HTTP-status check to an error-code check for
`"SlowDown"`, `"RequestThrottled"`, and `"RequestTimeout"`. The bound
propagates to the two call sites in `s3.rs` and `kms.rs`; all concrete
SDK error types already implement `ProvideErrorMetadata`.

```commit-message
S3 can return throttling errors as HTTP 200 with the error code
embedded in the XML response body (the "streaming commit" path).
The AWS SDK detects this via body_is_error() and produces a
SdkError::ServiceError with raw status 200 and parsed code
"SlowDown" / "RequestThrottled" / "RequestTimeout".

The previous fix (#19197) only checked the HTTP status code in the
ServiceError arm of is_retryable(), so these 200 responses were
still treated as non-retryable, causing backup failures when S3
throttles under high load.

Tighten is_retryable<T> to require T: ProvideErrorMetadata and fall
through from the HTTP-status check to an error-code check so all
three throttling codes are retried regardless of response status.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note

```release-note
Fix backup failures caused by S3 SlowDown / RequestThrottled responses
arriving as HTTP 200 with an error body not being retried.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AWS retry behavior by using service error metadata to identify retryable throttling conditions, including S3-style throttling errors that can appear with HTTP 200.

* **Refactor**
  * Updated AWS error classification and error conversions to rely on richer service error metadata for more accurate retry decisions.

* **Tests**
  * Expanded unit tests to cover the new HTTP 200 throttling retry behavior, including verification that unrelated HTTP 200 service errors are not treated as retryable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->