### PR TITLE
[cherr-pick] raftstore: fix unreasonable snapshot cancel checking (#18873) #19101

### DIFF
--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -4467,10 +4467,19 @@ where
         self.fsm.peer.schedule_raftlog_gc(self.ctx, compact_to);
         self.fsm.peer.last_compacted_idx = compact_to;
         let transfer_leader_state = &mut self.fsm.peer.transfer_leader_state;
-        self.fsm.peer.raft_group.mut_store().on_compact_raftlog(
-            compact_to,
-            transfer_leader_state.cache_warmup_state.as_mut(),
-        );
+        self.fsm
+            .peer
+            .raft_group
+            .mut_store()
+            .on_compact_raftlog_cache(
+                compact_to,
+                transfer_leader_state.cache_warmup_state.as_mut(),
+            );
+        self.fsm
+            .peer
+            .raft_group
+            .mut_store()
+            .cancel_generating_snap(Some(compact_to));
         if self.fsm.peer.is_witness() {
             self.fsm.peer.last_compacted_time = Instant::now();
         }
@@ -6126,10 +6135,14 @@ where
         // leader may call `get_term()` on the latest replicated index, so compact
         // entries before `alive_cache_idx` instead of `alive_cache_idx + 1`.
         let transfer_leader_state = &mut self.fsm.peer.transfer_leader_state;
-        self.fsm.peer.raft_group.mut_store().on_compact_raftlog(
-            std::cmp::min(alive_cache_idx, applied_idx + 1),
-            transfer_leader_state.cache_warmup_state.as_mut(),
-        );
+        self.fsm
+            .peer
+            .raft_group
+            .mut_store()
+            .on_compact_raftlog_cache(
+                std::cmp::min(alive_cache_idx, applied_idx + 1),
+                transfer_leader_state.cache_warmup_state.as_mut(),
+            );
         if needs_evict_entry_cache(self.ctx.cfg.evict_cache_on_memory_ratio) {
             self.fsm.peer.mut_store().evict_entry_cache(true);
             if !self.fsm.peer.get_store().is_entry_cache_empty() {
@@ -6185,6 +6198,15 @@ where
                 .inc();
             return;
         }
+
+        // If RaftEngine's compact idx exceeds the snapshot idx,
+        // means the snapshot idx has already been compacted.
+        // We should cancel the snapshot generating as it is now out of date.
+        self.fsm
+            .peer
+            .raft_group
+            .mut_store()
+            .cancel_generating_snap(Some(compact_idx));
 
         // Create a compact log request and notify directly.
         let region_id = self.fsm.peer.region().get_id();

--- a/components/raftstore/src/store/peer_storage.rs
+++ b/components/raftstore/src/store/peer_storage.rs
@@ -650,9 +650,13 @@ where
         *gen_snap_task = Some(task);
     }
 
-    pub fn on_compact_raftlog(&mut self, idx: u64, state: Option<&mut CacheWarmupState>) {
+    pub fn on_compact_raftlog_cache(&mut self, idx: u64, state: Option<&mut CacheWarmupState>) {
         self.entry_storage.compact_entry_cache(idx, state);
+<<<<<<< HEAD
         self.cancel_generating_snap(Some(idx));
+=======
+        self.entry_storage.compact_term_cache(idx);
+>>>>>>> 205efbd2b6 (raftstore: fix unreasonable snapshot cancel checking (#18873))
     }
 
     // Apply the peer with given snapshot.

--- a/components/raftstore/src/store/peer_storage.rs
+++ b/components/raftstore/src/store/peer_storage.rs
@@ -652,11 +652,6 @@ where
 
     pub fn on_compact_raftlog_cache(&mut self, idx: u64, state: Option<&mut CacheWarmupState>) {
         self.entry_storage.compact_entry_cache(idx, state);
-<<<<<<< HEAD
-        self.cancel_generating_snap(Some(idx));
-=======
-        self.entry_storage.compact_term_cache(idx);
->>>>>>> 205efbd2b6 (raftstore: fix unreasonable snapshot cancel checking (#18873))
     }
 
     // Apply the peer with given snapshot.

--- a/components/raftstore/src/store/peer_storage.rs
+++ b/components/raftstore/src/store/peer_storage.rs
@@ -1847,6 +1847,33 @@ pub mod tests {
         }
     }
 
+    #[test]
+    fn test_compact_raftlog_cache_does_not_cancel_generating_snap() {
+        let td = Builder::new().prefix("tikv-store-test").tempdir().unwrap();
+        let (sched, _) = dummy_scheduler();
+        let (dummy_scheduler, _) = dummy_scheduler();
+        let mut s = new_storage(sched, dummy_scheduler, &td);
+        let (_tx, rx) = channel();
+        let canceled = Arc::new(AtomicBool::new(false));
+        s.set_snap_state(SnapState::Generating {
+            canceled: Arc::clone(&canceled),
+            index: Arc::new(AtomicU64::new(5)),
+            receiver: rx,
+        });
+
+        // Entry-cache compaction is not allowed to cancel an in-flight snapshot.
+        // Otherwise a healthy snapshot generation can be discarded before the real
+        // raft-engine compact index overtakes the snapshot index.
+        s.on_compact_raftlog_cache(10, None);
+
+        assert!(!canceled.load(Ordering::SeqCst));
+
+        // The actual stale-snapshot cancel path is still driven explicitly by
+        // `cancel_generating_snap`.
+        s.cancel_generating_snap(Some(10));
+        assert!(canceled.load(Ordering::SeqCst));
+    }
+
     fn test_storage_create_snapshot_for_role(role: &str, expected_snapshot_file_count: usize) {
         let ents = vec![new_entry(3, 3), new_entry(4, 4), new_entry(5, 5)];
         let mut cs = ConfState::default();


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/tikv/tikv/pull/19101 for hotfix.

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #18872 

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Adjust cancel generating snapshot index from `entry_cache_compact_idx` to `raftengine_compact_index`.  
This prevents overly aggressive cache compaction that, after a forced GC on the leader, could continuously cancel snapshot generation.  

```
As mentioned in issue #18872 , if a node is unable to synchronize logs due to a network partition, other nodes will implicitly mark it as a "down peer" (specifically, if `truncated_idx > replicated_idx`).  

However, the advancement of `entry_cache_compact_idx` does not take into account the `replicated_idx` of the "down peer". 
As other active peers continue to write and synchronize, the cache compaction idx will continue to advance, causing the `snapshot_idx` to be older than the `entry_cache_compact_idx` , resulting in frequent cancellation of snapshot generation.

Therefore, we should use `raftengine_compact_index` as the checker idx, which considers the `replicated_idx `of all peers.

**Before Modification**
<img width="1237" height="411" alt="image" src="https://github.com/user-attachments/assets/2208038a-a3f0-4ed2-bce6-eea699624854" />
<img width="1216" height="393" alt="image" src="https://github.com/user-attachments/assets/293a356d-ad9a-4867-a265-f5f42119bcb8" />

**After Modification**
<img width="1222" height="405" alt="image" src="https://github.com/user-attachments/assets/0460ee93-6264-469a-977d-3bfb741226e9" />
<img width="1227" height="396" alt="image" src="https://github.com/user-attachments/assets/d87f2ccf-0aaa-4df9-a54c-ba21965611fd" />
### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
fix unreasonable snapshot cancel checking
```

