### PR TITLE
storage: downgrade normal unsafe-destroy-range flow-control INFO logs and add outcome counter

### DIFF
--- a/src/storage/txn/flow_controller/singleton_flow_controller.rs
+++ b/src/storage/txn/flow_controller/singleton_flow_controller.rs
@@ -433,10 +433,13 @@ impl<E: FlowControlFactorStore + Send + 'static> FlowChecker<E> {
                     {
                         let v = long_term_pending_bytes.get_avg();
                         if v <= soft {
-                            info!(
+                            // Bookkeeping only: record the baseline for the later
+                            // jump check. Downgraded to DEBUG to avoid a log storm
+                            // when UDR is triggered at very high frequency.
+                            debug!(
                                 "before unsafe destroy range";
                                 "cf" => cf,
-                                "pending_bytes" => v
+                                "pending_bytes_log2" => v
                             );
                             cf_checker.pending_bytes_before_unsafe_destroy_range = Some(v);
                         }
@@ -468,26 +471,34 @@ impl<E: FlowControlFactorStore + Send + 'static> FlowChecker<E> {
                         if current_pending_bytes >= soft || avg_pending_bytes >= soft {
                             // There is a pending bytes jump. Flow control for
                             // compaction bytes won't be re-enabled until the
-                            // pending bytes drop below the soft limit.
+                            // pending bytes drop below the soft limit. This is the
+                            // abnormal path that deserves a visible log line.
                             SCHED_THROTTLE_ACTION_COUNTER
                                 .with_label_values(&[cf, "pending_bytes_jump"])
                                 .inc();
-                        } else {
-                            cf_checker.pending_bytes_before_unsafe_destroy_range = None;
                             info!(
+                                "pending compaction bytes jump after unsafe destroy range";
+                                "cf" => cf,
+                                "before_log2" => before,
+                                "current_pending_bytes_log2" => current_pending_bytes,
+                                "avg_pending_bytes_log2" => avg_pending_bytes,
+                                "soft_limit_log2" => soft,
+                            );
+                        } else {
+                            // Normal path: pending bytes were cleared or dropped,
+                            // which is the vast majority of UDR events. Keep it out
+                            // of the default log and only track it with a metric to
+                            // avoid a log storm; downgrade the state-change log to
+                            // DEBUG.
+                            cf_checker.pending_bytes_before_unsafe_destroy_range = None;
+                            SCHED_THROTTLE_ACTION_COUNTER
+                                .with_label_values(&[cf, "pending_bytes_no_jump"])
+                                .inc();
+                            debug!(
                                 "re-enabled compaction pending bytes flow control";
                                 "cf" => cf,
                             );
                         }
-
-                        info!(
-                            "after unsafe destroy range";
-                            "cf" => cf,
-                            "before" => before,
-                            "current_pending_bytes" => current_pending_bytes,
-                            "avg_pending_bytes" => avg_pending_bytes,
-                            "soft_limit" => soft,
-                        );
                     }
                 }
             }
@@ -639,8 +650,8 @@ impl<E: FlowControlFactorStore + Send + 'static> FlowChecker<E> {
                     info!(
                         "pending compaction bytes is back to normal";
                         "cf" => &cf,
-                        "pending_compaction_bytes" => pending_compaction_bytes,
-                        "before" => before
+                        "pending_compaction_bytes_log2" => pending_compaction_bytes,
+                        "before_log2" => before
                     );
                     checker.pending_bytes_before_unsafe_destroy_range = None;
                 }


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: Close #19685

What's Changed:

- On the `BeforeUnsafeDestroyRange` path, downgrade the per-CF `before unsafe destroy range` INFO to DEBUG. The baseline record (`pending_bytes_before_unsafe_destroy_range`) is kept, so jump detection is unaffected.
- On the `AfterUnsafeDestroyRange` path, stop emitting INFO on every event. The normal path (pending bytes cleared or below the soft limit) no longer logs at INFO: `re-enabled compaction pending bytes flow control` is downgraded to DEBUG and the unconditional `after unsafe destroy range` INFO is removed.
- Only the abnormal path — a pending-bytes jump where `current_pending_bytes >= soft || avg_pending_bytes >= soft` — now emits a single dedicated INFO `pending compaction bytes jump after unsafe destroy range`, carrying `before / current_pending_bytes / avg_pending_bytes / soft_limit / cf`.
- Add a `pending_bytes_no_jump` type to the existing `tikv_scheduler_throttle_action_total` counter (labels `cf`, `type`), symmetric to the existing `pending_bytes_jump`. The two together keep UDR activity and the normal-vs-jump outcome observable after the log downgrade — no new metric and no extra cardinality dimension.

No flow-control decision logic is changed; this only adjusts log levels/visibility and adds one metric type. Behavior is covered by the existing `flow_controller` unit tests.

```commit-message
storage: downgrade normal unsafe-destroy-range flow-control INFO logs and add outcome counter

The singleton flow controller emits per-CF INFO logs on both the before and
after paths of every UnsafeDestroyRange (UDR) event: `before unsafe destroy
range`, `after unsafe destroy range`, and `re-enabled compaction pending
bytes flow control`. These are internal bookkeeping to detect an abnormal
pending-compaction-bytes jump around UDR. When UDR frequency spikes they fan
out by event x CF and flood the log — real-world incident data shows this
pair of source lines accounting for ~14.7% of the daily log delta, almost
all of it the normal `after=-inf` (pending bytes cleared) case.

Downgrade the routine before/after bookkeeping to DEBUG and stop emitting the
unconditional after INFO. Only the abnormal jump path (current or average
pending bytes back above the soft limit after UDR) keeps a single INFO line
with before/current/avg/soft context.

Add a `pending_bytes_no_jump` type to the existing
tikv_scheduler_throttle_action_total counter, symmetric to the existing
`pending_bytes_jump`, so UDR activity and the normal-vs-jump outcome stay
observable through metrics. No flow-control decision logic is changed.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [x] Need to cherry-pick to the release branch

### Check List

Tests

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note

```release-note
Reduce `unsafe destroy range` flow-control INFO log noise: the routine before/after pending-compaction-bytes bookkeeping is downgraded to DEBUG, and only an abnormal pending-bytes jump after unsafe destroy range is logged at INFO. Add a `pending_bytes_no_jump` type to the `tikv_scheduler_throttle_action_total` metric so the UDR outcome distribution stays observable.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced flow control monitoring by adding dedicated metrics counters to track pending bytes state transitions.
  * Adjusted logging levels and updated field naming conventions for improved observability of flow control events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->