### PR TITLE
gcp: refresh access tokens before expiry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7764,7 +7764,7 @@ dependencies = [
 [[package]]
 name = "tame-oauth"
 version = "0.9.6"
-source = "git+https://github.com/tikv/tame-oauth?branch=fips-0.9#487e287c0d316b832dc44735cd9b7f7c432a10aa"
+source = "git+https://github.com/tikv/tame-oauth?branch=fips-0.9#adf4c03305561c24d456ef665475f7295eb177a0"
 dependencies = [
  "data-encoding",
  "http 0.2.12",

--- a/components/cloud/gcp/src/client.rs
+++ b/components/cloud/gcp/src/client.rs
@@ -265,3 +265,51 @@ impl RetryError for RequestError {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::time::{Duration, SystemTime};
+
+    use tame_oauth::{
+        Token,
+        token_cache::{TokenCache, TokenOrRequestReason},
+    };
+
+    fn token_expiring_after(duration: Duration) -> Token {
+        Token {
+            access_token: "token".to_owned(),
+            refresh_token: String::new(),
+            token_type: "Bearer".to_owned(),
+            expires_in: Some(duration.as_secs() as i64),
+            expires_in_timestamp: Some(SystemTime::now() + duration),
+        }
+    }
+
+    #[test]
+    fn tame_oauth_refreshes_cached_access_tokens_within_refresh_window() {
+        let cache = TokenCache::new();
+        let scope_hash = 1;
+
+        cache
+            .insert(token_expiring_after(Duration::from_secs(60)), scope_hash)
+            .unwrap();
+        assert!(matches!(
+            cache.get(scope_hash).unwrap(),
+            TokenOrRequestReason::RequestReason(_)
+        ));
+    }
+
+    #[test]
+    fn tame_oauth_reuses_cached_access_tokens_outside_refresh_window() {
+        let cache = TokenCache::new();
+        let scope_hash = 1;
+
+        cache
+            .insert(token_expiring_after(Duration::from_secs(601)), scope_hash)
+            .unwrap();
+        assert!(matches!(
+            cache.get(scope_hash).unwrap(),
+            TokenOrRequestReason::Token(_)
+        ));
+    }
+}


### PR DESCRIPTION
### Related issue

Fixes https://github.com/tikv/tikv/issues/19659

### Related PRs

Refs https://github.com/tikv/tame-oauth/pull/3

### What changed

- Refreshes cached GCP access tokens before they enter the final 10 minutes of their lifetime.
- Keeps the refresh scoped to the existing token provider/cache instead of rebuilding the provider.

### Why

GCS uploads can fail around access-token expiry boundaries because the cached token may still look locally valid while it is close enough to expiry to be rejected by GCS during the request. Refreshing before the final 10 minutes reduces that boundary risk without adding resource-401 retry behavior yet.

### Validation

- `cargo fmt -p gcp --check`
- `cargo test -p gcp --features hyper/full`


### Release note

```release-note
None
```