### PR TITLE
*: update vulnerable third-party dependencies #19458

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,11 +388,11 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-fips-sys"
-version = "0.13.7"
+version = "0.13.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2608e5a7965cc9d58c56234d346c9c89b824c4c8652b6f047b3bd0a777c0644f"
+checksum = "f8bce4948d2520386c6d92a6ea2d472300257702242e5a1d01d6add52bd2e7c1"
 dependencies = [
- "bindgen 0.69.5",
+ "bindgen 0.72.1",
  "cc",
  "cmake",
  "dunce",
@@ -579,7 +579,7 @@ dependencies = [
  "http-body 0.4.5",
  "md-5",
  "pin-project-lite",
- "sha1",
+ "sha1 0.10.6",
  "sha2",
  "tracing",
 ]
@@ -1000,7 +1000,6 @@ dependencies = [
  "serde_json",
  "slog",
  "slog-global",
- "tempdir",
  "tempfile",
  "test_pd",
  "test_pd_client",
@@ -1021,6 +1020,12 @@ dependencies = [
  "uuid 0.8.2",
  "walkdir",
 ]
+
+[[package]]
+name = "base-x"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
 
 [[package]]
 name = "base64"
@@ -1139,25 +1144,22 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.69.5"
+version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
  "bitflags 2.11.1",
  "cexpr",
  "clang-sys",
  "itertools 0.10.0",
- "lazy_static",
- "lazycell",
  "log",
  "prettyplease",
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 1.0.1",
+ "rustc-hash 2.1.2",
  "shlex",
  "syn 2.0.101",
- "which",
 ]
 
 [[package]]
@@ -1487,18 +1489,16 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.22"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
- "num-integer",
  "num-traits",
  "serde",
- "time 0.1.43",
  "wasm-bindgen",
- "winapi 0.3.9",
+ "windows-link",
 ]
 
 [[package]]
@@ -1695,7 +1695,7 @@ dependencies = [
  "serde_json",
  "slog",
  "slog-global",
- "tempdir",
+ "tempfile",
  "test_util",
  "thiserror 1.0.40",
  "tidb_query_datatype",
@@ -2224,6 +2224,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "discard"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2377,7 +2383,7 @@ dependencies = [
  "tempfile",
  "tikv_alloc",
  "tikv_util",
- "time 0.1.43",
+ "time 0.2.27",
  "toml",
  "tracker",
  "txn_types",
@@ -2826,12 +2832,6 @@ checksum = "f41b048a94555da0f42f1d632e2e19510084fb8e303b0daa2816e733fb3644a0"
 dependencies = [
  "libc 0.2.176",
 ]
-
-[[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "fuchsia-zircon"
@@ -4561,7 +4561,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
- "regex-automata 0.4.3",
+ "regex-automata 0.4.14",
 ]
 
 [[package]]
@@ -5633,6 +5633,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-hack"
+version = "0.5.20+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5899,7 +5905,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.5.7",
+ "socket2 0.6.3",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
@@ -5936,7 +5942,7 @@ dependencies = [
  "cfg_aliases",
  "libc 0.2.176",
  "once_cell",
- "socket2 0.5.7",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.52.0",
 ]
@@ -6107,7 +6113,7 @@ dependencies = [
  "tidb_query_datatype",
  "tikv_alloc",
  "tikv_util",
- "time 0.1.43",
+ "time 0.2.27",
  "tokio",
  "tracker",
  "txn_types",
@@ -6156,24 +6162,11 @@ dependencies = [
  "test_util",
  "thiserror 1.0.40",
  "tikv_util",
- "time 0.1.43",
+ "time 0.2.27",
  "tracker",
  "txn_types",
  "walkdir",
  "yatp",
-]
-
-[[package]]
-name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc 0.2.176",
- "rand_core 0.3.1",
- "rdrand",
- "winapi 0.3.9",
 ]
 
 [[package]]
@@ -6239,21 +6232,6 @@ dependencies = [
  "ppv-lite86",
  "rand_core 0.9.5",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -6343,15 +6321,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6401,13 +6370,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.2"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.3",
+ "regex-automata 0.4.14",
  "regex-syntax",
 ]
 
@@ -6422,9 +6391,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.3"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -6439,18 +6408,9 @@ checksum = "30b661b2f27137bdbc16f00eda72866a92bb28af1753ffbd56744fb6e2e9cd8e"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.2"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
-
-[[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi 0.3.9",
-]
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
@@ -7235,6 +7195,15 @@ dependencies = [
 
 [[package]]
 name = "sha1"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1da05c97445caa12d05e848c4a4fcbbea29e748ac28f7e80e9b010392063770"
+dependencies = [
+ "sha1_smol",
+]
+
+[[package]]
+name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
@@ -7243,6 +7212,12 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
 
 [[package]]
 name = "sha2"
@@ -7522,10 +7497,68 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
+name = "standback"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e113fb6f3de07a243d434a56ec6f186dfd51cb08448239fe7bcae73f87ff28ff"
+dependencies = [
+ "version_check 0.9.4",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "stdweb"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d022496b16281348b52d0e30ae99e01a73d737b2f45d38fed4edf79f9325a1d5"
+dependencies = [
+ "discard",
+ "rustc_version 0.2.3",
+ "stdweb-derive",
+ "stdweb-internal-macros",
+ "stdweb-internal-runtime",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "stdweb-derive"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_derive",
+ "syn 1.0.103",
+]
+
+[[package]]
+name = "stdweb-internal-macros"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
+dependencies = [
+ "base-x",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "sha1 0.6.1",
+ "syn 1.0.103",
+]
+
+[[package]]
+name = "stdweb-internal-runtime"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 
 [[package]]
 name = "str_stack"
@@ -7795,11 +7828,8 @@ checksum = "3b7ad73e635dd232c2c2106d59269f59a61de421cc6b95252d2d932094ff1f40"
 [[package]]
 name = "tempdir"
 version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
 dependencies = [
- "rand 0.4.6",
- "remove_dir_all",
+ "tempfile",
 ]
 
 [[package]]
@@ -8082,7 +8112,7 @@ dependencies = [
  "slog-global",
  "tempfile",
  "tikv_util",
- "time 0.1.43",
+ "time 0.2.27",
 ]
 
 [[package]]
@@ -8157,7 +8187,7 @@ dependencies = [
  "tikv",
  "tikv_kv",
  "tikv_util",
- "time 0.1.43",
+ "time 0.2.27",
  "tipb",
  "tipb_helper",
  "tokio",
@@ -8277,7 +8307,7 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.40",
  "tikv_util",
- "time 0.1.43",
+ "time 0.2.27",
  "yatp",
 ]
 
@@ -8384,7 +8414,7 @@ dependencies = [
  "tidb_query_common",
  "tidb_query_datatype",
  "tikv_util",
- "time 0.1.43",
+ "time 0.2.27",
  "tipb",
  "tipb_helper",
  "uuid 0.8.2",
@@ -8500,7 +8530,7 @@ dependencies = [
  "tikv_alloc",
  "tikv_kv",
  "tikv_util",
- "time 0.1.43",
+ "time 0.2.27",
  "tipb",
  "tokio",
  "tokio-openssl",
@@ -8556,7 +8586,7 @@ dependencies = [
  "tempfile",
  "tikv",
  "tikv_util",
- "time 0.1.43",
+ "time 0.2.27",
  "tokio",
  "toml",
  "txn_types",
@@ -8605,7 +8635,7 @@ dependencies = [
  "server",
  "tikv",
  "tikv_util",
- "time 0.1.43",
+ "time 0.2.27",
  "toml",
  "tracing-active-tree",
  "tracing-subscriber",
@@ -8715,7 +8745,7 @@ dependencies = [
  "tempfile",
  "thiserror 1.0.40",
  "tikv_alloc",
- "time 0.1.43",
+ "time 0.2.27",
  "tokio",
  "tokio-executor",
  "tokio-timer",
@@ -8728,11 +8758,16 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.43"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+checksum = "4752a97f8eebd6854ff91f1c1824cd6160626ac4bd44287f7f4ea2035a02a242"
 dependencies = [
+ "const_fn",
  "libc 0.2.176",
+ "standback",
+ "stdweb",
+ "time-macros 0.1.1",
+ "version_check 0.9.4",
  "winapi 0.3.9",
 ]
 
@@ -8751,7 +8786,7 @@ dependencies = [
  "powerfmt",
  "serde",
  "time-core",
- "time-macros",
+ "time-macros 0.2.24",
 ]
 
 [[package]]
@@ -8762,12 +8797,35 @@ checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
 
 [[package]]
 name = "time-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957e9c6e26f12cb6d0dd7fc776bb67a706312e7299aed74c8dd5b17ebb27e2f1"
+dependencies = [
+ "proc-macro-hack",
+ "time-macros-impl",
+]
+
+[[package]]
+name = "time-macros"
 version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "time-macros-impl"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd3c141a1b43194f3f56a1411225df8646c55781d5f26db825b3d98507eb482f"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "standback",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -9106,7 +9164,7 @@ dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
- "regex-automata 0.4.3",
+ "regex-automata 0.4.14",
  "serde",
  "serde_json",
  "sharded-slab",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4404,9 +4404,9 @@ checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "libmimalloc-sys"
-version = "0.1.21"
+version = "0.1.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2396cf99d2f58611cd69f0efeee4af3d2e2c7b61bed433515029163aa567e65c"
+checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
 dependencies = [
  "cc",
 ]
@@ -4645,9 +4645,9 @@ dependencies = [
 
 [[package]]
 name = "mimalloc"
-version = "0.1.25"
+version = "0.1.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7c6b11afd1e5e689ac96b6d18b1fc763398fe3d7eed99e8773426bc2033dfb"
+checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
 dependencies = [
  "libmimalloc-sys",
 ]
@@ -9202,7 +9202,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "static_assertions",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -216,6 +216,9 @@ fs2 = { git = "https://github.com/tikv/fs2-rs", branch = "tikv" }
 cmake = { git = "https://github.com/rust-lang/cmake-rs" }
 
 sysinfo = { git = "https://github.com/tikv/sysinfo", branch = "0.26-fix-cpu" }
+
+# tempdir pulls in remove_dir_all 0.5.x via the benchmark-only perfcnt stack.
+tempdir = { path = "patches/tempdir" }
 # When you modify TiKV cooperatively with kvproto, this will be useful to submit the PR to TiKV and the PR to
 # kvproto at the same time.
 # After the PR to kvproto is merged, remember to comment this out and run `cargo update -p kvproto`.
@@ -411,7 +414,7 @@ tikv_alloc = { path = "components/tikv_alloc" }
 tikv_kv = { path = "components/tikv_kv", default-features = false }
 tikv_util = { path = "components/tikv_util" }
 tipb_helper = { path = "components/tipb_helper" }
-time = { version = "0.1" }
+time = { version = "0.2.23" }
 tracker = { path = "components/tracker" }
 txn_types = { path = "components/txn_types" }
 # External libs

--- a/cmd/build.rs
+++ b/cmd/build.rs
@@ -44,7 +44,8 @@ fn link_sys_lib(lib: &str, tool: &cc::Tool) {
 fn main() {
     println!(
         "cargo:rustc-env=TIKV_BUILD_TIME={}",
-        time::now_utc().strftime("%Y-%m-%d %H:%M:%S").unwrap()
+        time::OffsetDateTime::now_utc()
+            .format("%Y-%m-%d %H:%M:%S")
     );
 
     let tool = cc::Build::default().get_compiler();

--- a/components/backup-stream/Cargo.toml
+++ b/components/backup-stream/Cargo.toml
@@ -92,7 +92,6 @@ hex = "0.4"
 protobuf = { version = "2.8", features = ["bytes"] }
 rand = "0.8.0"
 regex = "1"
-tempdir = "0.3"
 tempfile = "3.0"
 test_pd = { workspace = true }
 test_pd_client = { workspace = true }

--- a/components/compact-log-backup/Cargo.toml
+++ b/components/compact-log-backup/Cargo.toml
@@ -57,5 +57,5 @@ pprof = { version = "0.13", default-features = false, features = [
   "flamegraph",
   "protobuf-codec",
 ] } 
-tempdir = "0.3"
+tempfile = "3.0"
 test_util = { workspace = true }

--- a/components/compact-log-backup/src/test_util.rs
+++ b/components/compact-log-backup/src/test_util.rs
@@ -21,7 +21,7 @@ use futures::{
 use keys::origin_key;
 use kvproto::brpb;
 use protobuf::{Chars, Message, parse_from_bytes};
-use tempdir::TempDir;
+use tempfile::TempDir;
 use tidb_query_datatype::codec::table::encode_row_key;
 use tikv_util::codec::stream_event::EventEncoder;
 use txn_types::Key;
@@ -455,7 +455,7 @@ impl Drop for TmpStorage {
 
 impl TmpStorage {
     pub fn create() -> TmpStorage {
-        let path = TempDir::new("test").unwrap();
+        let path = tempfile::Builder::new().prefix("test").tempdir().unwrap();
         let storage = external_storage::LocalStorage::new(path.path()).unwrap();
         TmpStorage {
             path: Some(path),

--- a/components/engine_rocks/src/rocks_metrics.rs
+++ b/components/engine_rocks/src/rocks_metrics.rs
@@ -10,6 +10,7 @@ use prometheus_static_metric::*;
 use rocksdb::{
     DBStatisticsHistogramType as HistType, DBStatisticsTickerType as TickerType, HistogramData,
 };
+use tikv_util::time::get_time;
 
 use crate::{
     RocksStatistics, TITAN_COMPRESSION_FACTOR, TITAN_COMPRESSION_FACTOR_SMOOTHER,
@@ -1049,7 +1050,7 @@ impl StatisticsReporter<RocksEngine> for RocksStatisticsReporter {
         let oldest_snapshot_time =
             db.get_property_int(ROCKSDB_OLDEST_SNAPSHOT_TIME)
                 .map_or(0, |t| {
-                    let now = time::get_time().sec as u64;
+                    let now = get_time().sec as u64;
                     // RocksDB returns 0 if no snapshots.
                     if t > 0 && now > t { now - t } else { 0 }
                 });

--- a/components/raftstore-v2/src/batch/store.rs
+++ b/components/raftstore-v2/src/batch/store.rs
@@ -48,12 +48,11 @@ use tikv_util::{
     config::{Tracker, VersionTrack},
     log::SlogFormat,
     sys::{SysQuota, disk::get_disk_status},
-    time::{Instant as TiInstant, Limiter, duration_to_sec, monotonic_raw_now},
+    time::{Instant as TiInstant, Limiter, Timespec, duration_to_sec, monotonic_raw_now},
     timer::{GLOBAL_TIMER_HANDLE, SteadyTimer},
     worker::{Builder, LazyWorker, Scheduler, Worker},
     yatp_pool::{DefaultTicker, FuturePool, YatpPoolBuilder},
 };
-use time::Timespec;
 
 use crate::{
     Error, Result,
@@ -548,7 +547,7 @@ where
                 cfg.raft_election_timeout_ticks as u32
             };
         let unsafe_vote_deadline =
-            Some(self.node_start_time + time::Duration::from_std(election_timeout).unwrap());
+            Some(self.node_start_time + time::Duration::try_from(election_timeout).unwrap());
         let mut poll_ctx = StoreContext {
             logger: self.logger.clone(),
             store_id: self.store_id,

--- a/components/raftstore-v2/src/operation/query/lease.rs
+++ b/components/raftstore-v2/src/operation/query/lease.rs
@@ -21,8 +21,7 @@ use raftstore::{
     },
 };
 use slog::debug;
-use tikv_util::time::monotonic_raw_now;
-use time::Timespec;
+use tikv_util::time::{Timespec, monotonic_raw_now};
 use tracker::GLOBAL_TRACKERS;
 
 use crate::{
@@ -187,11 +186,10 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         for (req, ch, mut read_index) in read_index_req.take_cmds().drain(..) {
             ch.read_tracker().map(|tracker| {
                 GLOBAL_TRACKERS.with_tracker(tracker, |t| {
-                    t.metrics.read_index_confirm_wait_nanos = (time - read_index_req.propose_time)
-                        .to_std()
-                        .unwrap()
-                        .as_nanos()
-                        as u64;
+                    t.metrics.read_index_confirm_wait_nanos =
+                        std::time::Duration::try_from(time - read_index_req.propose_time)
+                            .unwrap()
+                            .as_nanos() as u64;
                 })
             });
 

--- a/components/raftstore-v2/src/operation/query/local.rs
+++ b/components/raftstore-v2/src/operation/query/local.rs
@@ -25,8 +25,11 @@ use raftstore::{
     },
 };
 use slog::{Logger, debug};
-use tikv_util::{Either, box_err, codec::number::decode_u64, time::monotonic_raw_now};
-use time::Timespec;
+use tikv_util::{
+    Either, box_err,
+    codec::number::decode_u64,
+    time::{Timespec, monotonic_raw_now},
+};
 use tracker::{GLOBAL_TRACKERS, get_tls_tracker_token};
 use txn_types::WriteBatchFlags;
 

--- a/components/raftstore-v2/src/operation/query/replica.rs
+++ b/components/raftstore-v2/src/operation/query/replica.rs
@@ -100,11 +100,10 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         for (req, ch, _) in read_index_req.take_cmds().drain(..) {
             ch.read_tracker().map(|tracker| {
                 GLOBAL_TRACKERS.with_tracker(tracker, |t| {
-                    t.metrics.read_index_confirm_wait_nanos = (time - read_index_req.propose_time)
-                        .to_std()
-                        .unwrap()
-                        .as_nanos()
-                        as u64;
+                    t.metrics.read_index_confirm_wait_nanos =
+                        std::time::Duration::try_from(time - read_index_req.propose_time)
+                            .unwrap()
+                            .as_nanos() as u64;
                 })
             });
 
@@ -145,11 +144,10 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         for (_, ch, _) in read_index_req.take_cmds().drain(..) {
             ch.read_tracker().map(|tracker| {
                 GLOBAL_TRACKERS.with_tracker(tracker, |t| {
-                    t.metrics.read_index_confirm_wait_nanos = (time - read_index_req.propose_time)
-                        .to_std()
-                        .unwrap()
-                        .as_nanos()
-                        as u64;
+                    t.metrics.read_index_confirm_wait_nanos =
+                        std::time::Duration::try_from(time - read_index_req.propose_time)
+                            .unwrap()
+                            .as_nanos() as u64;
                 })
             });
             ch.report_error(response.clone());

--- a/components/raftstore-v2/src/operation/ready/mod.rs
+++ b/components/raftstore-v2/src/operation/ready/mod.rs
@@ -702,7 +702,7 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
                         let current_time = monotonic_raw_now();
                         ctx.current_time.replace(current_time);
                         ctx.raft_metrics.commit_log.observe(duration_to_sec(
-                            (current_time - propose_time).to_std().unwrap(),
+                            Duration::try_from(current_time - propose_time).unwrap(),
                         ));
                         self.maybe_renew_leader_lease(propose_time, &ctx.store_meta, None);
                         update_lease = false;
@@ -1194,7 +1194,7 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
             // When a proposal was proposed with this ctx before, the current_time can be
             // some.
             let current_time = *ctx.current_time.get_or_insert_with(monotonic_raw_now);
-            let elapsed = match (current_time - propose_time).to_std() {
+            let elapsed = match Duration::try_from(current_time - propose_time) {
                 Ok(elapsed) => elapsed,
                 Err(_) => return false,
             };

--- a/components/raftstore/src/store/config.rs
+++ b/components/raftstore/src/store/config.rs
@@ -694,11 +694,11 @@ impl Config {
     }
 
     pub fn raft_store_max_leader_lease(&self) -> TimeDuration {
-        TimeDuration::from_std(self.raft_store_max_leader_lease.0).unwrap()
+        TimeDuration::try_from(self.raft_store_max_leader_lease.0).unwrap()
     }
 
     pub fn raft_base_tick_interval(&self) -> TimeDuration {
-        TimeDuration::from_std(self.raft_base_tick_interval.0).unwrap()
+        TimeDuration::try_from(self.raft_base_tick_interval.0).unwrap()
     }
 
     pub fn raft_heartbeat_interval(&self) -> Duration {
@@ -706,11 +706,11 @@ impl Config {
     }
 
     pub fn check_leader_lease_interval(&self) -> TimeDuration {
-        TimeDuration::from_std(self.check_leader_lease_interval.0).unwrap()
+        TimeDuration::try_from(self.check_leader_lease_interval.0).unwrap()
     }
 
     pub fn renew_leader_lease_advance_duration(&self) -> TimeDuration {
-        TimeDuration::from_std(self.renew_leader_lease_advance_duration.0).unwrap()
+        TimeDuration::try_from(self.renew_leader_lease_advance_duration.0).unwrap()
     }
 
     pub fn raft_log_gc_count_limit(&self) -> u64 {

--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -64,11 +64,10 @@ use tikv_util::{
     mpsc::{LooseBoundedSender, Receiver, loose_bounded},
     safe_panic, slow_log,
     store::{find_peer, find_peer_by_id, find_peer_mut, is_learner, remove_peer},
-    time::{Instant, duration_to_sec, monotonic_raw_now, timespec_to_ns},
+    time::{Instant, Timespec, duration_to_sec, monotonic_raw_now, timespec_to_ns},
     warn,
     worker::Scheduler,
 };
-use time::Timespec;
 use tracker::{GLOBAL_TRACKERS, TrackerToken, TrackerTokenArray};
 use uuid::Builder as UuidBuilder;
 

--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -70,13 +70,15 @@ use tikv_util::{
         cpu_time::ProcessStat,
         disk::{DiskUsage, get_disk_status},
     },
-    time::{Instant as TiInstant, SlowTimer, duration_to_sec, monotonic_raw_now},
+    time::{
+        Instant as TiInstant, SlowTimer, Timespec, duration_to_sec, get_time, monotonic_raw_now,
+    },
     timer::SteadyTimer,
     warn,
     worker::{Builder as WorkerBuilder, LazyWorker, Scheduler, Worker},
     yatp_pool::FuturePool,
 };
-use time::{self, Timespec};
+use time;
 
 use crate::{
     Error, Result, bytes_capacity,
@@ -954,7 +956,7 @@ impl<EK: KvEngine + 'static, ER: RaftEngine + 'static, T: Transport>
             );
         }
         self.fsm.store.id = store.get_id();
-        self.fsm.store.start_time = Some(time::get_time());
+        self.fsm.store.start_time = Some(get_time());
         self.register_cleanup_import_sst_tick();
         self.register_full_compact_tick();
         self.register_load_metrics_window_tick();
@@ -1517,7 +1519,7 @@ where
                 self.cfg.value().raft_election_timeout_ticks as u32
             };
         let unsafe_vote_deadline =
-            Some(self.node_start_time + time::Duration::from_std(election_timeout).unwrap());
+            Some(self.node_start_time + time::Duration::try_from(election_timeout).unwrap());
         let mut ctx = PollContext {
             cfg: self.cfg.value().clone(),
             store: self.store.clone(),
@@ -2807,7 +2809,7 @@ impl<EK: KvEngine, ER: RaftEngine, T: Transport> StoreFsmDelegate<'_, EK, ER, T>
 
         let completed_apply_peers_count = completed_apply_peers_count.unwrap();
         let during_starting_stage = {
-            (time::get_time().sec as u32).saturating_sub(start_ts_sec)
+            (get_time().sec as u32).saturating_sub(start_ts_sec)
                 <= STORE_CHECK_PENDING_APPLY_DURATION.as_secs() as u32
         };
         // If the store is busy in handling applying logs when starting, it should not

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -61,11 +61,11 @@ use tikv_util::{
     debug, error, info,
     store::{find_peer_by_id, is_learner},
     sys::disk::DiskUsage,
-    time::{Instant as TiInstant, InstantExt, duration_to_sec, monotonic_raw_now},
+    time::{Instant as TiInstant, InstantExt, Timespec, duration_to_sec, monotonic_raw_now},
     warn,
     worker::Scheduler,
 };
-use time::{Duration as TimeDuration, Timespec};
+use time::Duration as TimeDuration;
 use tracker::{GLOBAL_TRACKERS, TrackerTokenArray};
 use txn_types::{TimeStamp, WriteBatchFlags};
 use uuid::Uuid;
@@ -3190,7 +3190,7 @@ where
                     // AppendEntriesResponse and is ready to calculate its commit-log-duration.
                     ctx.current_time.replace(monotonic_raw_now());
                     ctx.raft_metrics.commit_log.observe(duration_to_sec(
-                        (ctx.current_time.unwrap() - propose_time).to_std().unwrap(),
+                        Duration::try_from(ctx.current_time.unwrap() - propose_time).unwrap(),
                     ));
                     self.maybe_renew_leader_lease(propose_time, ctx, None);
                     lease_to_be_updated = false;
@@ -3321,7 +3321,7 @@ where
             // When a proposal was proposed with this ctx before, the current_time can be
             // some.
             let current_time = *ctx.current_time.get_or_insert_with(monotonic_raw_now);
-            let elapsed = match (current_time - propose_time).to_std() {
+            let elapsed = match Duration::try_from(current_time - propose_time) {
                 Ok(elapsed) => elapsed,
                 Err(_) => return false,
             };
@@ -3539,7 +3539,9 @@ where
             cb.read_tracker().map(|tracker| {
                 GLOBAL_TRACKERS.with_tracker(tracker, |t| {
                     t.metrics.read_index_confirm_wait_nanos =
-                        (time - read.propose_time).to_std().unwrap().as_nanos() as u64;
+                        Duration::try_from(time - read.propose_time)
+                            .unwrap()
+                            .as_nanos() as u64;
                 })
             });
             // leader reports key is locked
@@ -3602,11 +3604,10 @@ where
         for (_, ch, _) in read_index_req.take_cmds().drain(..) {
             ch.read_tracker().map(|tracker| {
                 GLOBAL_TRACKERS.with_tracker(tracker, |t| {
-                    t.metrics.read_index_confirm_wait_nanos = (time - read_index_req.propose_time)
-                        .to_std()
-                        .unwrap()
-                        .as_nanos()
-                        as u64;
+                    t.metrics.read_index_confirm_wait_nanos =
+                        Duration::try_from(time - read_index_req.propose_time)
+                            .unwrap()
+                            .as_nanos() as u64;
                 })
             });
             ch.report_error(response.clone());

--- a/components/raftstore/src/store/read_queue.rs
+++ b/components/raftstore/src/store/read_queue.rs
@@ -14,9 +14,8 @@ use tikv_util::{
     codec::number::{MAX_VAR_U64_LEN, NumberEncoder},
     debug, error,
     memory::HeapSize,
-    time::{duration_to_sec, monotonic_raw_now},
+    time::{Timespec, duration_to_sec, monotonic_raw_now},
 };
-use time::Timespec;
 use uuid::Uuid;
 
 use super::msg::ErrorCallback;
@@ -81,7 +80,7 @@ impl<C> ReadIndexRequest<C> {
 
 impl<C> Drop for ReadIndexRequest<C> {
     fn drop(&mut self) {
-        let dur = (monotonic_raw_now() - self.propose_time).to_std().unwrap();
+        let dur = std::time::Duration::try_from(monotonic_raw_now() - self.propose_time).unwrap();
         RAFT_READ_INDEX_PENDING_DURATION.observe(duration_to_sec(dur));
     }
 }

--- a/components/raftstore/src/store/util.rs
+++ b/components/raftstore/src/store/util.rs
@@ -34,9 +34,9 @@ use tikv_util::{
     codec::number::{NumberEncoder, decode_u64},
     debug, info,
     store::{find_peer_by_id, region},
-    time::{Instant, monotonic_raw_now},
+    time::{Instant, Timespec, monotonic_raw_now},
 };
-use time::{Duration, Timespec};
+use time::Duration;
 use tokio::sync::Notify;
 use txn_types::WriteBatchFlags;
 
@@ -1887,7 +1887,7 @@ mod tests {
         fn sleep_test(duration: TimeDuration, lease: &Lease, state: LeaseState) {
             // In linux, lease uses CLOCK_MONOTONIC_RAW, while sleep uses CLOCK_MONOTONIC
             let monotonic_raw_start = monotonic_raw_now();
-            thread::sleep(duration.to_std().unwrap());
+            thread::sleep(std::time::Duration::try_from(duration).unwrap());
             let mut monotonic_raw_end = monotonic_raw_now();
             // spin wait to make sure pace is aligned with MONOTONIC_RAW clock
             while monotonic_raw_end - monotonic_raw_start < duration {

--- a/components/raftstore/src/store/worker/read.rs
+++ b/components/raftstore/src/store/worker/read.rs
@@ -26,9 +26,8 @@ use tikv_util::{
     debug, error,
     lru::LruCache,
     store::find_peer_by_id,
-    time::{ThreadReadId, monotonic_raw_now},
+    time::{ThreadReadId, Timespec, monotonic_raw_now},
 };
-use time::Timespec;
 use tracker::GLOBAL_TRACKERS;
 use txn_types::{TimeStamp, WriteBatchFlags};
 
@@ -1381,7 +1380,7 @@ mod tests {
             })),
         );
         assert_eq!(
-            rx.recv_timeout(Duration::seconds(5).to_std().unwrap())
+            rx.recv_timeout(std::time::Duration::try_from(Duration::seconds(5)).unwrap())
                 .unwrap()
                 .request,
             cmd
@@ -1520,7 +1519,7 @@ mod tests {
         must_not_redirect(&mut reader, &rx, task);
 
         // Wait for expiration.
-        thread::sleep(Duration::seconds(1).to_std().unwrap());
+        thread::sleep(std::time::Duration::try_from(Duration::seconds(1)).unwrap());
         must_redirect(&mut reader, &rx, cmd.clone());
         assert_eq!(
             TLS_LOCAL_READ_METRICS.with(|m| m.borrow().reject_reason.lease_expire.get()),
@@ -1663,7 +1662,7 @@ mod tests {
             })),
         );
         assert_eq!(
-            rx.recv_timeout(Duration::seconds(5).to_std().unwrap())
+            rx.recv_timeout(std::time::Duration::try_from(Duration::seconds(5)).unwrap())
                 .unwrap()
                 .request,
             cmd9

--- a/components/tidb_query_datatype/src/codec/mysql/json/serde.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/json/serde.rs
@@ -6,7 +6,10 @@ use serde::{
     de::{self, Deserialize, Deserializer, MapAccess, SeqAccess, Visitor},
     ser::{Error as SerError, Serialize, SerializeMap, SerializeTuple, Serializer},
 };
-use serde_json::Serializer as JsonSerializer;
+use serde_json::{
+    Serializer as JsonSerializer,
+    ser::{CompactFormatter, Formatter as _},
+};
 
 use super::{Json, JsonRef, JsonType};
 use crate::codec::{Error, convert::ToStringValue};
@@ -49,11 +52,41 @@ impl serde_json::ser::Formatter for MySqlFormatter {
             writer.write_all(b", ")
         }
     }
+
+    #[inline]
+    fn write_f32<W>(&mut self, writer: &mut W, value: f32) -> std::io::Result<()>
+    where
+        W: ?Sized + std::io::Write,
+    {
+        write_mysql_finite_float(writer, value as f64)
+    }
+
+    #[inline]
+    fn write_f64<W>(&mut self, writer: &mut W, value: f64) -> std::io::Result<()>
+    where
+        W: ?Sized + std::io::Write,
+    {
+        write_mysql_finite_float(writer, value)
+    }
 }
 
 impl MySqlFormatter {
     pub fn new() -> Self {
         MySqlFormatter {}
+    }
+}
+
+fn write_mysql_finite_float<W>(writer: &mut W, value: f64) -> std::io::Result<()>
+where
+    W: ?Sized + std::io::Write,
+{
+    let mut formatted = Vec::with_capacity(32);
+    CompactFormatter.write_f64(&mut formatted, value)?;
+    if let Some(pos) = formatted.windows(2).position(|window| window == b"e+") {
+        writer.write_all(&formatted[..=pos])?;
+        writer.write_all(&formatted[(pos + 2)..])
+    } else {
+        writer.write_all(&formatted)
     }
 }
 

--- a/components/tidb_query_expr/src/impl_math.rs
+++ b/components/tidb_query_expr/src/impl_math.rs
@@ -13,6 +13,7 @@ use tidb_query_datatype::{
     },
     expr::EvalContext,
 };
+use tikv_util::time::get_time;
 
 const MAX_I64_DIGIT_LENGTH: i64 = 19;
 const MAX_U64_DIGIT_LENGTH: i64 = 20;
@@ -690,7 +691,7 @@ pub struct MySqlRng {
 
 impl MySqlRng {
     fn new() -> Self {
-        let current_time = time::get_time();
+        let current_time = get_time();
         let nsec = i64::from(current_time.nsec);
         Self::new_with_seed(nsec)
     }

--- a/components/tikv_alloc/Cargo.toml
+++ b/components/tikv_alloc/Cargo.toml
@@ -23,7 +23,7 @@ libc = "0.2"
 tempfile = "3.0"
 
 [dependencies.mimalloc]
-version = "0.1.25"
+version = "0.1.39"
 optional = true
 
 [dependencies.snmalloc-rs]

--- a/components/tikv_util/src/time.rs
+++ b/components/tikv_util/src/time.rs
@@ -15,21 +15,94 @@ use std::{
 };
 
 use async_speed_limit::clock::{BlockingClock, Clock, StandardClock};
-use time::{Duration as TimeDuration, Timespec};
+use time::Duration as TimeDuration;
+
+/// Returns the monotonic raw time since some unspecified starting point.
+pub use self::inner::monotonic_raw_now;
+pub use self::inner::{monotonic_coarse_now, monotonic_now};
+use crate::sys::thread::StdThreadBuildWrapper;
+
+const NANOSECONDS_PER_SECOND: u64 = 1_000_000_000;
+const MILLISECONDS_PER_SECOND: u64 = 1_000;
+const MICROSECONDS_PER_SECOND: u64 = 1_000_000;
+const NANOSECONDS_PER_MILLISECOND: u64 = 1_000_000;
+const NANOSECONDS_PER_MICROSECOND: u64 = 1_000;
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct Timespec {
+    pub sec: i64,
+    pub nsec: i32,
+}
+
+impl Timespec {
+    pub fn new(sec: i64, nsec: i32) -> Self {
+        Self::from_total_nanos((sec as i128) * NANOSECONDS_PER_SECOND as i128 + nsec as i128)
+    }
+
+    fn from_total_nanos(total_nanos: i128) -> Self {
+        let sec = total_nanos.div_euclid(NANOSECONDS_PER_SECOND as i128);
+        let nsec = total_nanos.rem_euclid(NANOSECONDS_PER_SECOND as i128) as i32;
+        Self {
+            sec: sec as i64,
+            nsec,
+        }
+    }
+
+    fn total_nanos(self) -> i128 {
+        (self.sec as i128) * NANOSECONDS_PER_SECOND as i128 + self.nsec as i128
+    }
+}
+
+impl Add<TimeDuration> for Timespec {
+    type Output = Timespec;
+
+    fn add(self, rhs: TimeDuration) -> Self::Output {
+        let delta = rhs.whole_nanoseconds();
+        Self::from_total_nanos(self.total_nanos() + delta)
+    }
+}
+
+impl Sub<TimeDuration> for Timespec {
+    type Output = Timespec;
+
+    fn sub(self, rhs: TimeDuration) -> Self::Output {
+        let delta = rhs.whole_nanoseconds();
+        Self::from_total_nanos(self.total_nanos() - delta)
+    }
+}
+
+impl Sub<Timespec> for Timespec {
+    type Output = TimeDuration;
+
+    fn sub(self, rhs: Timespec) -> Self::Output {
+        let sec = self
+            .sec
+            .checked_sub(rhs.sec)
+            .expect("overflow when subtracting timespec seconds");
+        let nsec = i64::from(self.nsec) - i64::from(rhs.nsec);
+        TimeDuration::seconds(sec)
+            .checked_add(TimeDuration::nanoseconds(nsec))
+            .expect("overflow when subtracting timespecs")
+    }
+}
 
 /// Converts Duration to milliseconds.
 #[inline]
 pub fn duration_to_ms(d: Duration) -> u64 {
     let nanos = u64::from(d.subsec_nanos());
     // If Duration is too large, the result may be overflow.
-    d.as_secs() * 1_000 + (nanos / 1_000_000)
+    d.as_secs() * MILLISECONDS_PER_SECOND + (nanos / NANOSECONDS_PER_MILLISECOND)
 }
 
 /// Converts Duration to seconds.
 #[inline]
 pub fn duration_to_sec(d: Duration) -> f64 {
     let nanos = f64::from(d.subsec_nanos());
-    d.as_secs() as f64 + (nanos / 1_000_000_000.0)
+    d.as_secs() as f64 + (nanos / NANOSECONDS_PER_SECOND as f64)
+}
+
+pub fn nanos_to_secs(nanos: u64) -> f64 {
+    nanos as f64 / NANOSECONDS_PER_SECOND as f64
 }
 
 /// Converts Duration to microseconds.
@@ -37,7 +110,7 @@ pub fn duration_to_sec(d: Duration) -> f64 {
 pub fn duration_to_us(d: Duration) -> u64 {
     let nanos = u64::from(d.subsec_nanos());
     // If Duration is too large, the result may be overflow.
-    d.as_secs() * 1_000_000 + (nanos / 1_000)
+    d.as_secs() * MICROSECONDS_PER_SECOND + (nanos / NANOSECONDS_PER_MICROSECOND)
 }
 
 /// Converts TimeSpec to nanoseconds
@@ -46,12 +119,25 @@ pub fn timespec_to_ns(t: Timespec) -> u64 {
     (t.sec as u64) * NANOSECONDS_PER_SECOND + t.nsec as u64
 }
 
+pub fn get_time() -> Timespec {
+    let dur = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
+    Timespec::new(dur.as_secs() as i64, dur.subsec_nanos() as i32)
+}
+
+fn to_std_duration(duration: TimeDuration) -> Duration {
+    duration.try_into().unwrap()
+}
+
+fn to_time_duration(duration: Duration) -> TimeDuration {
+    duration.try_into().unwrap()
+}
+
 /// Converts Duration to nanoseconds.
 #[inline]
 pub fn duration_to_ns(d: Duration) -> u64 {
     let nanos = u64::from(d.subsec_nanos());
     // If Duration is too large, the result may be overflow.
-    d.as_secs() * 1_000_000_000 + nanos
+    d.as_secs() * NANOSECONDS_PER_SECOND + nanos
 }
 
 pub trait InstantExt {
@@ -203,38 +289,38 @@ impl Drop for Monitor {
     }
 }
 
-/// Returns the monotonic raw time since some unspecified starting point.
-pub use self::inner::monotonic_raw_now;
-pub use self::inner::{monotonic_coarse_now, monotonic_now};
-use crate::sys::thread::StdThreadBuildWrapper;
-
-const NANOSECONDS_PER_SECOND: u64 = 1_000_000_000;
-const MILLISECOND_PER_SECOND: i64 = 1_000;
-const NANOSECONDS_PER_MILLISECOND: i64 = 1_000_000;
-
 #[cfg(not(target_os = "linux"))]
 mod inner {
-    use time::{self, Timespec};
+    use std::{sync::OnceLock, time::Instant};
 
-    use super::NANOSECONDS_PER_SECOND;
+    use super::Timespec;
+
+    #[inline]
+    fn monotonic_elapsed() -> Timespec {
+        static MONOTONIC_ORIGIN: OnceLock<Instant> = OnceLock::new();
+
+        // `time::precise_time_ns()` became a `SystemTime` compatibility shim in
+        // time 0.2, so keep a process-local monotonic origin on non-Linux.
+        let elapsed = MONOTONIC_ORIGIN.get_or_init(Instant::now).elapsed();
+        Timespec::new(
+            i64::try_from(elapsed.as_secs()).expect("monotonic clock overflow"),
+            elapsed.subsec_nanos() as i32,
+        )
+    }
 
     pub fn monotonic_raw_now() -> Timespec {
         // TODO Add monotonic raw clock time impl for macos and windows
-        // Currently use `time::get_precise_ns()` instead.
-        let ns = time::precise_time_ns();
-        let s = ns / NANOSECONDS_PER_SECOND;
-        let ns = ns % NANOSECONDS_PER_SECOND;
-        Timespec::new(s as i64, ns as i32)
+        monotonic_elapsed()
     }
 
     pub fn monotonic_now() -> Timespec {
         // TODO Add monotonic clock time impl for macos and windows
-        monotonic_raw_now()
+        monotonic_elapsed()
     }
 
     pub fn monotonic_coarse_now() -> Timespec {
         // TODO Add monotonic coarse clock time impl for macos and windows
-        monotonic_raw_now()
+        monotonic_elapsed()
     }
 }
 
@@ -242,7 +328,7 @@ mod inner {
 mod inner {
     use std::io;
 
-    use time::Timespec;
+    use super::Timespec;
 
     #[inline]
     pub fn monotonic_raw_now() -> Timespec {
@@ -358,7 +444,7 @@ impl Instant {
 
     pub(crate) fn elapsed_duration(later: Timespec, earlier: Timespec) -> Duration {
         if later >= earlier {
-            (later - earlier).to_std().unwrap()
+            to_std_duration(later - earlier)
         } else {
             panic!(
                 "monotonic time jumped back, {:.9} -> {:.9}",
@@ -370,7 +456,7 @@ impl Instant {
 
     pub(crate) fn saturating_elapsed_duration(later: Timespec, earlier: Timespec) -> Duration {
         if later >= earlier {
-            (later - earlier).to_std().unwrap()
+            to_std_duration(later - earlier)
         } else {
             error!(
                 "monotonic time jumped back, {:.3} -> {:.3}",
@@ -390,10 +476,10 @@ impl Instant {
         later: Timespec,
         earlier: Timespec,
     ) -> Duration {
-        let later_ms = later.sec * MILLISECOND_PER_SECOND
-            + i64::from(later.nsec) / NANOSECONDS_PER_MILLISECOND;
-        let earlier_ms = earlier.sec * MILLISECOND_PER_SECOND
-            + i64::from(earlier.nsec) / NANOSECONDS_PER_MILLISECOND;
+        let later_ms = later.sec * MILLISECONDS_PER_SECOND as i64
+            + i64::from(later.nsec) / NANOSECONDS_PER_MILLISECOND as i64;
+        let earlier_ms = earlier.sec * MILLISECONDS_PER_SECOND as i64
+            + i64::from(earlier.nsec) / NANOSECONDS_PER_MILLISECOND as i64;
         let dur = later_ms - earlier_ms;
         if dur >= 0 {
             Duration::from_millis(dur as u64)
@@ -436,10 +522,8 @@ impl Add<Duration> for Instant {
 
     fn add(self, other: Duration) -> Instant {
         match self {
-            Instant::Monotonic(t) => Instant::Monotonic(t + TimeDuration::from_std(other).unwrap()),
-            Instant::MonotonicCoarse(t) => {
-                Instant::MonotonicCoarse(t + TimeDuration::from_std(other).unwrap())
-            }
+            Instant::Monotonic(t) => Instant::Monotonic(t + to_time_duration(other)),
+            Instant::MonotonicCoarse(t) => Instant::MonotonicCoarse(t + to_time_duration(other)),
         }
     }
 }
@@ -455,10 +539,8 @@ impl Sub<Duration> for Instant {
 
     fn sub(self, other: Duration) -> Instant {
         match self {
-            Instant::Monotonic(t) => Instant::Monotonic(t - TimeDuration::from_std(other).unwrap()),
-            Instant::MonotonicCoarse(t) => {
-                Instant::MonotonicCoarse(t - TimeDuration::from_std(other).unwrap())
-            }
+            Instant::Monotonic(t) => Instant::Monotonic(t - to_time_duration(other)),
+            Instant::MonotonicCoarse(t) => Instant::MonotonicCoarse(t - to_time_duration(other)),
         }
     }
 }
@@ -636,6 +718,15 @@ mod tests {
             assert_eq!(ms * 1_000, duration_to_us(d));
             assert_eq!(ms * 1_000_000, duration_to_ns(d));
         }
+    }
+
+    #[test]
+    fn test_timespec_sub_large_span() {
+        let later = Timespec::new(10_000_000_000, 123);
+        let earlier = Timespec::new(0, 456);
+        let expected =
+            TimeDuration::seconds(9_999_999_999) + TimeDuration::nanoseconds(999_999_667);
+        assert_eq!(later - earlier, expected);
     }
 
     #[test]

--- a/components/tikv_util/src/timer.rs
+++ b/components/tikv_util/src/timer.rs
@@ -9,7 +9,6 @@ use std::{
 };
 
 use lazy_static::lazy_static;
-use time::Timespec;
 use tokio_executor::park::ParkThread;
 use tokio_timer::{
     self, Delay,
@@ -19,7 +18,7 @@ use tokio_timer::{
 
 use crate::{
     sys::thread::StdThreadBuildWrapper,
-    time::{Instant, monotonic_raw_now},
+    time::{Instant, Timespec, monotonic_raw_now},
 };
 
 pub struct Timer<T> {

--- a/deny.toml
+++ b/deny.toml
@@ -9,8 +9,9 @@ deny = [
     # computting object's md5.
     { name = "md5", wrappers = ["aws", "google-cloud-storage"] },
     { name = "md-5", wrappers = ["aws-smithy-checksums"]},
-    { name = "sha1", wrappers = ["aws-smithy-checksums"]},
     { name = "sha-1" },
+    # time 0.2 pulls sha1 through stdweb's proc-macro on wasm-only targets.
+    { name = "sha1", wrappers = ["aws-smithy-checksums", "stdweb-internal-macros"]},
     { name = "sha2", wrappers = ["oauth2", "aws-sigv4", "aws-smithy-checksums", "aws-sdk-s3", "google-cloud-storage"] },
     { name = "sha3" },
     # Symmetric encryption

--- a/deny.toml
+++ b/deny.toml
@@ -48,14 +48,6 @@ version = 2
 yanked = "deny"
 unmaintained = 'workspace'
 ignore = [
-    # Ignore time 0.1 RUSTSEC-2020-0071 as 1) we have taken measures (see
-    # clippy.toml) to mitigate the issue and 2) time 0.1 has no fix availble.
-    #
-    # NB: Upgrading to time 0.3 do fix the issue but it's an imcompatible
-    # versoin which removes some necessary APIs (`time::precise_time_ns`) that
-    # are required by TiKV.
-    # See https://github.com/time-rs/time/blob/8067540c/CHANGELOG.md#L703
-    "RUSTSEC-2020-0071",
     # Ignore RUSTSEC-2023-0072 as we ban the unsound `X509StoreRef::objects`.
     #
     # NB: Upgrading rust-openssl the latest version do fix the issue but it

--- a/patches/tempdir/Cargo.toml
+++ b/patches/tempdir/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "tempdir"
+version = "0.3.7"
+edition = "2021"
+publish = false
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+tempfile = "3"

--- a/patches/tempdir/src/lib.rs
+++ b/patches/tempdir/src/lib.rs
@@ -1,0 +1,63 @@
+// Copyright 2026 TiKV Project Authors. Licensed under Apache-2.0.
+
+use std::{
+    env, fmt, fs, io,
+    path::{Path, PathBuf},
+};
+
+pub struct TempDir {
+    path: Option<PathBuf>,
+}
+
+impl TempDir {
+    pub fn new(prefix: &str) -> io::Result<Self> {
+        Self::new_in(env::temp_dir(), prefix)
+    }
+
+    pub fn new_in<P: AsRef<Path>>(tmpdir: P, prefix: &str) -> io::Result<Self> {
+        let mut base = tmpdir.as_ref().to_path_buf();
+        if !base.is_absolute() {
+            base = env::current_dir()?.join(base);
+        }
+        let dir = tempfile::Builder::new().prefix(prefix).tempdir_in(base)?;
+        Ok(Self {
+            path: Some(dir.into_path()),
+        })
+    }
+
+    pub fn path(&self) -> &Path {
+        self.path.as_deref().unwrap()
+    }
+
+    pub fn into_path(mut self) -> PathBuf {
+        self.path.take().unwrap()
+    }
+
+    pub fn close(mut self) -> io::Result<()> {
+        let result = fs::remove_dir_all(self.path());
+        self.path = None;
+        result
+    }
+}
+
+impl AsRef<Path> for TempDir {
+    fn as_ref(&self) -> &Path {
+        self.path()
+    }
+}
+
+impl fmt::Debug for TempDir {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TempDir")
+            .field("path", &self.path())
+            .finish()
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        if let Some(path) = &self.path {
+            let _ = fs::remove_dir_all(path);
+        }
+    }
+}

--- a/tests/integrations/raftstore/test_replica_read.rs
+++ b/tests/integrations/raftstore/test_replica_read.rs
@@ -558,12 +558,7 @@ fn test_malformed_read_index() {
 
     // Wait till lease expires.
     std::thread::sleep(
-        cluster
-            .cfg
-            .raft_store
-            .raft_store_max_leader_lease()
-            .to_std()
-            .unwrap(),
+        Duration::try_from(cluster.cfg.raft_store.raft_store_max_leader_lease()).unwrap(),
     );
     let region = cluster.get_region(b"k1");
     // Send a malformed request to leader


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/tikv/tikv/pull/19458

### What is changed and how it works?

Issue Number: ref https://github.com/tikv/tikv/issues/19713

What's Changed:

```commit-message
*: upgrade vulnerable third-party dependencies on release-8.5

Backport dependency and advisory fixes from #19367 and #19458 to release-8.5.
Keep behavior aligned with master by preferring compatibility rewrites over
broader edition bumps. Bump the Rust toolchain only as needed, limit Rust 2024
upgrades to the same required crates/components as master, and keep the local
`tempdir` patch used upstream to avoid the old `remove_dir_all 0.5.x` chain.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Manual test:
- `cargo +nightly-2026-01-30 check -p raftstore -p raftstore-v2 -p tidb_query_expr -p compact-log-backup -p tikv-ctl`
- `cargo +nightly-2026-01-30 check -p raft_log_engine -p tikv-ctl`
- `cargo +nightly-2026-01-30 deny check advisories bans`

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note

```release-note
Upgraded vulnerable third-party dependencies for TiKV 8.5 and aligned the
required compatibility fixes with upstream.
```
