### PR TITLE
raftstore: avoid creating empty snapshot SST for large KV

### DIFF
--- a/components/raftstore/src/store/snap/io.rs
+++ b/components/raftstore/src/store/snap/io.rs
@@ -222,7 +222,9 @@ where
 
     box_try!(snap.scan(cf, start_key, end_key, false, |key, value| {
         let entry_len = key.len() + value.len();
-        // Allow a single large entry to occupy one SST that exceeds the target size.
+        // Avoid producing an empty SST file, which can make RocksDB panic when
+        // ingested. Allow a single large entry to occupy one SST that exceeds
+        // the target size.
         if file_length > 0 && file_length + entry_len > raw_size_per_file as usize {
             cf_file.add_file(file_id); // add previous file
             file_length = 0;

--- a/components/raftstore/src/store/snap/io.rs
+++ b/components/raftstore/src/store/snap/io.rs
@@ -222,7 +222,8 @@ where
 
     box_try!(snap.scan(cf, start_key, end_key, false, |key, value| {
         let entry_len = key.len() + value.len();
-        if file_length + entry_len > raw_size_per_file as usize {
+        // Allow a single large entry to occupy one SST that exceeds the target size.
+        if file_length > 0 && file_length + entry_len > raw_size_per_file as usize {
             cf_file.add_file(file_id); // add previous file
             file_length = 0;
             file_id += 1;
@@ -522,7 +523,7 @@ mod tests {
     use std::{collections::HashMap, path::PathBuf};
 
     use engine_test::kv::KvTestEngine;
-    use engine_traits::CF_DEFAULT;
+    use engine_traits::{CF_DEFAULT, Peekable, SyncMutable};
     use tempfile::Builder;
     use tikv_util::time::Limiter;
 
@@ -688,6 +689,56 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn test_cf_build_sst_file_with_large_entry() {
+        let limiter = Limiter::new(f64::INFINITY);
+        let dir = Builder::new().prefix("test-snap-cf-db").tempdir().unwrap();
+        let db: KvTestEngine = open_test_empty_db(dir.path(), None, None).unwrap();
+        let key = keys::data_key(b"large");
+        let value = vec![b'v'; 256];
+        db.put_cf(CF_DEFAULT, &key, &value).unwrap();
+
+        let snap_cf_dir = Builder::new().prefix("test-snap-cf").tempdir().unwrap();
+        let mut cf_file = CfFile {
+            cf: CF_DEFAULT,
+            path: PathBuf::from(snap_cf_dir.path().to_str().unwrap()),
+            file_prefix: "test_sst".to_string(),
+            file_suffix: SST_FILE_SUFFIX.to_string(),
+            ..Default::default()
+        };
+        let stats = build_sst_cf_file_list::<KvTestEngine>(
+            &mut cf_file,
+            &db,
+            &db.snapshot(),
+            &keys::data_key(b"a"),
+            &keys::data_key(b"z"),
+            100,
+            &limiter,
+            None,
+            true,
+        )
+        .unwrap();
+
+        assert_eq!(stats.key_count, 1);
+        assert_eq!(stats.total_kv_size, key.len() + value.len());
+        assert_eq!(cf_file.file_paths().len(), 1);
+
+        let dir1 = Builder::new()
+            .prefix("test-snap-cf-db-apply")
+            .tempdir()
+            .unwrap();
+        let db1: KvTestEngine = open_test_empty_db(dir1.path(), None, None).unwrap();
+        let tmp_file_paths = cf_file.tmp_file_paths();
+        let tmp_file_paths = tmp_file_paths
+            .iter()
+            .map(|s| s.as_str())
+            .collect::<Vec<&str>>();
+        apply_sst_cf_files_by_ingest(&tmp_file_paths, &db1, CF_DEFAULT, vec![], vec![]).unwrap();
+
+        let applied_value = db1.get_value_cf(CF_DEFAULT, &key).unwrap().unwrap();
+        assert_eq!(&*applied_value, value.as_slice());
     }
 
     // This test verifies that building SST files is effectively limited by the I/O


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: close #19634

What's Changed:

```commit-message
raftstore: avoid creating empty snapshot SST for large KV

When building snapshot SST files, `build_sst_cf_file_list` rotated to a new
SST before writing the current key-value pair if the current raw size plus the
entry size exceeded `raw_size_per_file`.

If the first entry in an SST was larger than `raw_size_per_file`, this caused
TiKV to finish an empty SST writer before any entry was written. RocksDB rejects
empty SST files with `Invalid argument: Cannot create sst file with no entries`,
which made snapshot generation fail.

This PR changes the split condition to rotate only when the current SST already
contains data. A single oversized key-value entry is now allowed to occupy one
SST that exceeds the target raw size, while normal splitting behavior is kept
for subsequent entries.

A regression test is added to cover building and ingesting a snapshot SST that
contains one key-value entry larger than the configured per-file raw size.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [x] Need to cherry-pick to the release branch

### Check List

Tests

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note

```release-note
Fix a snapshot generation failure that could occur when one key-value entry is
larger than the configured snapshot SST file raw size.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of large key-value entries when building SST/snapshot files so a single large entry can be stored in one file without creating empty file boundaries.

* **Tests**
  * Added test coverage verifying SST/snapshot building and ingestion with a single large entry to ensure correctness end-to-end.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tikv/tikv/pull/19653?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->