### PR TITLE
*: fix cargo-deny CI for release-8.5 v8.5.3 cut

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3897,11 +3897,11 @@ dependencies = [
 
 [[package]]
 name = "matchers"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
- "regex-automata 0.1.8",
+ "regex-automata 0.4.3",
 ]
 
 [[package]]
@@ -4254,12 +4254,11 @@ dependencies = [
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.46.0"
+version = "0.50.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
 dependencies = [
- "overload",
- "winapi 0.3.9",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4542,12 +4541,6 @@ name = "outref"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4030760ffd992bef45b0ae3f10ce1aba99e33464c90d14dd7c039884963ddc7a"
-
-[[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "page_size"
@@ -5024,7 +5017,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.0",
  "rand_xorshift",
- "regex-syntax 0.8.2",
+ "regex-syntax",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -5561,7 +5554,7 @@ dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata 0.4.3",
- "regex-syntax 0.8.2",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -5571,8 +5564,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92b73c2a1770c255c240eaa4ee600df1704a38dc3feaa6e949e7fcd4f8dc09f9"
 dependencies = [
  "byteorder",
- "regex-syntax 0.6.29",
- "utf8-ranges",
 ]
 
 [[package]]
@@ -5583,7 +5574,7 @@ checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.2",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -5591,12 +5582,6 @@ name = "regex-lite"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30b661b2f27137bdbc16f00eda72866a92bb28af1753ffbd56744fb6e2e9cd8e"
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -7872,9 +7857,9 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.40"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -7897,9 +7882,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.27"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7908,9 +7893,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.32"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
  "valuable",
@@ -7929,9 +7914,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-serde"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
 dependencies = [
  "serde",
  "tracing-core",
@@ -7939,14 +7924,14 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.18"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
 dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
- "regex",
+ "regex-automata 0.4.3",
  "serde",
  "serde_json",
  "sharded-slab",
@@ -7994,7 +7979,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "static_assertions",
 ]
 
@@ -8089,12 +8074,6 @@ name = "utf16_iter"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
-
-[[package]]
-name = "utf8-ranges"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcfc827f90e53a02eaef5e535ee14266c1d569214c6aa70133a624d8a3164ba"
 
 [[package]]
 name = "utf8_iter"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1144,9 +1144,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.7.2"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "bytes-utils"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -450,6 +450,7 @@ tracing = { version = "0.1.39", default-features = false, features = [
 openssl = "0.10"
 openssl-sys = "0.9"
 heck = "0.3"
+bytes = "1.11"
 crossbeam = "0.8"
 crossbeam-channel = "0.5"
 crossbeam-utils = "0.8"

--- a/cmd/tikv-server/Cargo.toml
+++ b/cmd/tikv-server/Cargo.toml
@@ -40,7 +40,7 @@ tikv = { workspace = true }
 tikv_util = { workspace = true }
 toml = "0.5"
 tracing-active-tree = { workspace = true, optional = true }
-tracing-subscriber = { version = "0.3.17", default-features = false, features = [ "registry", "smallvec" ], optional = true }
+tracing-subscriber = { version = "0.3.20", default-features = false, features = [ "registry", "smallvec" ], optional = true }
 
 [build-dependencies]
 cc = "1.0"

--- a/components/cloud/aws/Cargo.toml
+++ b/components/cloud/aws/Cargo.toml
@@ -23,7 +23,7 @@ aws-smithy-runtime-api = { version = "1", features = [], default-features = fals
 aws-smithy-types = { version = "1", features = ["byte-stream-poll-next"] }
 
 base64 = "0.13.0"
-bytes = "1.0"
+bytes = { workspace = true }
 cloud = { workspace = true }
 fail = "0.5"
 futures = "0.3"

--- a/components/codec/Cargo.toml
+++ b/components/codec/Cargo.toml
@@ -14,7 +14,7 @@ thiserror = "1.0"
 tikv_alloc = { workspace = true }
 
 [dev-dependencies]
-bytes = "1.0"
+bytes = { workspace = true }
 panic_hook = { workspace = true }
 protobuf = "2"
 rand = "0.8"

--- a/components/in_memory_engine/Cargo.toml
+++ b/components/in_memory_engine/Cargo.toml
@@ -23,7 +23,7 @@ harness = false
 engine_traits = { workspace = true }
 collections = { workspace = true }
 crossbeam-skiplist = { workspace = true }
-bytes = "1.0"
+bytes = { workspace = true }
 crossbeam = { workspace = true }
 futures = { version = "0.3", features = ["compat"] }
 tikv_util = { workspace = true }

--- a/components/raftstore-v2/Cargo.toml
+++ b/components/raftstore-v2/Cargo.toml
@@ -27,7 +27,7 @@ test-engines-panic = [
 
 [dependencies]
 batch-system = { workspace = true }
-bytes = "1.0"
+bytes = { workspace = true }
 causal_ts = { workspace = true }
 collections = { workspace = true }
 concurrency_manager = { workspace = true }

--- a/components/raftstore/Cargo.toml
+++ b/components/raftstore/Cargo.toml
@@ -23,7 +23,7 @@ test-engines-panic = ["engine_test/test-engines-panic"]
 batch-system = { workspace = true }
 bitflags = "1.0.1"
 byteorder = "1.2"
-bytes = "1.0"
+bytes = { workspace = true }
 causal_ts = { workspace = true }
 chrono = { workspace = true }
 codec = { workspace = true }

--- a/components/tikv_util/Cargo.toml
+++ b/components/tikv_util/Cargo.toml
@@ -14,7 +14,7 @@ test-cgroup = []
 async-speed-limit = "0.4.2"
 backtrace = "0.3.9"
 byteorder = "1.2"
-bytes = "1.0"
+bytes = { workspace = true }
 chrono = { workspace = true }
 codec = { workspace = true }
 collections = { workspace = true }

--- a/deny.toml
+++ b/deny.toml
@@ -41,11 +41,9 @@ deny = [
 multiple-versions = "allow"
 
 [advisories]
-vulnerability = "deny"
-unmaintained = "allow" # FIXME: Deny it.
-unsound = "deny"
+version = 2
 yanked = "deny"
-notice = "warn"
+unmaintained = 'workspace'
 ignore = [
     # Ignore time 0.1 RUSTSEC-2020-0071 as 1) we have taken measures (see
     # clippy.toml) to mitigate the issue and 2) time 0.1 has no fix availble.
@@ -91,6 +89,14 @@ ignore = [
     # also upgrade the OpenSSL to v3.x which causes performance degradation.
     # See https://github.com/openssl/openssl/issues/17064
     "RUSTSEC-2025-0022",
+    # Ignore following warnings/errors temporarily. We are evaluating alternatives
+    # to replace them. Currently, these packages are stable and there are no known
+    # exploitable vulnerabilities affecting our use case.
+    "RUSTSEC-2025-0057",
+    "RUSTSEC-2021-0146",
+    "RUSTSEC-2023-0081",
+    "RUSTSEC-2024-0388",
+    "RUSTSEC-2024-0436",
 ]
 
 # TiKV is licensed under Apache 2.0, according to ASF 3RD PARTY LICENSE POLICY,
@@ -98,8 +104,7 @@ ignore = [
 # under certain conditions.
 # See https://www.apache.org/legal/resolved.html.
 [licenses]
-unlicensed = "deny"
-copyleft = "deny"
+version = 2
 private = { ignore = false }
 # Allow licenses in Category A
 allow = ["0BSD", "Apache-2.0", "BSD-3-Clause", "CC0-1.0", "ISC", "MIT", "Zlib", "Unicode-3.0"]

--- a/deny.toml
+++ b/deny.toml
@@ -97,6 +97,14 @@ ignore = [
     "RUSTSEC-2023-0081",
     "RUSTSEC-2024-0388",
     "RUSTSEC-2024-0436",
+    # aws-sdk-s3 transitively depends on lru 0.12.x, which triggers
+    # RUSTSEC-2026-0002 (Stacked Borrows UB). Upstream dependency
+    # constraints prevent upgrading at the moment.
+    "RUSTSEC-2026-0002",
+    # RUSTSEC-2026-0009 is fixed by https://github.com/tikv/tikv/pull/19367
+    # in master branch. Because the modification is too large,
+    # we decided on the release branch to ignore it.
+    "RUSTSEC-2026-0009",
 ]
 
 # TiKV is licensed under Apache 2.0, according to ASF 3RD PARTY LICENSE POLICY,

--- a/deny.toml
+++ b/deny.toml
@@ -110,6 +110,12 @@ ignore = [
     # rand::rng() / thread_rng() during logging, which TiKV does not do.
     # TODO: Upgrade rand to >=0.9.3 or >=0.10.1 when possible.
     "RUSTSEC-2026-0097",
+    # Ignore RUSTSEC-2026-0174, as it does not introduce safety issues, only
+    # violating ASCII invariants. Meanwhile, it only affects the `azure` crate,
+    # which can be upgraded after it fixes the issue.
+    #
+    # See: https://github.com/http-rs/http-types/issues/534
+    "RUSTSEC-2026-0174",
 ]
 
 # TiKV is licensed under Apache 2.0, according to ASF 3RD PARTY LICENSE POLICY,

--- a/deny.toml
+++ b/deny.toml
@@ -105,6 +105,11 @@ ignore = [
     # in master branch. Because the modification is too large,
     # we decided on the release branch to ignore it.
     "RUSTSEC-2026-0009",
+    # Ignore RUSTSEC-2026-0097 (unsound issue in rand with a custom logger using
+    # rand::rng()). The vulnerability requires a custom logger that calls
+    # rand::rng() / thread_rng() during logging, which TiKV does not do.
+    # TODO: Upgrade rand to >=0.9.3 or >=0.10.1 when possible.
+    "RUSTSEC-2026-0097",
 ]
 
 # TiKV is licensed under Apache 2.0, according to ASF 3RD PARTY LICENSE POLICY,

--- a/scripts/deny
+++ b/scripts/deny
@@ -2,8 +2,13 @@
 
 set -euo pipefail
 
+# use a standalone rust version to build and run deny to decouple from the code build environment
+RUST_VERSION="1.92.0"
+
+rustup toolchain install $RUST_VERSION --profile minimal --no-self-update
+
 # Update cargo-deny to the 0.15.1 version to fix the issue reported by https://github.com/tikv/tikv/pull/17987.
-cargo install --locked cargo-deny@0.15.1 2> /dev/null || echo "Install cargo-deny failed"
-cargo deny -V
-cargo deny fetch all
-cargo deny check --show-stats
+cargo +${RUST_VERSION} install --locked cargo-deny@0.18.9 2> /dev/null || echo "Install cargo-deny failed"
+cargo +${RUST_VERSION} deny -V
+cargo +${RUST_VERSION} deny fetch all
+cargo +${RUST_VERSION} deny check --show-stats


### PR DESCRIPTION
### What changed

Backports the cargo-deny CI compatibility fixes needed for the `release-8.5-20260609-v8.5.3` cut:

- Upgrade the `scripts/deny` path to run `cargo-deny@0.18.9` with a standalone Rust 1.92 toolchain.
- Update lockfile entries for `tracing-subscriber` and `bytes` advisories.
- Add release-branch advisory ignores for dependency issues that are already handled similarly on later release-8.5 branches.

### Backported changes

This PR includes changes from:

- #19248 / `c47d33dee`: upgrade `cargo-deny` and update `deny.toml` to the v2 config format.
- #18928 / `b6b8148b`: update `tracing-subscriber` and related lockfile entries for `RUSTSEC-2025-0055`.
- #19349 / `c4d7f121`: update `bytes` to `1.11.1`, use workspace `bytes`, and add the `RUSTSEC-2026-0009` release-branch ignore.
- #19524 / `7891aca4`: add the `RUSTSEC-2026-0097` release-branch ignore.
- `0aca50ee8` deny.toml hunk only: add the `RUSTSEC-2026-0174` release-branch ignore without backporting the unrelated resolver behavior change from #18786.

### Why

The old release cut still used `cargo-deny@0.15.1`, which can no longer parse current RustSec CVSS 4.0 advisories. After upgrading cargo-deny, the same old cut also needs the later release-8.5 deny/lockfile fixes so `make clippy` can pass against the current advisory database.

This keeps the GCP token refresh PR separate from CI/tooling maintenance.

### Validation

- `bash -n scripts/deny`
- `./scripts/deny` passed locally with `cargo-deny 0.18.9`


### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```