### PR TITLE
import: mark applied write cf txn source

### DIFF
--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -104,7 +104,7 @@ const HIGH_IMPORT_MEMORY_WATER_RATIO: f64 = 0.95;
 // cleaned up eventually.
 const DEFAULT_FORCE_PARTITION_RANGE_TTL_SECONDS: u64 = 3600;
 
-// See /workspace/tikv/pitr-txn-source/components/cdc/src/txn_source.rs
+// See components/cdc/src/txn_source.rs
 // cdc then ignores txn sources with this mask.
 const TXN_SOURCE_LIGHTNING_PHY_IMPORT_MASK: u64 = 1 << 16;
 
@@ -1752,7 +1752,6 @@ fn prepare_write(write: &mut Vec<u8>) -> bool {
         {
             let mut w = w.to_owned();
             // To tell CDC ignore this write.
-            // Perhaps we can give "physcial import mask" a better name?
             w.txn_source |= TXN_SOURCE_LIGHTNING_PHY_IMPORT_MASK;
             *write = w.as_ref().to_bytes();
             true

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -104,6 +104,10 @@ const HIGH_IMPORT_MEMORY_WATER_RATIO: f64 = 0.95;
 // cleaned up eventually.
 const DEFAULT_FORCE_PARTITION_RANGE_TTL_SECONDS: u64 = 3600;
 
+// See /workspace/tikv/pitr-txn-source/components/cdc/src/txn_source.rs
+// cdc then ignores txn sources with this mask.
+const TXN_SOURCE_LIGHTNING_PHY_IMPORT_MASK: u64 = 1 << 16;
+
 /// Check if the system has enough resources for import tasks
 async fn check_import_resources(mem_limit: u64) -> Result<()> {
     #[cfg(feature = "failpoints")]
@@ -251,7 +255,7 @@ impl RequestCollector {
         }
     }
 
-    fn accept_kv(&mut self, cf: &str, is_delete: bool, k: Vec<u8>, v: Vec<u8>) {
+    fn accept_kv(&mut self, cf: &str, is_delete: bool, k: Vec<u8>, mut v: Vec<u8>) {
         debug!("Accepting KV."; "cf" => %cf,
             "key" => %log_wrappers::Value::key(&k),
             "value" => %log_wrappers::Value::key(&v));
@@ -269,7 +273,7 @@ impl RequestCollector {
         let m = if is_delete {
             Modify::Delete(cf, Key::from_encoded(k))
         } else {
-            if cf == CF_WRITE && !write_needs_restore(&v) {
+            if cf == CF_WRITE && !prepare_write(&mut v) {
                 return;
             }
 
@@ -1735,7 +1739,7 @@ impl<E: Engine> ImportSst for ImportSstService<E> {
     }
 }
 
-fn write_needs_restore(write: &[u8]) -> bool {
+fn prepare_write(write: &mut Vec<u8>) -> bool {
     let w = WriteRef::parse(write);
     match w {
         Ok(w)
@@ -1746,6 +1750,11 @@ fn write_needs_restore(write: &[u8]) -> bool {
                 WriteType::Put | WriteType::Delete
             ) =>
         {
+            let mut w = w.to_owned();
+            // To tell CDC ignore this write.
+            // Perhaps we can give "physcial import mask" a better name?
+            w.txn_source |= TXN_SOURCE_LIGHTNING_PHY_IMPORT_MASK;
+            *write = w.as_ref().to_bytes();
             true
         }
         Ok(w) => {

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -1880,13 +1880,16 @@ mod test {
     use txn_types::{Key, TimeStamp, Write, WriteBatchFlags, WriteType};
 
     use crate::{
-        import::sst_service::{RequestCollector, check_local_region_stale},
+        import::sst_service::{
+            RequestCollector, TXN_SOURCE_LIGHTNING_PHY_IMPORT_MASK, check_local_region_stale,
+        },
         server::raftkv,
     };
 
     fn write(key: &[u8], ty: WriteType, commit_ts: u64, start_ts: u64) -> (Vec<u8>, Vec<u8>) {
         let k = Key::from_raw(key).append_ts(TimeStamp::new(commit_ts));
-        let v = Write::new(ty, TimeStamp::new(start_ts), None);
+        let mut v = Write::new(ty, TimeStamp::new(start_ts), None);
+        v.txn_source |= TXN_SOURCE_LIGHTNING_PHY_IMPORT_MASK;
         (k.into_encoded(), v.as_ref().to_bytes())
     }
 

--- a/tests/integrations/import/test_apply_log.rs
+++ b/tests/integrations/import/test_apply_log.rs
@@ -64,6 +64,7 @@ fn test_apply_write_cf_sets_txn_source() {
         .unwrap()
         .unwrap();
     let write = WriteRef::parse(&write_value).unwrap();
+    // See components/cdc/src/txn_source.rs, LIGHTNING_PHYSICAL_IMPORT_SHIFT
     let expected_txn_source = old_txn_source | (1 << 16);
     assert_eq!(write.txn_source, expected_txn_source);
 }

--- a/tests/integrations/import/test_apply_log.rs
+++ b/tests/integrations/import/test_apply_log.rs
@@ -1,11 +1,12 @@
 // Copyright 2024 TiKV Project Authors. Licensed under Apache-2.0.
 
-use engine_traits::CF_DEFAULT;
+use engine_traits::{CF_DEFAULT, CF_WRITE, Peekable};
 use external_storage::LocalStorage;
 use kvproto::import_sstpb::ApplyRequest;
 use tempfile::TempDir;
 use test_sst_importer::*;
 use tikv_util::sys::disk::{self, DiskUsage};
+use txn_types::{Key, TimeStamp, Write, WriteRef, WriteType};
 
 use super::util::*;
 
@@ -30,6 +31,41 @@ fn test_basic_apply() {
     req.set_storage_backend(local_storage(&tmp));
     import.apply(&req).unwrap();
     check_applied_kvs_cf(&tikv, &ctx, CF_DEFAULT, default_rewritten.into_iter());
+}
+
+#[test]
+fn test_apply_write_cf_sets_txn_source() {
+    let (cluster, ctx, _tikv, import) = new_cluster_and_tikv_import_client();
+    let tmp = TempDir::new().unwrap();
+    let storage = LocalStorage::new(tmp.path()).unwrap();
+    let old_txn_source = 0b101;
+    let write = Write::new(WriteType::Put, TimeStamp::new(9), None)
+        .set_txn_source(old_txn_source)
+        .as_ref()
+        .to_bytes();
+    let mut sst_meta = make_plain_file(
+        &storage,
+        "file_write.log",
+        std::iter::once((&b"k1"[..], write.as_slice(), 10)),
+    );
+    sst_meta.set_cf(CF_WRITE.to_owned());
+    register_range_for(&mut sst_meta, b"k1", b"k2");
+    let mut req = ApplyRequest::new();
+    req.set_context(ctx.clone());
+    req.set_rewrite_rules(vec![rewrite_for(&mut sst_meta, b"k", b"r")].into());
+    req.set_metas(vec![sst_meta].into());
+    req.set_storage_backend(local_storage(&tmp));
+    import.apply(&req).unwrap();
+
+    let engine = cluster.get_engine(ctx.get_peer().get_store_id());
+    let key = Key::from_raw(b"r1").append_ts(TimeStamp::new(10));
+    let write_value = engine
+        .get_value_cf(CF_WRITE, &keys::data_key(key.as_encoded()))
+        .unwrap()
+        .unwrap();
+    let write = WriteRef::parse(&write_value).unwrap();
+    let expected_txn_source = old_txn_source | (1 << 16);
+    assert_eq!(write.txn_source, expected_txn_source);
 }
 
 #[test]


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: close #19669, ref pingcap/tidb#68660

What's Changed:

```commit-message
import: mark applied write CF entries with physical import txn source

PITR restores write CF records through apply log. Before this change, restored Put/Delete write records did not carry a transaction source bit that TiCDC can use to distinguish PITR-imported data from normal user writes.

This change marks restored write CF Put/Delete records with the Lightning physical import txn source bit while preserving existing txn_source bits. TiCDC already filters rows with this bit, so a changefeed whose checkpoint is after RestoreTS can ignore PITR-imported data and only replicate later incremental changes.

Unsupported write types and unparsable writes keep the existing skip behavior.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`: N/A
- [ ] Need to cherry-pick to the release branch

### Check List

Tests

- [ ] Unit test
- [x] Integration test
- [ ] Manual test
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note

```release-note
Mark PITR-restored write CF entries with the physical import transaction source so TiCDC can ignore PITR-imported data.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * SST import now correctly preserves and tags transaction-source metadata for supported write types (put/delete), avoiding lost or inconsistent transaction information.

* **Tests**
  * Added/updated integration tests to verify transaction-source tagging during import and after reads, and to ensure unsupported write types are ignored during tagging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->