### PR TITLE
coprocessor: rescale analyze histogram sampling rate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8440,6 +8440,7 @@ dependencies = [
  "log_wrappers",
  "match-template",
  "protobuf 2.8.0",
+ "rand 0.7.3",
  "slog",
  "slog-global",
  "smallvec",
@@ -8938,7 +8939,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "tipb"
 version = "0.0.1"
-source = "git+https://github.com/pingcap/tipb.git#c84c57424fa7c7f1a51042991e6ec78d3f9fe5b3"
+source = "git+https://github.com/0xTars/tipb.git?branch=issue-67449-ndv-rate-hll#c243e7186858d43c5e622af97cc145fdb49a2080"
 dependencies = [
  "futures 0.3.15",
  "grpcio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -377,7 +377,7 @@ grpcio = { version = "0.10.4", default-features = false, features = [
 grpcio-health = { version = "0.10.4", default-features = false, features = [
   "protobuf-codec",
 ] }
-tipb = { git = "https://github.com/pingcap/tipb.git" }
+tipb = { git = "https://github.com/0xTars/tipb.git", branch = "issue-67449-ndv-rate-hll" }
 kvproto = { git = "https://github.com/pingcap/kvproto.git" }
 yatp = { git = "https://github.com/tikv/yatp.git", branch = "master" }
 tokio-timer = { git = "https://github.com/tikv/tokio", branch = "tokio-timer-hotfix" }

--- a/components/tidb_query_executors/Cargo.toml
+++ b/components/tidb_query_executors/Cargo.toml
@@ -18,6 +18,7 @@ kvproto = { workspace = true }
 log_wrappers = { workspace = true }
 match-template = "0.0.1"
 protobuf = { version = "2.8", features = ["bytes"] }
+rand = "0.7.3"
 slog = { workspace = true }
 slog-global = { workspace = true }
 smallvec = "1.4"

--- a/components/tidb_query_executors/src/table_scan_executor.rs
+++ b/components/tidb_query_executors/src/table_scan_executor.rs
@@ -116,6 +116,11 @@ impl<S: Storage, F: KvFormat> BatchTableScanExecutor<S, F> {
         })?;
         Ok(Self(wrapper))
     }
+
+    #[inline]
+    pub fn set_row_sample_rate(&mut self, sample_rate: f64) {
+        self.0.set_row_sample_rate(sample_rate);
+    }
 }
 
 #[async_trait]
@@ -881,6 +886,36 @@ mod tests {
         let exec_summary = s.summary_per_executor[1];
         assert_eq!(2, exec_summary.num_produced_rows);
         assert_eq!(1, exec_summary.num_iterations);
+    }
+
+    #[test]
+    fn test_row_sample_rate_zero_skips_decoding() {
+        let helper = TableScanTestHelper::new();
+        let mut executor = BatchTableScanExecutor::<_, ApiV1>::new(
+            helper.store(),
+            Arc::new(EvalConfig::default()),
+            helper.columns_info_by_idx(&[0, 1, 2]),
+            vec![helper.whole_table_range()],
+            vec![],
+            false,
+            false,
+            vec![],
+        )
+        .unwrap();
+        executor.set_row_sample_rate(0.0);
+
+        loop {
+            let result = block_on(executor.next_batch(2));
+            assert!(result.logical_rows.is_empty());
+            assert_eq!(result.physical_columns.rows_len(), 0);
+            if result.is_drained.unwrap().stop() {
+                break;
+            }
+        }
+
+        let mut stats = ExecuteStats::new(1);
+        executor.collect_exec_stats(&mut stats);
+        assert_eq!(stats.scanned_rows_per_range, vec![5]);
     }
 
     #[test]

--- a/components/tidb_query_executors/src/util/scan_executor.rs
+++ b/components/tidb_query_executors/src/util/scan_executor.rs
@@ -3,6 +3,7 @@
 use api_version::{KvFormat, keyspace::KvPairEntry};
 use async_trait::async_trait;
 use kvproto::coprocessor::KeyRange;
+use rand::{Rng, SeedableRng, rngs::StdRng};
 use tidb_query_common::{
     Result,
     metrics::{ExecutorName, record_executor_work},
@@ -57,6 +58,11 @@ pub struct ScanExecutor<S: Storage, I: ScanExecutorImpl, F: KvFormat> {
     /// or there was an error scanning the table, this flag will be set to
     /// `true` and `next_batch` should be never called again.
     is_ended: bool,
+
+    /// Row-level Bernoulli sampling rate. It lets ANALYZE count every scanned
+    /// row while only decoding rows selected for sketch/sample collection.
+    row_sample_rate: f64,
+    row_sample_rng: StdRng,
 }
 
 pub struct ScanExecutorOptions<S, I> {
@@ -104,7 +110,29 @@ impl<S: Storage, I: ScanExecutorImpl, F: KvFormat> ScanExecutor<S, I, F> {
                 load_commit_ts,
             }),
             is_ended: false,
+            row_sample_rate: 1.0,
+            row_sample_rng: StdRng::from_entropy(),
         })
+    }
+
+    /// Sets the row sampling rate. This is intentionally a scan-executor knob
+    /// so skipped rows still contribute to scanner execution statistics, but
+    /// avoid decode and downstream collection cost.
+    pub fn set_row_sample_rate(&mut self, sample_rate: f64) {
+        if sample_rate.is_finite() {
+            self.row_sample_rate = sample_rate.clamp(0.0, 1.0);
+        }
+    }
+
+    #[inline]
+    fn should_sample_row(&mut self) -> bool {
+        if self.row_sample_rate >= 1.0 {
+            return true;
+        }
+        if self.row_sample_rate <= 0.0 {
+            return false;
+        }
+        self.row_sample_rng.gen_range(0.0, 1.0) < self.row_sample_rate
     }
 
     /// Fills a column vector and returns whether or not all ranges are drained.
@@ -136,6 +164,9 @@ impl<S: Storage, I: ScanExecutorImpl, F: KvFormat> ScanExecutor<S, I, F> {
                 let (key, value) = row.kv();
                 scanned_kv_bytes =
                     scanned_kv_bytes.saturating_add((key.len() + value.len()) as u64);
+                if !self.should_sample_row() {
+                    continue;
+                }
                 if let Err(e) = self
                     .imp
                     .process_kv_pair(key, value, columns, row.commit_ts())

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -47,8 +47,12 @@ use tokio::sync::Semaphore;
 use super::config_manager::CopConfigManager;
 use crate::{
     coprocessor::{
-        cache::CachedRequestHandler, interceptors::*, metrics::*,
-        statistics::analyze_context::AnalyzeContext, tracker::Tracker, *,
+        cache::CachedRequestHandler,
+        interceptors::*,
+        metrics::*,
+        statistics::{analyze::AnalyzeSamplingResult, analyze_context::AnalyzeContext},
+        tracker::Tracker,
+        *,
     },
     read_pool::ReadPoolHandle,
     server::Config,
@@ -65,6 +69,178 @@ use crate::{
 /// light ones, which means they don't need a permit from the semaphore before
 /// execution.
 const LIGHT_TASK_THRESHOLD: Duration = Duration::from_millis(5);
+fn elapsed_ms(start: Instant) -> u64 {
+    start.saturating_elapsed().as_millis() as u64
+}
+
+fn is_analyze_full_sampling_batch_request(req: &coppb::Request) -> bool {
+    if req.get_tp() != REQ_TYPE_ANALYZE || req.get_tasks().is_empty() {
+        return false;
+    }
+    let start = Instant::now();
+    let mut analyze = AnalyzeReq::default();
+    let merge_res = Message::merge_from_bytes(&mut analyze, req.get_data());
+    if let Err(err) = merge_res {
+        info!("analyze full sampling trace";
+            "component" => "tikv",
+            "phase" => "tikv.inspect_batch_request",
+            "event" => "finish",
+            "request_bytes" => req.get_data().len(),
+            "batch_task_count" => req.get_tasks().len(),
+            "elapsed_ms" => elapsed_ms(start),
+            "success" => false,
+            "err" => ?err,
+        );
+        return false;
+    }
+    let is_full_sampling =
+        analyze.get_tp() == AnalyzeType::TypeFullSampling && analyze.has_col_req();
+    if is_full_sampling {
+        info!("analyze full sampling trace";
+            "component" => "tikv",
+            "phase" => "tikv.inspect_batch_request",
+            "event" => "finish",
+            "request_bytes" => req.get_data().len(),
+            "batch_task_count" => req.get_tasks().len(),
+            "elapsed_ms" => elapsed_ms(start),
+            "success" => true,
+            "is_full_sampling" => is_full_sampling,
+        );
+    }
+    is_full_sampling
+}
+
+fn response_has_error(resp: &coppb::Response) -> bool {
+    resp.has_region_error() || resp.has_locked() || !resp.get_other_error().is_empty()
+}
+
+fn record_coprocessor_response_size(resp_size: u64) {
+    COPR_RESP_SIZE.inc_by(resp_size);
+    record_network_out_bytes(resp_size);
+    with_tls_tracker(|tracker| {
+        tracker.metrics.coprocessor_response_bytes = tracker
+            .metrics
+            .coprocessor_response_bytes
+            .saturating_add(resp_size);
+    });
+}
+
+struct AnalyzeFullSamplingTaskResult {
+    response: coppb::Response,
+    sampling_result: Option<AnalyzeSamplingResult>,
+}
+
+struct AnalyzeFullSamplingBatchTaskResult {
+    task_id: u64,
+    response: coppb::Response,
+    sampling_result: Option<AnalyzeSamplingResult>,
+}
+
+fn set_analyze_sampling_response_data(
+    resp: &mut coppb::Response,
+    sampling_result: AnalyzeSamplingResult,
+    response_kind: &'static str,
+) -> Result<()> {
+    let start = Instant::now();
+    let data = sampling_result.write_to_bytes()?;
+    debug!("analyze full sampling trace";
+        "component" => "tikv",
+        "phase" => "tikv.set_sampling_response_data",
+        "event" => "finish",
+        "response_kind" => response_kind,
+        "elapsed_ms" => elapsed_ms(start),
+        "response_bytes" => data.len(),
+    );
+    record_coprocessor_response_size(data.len() as u64);
+    resp.set_data(data);
+    Ok(())
+}
+
+fn analyze_full_sampling_batch_response(
+    mut output: AnalyzeFullSamplingBatchTaskResult,
+) -> Result<coppb::StoreBatchTaskResponse> {
+    if let Some(sampling_result) = output.sampling_result.take() {
+        set_analyze_sampling_response_data(&mut output.response, sampling_result, "batch_task")?;
+    }
+
+    let mut response = coppb::StoreBatchTaskResponse::new();
+    response.set_task_id(output.task_id);
+    response.set_data(output.response.take_data());
+    if let Some(err) = output.response.region_error.take() {
+        response.set_region_error(err);
+    }
+    if let Some(lock_info) = output.response.locked.take() {
+        response.set_locked(lock_info);
+    }
+    response.set_other_error(output.response.take_other_error());
+    response.set_exec_details_v2(output.response.take_exec_details_v2());
+    Ok(response)
+}
+
+fn finish_analyze_full_sampling_batch_response(
+    mut top: AnalyzeFullSamplingTaskResult,
+    mut batch_outputs: Vec<AnalyzeFullSamplingBatchTaskResult>,
+) -> Result<coppb::Response> {
+    let finish_start = Instant::now();
+    let can_reduce = !response_has_error(&top.response)
+        && top.sampling_result.is_some()
+        && batch_outputs.iter().all(|output| {
+            !response_has_error(&output.response) && output.sampling_result.is_some()
+        });
+
+    if can_reduce {
+        let batch_task_count = batch_outputs.len();
+        let merge_start = Instant::now();
+        let mut merged = top.sampling_result.take().unwrap();
+        for output in &mut batch_outputs {
+            merged.merge_from(output.sampling_result.take().unwrap())?;
+        }
+        info!("analyze full sampling trace";
+            "component" => "tikv",
+            "phase" => "tikv.merge_sampling_results",
+            "event" => "finish",
+            "success" => true,
+            "elapsed_ms" => elapsed_ms(merge_start),
+            "total_task_count" => batch_task_count + 1,
+            "batch_task_count" => batch_task_count,
+        );
+        set_analyze_sampling_response_data(&mut top.response, merged, "reduced_top")?;
+        top.response.set_batch_responses(Default::default());
+        info!("analyze full sampling trace";
+            "component" => "tikv",
+            "phase" => "tikv.reduce_batch_response",
+            "event" => "finish",
+            "success" => true,
+            "reduced" => true,
+            "elapsed_ms" => elapsed_ms(finish_start),
+            "total_task_count" => batch_task_count + 1,
+            "batch_task_count" => batch_task_count,
+            "response_bytes" => top.response.get_data().len(),
+        );
+        return Ok(top.response);
+    }
+
+    if let Some(sampling_result) = top.sampling_result.take() {
+        set_analyze_sampling_response_data(&mut top.response, sampling_result, "fallback_top")?;
+    }
+    let mut batch_responses = Vec::with_capacity(batch_outputs.len());
+    for output in batch_outputs {
+        batch_responses.push(analyze_full_sampling_batch_response(output)?);
+    }
+    let batch_response_count = batch_responses.len();
+    top.response.set_batch_responses(batch_responses.into());
+    info!("analyze full sampling trace";
+        "component" => "tikv",
+        "phase" => "tikv.reduce_batch_response",
+        "event" => "finish",
+        "success" => true,
+        "reduced" => false,
+        "elapsed_ms" => elapsed_ms(finish_start),
+        "response_bytes" => top.response.get_data().len(),
+        "batch_response_count" => batch_response_count,
+    );
+    Ok(top.response)
+}
 
 /// A pool to build and run Coprocessor request handlers.
 #[derive(Clone)]
@@ -302,9 +478,23 @@ impl<E: Engine> Endpoint<E> {
             }
             REQ_TYPE_ANALYZE => {
                 let mut analyze = AnalyzeReq::default();
+                let unmarshal_start = Instant::now();
                 box_try!(analyze.merge_from(&mut input));
                 if start_ts == 0 {
                     start_ts = analyze.get_start_ts_fallback();
+                }
+                if analyze.get_tp() == AnalyzeType::TypeFullSampling {
+                    debug!("analyze full sampling trace";
+                        "component" => "tikv",
+                        "phase" => "tikv.unmarshal_analyze_req",
+                        "event" => "finish",
+                        "elapsed_ms" => elapsed_ms(unmarshal_start),
+                        "request_bytes" => data.len(),
+                        "range_count" => ranges.len(),
+                        "region_id" => context.get_region_id(),
+                        "start_ts" => start_ts,
+                        "has_column_request" => analyze.has_col_req(),
+                    );
                 }
 
                 req_tag = match analyze.get_tp() {
@@ -547,14 +737,7 @@ impl<E: Engine> Endpoint<E> {
         let mut resp = match result {
             Ok(resp) => {
                 let resp_size = resp.data.len() as u64;
-                COPR_RESP_SIZE.inc_by(resp_size);
-                record_network_out_bytes(resp_size);
-                with_tls_tracker(|tracker| {
-                    tracker.metrics.coprocessor_response_bytes = tracker
-                        .metrics
-                        .coprocessor_response_bytes
-                        .saturating_add(resp_size);
-                });
+                record_coprocessor_response_size(resp_size);
                 resp
             }
             Err(e) => {
@@ -574,6 +757,147 @@ impl<E: Engine> Endpoint<E> {
         resp.set_exec_details_v2(exec_details_v2);
         resp.set_latest_buckets_version(buckets_version);
         Ok(resp)
+    }
+
+    async fn handle_analyze_full_sampling_request_impl(
+        semaphore: Option<Arc<Semaphore>>,
+        mut tracker: Box<Tracker<E>>,
+        handler_builder: RequestHandlerBuilder<E::IMSnap>,
+    ) -> Result<AnalyzeFullSamplingTaskResult> {
+        let total_start = Instant::now();
+        let region_id = tracker.req_ctx.context.get_region_id();
+        let start_ts = tracker.req_ctx.txn_start_ts.into_inner();
+        debug!("analyze full sampling trace";
+            "component" => "tikv",
+            "phase" => "tikv.handle_full_sampling",
+            "event" => "start",
+            "region_id" => region_id,
+            "start_ts" => start_ts,
+            "range_count" => tracker.req_ctx.ranges.len(),
+        );
+        with_tls_tracker(|tracker1| {
+            record_network_in_bytes(tracker1.metrics.grpc_req_size);
+        });
+        tracker.on_scheduled();
+        tracker.req_ctx.deadline.check()?;
+
+        // Safety: spawning this function using a `FuturePool` ensures that a TLS engine
+        // exists.
+        let snapshot_start = Instant::now();
+        let snapshot = unsafe { Self::get_snapshot_with_timeout(&tracker.req_ctx).await }?;
+        debug!("analyze full sampling trace";
+            "component" => "tikv",
+            "phase" => "tikv.get_snapshot",
+            "event" => "finish",
+            "region_id" => region_id,
+            "start_ts" => start_ts,
+            "elapsed_ms" => elapsed_ms(snapshot_start),
+        );
+
+        let latest_buckets = snapshot.ext().get_buckets();
+        let region_cache_snap = snapshot.ext().in_memory_engine_hit();
+        tracker.adjust_snapshot_type(region_cache_snap);
+
+        if let Some(ref buckets) = latest_buckets {
+            if buckets.version > tracker.req_ctx.context.buckets_version
+                && tracker.req_ctx.context.buckets_version != 0
+            {
+                let mut bucket_not_match = errorpb::BucketVersionNotMatch::default();
+                bucket_not_match.set_version(buckets.version);
+                bucket_not_match.set_keys(buckets.keys.clone().into());
+                let mut err = errorpb::Error::default();
+                err.set_bucket_version_not_match(bucket_not_match);
+                return Err(Error::Region(err));
+            }
+        }
+
+        tracker.on_snapshot_finished();
+        tracker.req_ctx.deadline.check()?;
+        tracker.buckets = latest_buckets;
+        let buckets_version = tracker.buckets.as_ref().map_or(0, |b| b.version);
+
+        let handler_start = Instant::now();
+        let mut handler = handler_builder(snapshot, &tracker.req_ctx)?;
+        debug!("analyze full sampling trace";
+            "component" => "tikv",
+            "phase" => "tikv.build_analyze_handler",
+            "event" => "finish",
+            "region_id" => region_id,
+            "start_ts" => start_ts,
+            "elapsed_ms" => elapsed_ms(handler_start),
+        );
+        tracker.on_begin_all_items();
+
+        let deadline = tracker.req_ctx.deadline;
+        let scan_start = Instant::now();
+        let handle_request_future =
+            check_deadline(handler.handle_analyze_full_sampling(), deadline);
+        let handle_request_future = track(handle_request_future, tracker.as_mut());
+
+        let deadline_res = if let Some(semaphore) = &semaphore {
+            limit_concurrency(handle_request_future, semaphore, LIGHT_TASK_THRESHOLD).await
+        } else {
+            handle_request_future.await
+        };
+        let result = deadline_res.map_err(Error::from).and_then(|res| res);
+        debug!("analyze full sampling trace";
+            "component" => "tikv",
+            "phase" => "tikv.execute_full_sampling_handler",
+            "event" => "finish",
+            "region_id" => region_id,
+            "start_ts" => start_ts,
+            "elapsed_ms" => elapsed_ms(scan_start),
+            "success" => result.is_ok(),
+        );
+
+        let collect_stats_start = Instant::now();
+        let mut exec_summary = ExecSummary::default();
+        handler.collect_scan_summary(&mut exec_summary);
+        tracker.collect_scan_process_time(exec_summary);
+        let mut storage_stats = Statistics::default();
+        handler.collect_scan_statistics(&mut storage_stats);
+        tracker.collect_storage_statistics(storage_stats);
+        debug!("analyze full sampling trace";
+            "component" => "tikv",
+            "phase" => "tikv.collect_scan_details",
+            "event" => "finish",
+            "region_id" => region_id,
+            "start_ts" => start_ts,
+            "elapsed_ms" => elapsed_ms(collect_stats_start),
+        );
+
+        let (mut resp, sampling_result) = match result {
+            Ok(sampling_result) => (coppb::Response::default(), Some(sampling_result)),
+            Err(e) => {
+                if let Error::DefaultNotFound(errmsg) = &e {
+                    error!("default not found in coprocessor request processing";
+                        "err" => errmsg,
+                        "reqCtx" => ?&tracker.req_ctx,
+                    );
+                }
+                (make_error_response(e), None)
+            }
+        };
+
+        let (exec_details, exec_details_v2) = tracker.get_exec_details();
+        tracker.on_finish_all_items();
+        record_logical_read_bytes(exec_details_v2.get_scan_detail_v2().processed_versions_size);
+        resp.set_exec_details(exec_details);
+        resp.set_exec_details_v2(exec_details_v2);
+        resp.set_latest_buckets_version(buckets_version);
+        debug!("analyze full sampling trace";
+            "component" => "tikv",
+            "phase" => "tikv.handle_full_sampling",
+            "event" => "finish",
+            "region_id" => region_id,
+            "start_ts" => start_ts,
+            "elapsed_ms" => elapsed_ms(total_start),
+            "success" => sampling_result.is_some(),
+        );
+        Ok(AnalyzeFullSamplingTaskResult {
+            response: resp,
+            sampling_result,
+        })
     }
 
     /// Handle a unary request and run on the read pool.
@@ -636,6 +960,143 @@ impl<E: Engine> Endpoint<E> {
         }
     }
 
+    fn handle_analyze_full_sampling_request(
+        &self,
+        r: ParseCopRequestResult<E::IMSnap>,
+    ) -> impl Future<Output = Result<AnalyzeFullSamplingTaskResult>> {
+        let req_ctx = r.req_ctx;
+        let priority = req_ctx.context.get_priority();
+        let task_id = req_ctx.build_task_id();
+        let key_ranges: Vec<_> = req_ctx
+            .ranges
+            .iter()
+            .map(|key_range| (key_range.get_start().to_vec(), key_range.get_end().to_vec()))
+            .collect();
+        let resource_tag = self
+            .resource_tag_factory
+            .new_tag_with_key_ranges(&req_ctx.context, key_ranges);
+        let mut allocated_bytes = resource_tag.approximate_heap_size();
+
+        let metadata = TaskMetadata::from_ctx(req_ctx.context.get_resource_control_context());
+        let resource_limiter = self.resource_ctl.as_ref().and_then(|r| {
+            r.get_resource_limiter(
+                req_ctx
+                    .context
+                    .get_resource_control_context()
+                    .get_resource_group_name(),
+                req_ctx.context.get_request_source(),
+                req_ctx
+                    .context
+                    .get_resource_control_context()
+                    .get_override_priority(),
+            )
+        });
+        let tracker = Box::new(Tracker::new(req_ctx, r.req_tag, self.slow_log_threshold));
+        allocated_bytes += tracker.approximate_mem_size();
+
+        let (tx, rx) = oneshot::channel();
+        let future = Self::handle_analyze_full_sampling_request_impl(
+            self.semaphore.clone(),
+            tracker,
+            r.handler_builder,
+        )
+        .in_resource_metering_tag(resource_tag)
+        .map(move |res| {
+            let _ = tx.send(res);
+        });
+        let spawn_fut_result = self.read_pool_spawn_with_memory_quota_check(
+            allocated_bytes,
+            future,
+            priority,
+            task_id,
+            metadata,
+            resource_limiter,
+        );
+        async move {
+            spawn_fut_result?.await?;
+            rx.map_err(|_| Error::MaxPendingTasksExceeded).await?
+        }
+    }
+
+    fn parse_and_handle_analyze_full_sampling_batch_request(
+        &self,
+        mut req: coppb::Request,
+        peer: Option<String>,
+        tracker: ::tracker::TrackerToken,
+    ) -> impl Future<Output = MemoryTraceGuard<coppb::Response>> {
+        let total_start = Instant::now();
+        let region_id = req.get_context().get_region_id();
+        let start_ts = req.start_ts;
+        let initial_batch_task_count = req.get_tasks().len();
+        info!("analyze full sampling trace";
+            "component" => "tikv",
+            "phase" => "tikv.handle_batch_request",
+            "event" => "start",
+            "region_id" => region_id,
+            "start_ts" => start_ts,
+            "batch_task_count" => initial_batch_task_count,
+            "request_bytes" => req.get_data().len(),
+        );
+        let result_of_batch = self.process_analyze_full_sampling_batch_tasks(&mut req, &peer);
+        set_tls_tracker_token(tracker);
+        with_tls_tracker(|tracker| {
+            tracker.metrics.grpc_req_size = req.compute_size() as u64;
+        });
+        let result_of_future = self
+            .parse_request_and_check_memory_locks(req, peer, false)
+            .map(|r| self.handle_analyze_full_sampling_request(r));
+        with_tls_tracker(|tracker| {
+            tracker.metrics.grpc_process_nanos =
+                tracker.req_info.begin.saturating_elapsed().as_nanos() as u64;
+        });
+
+        async move {
+            let mut res = match result_of_future {
+                Err(e) => {
+                    let top = AnalyzeFullSamplingTaskResult {
+                        response: make_error_response(e),
+                        sampling_result: None,
+                    };
+                    let batch_outputs = result_of_batch.await;
+                    finish_analyze_full_sampling_batch_response(top, batch_outputs)
+                        .unwrap_or_else(make_error_response)
+                }
+                Ok(handle_fut) => {
+                    let (handle_res, batch_outputs) = futures::join!(handle_fut, result_of_batch);
+                    let top = handle_res.unwrap_or_else(|e| AnalyzeFullSamplingTaskResult {
+                        response: make_error_response(e),
+                        sampling_result: None,
+                    });
+                    finish_analyze_full_sampling_batch_response(top, batch_outputs)
+                        .unwrap_or_else(make_error_response)
+                }
+            };
+            GLOBAL_TRACKERS.with_tracker(tracker, |tracker| {
+                let exec_detail_v2 = res.mut_exec_details_v2();
+                tracker.write_scan_detail(exec_detail_v2.mut_scan_detail_v2());
+                tracker.merge_time_detail(exec_detail_v2.mut_time_detail_v2());
+            });
+            GLOBAL_TRACKERS.remove(tracker);
+            info!("analyze full sampling trace";
+                "component" => "tikv",
+                "phase" => "tikv.handle_batch_request",
+                "event" => "finish",
+                "region_id" => region_id,
+                "start_ts" => start_ts,
+                "elapsed_ms" => elapsed_ms(total_start),
+                "batch_task_count" => initial_batch_task_count,
+                "response_bytes" => res.get_data().len(),
+                "batch_response_count" => res.get_batch_responses().len(),
+                "success" => !res.has_region_error() && !res.has_locked() && res.get_other_error().is_empty(),
+                "has_region_error" => res.has_region_error(),
+                "has_locked" => res.has_locked(),
+                "other_error" => res.get_other_error(),
+            );
+            let memory_size = res.data.capacity();
+            MEMTRACE_ANALYZE.trace_guard(res, memory_size)
+        }
+    }
+
     /// Parses and handles a unary request. Returns a future that will never
     /// fail. If there are errors during parsing or handling, they will be
     /// converted into a `Response` as the success result of the future.
@@ -659,6 +1120,11 @@ impl<E: Engine> Endpoint<E> {
             pb_error.set_server_is_busy(busy_err);
             let resp = make_error_response(Error::Region(pb_error));
             return Either::Left(async move { resp.into() });
+        }
+
+        if is_analyze_full_sampling_batch_request(&req) {
+            let fut = self.parse_and_handle_analyze_full_sampling_batch_request(req, peer, tracker);
+            return Either::Right(Either::Left(fut));
         }
 
         let result_of_batch = self.process_batch_tasks(&mut req, &peer);
@@ -696,7 +1162,7 @@ impl<E: Engine> Endpoint<E> {
             GLOBAL_TRACKERS.remove(tracker);
             res
         };
-        Either::Right(fut)
+        Either::Right(Either::Right(fut))
     }
 
     // process_batch_tasks process the input batched coprocessor tasks if any,
@@ -771,6 +1237,106 @@ impl<E: Engine> Endpoint<E> {
                 Err(e) => batch_futs.push(future::Either::Right(async move {
                     make_error_batch_response(&mut response, e);
                     response
+                })),
+            }
+        }
+        stream::FuturesOrdered::from_iter(batch_futs).collect()
+    }
+
+    fn process_analyze_full_sampling_batch_tasks(
+        &self,
+        req: &mut coppb::Request,
+        peer: &Option<String>,
+    ) -> impl Future<Output = Vec<AnalyzeFullSamplingBatchTaskResult>> {
+        let extract_start = Instant::now();
+        let mut batch_futs = Vec::with_capacity(req.tasks.len());
+        let batch_reqs: Vec<(coppb::Request, u64)> = req
+            .take_tasks()
+            .iter_mut()
+            .map(|task| {
+                let mut new_req = req.clone();
+                new_req.is_cache_enabled = false;
+                new_req.ranges = task.take_ranges();
+                let new_context = new_req.mut_context();
+                new_context.set_region_id(task.get_region_id());
+                new_context.set_region_epoch(task.take_region_epoch());
+                new_context.set_peer(task.take_peer());
+                (new_req, task.get_task_id())
+            })
+            .collect();
+        info!("analyze full sampling trace";
+            "component" => "tikv",
+            "phase" => "tikv.extract_batch_tasks",
+            "event" => "finish",
+            "elapsed_ms" => elapsed_ms(extract_start),
+            "batch_task_count" => batch_reqs.len(),
+        );
+        for (cur_req, task_id) in batch_reqs.into_iter() {
+            let region_id = cur_req.get_context().get_region_id();
+            let start_ts = cur_req.start_ts;
+            let request_info = RequestInfo::new(
+                cur_req.get_context(),
+                RequestType::Unknown,
+                cur_req.start_ts,
+            );
+            match self.parse_request_and_check_memory_locks(cur_req, peer.clone(), false) {
+                Ok(r) => {
+                    let cur_tracker = GLOBAL_TRACKERS.insert(::tracker::Tracker::new(request_info));
+                    set_tls_tracker_token(cur_tracker);
+                    let fut = self.handle_analyze_full_sampling_request(r);
+                    let fut = async move {
+                        let task_start = Instant::now();
+                        debug!("analyze full sampling trace";
+                            "component" => "tikv",
+                            "phase" => "tikv.handle_batch_sub_task",
+                            "event" => "start",
+                            "task_id" => task_id,
+                            "region_id" => region_id,
+                            "start_ts" => start_ts,
+                        );
+                        let mut output = match fut.await {
+                            Ok(output) => AnalyzeFullSamplingBatchTaskResult {
+                                task_id,
+                                response: output.response,
+                                sampling_result: output.sampling_result,
+                            },
+                            Err(e) => AnalyzeFullSamplingBatchTaskResult {
+                                task_id,
+                                response: make_error_response(e),
+                                sampling_result: None,
+                            },
+                        };
+                        debug!("analyze full sampling trace";
+                            "component" => "tikv",
+                            "phase" => "tikv.handle_batch_sub_task",
+                            "event" => "finish",
+                            "task_id" => task_id,
+                            "region_id" => region_id,
+                            "start_ts" => start_ts,
+                            "elapsed_ms" => elapsed_ms(task_start),
+                            "success" => output.sampling_result.is_some() && !response_has_error(&output.response),
+                            "response_bytes" => output.response.get_data().len(),
+                            "has_region_error" => output.response.has_region_error(),
+                            "has_locked" => output.response.has_locked(),
+                            "other_error" => output.response.get_other_error(),
+                        );
+                        GLOBAL_TRACKERS.with_tracker(cur_tracker, |tracker| {
+                            tracker.write_scan_detail(
+                                output.response.mut_exec_details_v2().mut_scan_detail_v2(),
+                            );
+                        });
+                        GLOBAL_TRACKERS.remove(cur_tracker);
+                        output
+                    };
+
+                    batch_futs.push(future::Either::Left(fut));
+                }
+                Err(e) => batch_futs.push(future::Either::Right(async move {
+                    AnalyzeFullSamplingBatchTaskResult {
+                        task_id,
+                        response: make_error_response(e),
+                        sampling_result: None,
+                    }
                 })),
             }
         }

--- a/src/coprocessor/mod.rs
+++ b/src/coprocessor/mod.rs
@@ -48,6 +48,7 @@ use tikv_alloc::{Id, MemoryTrace, MemoryTraceGuard, mem_trace};
 use tikv_util::{deadline::Deadline, memory::HeapSize, time::Duration};
 use txn_types::TsSet;
 
+use self::statistics::analyze::AnalyzeSamplingResult;
 pub use self::{
     endpoint::Endpoint,
     error::{Error, Result},
@@ -68,6 +69,15 @@ pub trait RequestHandler: Send {
     /// Processes current request and produces a response.
     async fn handle_request(&mut self) -> Result<MemoryTraceGuard<coppb::Response>> {
         panic!("unary request is not supported for this handler");
+    }
+
+    /// Processes an analyze full-sampling request and keeps the typed sampling
+    /// result alive for callers that need to merge several region results
+    /// before protobuf serialization.
+    async fn handle_analyze_full_sampling(&mut self) -> Result<AnalyzeSamplingResult> {
+        Err(Error::Other(
+            "analyze full sampling is not supported for this handler".to_owned(),
+        ))
     }
 
     /// Processes current request and produces streaming responses.

--- a/src/coprocessor/statistics/analyze.rs
+++ b/src/coprocessor/statistics/analyze.rs
@@ -79,7 +79,7 @@ impl<S: Snapshot, F: KvFormat> RowSampleBuilder<S, F> {
         let ndv_rate = if ndv_rate > 0.0 { ndv_rate } else { 1.0 };
         let build_singletons = ndv_rate < 1.0;
         let common_handle_ids = req.take_primary_column_ids();
-        let table_scanner = BatchTableScanExecutor::new(
+        let mut table_scanner = BatchTableScanExecutor::new(
             storage,
             Arc::new(EvalConfig::default()),
             columns_info.clone(),
@@ -89,6 +89,9 @@ impl<S: Snapshot, F: KvFormat> RowSampleBuilder<S, F> {
             false, // Streaming mode is not supported in Analyze request, always false here
             req.take_primary_prefix_column_ids(),
         )?;
+        if build_singletons {
+            table_scanner.set_row_sample_rate(ndv_rate);
+        }
         Ok(Self {
             data: table_scanner,
             accumulated_storage_stats: Statistics::default(),

--- a/src/coprocessor/statistics/analyze.rs
+++ b/src/coprocessor/statistics/analyze.rs
@@ -3,9 +3,11 @@
 use std::{cmp::Reverse, collections::BinaryHeap, hash::Hasher, mem, sync::Arc};
 
 use api_version::KvFormat;
+use collections::HashSet;
 use kvproto::coprocessor::KeyRange;
-use mur3::Hasher128;
+use mur3::{Hasher128, murmurhash3_x64_128};
 use rand::{Rng, rngs::StdRng};
+use tidb_query_common::execute_stats::ExecuteStats;
 use tidb_query_datatype::{
     FieldTypeAccessor,
     codec::{
@@ -24,7 +26,12 @@ use tikv_util::{
 };
 use tipb::{self, AnalyzeColumnsReq};
 
-use super::{cmsketch::CmSketch, fmsketch::FmSketch, histogram::Histogram};
+use super::{
+    cmsketch::CmSketch,
+    fmsketch::FmSketch,
+    histogram::Histogram,
+    hll::{DEFAULT_HLL_PRECISION, Hll},
+};
 use crate::{
     coprocessor::{MEMTRACE_ANALYZE, dag::TikvStorage, metrics, *},
     storage::{Snapshot, SnapshotStore, Statistics},
@@ -40,6 +47,8 @@ pub(crate) struct RowSampleBuilder<S: Snapshot, F: KvFormat> {
     max_sample_size: usize,
     max_fm_sketch_size: usize,
     sample_rate: f64,
+    // Whether to build per-row singleton sketches (only needed when ndv_rate < 1).
+    build_singletons: bool,
     columns_info: Vec<tipb::ColumnInfo>,
     column_groups: Vec<tipb::AnalyzeColumnGroup>,
     quota_limiter: Arc<QuotaLimiter>,
@@ -59,6 +68,16 @@ impl<S: Snapshot, F: KvFormat> RowSampleBuilder<S, F> {
         if columns_info.is_empty() {
             return Err(box_err!("empty columns_info"));
         }
+        let max_sample_size = req.get_sample_size() as usize;
+        let sample_rate = req.get_sample_rate();
+        // `ndv_rate < 1` signals that NDV sampling is on, which means: build the
+        // singleton HLL sketches that feed the GEE f1 estimate. When unset (0),
+        // treat it as full rate (no NDV sampling). At full rate the FM sketch is
+        // already an exact NDV, so skip the singleton sketches to save CPU, memory,
+        // and serialized bytes.
+        let ndv_rate = req.get_ndv_rate();
+        let ndv_rate = if ndv_rate > 0.0 { ndv_rate } else { 1.0 };
+        let build_singletons = ndv_rate < 1.0;
         let common_handle_ids = req.take_primary_column_ids();
         let table_scanner = BatchTableScanExecutor::new(
             storage,
@@ -73,9 +92,10 @@ impl<S: Snapshot, F: KvFormat> RowSampleBuilder<S, F> {
         Ok(Self {
             data: table_scanner,
             accumulated_storage_stats: Statistics::default(),
-            max_sample_size: req.get_sample_size() as usize,
+            max_sample_size,
             max_fm_sketch_size: req.get_sketch_size() as usize,
-            sample_rate: req.get_sample_rate(),
+            sample_rate,
+            build_singletons,
             columns_info,
             column_groups: req.take_column_groups().into(),
             quota_limiter,
@@ -89,12 +109,14 @@ impl<S: Snapshot, F: KvFormat> RowSampleBuilder<S, F> {
                 self.max_sample_size,
                 self.max_fm_sketch_size,
                 self.columns_info.len() + self.column_groups.len(),
+                self.build_singletons,
             ));
         }
         Box::new(BernoulliRowSampleCollector::new(
             self.sample_rate,
             self.max_fm_sketch_size,
             self.columns_info.len() + self.column_groups.len(),
+            self.build_singletons,
         ))
     }
 
@@ -158,6 +180,10 @@ impl<S: Snapshot, F: KvFormat> RowSampleBuilder<S, F> {
                     .inc();
                 let _guard = sample.observe_cpu();
                 is_drained = result.is_drained?.stop();
+                let mut exec_stats = ExecuteStats::new(0);
+                self.data.collect_exec_stats(&mut exec_stats);
+                collector.mut_base().count +=
+                    exec_stats.scanned_rows_per_range.into_iter().sum::<usize>() as u64;
 
                 let columns_slice = result.physical_columns.as_slice();
                 let mut column_vals: Vec<Vec<u8>> = vec![vec![]; self.columns_info.len()];
@@ -191,7 +217,7 @@ impl<S: Snapshot, F: KvFormat> RowSampleBuilder<S, F> {
                         }
                         read_size += column_vals[i].len();
                     }
-                    collector.mut_base().count += 1;
+                    collector.mut_base().sketch_sample_count += 1;
                     collector.collect_column_group(
                         &column_vals,
                         &collation_key_vals,
@@ -217,6 +243,10 @@ impl<S: Snapshot, F: KvFormat> RowSampleBuilder<S, F> {
                     .inc_by(quota_delay.as_micros() as u64);
             }
         }
+        // NDV sub-sampling only tallies null_count/total_sizes for rows that
+        // passed the rate check. Rescale them back to per-population estimates
+        // before the single-column-group copy below picks them up.
+        collector.mut_base().rescale_null_count_and_total_sizes();
         for i in 0..self.column_groups.len() {
             let offsets = self.column_groups[i].get_column_offsets();
             if offsets.len() != 1 {
@@ -228,8 +258,15 @@ impl<S: Snapshot, F: KvFormat> RowSampleBuilder<S, F> {
             // iterating all rows. Also, we can directly copy total_size and null_count.
             let col_pos = offsets[0] as usize;
             let col_group_pos = self.columns_info.len() + i;
-            collector.mut_base().fm_sketches[col_group_pos] =
-                collector.mut_base().fm_sketches[col_pos].clone();
+            // Copy whichever sketch type this mode populated; the other Vec is
+            // empty (see BaseRowSampleCollector::new).
+            if collector.mut_base().build_singletons {
+                collector.mut_base().singleton_sketches[col_group_pos] =
+                    collector.mut_base().singleton_sketches[col_pos].clone();
+            } else {
+                collector.mut_base().fm_sketches[col_group_pos] =
+                    collector.mut_base().fm_sketches[col_pos].clone();
+            }
             collector.mut_base().null_count[col_group_pos] =
                 collector.mut_base().null_count[col_pos];
             collector.mut_base().total_sizes[col_group_pos] =
@@ -266,11 +303,69 @@ trait RowSampleCollector: Send {
     }
 }
 
+// SingletonSketch tracks which hashes have been seen exactly once (`once`)
+// versus more than once (`multi`) so into_hlls can build a "seen exactly once"
+// HLL. Both sets are transient per scan and bounded by the sampled distinct
+// count.
+#[derive(Clone)]
+struct SingletonSketch {
+    once: HashSet<u64>,
+    multi: HashSet<u64>,
+}
+
+impl SingletonSketch {
+    fn new() -> SingletonSketch {
+        SingletonSketch {
+            once: HashSet::with_capacity_and_hasher(0, Default::default()),
+            multi: HashSet::with_capacity_and_hasher(0, Default::default()),
+        }
+    }
+
+    fn insert(&mut self, bytes: &[u8]) {
+        let hash = murmurhash3_x64_128(bytes, 0).0;
+        self.insert_hash_value(hash);
+    }
+
+    fn insert_hash_value(&mut self, hash_val: u64) {
+        if self.multi.contains(&hash_val) {
+            return;
+        }
+        if self.once.remove(&hash_val) {
+            self.multi.insert(hash_val);
+        } else {
+            self.once.insert(hash_val);
+        }
+    }
+
+    /// Builds this region's NDV and singleton HyperLogLog sketches. The NDV
+    /// sketch covers every distinct hash (once + multi); the singleton sketch
+    /// covers only hashes seen exactly once. TiDB unions these across regions
+    /// to estimate the global singleton (f1) count via a leave-one-out.
+    fn into_hlls(self, precision: u8) -> (tipb::HllSketch, tipb::HllSketch) {
+        let mut ndv = Hll::new(precision);
+        let mut singleton = Hll::new(precision);
+        for &hash in &self.once {
+            ndv.insert_hash_value(hash);
+            singleton.insert_hash_value(hash);
+        }
+        for &hash in &self.multi {
+            ndv.insert_hash_value(hash);
+        }
+        (ndv.into(), singleton.into())
+    }
+}
+
 #[derive(Clone)]
 struct BaseRowSampleCollector {
     null_count: Vec<i64>,
     count: u64,
+    sketch_sample_count: u64,
+    // fm_sketches and singleton_sketches are mutually exclusive by build_singletons:
+    // the FM sketch backs the exact NDV at full rate, the HLLs back the GEE f1
+    // estimate under NDV sub-sampling. Only the active one is allocated (see new).
     fm_sketches: Vec<FmSketch>,
+    singleton_sketches: Vec<SingletonSketch>,
+    build_singletons: bool,
     rng: StdRng,
     total_sizes: Vec<i64>,
     memory_usage: usize,
@@ -282,7 +377,10 @@ impl Default for BaseRowSampleCollector {
         BaseRowSampleCollector {
             null_count: vec![],
             count: 0,
+            sketch_sample_count: 0,
             fm_sketches: vec![],
+            singleton_sketches: vec![],
+            build_singletons: false,
             rng: StdRng::from_entropy(),
             total_sizes: vec![],
             memory_usage: 0,
@@ -291,12 +389,46 @@ impl Default for BaseRowSampleCollector {
     }
 }
 
+/// Scales `sampled` (accumulated over `sample_count` rows) into an estimate
+/// over `total_row_count` rows using round-half-up integer division. Returns
+/// 0 when `sampled` or `sample_count` is non-positive. A `u128` intermediate
+/// avoids overflow in `sampled * total_row_count` for large tables.
+fn rescale_sampled_value(sampled: i64, total_row_count: u64, sample_count: u64) -> i64 {
+    if sampled <= 0 || sample_count == 0 {
+        return 0;
+    }
+    let sampled = sampled as u128;
+    let total_row_count = total_row_count as u128;
+    let sample_count = sample_count as u128;
+    // Round-half-up integer division: floor(a*b/c + 1/2).
+    let scaled = (sampled * total_row_count + sample_count / 2) / sample_count;
+    scaled.min(i64::MAX as u128) as i64
+}
+
 impl BaseRowSampleCollector {
-    fn new(max_fm_sketch_size: usize, col_and_group_len: usize) -> BaseRowSampleCollector {
+    fn new(
+        max_fm_sketch_size: usize,
+        col_and_group_len: usize,
+        build_singletons: bool,
+    ) -> BaseRowSampleCollector {
         BaseRowSampleCollector {
             null_count: vec![0; col_and_group_len],
             count: 0,
-            fm_sketches: vec![FmSketch::new(max_fm_sketch_size); col_and_group_len],
+            sketch_sample_count: 0,
+            // NDV sub-sampling derives the column NDV from the singleton sketches'
+            // HLLs (see SingletonSketch::into_hlls), so the FM sketch is dead weight
+            // there; allocate only the sketch type this mode actually fills.
+            fm_sketches: if build_singletons {
+                vec![]
+            } else {
+                vec![FmSketch::new(max_fm_sketch_size); col_and_group_len]
+            },
+            singleton_sketches: if build_singletons {
+                vec![SingletonSketch::new(); col_and_group_len]
+            } else {
+                vec![]
+            },
+            build_singletons,
             rng: StdRng::from_entropy(),
             total_sizes: vec![0; col_and_group_len],
             memory_usage: 0,
@@ -336,7 +468,13 @@ impl BaseRowSampleCollector {
                     hasher.write(&columns_val[*j as usize]);
                 }
             }
-            self.fm_sketches[col_len + i].insert_hash_value(hasher.finish());
+            let hash = hasher.finish();
+            // See collect_column: only the sketch type this mode allocated is filled.
+            if self.build_singletons {
+                self.singleton_sketches[col_len + i].insert_hash_value(hash);
+            } else {
+                self.fm_sketches[col_len + i].insert_hash_value(hash);
+            }
         }
     }
 
@@ -351,12 +489,52 @@ impl BaseRowSampleCollector {
                 self.null_count[i] += 1;
                 continue;
             }
-            if columns_info[i].as_accessor().is_string_like() {
-                self.fm_sketches[i].insert(&collation_keys_val[i]);
+            let key: &[u8] = if columns_info[i].as_accessor().is_string_like() {
+                &collation_keys_val[i]
             } else {
-                self.fm_sketches[i].insert(&columns_val[i]);
+                &columns_val[i]
+            };
+            // FM and singleton sketches are mutually exclusive: only the one this
+            // mode allocated is filled (see BaseRowSampleCollector::new).
+            if self.build_singletons {
+                self.singleton_sketches[i].insert(key);
+            } else {
+                self.fm_sketches[i].insert(key);
             }
             self.total_sizes[i] += columns_val[i].len() as i64 - 1;
+        }
+    }
+
+    /// Converts per-column null counts and total sizes gathered from the NDV
+    /// sub-sample into estimates over the full row population. `count` is the
+    /// exact scanned row count (reported via `scanned_rows_per_range`) and is
+    /// only read here as the scaling divisor — it is never modified. No-op
+    /// when no sub-sampling occurred (`sketch_sample_count == 0` or every
+    /// scanned row was sampled).
+    fn rescale_null_count_and_total_sizes(&mut self) {
+        let sample_count = self.sketch_sample_count;
+        let total_row_count = self.count;
+        // sample_count > total_row_count would scale stats *down* and corrupt
+        // them — that's an invariant violation, not a real input.
+        debug_assert!(
+            total_row_count >= sample_count,
+            "total_row_count ({}) must be >= sample_count ({})",
+            total_row_count,
+            sample_count,
+        );
+        // No sub-sampling: values are already exact.
+        if sample_count == 0 {
+            return;
+        }
+        // Scaling factor is 1.0; nothing to do.
+        if total_row_count == sample_count {
+            return;
+        }
+        for nc in &mut self.null_count {
+            *nc = rescale_sampled_value(*nc, total_row_count, sample_count);
+        }
+        for ts in &mut self.total_sizes {
+            *ts = rescale_sampled_value(*ts, total_row_count, sample_count);
         }
     }
 
@@ -368,6 +546,23 @@ impl BaseRowSampleCollector {
             .map(|fm_sketch| fm_sketch.into())
             .collect();
         proto_collector.set_fm_sketch(pb_fm_sketches);
+        // Only build the per-region HLL sketches when NDV sub-sampling is on;
+        // otherwise leave the fields empty so TiDB skips the f1 estimate. Each
+        // region contributes an NDV HLL (all distinct values) and a singleton HLL
+        // (values seen exactly once), which TiDB unions across regions. HLL is
+        // fixed-size, so TiDB can retain one per region without O(regions) blowup.
+        if self.build_singletons {
+            let mut pb_hll_ndv = Vec::with_capacity(self.singleton_sketches.len());
+            let mut pb_hll_singleton = Vec::with_capacity(self.singleton_sketches.len());
+            for sketch in mem::take(&mut self.singleton_sketches) {
+                let (ndv, singleton) = sketch.into_hlls(DEFAULT_HLL_PRECISION);
+                pb_hll_ndv.push(ndv);
+                pb_hll_singleton.push(singleton);
+            }
+            proto_collector.set_hll_ndv_sketch(pb_hll_ndv.into_iter().collect());
+            proto_collector.set_hll_singleton_sketch(pb_hll_singleton.into_iter().collect());
+        }
+        proto_collector.set_sketch_sample_count(self.sketch_sample_count as i64);
         proto_collector.set_total_size(self.total_sizes.clone());
     }
 
@@ -397,9 +592,14 @@ impl BernoulliRowSampleCollector {
         sample_rate: f64,
         max_fm_sketch_size: usize,
         col_and_group_len: usize,
+        build_singletons: bool,
     ) -> BernoulliRowSampleCollector {
         BernoulliRowSampleCollector {
-            base: BaseRowSampleCollector::new(max_fm_sketch_size, col_and_group_len),
+            base: BaseRowSampleCollector::new(
+                max_fm_sketch_size,
+                col_and_group_len,
+                build_singletons,
+            ),
             samples: Vec::new(),
             sample_rate,
         }
@@ -484,9 +684,14 @@ impl ReservoirRowSampleCollector {
         max_sample_size: usize,
         max_fm_sketch_size: usize,
         col_and_group_len: usize,
+        build_singletons: bool,
     ) -> ReservoirRowSampleCollector {
         ReservoirRowSampleCollector {
-            base: BaseRowSampleCollector::new(max_fm_sketch_size, col_and_group_len),
+            base: BaseRowSampleCollector::new(
+                max_fm_sketch_size,
+                col_and_group_len,
+                build_singletons,
+            ),
             samples: BinaryHeap::new(),
             max_sample_size,
         }
@@ -956,6 +1161,97 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_singleton_sketch_into_hlls() {
+        use super::super::hll::{DEFAULT_HLL_PRECISION, Hll};
+        // HLL needs a uniformly distributed hash; mix sequential keys with splitmix64.
+        fn mix(x: u64) -> u64 {
+            let mut z = x.wrapping_add(0x9E37_79B9_7F4A_7C15);
+            z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+            z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+            z ^ (z >> 31)
+        }
+        let mut sketch = SingletonSketch::new();
+        // 1000 values seen once (singletons) and 1000 seen twice (not singletons).
+        for i in 0..1000u64 {
+            sketch.insert_hash_value(mix(i));
+        }
+        for i in 1000..2000u64 {
+            let h = mix(i);
+            sketch.insert_hash_value(h);
+            sketch.insert_hash_value(h);
+        }
+        let (ndv_proto, singleton_proto) = sketch.into_hlls(DEFAULT_HLL_PRECISION);
+        // Singleton values are a subset of all distinct values, so the singleton
+        // sketch is dominated register-by-register by the NDV sketch.
+        assert_eq!(
+            ndv_proto.get_registers().len(),
+            singleton_proto.get_registers().len()
+        );
+        for (n, s) in ndv_proto
+            .get_registers()
+            .iter()
+            .zip(singleton_proto.get_registers())
+        {
+            assert!(s <= n);
+        }
+        // NDV covers ~2000 distinct values; singletons ~1000.
+        let ndv = Hll::from(&ndv_proto).count() as f64;
+        let singleton = Hll::from(&singleton_proto).count() as f64;
+        assert!((ndv - 2000.0).abs() / 2000.0 < 0.05, "ndv={ndv}");
+        assert!(
+            (singleton - 1000.0).abs() / 1000.0 < 0.05,
+            "singleton={singleton}"
+        );
+    }
+
+    #[test]
+    fn test_rescale_sampled_value() {
+        // Non-positive inputs short-circuit to 0.
+        assert_eq!(rescale_sampled_value(0, 100, 10), 0);
+        assert_eq!(rescale_sampled_value(-3, 100, 10), 0);
+        assert_eq!(rescale_sampled_value(5, 100, 0), 0);
+        // Exact scaling: 3 out of 10 sampled rows ⇒ 30 out of 100.
+        assert_eq!(rescale_sampled_value(3, 100, 10), 30);
+        // Round-half-up: (2*7 + 5/2) / 5 = 16/5 = 3 (vs truncated 2).
+        assert_eq!(rescale_sampled_value(2, 7, 5), 3);
+        // sample_count == total_row_count is normally short-circuited by the
+        // caller, but the helper still returns the input unchanged.
+        assert_eq!(rescale_sampled_value(5, 5, 5), 5);
+    }
+
+    #[test]
+    fn test_rescale_null_count_and_total_sizes() {
+        let mut base = BaseRowSampleCollector::new(8, 2, true);
+        base.count = 100;
+        base.sketch_sample_count = 10;
+        base.null_count = vec![2, 0];
+        base.total_sizes = vec![50, 30];
+        base.rescale_null_count_and_total_sizes();
+        // Scaling factor 10x.
+        assert_eq!(base.null_count, vec![20, 0]);
+        assert_eq!(base.total_sizes, vec![500, 300]);
+
+        // sketch_sample_count == 0 ⇒ no-op (values exact already).
+        let mut base = BaseRowSampleCollector::new(8, 1, true);
+        base.count = 100;
+        base.null_count = vec![7];
+        base.total_sizes = vec![42];
+        base.rescale_null_count_and_total_sizes();
+        assert_eq!(base.null_count, vec![7]);
+        assert_eq!(base.total_sizes, vec![42]);
+
+        // sketch_sample_count == count ⇒ no-op (scale factor 1.0).
+        let mut base = BaseRowSampleCollector::new(8, 1, true);
+        base.count = 50;
+        base.sketch_sample_count = 50;
+        base.null_count = vec![3];
+        base.total_sizes = vec![17];
+        base.rescale_null_count_and_total_sizes();
+        assert_eq!(base.null_count, vec![3]);
+        assert_eq!(base.total_sizes, vec![17]);
+    }
+
+    #[test]
     fn test_sample_collector() {
         let max_sample_size = 3;
         let max_fm_sketch_size = 10;
@@ -992,7 +1288,7 @@ mod tests {
             nums.push(datum::encode_value(&mut ctx, &[Datum::I64(i as i64)]).unwrap());
         }
         for loop_i in 0..loop_cnt {
-            let mut collector = ReservoirRowSampleCollector::new(sample_num, 1000, 1);
+            let mut collector = ReservoirRowSampleCollector::new(sample_num, 1000, 1, true);
             for row in &nums {
                 collector.sampling(std::slice::from_ref(row));
             }
@@ -1040,7 +1336,7 @@ mod tests {
         }
         for loop_i in 0..loop_cnt {
             let mut collector =
-                BernoulliRowSampleCollector::new(sample_num as f64 / row_num as f64, 1000, 1);
+                BernoulliRowSampleCollector::new(sample_num as f64 / row_num as f64, 1000, 1, true);
             for row in &nums {
                 collector.sampling(std::slice::from_ref(row));
             }
@@ -1085,7 +1381,7 @@ mod tests {
         }
         {
             // Test for ReservoirRowSampleCollector
-            let mut collector = ReservoirRowSampleCollector::new(sample_num, 1000, 1);
+            let mut collector = ReservoirRowSampleCollector::new(sample_num, 1000, 1, true);
             for row in &nums {
                 collector.sampling(std::slice::from_ref(row));
             }
@@ -1094,12 +1390,35 @@ mod tests {
         {
             // Test for BernoulliRowSampleCollector
             let mut collector =
-                BernoulliRowSampleCollector::new(sample_num as f64 / row_num as f64, 1000, 1);
+                BernoulliRowSampleCollector::new(sample_num as f64 / row_num as f64, 1000, 1, true);
             for row in &nums {
                 collector.sampling(std::slice::from_ref(row));
             }
             assert_eq!(collector.samples.len(), 0);
         }
+    }
+
+    #[test]
+    fn test_build_singletons_gate() {
+        // ndv_rate >= 1 maps to build_singletons = false: only the FM sketch is
+        // built; the per-region HLL fields stay empty so the work and bytes are saved.
+        let mut base = BaseRowSampleCollector::new(1000, 1, false);
+        base.fm_sketches[0].insert(b"x");
+        let mut proto = tipb::RowSampleCollector::default();
+        base.fill_proto(&mut proto);
+        assert_eq!(proto.get_fm_sketch().len(), 1);
+        assert!(proto.get_hll_ndv_sketch().is_empty());
+        assert!(proto.get_hll_singleton_sketch().is_empty());
+
+        // ndv_rate < 1 maps to build_singletons = true: HLL sketches are emitted
+        // (one NDV + one singleton per column) and no FM sketch is built.
+        let mut base = BaseRowSampleCollector::new(1000, 1, true);
+        base.singleton_sketches[0].insert(b"x");
+        let mut proto = tipb::RowSampleCollector::default();
+        base.fill_proto(&mut proto);
+        assert!(proto.get_fm_sketch().is_empty());
+        assert_eq!(proto.get_hll_ndv_sketch().len(), 1);
+        assert_eq!(proto.get_hll_singleton_sketch().len(), 1);
     }
 }
 
@@ -1167,7 +1486,7 @@ mod benches {
 
     #[bench]
     fn bench_collect_column(b: &mut test::Bencher) {
-        let mut collector = BaseRowSampleCollector::new(10000, 4);
+        let mut collector = BaseRowSampleCollector::new(10000, 4, true);
         let (column_vals, collation_key_vals, columns_info, _) = prepare_arguments();
         b.iter(|| {
             collector.collect_column(&column_vals, &collation_key_vals, &columns_info);
@@ -1176,7 +1495,7 @@ mod benches {
 
     #[bench]
     fn bench_collect_column_group(b: &mut test::Bencher) {
-        let mut collector = BaseRowSampleCollector::new(10000, 4);
+        let mut collector = BaseRowSampleCollector::new(10000, 4, true);
         let (column_vals, collation_key_vals, columns_info, column_groups) = prepare_arguments();
         b.iter(|| {
             collector.collect_column_group(

--- a/src/coprocessor/statistics/analyze.rs
+++ b/src/coprocessor/statistics/analyze.rs
@@ -1,12 +1,20 @@
 // Copyright 2017 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::{cmp::Reverse, collections::BinaryHeap, hash::Hasher, mem, sync::Arc};
+use std::{
+    cmp::Reverse,
+    collections::BinaryHeap,
+    hash::Hasher,
+    mem,
+    sync::Arc,
+    time::{Duration, Instant},
+};
 
 use api_version::KvFormat;
 use collections::HashSet;
 use kvproto::coprocessor::KeyRange;
 use mur3::{Hasher128, murmurhash3_x64_128};
-use rand::{Rng, rngs::StdRng};
+use protobuf::Message;
+use rand::{Rng, SeedableRng, rngs::StdRng};
 use tidb_query_common::execute_stats::ExecuteStats;
 use tidb_query_datatype::{
     FieldTypeAccessor,
@@ -37,6 +45,9 @@ use crate::{
     storage::{Snapshot, SnapshotStore, Statistics},
 };
 
+fn duration_ms(duration: Duration) -> u64 {
+    duration.as_millis() as u64
+}
 pub(crate) struct RowSampleBuilder<S: Snapshot, F: KvFormat> {
     pub(crate) data: BatchTableScanExecutor<TikvStorage<SnapshotStore<S>>, F>,
     /// Accumulated storage statistics for this request. Filled per batch so
@@ -139,12 +150,20 @@ impl<S: Snapshot, F: KvFormat> RowSampleBuilder<S, F> {
         let mut is_drained = false;
         let mut collector = self.new_collector();
         let mut ctx = EvalContext::default();
+        let scan_start = Instant::now();
+        let mut batch_count = 0_u64;
+        let mut read_bytes = 0_usize;
+        let mut next_batch_elapsed = Duration::ZERO;
+        let mut encode_collect_elapsed = Duration::ZERO;
+        let mut quota_consume_elapsed = Duration::ZERO;
+        let mut quota_delay_total = Duration::ZERO;
         while !is_drained {
             // Use background limiters for both manual and auto analyze so that iops_limiter
             // (and other background quotas) apply to manual analyze as well.
             let mut sample = self.quota_limiter.new_sample(false);
             let mut read_size: usize = 0;
             {
+                let next_batch_start = Instant::now();
                 let result = {
                     let (duration, res) = sample
                         .observe_cpu_async(self.data.next_batch(BATCH_MAX_SIZE))
@@ -152,6 +171,8 @@ impl<S: Snapshot, F: KvFormat> RowSampleBuilder<S, F> {
                     sample.add_cpu_time(duration);
                     res
                 };
+                next_batch_elapsed += next_batch_start.elapsed();
+                batch_count += 1;
 
                 // Use request-scoped storage stats for IOPS (like collect_scan_statistics),
                 // and count only RocksDB block reads as an approximation of disk IOPS.
@@ -188,6 +209,7 @@ impl<S: Snapshot, F: KvFormat> RowSampleBuilder<S, F> {
                 collector.mut_base().count +=
                     exec_stats.scanned_rows_per_range.into_iter().sum::<usize>() as u64;
 
+                let encode_collect_start = Instant::now();
                 let columns_slice = result.physical_columns.as_slice();
                 let mut column_vals: Vec<Vec<u8>> = vec![vec![]; self.columns_info.len()];
                 let mut collation_key_vals: Vec<Vec<u8>> = vec![vec![]; self.columns_info.len()];
@@ -229,16 +251,21 @@ impl<S: Snapshot, F: KvFormat> RowSampleBuilder<S, F> {
                     );
                     collector.collect_column(&column_vals, &collation_key_vals, &self.columns_info);
                 }
+                encode_collect_elapsed += encode_collect_start.elapsed();
             }
 
             sample.add_read_bytes(read_size);
+            read_bytes += read_size;
             // Don't let analyze bandwidth limit the quota limiter, this is already limited
             // in rate limiter.
+            let quota_consume_start = Instant::now();
             let quota_delay = {
                 // Use background limiters for both manual and auto analyze so that iops_limiter
                 // applies to manual analyze as well.
                 self.quota_limiter.consume_sample(sample, false).await
             };
+            quota_consume_elapsed += quota_consume_start.elapsed();
+            quota_delay_total += quota_delay;
 
             if !quota_delay.is_zero() {
                 NON_TXN_COMMAND_THROTTLE_TIME_COUNTER_VEC_STATIC
@@ -246,10 +273,29 @@ impl<S: Snapshot, F: KvFormat> RowSampleBuilder<S, F> {
                     .inc_by(quota_delay.as_micros() as u64);
             }
         }
-        // NDV sub-sampling only tallies null_count/total_sizes for rows that
-        // passed the rate check. Rescale them back to per-population estimates
-        // before the single-column-group copy below picks them up.
+        debug!("analyze full sampling trace";
+            "component" => "tikv",
+            "phase" => "tikv.scan_full_sampling_table",
+            "event" => "finish",
+            "elapsed_ms" => scan_start.elapsed().as_millis() as u64,
+            "next_batch_elapsed_ms" => duration_ms(next_batch_elapsed),
+            "encode_collect_elapsed_ms" => duration_ms(encode_collect_elapsed),
+            "quota_consume_elapsed_ms" => duration_ms(quota_consume_elapsed),
+            "quota_delay_ms" => duration_ms(quota_delay_total),
+            "batch_count" => batch_count,
+            "scanned_rows" => collector.mut_base().count,
+            "read_bytes" => read_bytes,
+            "columns" => self.columns_info.len(),
+            "column_groups" => self.column_groups.len(),
+            "max_sample_size" => self.max_sample_size,
+            "sample_rate" => self.sample_rate,
+            "is_auto_analyze" => self.is_auto_analyze,
+        );
+        // Row-level NDV sub-sampling only tallies null_count/total_sizes for
+        // selected rows. Rescale them before the single-column-group copy so
+        // derived columns see corrected values.
         collector.mut_base().rescale_null_count_and_total_sizes();
+        let column_group_fixup_start = Instant::now();
         for i in 0..self.column_groups.len() {
             let offsets = self.column_groups[i].get_column_offsets();
             if offsets.len() != 1 {
@@ -275,12 +321,30 @@ impl<S: Snapshot, F: KvFormat> RowSampleBuilder<S, F> {
             collector.mut_base().total_sizes[col_group_pos] =
                 collector.mut_base().total_sizes[col_pos];
         }
+        debug!("analyze full sampling trace";
+            "component" => "tikv",
+            "phase" => "tikv.column_group_fixup",
+            "event" => "finish",
+            "elapsed_ms" => duration_ms(column_group_fixup_start.elapsed()),
+            "column_groups" => self.column_groups.len(),
+        );
         Ok(AnalyzeSamplingResult::new(collector))
     }
 }
 
+type BernoulliSamples = Vec<Vec<Vec<u8>>>;
+type ReservoirSamples = BinaryHeap<Reverse<(i64, Vec<Vec<u8>>)>>;
+
 trait RowSampleCollector: Send {
     fn mut_base(&mut self) -> &mut BaseRowSampleCollector;
+    fn take_base(&mut self) -> BaseRowSampleCollector;
+    fn merge_collector(&mut self, other: Box<dyn RowSampleCollector>) -> Result<()>;
+    fn take_bernoulli_samples(&mut self) -> Option<BernoulliSamples> {
+        None
+    }
+    fn take_reservoir_samples(&mut self) -> Option<ReservoirSamples> {
+        None
+    }
     fn collect_column_group(
         &mut self,
         columns_val: &[Vec<u8>],
@@ -337,6 +401,16 @@ impl SingletonSketch {
             self.multi.insert(hash_val);
         } else {
             self.once.insert(hash_val);
+        }
+    }
+
+    fn merge_from(&mut self, other: SingletonSketch) {
+        for hash in other.once {
+            self.insert_hash_value(hash);
+        }
+        for hash in other.multi {
+            self.once.remove(&hash);
+            self.multi.insert(hash);
         }
     }
 
@@ -408,6 +482,28 @@ fn rescale_sampled_value(sampled: i64, total_row_count: u64, sample_count: u64) 
     scaled.min(i64::MAX as u128) as i64
 }
 
+fn add_i64_repeated(dst: &mut Vec<i64>, src: &[i64]) {
+    if dst.len() < src.len() {
+        dst.resize(src.len(), 0);
+    }
+    for (idx, value) in src.iter().enumerate() {
+        dst[idx] += value;
+    }
+}
+
+fn row_sample_memory_usage(row: &[Vec<u8>]) -> usize {
+    row.iter().map(Vec::capacity).sum()
+}
+
+fn bernoulli_samples_memory_usage(samples: &[Vec<Vec<u8>>]) -> usize {
+    samples.iter().map(|row| row_sample_memory_usage(row)).sum()
+}
+
+fn release_reported_memory_usage(base: &mut BaseRowSampleCollector) {
+    base.memory_usage = 0;
+    base.report_memory_usage(true);
+}
+
 impl BaseRowSampleCollector {
     fn new(
         max_fm_sketch_size: usize,
@@ -436,6 +532,32 @@ impl BaseRowSampleCollector {
             total_sizes: vec![0; col_and_group_len],
             memory_usage: 0,
             reported_memory_usage: 0,
+        }
+    }
+
+    fn merge_from(&mut self, other: &mut BaseRowSampleCollector) {
+        self.count += other.count;
+        self.sketch_sample_count += other.sketch_sample_count;
+        add_i64_repeated(&mut self.null_count, &other.null_count);
+        add_i64_repeated(&mut self.total_sizes, &other.total_sizes);
+
+        for (idx, other_sketch) in mem::take(&mut other.fm_sketches).into_iter().enumerate() {
+            if idx >= self.fm_sketches.len() {
+                self.fm_sketches.push(other_sketch);
+            } else {
+                self.fm_sketches[idx].merge(&other_sketch);
+            }
+        }
+
+        for (idx, other_sketch) in mem::take(&mut other.singleton_sketches)
+            .into_iter()
+            .enumerate()
+        {
+            if idx >= self.singleton_sketches.len() {
+                self.singleton_sketches.push(other_sketch);
+            } else {
+                self.singleton_sketches[idx].merge_from(other_sketch);
+            }
         }
     }
 
@@ -623,6 +745,30 @@ impl RowSampleCollector for BernoulliRowSampleCollector {
     fn mut_base(&mut self) -> &mut BaseRowSampleCollector {
         &mut self.base
     }
+
+    fn take_base(&mut self) -> BaseRowSampleCollector {
+        mem::take(&mut self.base)
+    }
+
+    fn merge_collector(&mut self, mut other: Box<dyn RowSampleCollector>) -> Result<()> {
+        let mut samples = other.take_bernoulli_samples().ok_or_else(|| {
+            Error::Other("cannot merge reservoir samples into bernoulli samples".to_owned())
+        })?;
+        let sample_memory_usage = bernoulli_samples_memory_usage(&samples);
+        self.samples.append(&mut samples);
+        self.base.memory_usage += sample_memory_usage;
+        self.base.report_memory_usage(false);
+
+        let mut other_base = other.take_base();
+        release_reported_memory_usage(&mut other_base);
+        self.base.merge_from(&mut other_base);
+        Ok(())
+    }
+
+    fn take_bernoulli_samples(&mut self) -> Option<BernoulliSamples> {
+        Some(mem::take(&mut self.samples))
+    }
+
     fn collect_column_group(
         &mut self,
         columns_val: &[Vec<u8>],
@@ -699,12 +845,54 @@ impl ReservoirRowSampleCollector {
             max_sample_size,
         }
     }
+
+    fn should_keep_weight(&self, weight: i64) -> bool {
+        if self.max_sample_size == 0 {
+            return false;
+        }
+        self.samples.len() < self.max_sample_size || self.samples.peek().unwrap().0.0 < weight
+    }
+
+    fn push_weighted_sample(&mut self, weight: i64, sample: Vec<Vec<u8>>) {
+        if self.samples.len() >= self.max_sample_size {
+            let (_, evicted) = self.samples.pop().unwrap().0;
+            self.base.memory_usage -= row_sample_memory_usage(&evicted);
+        }
+        self.base.memory_usage += row_sample_memory_usage(&sample);
+        self.samples.push(Reverse((weight, sample)));
+    }
 }
 
 impl RowSampleCollector for ReservoirRowSampleCollector {
     fn mut_base(&mut self) -> &mut BaseRowSampleCollector {
         &mut self.base
     }
+
+    fn take_base(&mut self) -> BaseRowSampleCollector {
+        mem::take(&mut self.base)
+    }
+
+    fn merge_collector(&mut self, mut other: Box<dyn RowSampleCollector>) -> Result<()> {
+        let samples = other.take_reservoir_samples().ok_or_else(|| {
+            Error::Other("cannot merge bernoulli samples into reservoir samples".to_owned())
+        })?;
+        for Reverse((weight, sample)) in samples {
+            if self.should_keep_weight(weight) {
+                self.push_weighted_sample(weight, sample);
+            }
+        }
+        self.base.report_memory_usage(false);
+
+        let mut other_base = other.take_base();
+        release_reported_memory_usage(&mut other_base);
+        self.base.merge_from(&mut other_base);
+        Ok(())
+    }
+
+    fn take_reservoir_samples(&mut self) -> Option<ReservoirSamples> {
+        Some(mem::take(&mut self.samples))
+    }
+
     fn collect_column_group(
         &mut self,
         columns_val: &[Vec<u8>],
@@ -732,25 +920,10 @@ impl RowSampleCollector for ReservoirRowSampleCollector {
     }
 
     fn sampling(&mut self, data: &[Vec<u8>]) {
-        // We should tolerate the abnormal case => `self.max_sample_size == 0`.
-        if self.max_sample_size == 0 {
-            return;
-        }
-        let mut need_push = false;
         let cur_rng = self.base.rng.gen_range(0, i64::MAX);
-        if self.samples.len() < self.max_sample_size {
-            need_push = true;
-        } else if self.samples.peek().unwrap().0.0 < cur_rng {
-            need_push = true;
-            let (_, evicted) = self.samples.pop().unwrap().0;
-            self.base.memory_usage -= evicted.iter().map(|x| x.capacity()).sum::<usize>();
-        }
-
-        if need_push {
-            let sample = data.to_vec();
-            self.base.memory_usage += sample.iter().map(|x| x.capacity()).sum::<usize>();
+        if self.should_keep_weight(cur_rng) {
+            self.push_weighted_sample(cur_rng, data.to_vec());
             self.base.report_memory_usage(false);
-            self.samples.push(Reverse((cur_rng, sample)));
         }
     }
 
@@ -1039,7 +1212,7 @@ impl From<SampleCollector> for tipb::SampleCollector {
     }
 }
 
-pub(crate) struct AnalyzeSamplingResult {
+pub struct AnalyzeSamplingResult {
     row_sample_collector: Box<dyn RowSampleCollector>,
 }
 
@@ -1048,6 +1221,16 @@ impl AnalyzeSamplingResult {
         AnalyzeSamplingResult {
             row_sample_collector,
         }
+    }
+
+    pub(crate) fn merge_from(&mut self, other: AnalyzeSamplingResult) -> Result<()> {
+        self.row_sample_collector
+            .merge_collector(other.row_sample_collector)
+    }
+
+    pub(crate) fn write_to_bytes(self) -> Result<Vec<u8>> {
+        let resp: tipb::AnalyzeColumnsResp = self.into();
+        Ok(box_try!(resp.write_to_bytes()))
     }
 }
 
@@ -1422,6 +1605,109 @@ mod tests {
         assert!(proto.get_fm_sketch().is_empty());
         assert_eq!(proto.get_hll_ndv_sketch().len(), 1);
         assert_eq!(proto.get_hll_singleton_sketch().len(), 1);
+    }
+
+    fn sorted_hashset(sketch: &tipb::FmSketch) -> Vec<u64> {
+        let mut hashes = sketch.get_hashset().to_vec();
+        hashes.sort_unstable();
+        hashes
+    }
+
+    fn test_sampling_result(
+        count: u64,
+        null_count: i64,
+        total_size: i64,
+        sample_weights: &[i64],
+        ndv_hashes: &[u64],
+    ) -> AnalyzeSamplingResult {
+        let mut collector = ReservoirRowSampleCollector::new(2, 1000, 1, false);
+        collector.base.count = count;
+        collector.base.null_count[0] = null_count;
+        collector.base.total_sizes[0] = total_size;
+        for hash in ndv_hashes {
+            collector.base.fm_sketches[0].insert_hash_value(*hash);
+        }
+        for weight in sample_weights {
+            collector.push_weighted_sample(*weight, vec![vec![*weight as u8]]);
+        }
+        AnalyzeSamplingResult::new(Box::new(collector))
+    }
+
+    fn test_singleton_sampling_result(
+        count: u64,
+        sketch_sample_count: u64,
+        once_hashes: &[u64],
+        multi_hashes: &[u64],
+    ) -> AnalyzeSamplingResult {
+        let mut collector = ReservoirRowSampleCollector::new(2, 1000, 1, true);
+        collector.base.count = count;
+        collector.base.sketch_sample_count = sketch_sample_count;
+        for hash in once_hashes {
+            collector.base.singleton_sketches[0].insert_hash_value(*hash);
+        }
+        for hash in multi_hashes {
+            collector.base.singleton_sketches[0].insert_hash_value(*hash);
+            collector.base.singleton_sketches[0].insert_hash_value(*hash);
+        }
+        AnalyzeSamplingResult::new(Box::new(collector))
+    }
+
+    #[test]
+    fn test_analyze_sampling_result_merge() {
+        let a = 10;
+        let b = 20;
+        let c = 30;
+        let mut result = test_sampling_result(2, 1, 10, &[1, 3], &[a, b]);
+        result
+            .merge_from(test_sampling_result(2, 2, 20, &[4], &[a, c]))
+            .unwrap();
+
+        let resp: tipb::AnalyzeColumnsResp = result.into();
+        let collector = resp.get_row_collector();
+        assert_eq!(collector.get_count(), 4);
+        assert_eq!(collector.get_null_counts(), &[3]);
+        assert_eq!(collector.get_total_size(), &[30]);
+
+        let mut sample_weights: Vec<_> = collector
+            .get_samples()
+            .iter()
+            .map(|sample| sample.get_weight())
+            .collect();
+        sample_weights.sort_unstable();
+        assert_eq!(sample_weights, vec![3, 4]);
+        assert_eq!(sorted_hashset(&collector.get_fm_sketch()[0]), vec![a, b, c]);
+    }
+
+    #[test]
+    fn test_analyze_sampling_result_merge_singleton_sketches() {
+        // Pick hashes with distinct HLL register indexes under p=14 so the
+        // tiny-set linear-count estimates are exact.
+        let a = 1u64 << 50;
+        let b = 2u64 << 50;
+        let c = 3u64 << 50;
+        let d = 4u64 << 50;
+
+        let mut result = test_singleton_sampling_result(2, 2, &[a, b], &[]);
+        result
+            .merge_from(test_singleton_sampling_result(3, 3, &[a, c], &[d]))
+            .unwrap();
+
+        let resp: tipb::AnalyzeColumnsResp = result.into();
+        let collector = resp.get_row_collector();
+        assert_eq!(collector.get_count(), 5);
+        assert_eq!(collector.get_sketch_sample_count(), 5);
+        assert!(collector.get_fm_sketch().is_empty());
+        assert_eq!(collector.get_hll_ndv_sketch().len(), 1);
+        assert_eq!(collector.get_hll_singleton_sketch().len(), 1);
+
+        // NDV is {a,b,c,d}; singleton values in the merged batch scope are
+        // {b,c}. `a` appears once in each input and `d` appears multiple times
+        // in the second input, so neither is a singleton after merge.
+        assert_eq!(Hll::from(&collector.get_hll_ndv_sketch()[0]).count(), 4);
+        assert_eq!(
+            Hll::from(&collector.get_hll_singleton_sketch()[0]).count(),
+            2
+        );
     }
 }
 

--- a/src/coprocessor/statistics/analyze.rs
+++ b/src/coprocessor/statistics/analyze.rs
@@ -58,6 +58,7 @@ pub(crate) struct RowSampleBuilder<S: Snapshot, F: KvFormat> {
     max_sample_size: usize,
     max_fm_sketch_size: usize,
     sample_rate: f64,
+    ndv_rate: f64,
     // Whether to build per-row singleton sketches (only needed when ndv_rate < 1).
     build_singletons: bool,
     columns_info: Vec<tipb::ColumnInfo>,
@@ -109,6 +110,7 @@ impl<S: Snapshot, F: KvFormat> RowSampleBuilder<S, F> {
             max_sample_size,
             max_fm_sketch_size: req.get_sketch_size() as usize,
             sample_rate,
+            ndv_rate,
             build_singletons,
             columns_info,
             column_groups: req.take_column_groups().into(),
@@ -127,11 +129,20 @@ impl<S: Snapshot, F: KvFormat> RowSampleBuilder<S, F> {
             ));
         }
         Box::new(BernoulliRowSampleCollector::new(
-            self.sample_rate,
+            self.histogram_sample_rate(),
             self.max_fm_sketch_size,
             self.columns_info.len() + self.column_groups.len(),
             self.build_singletons,
         ))
+    }
+
+    fn histogram_sample_rate(&self) -> f64 {
+        let first_stage_sample_rate = if self.build_singletons {
+            self.ndv_rate
+        } else {
+            1.0
+        };
+        (self.sample_rate / first_stage_sample_rate).min(1.0)
     }
 
     /// Merges accumulated storage statistics into `dest`. Used by the context

--- a/src/coprocessor/statistics/analyze_context.rs
+++ b/src/coprocessor/statistics/analyze_context.rs
@@ -120,13 +120,27 @@ impl<S: Snapshot, F: KvFormat> AnalyzeContext<S, F> {
         Ok(res_data)
     }
 
-    async fn handle_full_sampling(builder: &mut RowSampleBuilder<S, F>) -> Result<Vec<u8>> {
-        let sample_res = builder.collect_column_stats().await?;
-        let res_data = {
-            let res: tipb::AnalyzeColumnsResp = sample_res.into();
-            box_try!(res.write_to_bytes())
-        };
-        Ok(res_data)
+    async fn handle_full_sampling_result(&mut self) -> Result<AnalyzeSamplingResult> {
+        if self.req.get_tp() != AnalyzeType::TypeFullSampling {
+            return Err(Error::Other(
+                "typed analyze result is only supported for full sampling".to_owned(),
+            ));
+        }
+        let col_req = self.req.take_col_req();
+        let storage = self.storage.take().unwrap();
+        let ranges = std::mem::take(&mut self.ranges);
+
+        let mut builder = RowSampleBuilder::<_, F>::new(
+            col_req,
+            storage,
+            ranges,
+            self.quota_limiter.clone(),
+            self.is_auto_analyze,
+        )?;
+
+        let res = builder.collect_column_stats().await;
+        builder.merge_storage_stats_into(&mut self.storage_stats);
+        res
     }
 
     // handle_index is used to handle `AnalyzeIndexReq`,
@@ -272,21 +286,8 @@ impl<S: Snapshot, F: KvFormat> RequestHandler for AnalyzeContext<S, F> {
             }
 
             AnalyzeType::TypeFullSampling => {
-                let col_req = self.req.take_col_req();
-                let storage = self.storage.take().unwrap();
-                let ranges = std::mem::take(&mut self.ranges);
-
-                let mut builder = RowSampleBuilder::<_, F>::new(
-                    col_req,
-                    storage,
-                    ranges,
-                    self.quota_limiter.clone(),
-                    self.is_auto_analyze,
-                )?;
-
-                let res = AnalyzeContext::handle_full_sampling(&mut builder).await;
-                builder.merge_storage_stats_into(&mut self.storage_stats);
-                res
+                let res = self.handle_full_sampling_result().await;
+                res.and_then(AnalyzeSamplingResult::write_to_bytes)
             }
 
             AnalyzeType::TypeSampleIndex => Err(Error::Other(
@@ -307,6 +308,10 @@ impl<S: Snapshot, F: KvFormat> RequestHandler for AnalyzeContext<S, F> {
             }
             Err(e) => Err(e),
         }
+    }
+
+    async fn handle_analyze_full_sampling(&mut self) -> Result<AnalyzeSamplingResult> {
+        self.handle_full_sampling_result().await
     }
 
     fn collect_scan_statistics(&mut self, dest: &mut Statistics) {

--- a/src/coprocessor/statistics/fmsketch.rs
+++ b/src/coprocessor/statistics/fmsketch.rs
@@ -79,6 +79,16 @@ impl FmSketch {
             self.mask = mask;
         }
     }
+
+    pub(crate) fn merge(&mut self, other: &FmSketch) {
+        if self.mask < other.mask {
+            self.mask = other.mask;
+            self.hash_set.retain(|&x| x & self.mask == 0);
+        }
+        for hash in &other.hash_set {
+            self.insert_hash_value(*hash);
+        }
+    }
 }
 
 impl From<FmSketch> for tipb::FmSketch {

--- a/src/coprocessor/statistics/hll.rs
+++ b/src/coprocessor/statistics/hll.rs
@@ -1,0 +1,178 @@
+// Copyright 2026 TiKV Project Authors. Licensed under Apache-2.0.
+
+//! A minimal HyperLogLog used to estimate per-region distinct/singleton counts
+//! for ANALYZE NDV sub-sampling. Unlike the FM sketch it is a fixed-size
+//! register array (`1 << precision` bytes), so retaining one per region on the
+//! TiDB side stays bounded. It merges by register-wise max, which is exactly
+//! what the per-region leave-one-out (global singleton estimate) needs.
+//!
+//! The register layout and estimator must stay byte-for-byte identical to the
+//! Go implementation in TiDB (pkg/statistics): TiKV builds these sketches and
+//! TiDB reads the raw register bytes, unions them, and estimates cardinality.
+
+/// Default HyperLogLog precision. m = 1<<14 = 16384 one-byte registers (16
+/// KiB), ~0.8% standard error. The singleton estimate is a difference of close
+/// cardinalities, so the precision is deliberately not lower.
+pub const DEFAULT_HLL_PRECISION: u8 = 14;
+
+#[derive(Clone)]
+pub struct Hll {
+    precision: u8,
+    /// One byte per register; `registers.len() == 1 << precision`. Each
+    /// register holds the maximum observed rank (leftmost-set-bit position)
+    /// for hashes routed to it.
+    registers: Vec<u8>,
+}
+
+impl Hll {
+    pub fn new(precision: u8) -> Hll {
+        Hll {
+            precision,
+            registers: vec![0u8; 1usize << precision],
+        }
+    }
+
+    /// Routes `hash` to a register by its top `precision` bits and records the
+    /// rank (1 + leading zeros) of the remaining bits.
+    pub fn insert_hash_value(&mut self, hash: u64) {
+        let p = u32::from(self.precision);
+        let idx = (hash >> (64 - p)) as usize;
+        // Move the remaining 64-p bits to the top; the low p bits become zero.
+        let w = hash << p;
+        // rank in [1, 64-p+1]; the cap is hit only when every remaining bit is 0.
+        let rank = if w == 0 {
+            (64 - p + 1) as u8
+        } else {
+            (w.leading_zeros() + 1) as u8
+        };
+        if rank > self.registers[idx] {
+            self.registers[idx] = rank;
+        }
+    }
+
+    /// Register-wise max. `other` must have the same precision.
+    pub fn merge(&mut self, other: &Hll) {
+        debug_assert_eq!(self.precision, other.precision);
+        for (r, &o) in self.registers.iter_mut().zip(other.registers.iter()) {
+            if o > *r {
+                *r = o;
+            }
+        }
+    }
+
+    /// Estimated distinct count. Standard HyperLogLog with the small-range
+    /// (linear counting) correction; the large-range correction is unnecessary
+    /// for 64-bit hashes.
+    pub fn count(&self) -> u64 {
+        let m = self.registers.len() as f64;
+        let mut sum = 0.0f64;
+        let mut zeros = 0usize;
+        for &r in &self.registers {
+            sum += 2.0f64.powi(-(i32::from(r)));
+            if r == 0 {
+                zeros += 1;
+            }
+        }
+        let estimate = alpha(self.registers.len()) * m * m / sum;
+        if estimate <= 2.5 * m && zeros > 0 {
+            // Linear counting is more accurate when many registers are still empty.
+            return (m * (m / zeros as f64).ln()).round() as u64;
+        }
+        estimate.round() as u64
+    }
+}
+
+/// The HyperLogLog bias-correction constant alpha_m.
+fn alpha(m: usize) -> f64 {
+    match m {
+        16 => 0.673,
+        32 => 0.697,
+        64 => 0.709,
+        _ => 0.7213 / (1.0 + 1.079 / m as f64),
+    }
+}
+
+impl From<Hll> for tipb::HllSketch {
+    fn from(h: Hll) -> tipb::HllSketch {
+        let mut proto = tipb::HllSketch::default();
+        proto.set_precision(u32::from(h.precision));
+        proto.set_registers(h.registers); // move the register bytes, no clone
+        proto
+    }
+}
+
+impl From<&tipb::HllSketch> for Hll {
+    fn from(proto: &tipb::HllSketch) -> Hll {
+        Hll {
+            precision: proto.get_precision() as u8,
+            registers: proto.get_registers().to_vec(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // splitmix64 is a high-quality bijective 64-bit mixer; HLL needs a uniformly
+    // distributed hash (a plain multiplier skews the leading-zero rank).
+    fn splitmix64(x: u64) -> u64 {
+        let mut z = x.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        z ^ (z >> 31)
+    }
+
+    fn build(precision: u8, n: u64) -> Hll {
+        let mut h = Hll::new(precision);
+        for i in 0..n {
+            h.insert_hash_value(splitmix64(i));
+        }
+        h
+    }
+
+    #[test]
+    fn test_count_within_error() {
+        // p=14 has ~0.8% standard error; allow a generous 5% band.
+        for &n in &[0u64, 1, 100, 10_000, 200_000] {
+            let est = build(DEFAULT_HLL_PRECISION, n).count() as f64;
+            let err = if n == 0 {
+                est
+            } else {
+                (est - n as f64).abs() / n as f64
+            };
+            assert!(
+                (n == 0 && est == 0.0) || err < 0.05,
+                "n={n} est={est} err={err}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_merge_is_union() {
+        // Disjoint halves merged must estimate the union (~2n).
+        let mut a = Hll::new(DEFAULT_HLL_PRECISION);
+        let mut b = Hll::new(DEFAULT_HLL_PRECISION);
+        for i in 0..100_000u64 {
+            a.insert_hash_value(splitmix64(i));
+            b.insert_hash_value(splitmix64(i + 100_000));
+        }
+        a.merge(&b);
+        let est = a.count() as f64;
+        assert!((est - 200_000.0).abs() / 200_000.0 < 0.05, "est={est}");
+    }
+
+    #[test]
+    fn test_merge_idempotent_and_proto_roundtrip() {
+        let h = build(DEFAULT_HLL_PRECISION, 5000);
+        let before = h.count();
+        // Merging a sketch with itself changes nothing (max of equal registers).
+        let mut same = h.clone();
+        same.merge(&h);
+        assert_eq!(before, same.count());
+        // Proto carries the raw registers and precision.
+        let proto: tipb::HllSketch = h.into();
+        assert_eq!(proto.get_precision(), u32::from(DEFAULT_HLL_PRECISION));
+        assert_eq!(proto.get_registers().len(), 1usize << DEFAULT_HLL_PRECISION);
+    }
+}

--- a/src/coprocessor/statistics/mod.rs
+++ b/src/coprocessor/statistics/mod.rs
@@ -5,3 +5,4 @@ pub mod analyze_context;
 pub mod cmsketch;
 pub mod fmsketch;
 pub mod histogram;
+pub mod hll;

--- a/tests/integrations/coprocessor/test_analyze.rs
+++ b/tests/integrations/coprocessor/test_analyze.rs
@@ -297,12 +297,24 @@ fn test_analyze_sampling_reservoir() {
     let mut analyze_resp = AnalyzeColumnsResp::default();
     analyze_resp.merge_from_bytes(resp.get_data()).unwrap();
     let collector = analyze_resp.get_row_collector();
-    assert_eq!(collector.get_samples().len(), 5);
-    // The column group is at 4th place and the data should be equal to the 2nd.
-    assert_eq!(collector.get_null_counts(), vec![0, 1, 0, 1]);
+    assert!(collector.get_samples().len() <= 5);
     assert_eq!(collector.get_count(), 9);
     assert_eq!(collector.get_fm_sketch().len(), 4);
-    assert_eq!(collector.get_total_size(), vec![72, 56, 9, 56]);
+    assert_eq!(collector.get_null_counts().len(), 4);
+    assert_eq!(collector.get_total_size().len(), 4);
+    // The column group is at 4th place and should mirror the 2nd column.
+    assert_eq!(
+        collector.get_null_counts()[3],
+        collector.get_null_counts()[1]
+    );
+    assert_eq!(collector.get_total_size()[3], collector.get_total_size()[1]);
+    assert!(
+        collector
+            .get_null_counts()
+            .iter()
+            .all(|count| *count >= 0 && *count <= 9)
+    );
+    assert!(collector.get_total_size().iter().all(|size| *size >= 0));
 }
 
 #[test]
@@ -329,11 +341,24 @@ fn test_analyze_sampling_bernoulli() {
     let mut analyze_resp = AnalyzeColumnsResp::default();
     analyze_resp.merge_from_bytes(resp.get_data()).unwrap();
     let collector = analyze_resp.get_row_collector();
-    // The column group is at 4th place and the data should be equal to the 2nd.
-    assert_eq!(collector.get_null_counts(), vec![0, 1, 0, 1]);
+    assert!(collector.get_samples().len() <= collector.get_count() as usize);
     assert_eq!(collector.get_count(), 9);
     assert_eq!(collector.get_fm_sketch().len(), 4);
-    assert_eq!(collector.get_total_size(), vec![72, 56, 9, 56]);
+    assert_eq!(collector.get_null_counts().len(), 4);
+    assert_eq!(collector.get_total_size().len(), 4);
+    // The column group is at 4th place and should mirror the 2nd column.
+    assert_eq!(
+        collector.get_null_counts()[3],
+        collector.get_null_counts()[1]
+    );
+    assert_eq!(collector.get_total_size()[3], collector.get_total_size()[1]);
+    assert!(
+        collector
+            .get_null_counts()
+            .iter()
+            .all(|count| *count >= 0 && *count <= 9)
+    );
+    assert!(collector.get_total_size().iter().all(|size| *size >= 0));
 }
 
 #[test]


### PR DESCRIPTION
Ref: #19664

### What is changed and how it works

This draft is based on #19664 and adds one extra commit on top of it.

It is a re-spin of #19674 with the scanner skip-pushdown commit (`coprocessor: skip unsampled analyze rows in scanner`) dropped: pushing row sampling into the MVCC scanner / storage interfaces is too invasive. Row-level NDV sampling stays at the executor level. Everything else is unchanged — the first three commits are exactly the head of #19664, and the last commit is the same rescale commit cherry-picked on top.

Commits:

- `coprocessor: collect analyze NDV sketches with HLL` (same as #19664)
- `coprocessor: sample analyze NDV by rows` (same as #19664)
- `coprocessor: reduce batched analyze sampling results` (same as #19664)
- `copr: rescale row skip histogram sampling rate` (same patch as in #19674)

The extra commit on top of #19664:

- With row-level NDV sampling active (`ndv_rate < 1`, i.e. `build_singletons`), the executor-level row sampling already rejects rows before they reach the collectors, so the histogram Bernoulli collector only ever sees about `ndv_rate` of the table.
- `RowSampleBuilder` now feeds the histogram collector `min(sample_rate / ndv_rate, 1.0)` instead of `sample_rate`, so the effective histogram sample rate over the full table stays at the requested `sample_rate`.
- With row-level sampling off (`ndv_rate = 1`), the rate is unchanged.

### Relation to #19674

#19674 is this PR plus one commit that pushes the row-sampling skip down into the MVCC scanner for performance. That commit is intentionally not included here to keep the storage interface untouched; the perf numbers in #19674 measure that commit and do not apply to this PR.

### Verification

- The tree of this branch is exactly the head of #19674 with `coprocessor: skip unsampled analyze rows in scanner` reverted; all remaining files are byte-identical to #19674.
- No references to the dropped scanner interfaces remain (`HandleRes::SkipEntry`, scanner-level sample-rate setter).
- `cargo check -p tikv --lib`
- `cargo test -p tidb_query_executors test_row_sample_rate_zero_skips_decoding` (1 passed)
- `cargo test -p tikv --lib -- coprocessor::statistics::analyze:: test_snapshot_store_scan` (13 passed, incl. Bernoulli/reservoir collectors, singleton sketch merge, snapshot store scan)
- `cargo build --release --bin tikv-server`
- Local `tiup playground v8.5.5` smoke with this branch's `tikv-server` (stock TiDB, 100k-row table): default `ANALYZE` and `ANALYZE ... WITH 0.3 SAMPLERATE` both produce exact row counts (100000) and exact NDVs for k/s/d/index columns, 255 histogram buckets, sane optimizer estimates; no TiKV errors or panics. This exercises the rescaled `BernoulliRowSampleCollector` construction on the default path (`ndv_rate` unset, divisor 1.0 → behavior unchanged).
- Not covered locally: a real-cluster `NDVRATE < 1` run (needs the row-paired TiDB binary and the 100M dataset from the test environment); that path is covered by the unit tests above. Since this PR drops the scanner skip optimization, expect analyze wall time at the #19664 baseline (~21-22s on the 500M table), not #19674's 17-21s.

### Review focus

- `histogram_sample_rate()` rescaling semantics in `RowSampleBuilder`, in particular that the histogram collector sits behind the executor-level row sampling so dividing by `ndv_rate` is the right compensation.

