### PR TITLE
gcp: refresh access tokens before expiry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7842,7 +7842,7 @@ dependencies = [
 [[package]]
 name = "tame-oauth"
 version = "0.9.6"
-source = "git+https://github.com/tikv/tame-oauth?branch=fips-0.9#487e287c0d316b832dc44735cd9b7f7c432a10aa"
+source = "git+https://github.com/tikv/tame-oauth?branch=fips-0.9#adf4c03305561c24d456ef665475f7295eb177a0"
 dependencies = [
  "data-encoding",
  "http 0.2.12",

--- a/components/cloud/gcp/src/client.rs
+++ b/components/cloud/gcp/src/client.rs
@@ -265,3 +265,51 @@ impl RetryError for RequestError {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::time::{Duration, SystemTime};
+
+    use tame_oauth::{
+        Token,
+        token_cache::{TokenCache, TokenOrRequestReason},
+    };
+
+    fn token_expiring_after(duration: Duration) -> Token {
+        Token {
+            access_token: "token".to_owned(),
+            refresh_token: String::new(),
+            token_type: "Bearer".to_owned(),
+            expires_in: Some(duration.as_secs() as i64),
+            expires_in_timestamp: Some(SystemTime::now() + duration),
+        }
+    }
+
+    #[test]
+    fn tame_oauth_refreshes_cached_access_tokens_within_refresh_window() {
+        let cache = TokenCache::new();
+        let scope_hash = 1;
+
+        cache
+            .insert(token_expiring_after(Duration::from_secs(60)), scope_hash)
+            .unwrap();
+        assert!(matches!(
+            cache.get(scope_hash).unwrap(),
+            TokenOrRequestReason::RequestReason(_)
+        ));
+    }
+
+    #[test]
+    fn tame_oauth_reuses_cached_access_tokens_outside_refresh_window() {
+        let cache = TokenCache::new();
+        let scope_hash = 1;
+
+        cache
+            .insert(token_expiring_after(Duration::from_secs(601)), scope_hash)
+            .unwrap();
+        assert!(matches!(
+            cache.get(scope_hash).unwrap(),
+            TokenOrRequestReason::Token(_)
+        ));
+    }
+}


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: close #19659

What's Changed:

```commit-message
Update the locked tame-oauth revision to include the cached-token refresh window fix.

Add tests that assert cached access tokens are refreshed inside the final 10 minutes and reused outside that window.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [x] Need to cherry-pick to the release branch

### Check List

Tests

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note

```release-note
Fix GCS upload failures near OAuth access token expiry by refreshing cached access tokens before the final expiry window.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added unit tests covering OAuth token cache behavior around expiration, verifying that tokens expiring within ~60 seconds trigger a refresh request.
  * Verified that tokens with longer remaining lifetime (e.g., beyond ~10 minutes) are reused from the cache rather than refreshed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->