### PR TITLE
Release 8.5 20260608 v8.5.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8125,7 +8125,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "static_assertions",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3837,7 +3837,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git#a6b0bb0483986cbcec14530064f53b7f14facfa2"
+source = "git+https://github.com/tikv/rust-rocksdb.git#1c17b59dcb506302ed4684b3628c4a7165e0b86d"
 dependencies = [
  "bindgen 0.65.1",
  "bzip2-sys",
@@ -3856,7 +3856,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/tikv/rust-rocksdb.git#a6b0bb0483986cbcec14530064f53b7f14facfa2"
+source = "git+https://github.com/tikv/rust-rocksdb.git#1c17b59dcb506302ed4684b3628c4a7165e0b86d"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -5880,7 +5880,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git#a6b0bb0483986cbcec14530064f53b7f14facfa2"
+source = "git+https://github.com/tikv/rust-rocksdb.git#1c17b59dcb506302ed4684b3628c4a7165e0b86d"
 dependencies = [
  "libc 0.2.176",
  "librocksdb_sys",
@@ -7624,9 +7624,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemalloc-ctl"
-version = "0.5.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e37706572f4b151dff7a0146e040804e9c26fe3a3118591112f05cf12a4216c1"
+checksum = "661f1f6a57b3a36dc9174a2c10f19513b4866816e13425d3e418b11cc37bc24c"
 dependencies = [
  "libc 0.2.176",
  "paste",
@@ -7635,20 +7635,19 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemalloc-sys"
-version = "0.5.0+5.3.0"
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aeab4310214fe0226df8bfeb893a291a58b19682e8a07e1e1d4483ad4200d315"
+checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
 dependencies = [
  "cc",
- "fs_extra",
  "libc 0.2.176",
 ]
 
 [[package]]
 name = "tikv-jemallocator"
-version = "0.5.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20612db8a13a6c06d57ec83953694185a367e16945f66565e8028d2c0bd76979"
+checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
 dependencies = [
  "libc 0.2.176",
  "tikv-jemalloc-sys",
@@ -8813,7 +8812,7 @@ checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 [[package]]
 name = "yatp"
 version = "0.0.1"
-source = "git+https://github.com/tikv/yatp.git?branch=master#793be4d789d4bd15292fe4d06e38063b4ec9d48e"
+source = "git+https://github.com/tikv/yatp.git?branch=master#9fcf102bfcc3acaa0d992b018ada7593deb04d97"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-skiplist 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6535,9 +6535,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
 dependencies = [
  "lock_api",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3765,7 +3765,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git?branch=release-8.5#3586c08f7d29d6ee9eed2a5aa9d33ad24012a6d2"
+source = "git+https://github.com/pingcap/kvproto.git?branch=release-8.5#39498d6b17fc516bc18d178e981b0f76d18fcad6"
 dependencies = [
  "bytes",
  "futures 0.3.15",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8806,7 +8806,7 @@ checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 [[package]]
 name = "yatp"
 version = "0.0.1"
-source = "git+https://github.com/tikv/yatp.git?branch=master#9fcf102bfcc3acaa0d992b018ada7593deb04d97"
+source = "git+https://github.com/tikv/yatp.git?branch=master#1a2f56b52ca57cce4bb7825f706b073977a72098"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-skiplist 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8813,7 +8813,7 @@ checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 [[package]]
 name = "yatp"
 version = "0.0.1"
-source = "git+https://github.com/tikv/yatp.git?branch=master#793be4d789d4bd15292fe4d06e38063b4ec9d48e"
+source = "git+https://github.com/tikv/yatp.git?branch=master#9fcf102bfcc3acaa0d992b018ada7593deb04d97"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-skiplist 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2628,12 +2628,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fs_extra"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f2a4a2034423744d2cc7ca2068453168dcdb82c438419e639a26bd87839c674"
-
-[[package]]
 name = "fsevent"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3837,7 +3837,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git#a6b0bb0483986cbcec14530064f53b7f14facfa2"
+source = "git+https://github.com/tikv/rust-rocksdb.git#1c17b59dcb506302ed4684b3628c4a7165e0b86d"
 dependencies = [
  "bindgen 0.65.1",
  "bzip2-sys",
@@ -3856,7 +3856,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/tikv/rust-rocksdb.git#a6b0bb0483986cbcec14530064f53b7f14facfa2"
+source = "git+https://github.com/tikv/rust-rocksdb.git#1c17b59dcb506302ed4684b3628c4a7165e0b86d"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -5880,7 +5880,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git#a6b0bb0483986cbcec14530064f53b7f14facfa2"
+source = "git+https://github.com/tikv/rust-rocksdb.git#1c17b59dcb506302ed4684b3628c4a7165e0b86d"
 dependencies = [
  "libc 0.2.176",
  "librocksdb_sys",
@@ -7624,9 +7624,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemalloc-ctl"
-version = "0.5.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e37706572f4b151dff7a0146e040804e9c26fe3a3118591112f05cf12a4216c1"
+checksum = "661f1f6a57b3a36dc9174a2c10f19513b4866816e13425d3e418b11cc37bc24c"
 dependencies = [
  "libc 0.2.176",
  "paste",
@@ -7635,20 +7635,19 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemalloc-sys"
-version = "0.5.0+5.3.0"
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aeab4310214fe0226df8bfeb893a291a58b19682e8a07e1e1d4483ad4200d315"
+checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
 dependencies = [
  "cc",
- "fs_extra",
  "libc 0.2.176",
 ]
 
 [[package]]
 name = "tikv-jemallocator"
-version = "0.5.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20612db8a13a6c06d57ec83953694185a367e16945f66565e8028d2c0bd76979"
+checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
 dependencies = [
  "libc 0.2.176",
  "tikv-jemalloc-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ openssl-vendored = [
 # for testing configure propegate to other crates
 # https://stackoverflow.com/questions/41700543/can-we-share-test-utilites-between-crates
 testing = []
+docker_test = []  # Feature flag for Docker-specific tests
 
 [lib]
 name = "tikv"

--- a/clippy.toml
+++ b/clippy.toml
@@ -33,17 +33,6 @@ Adding hooks directly will omit system hooks, please use
 refer to https://github.com/tikv/tikv/pull/12442 and https://github.com/tikv/tikv/pull/15017 for more details.
 """
 
-# See more about RUSTSEC-2020-0071 in deny.toml.
-[[disallowed-methods]]
-path = "time::now"
-reason = "time::now is unsound, see RUSTSEC-2020-0071"
-[[disallowed-methods]]
-path = "time::at"
-reason = "time::at is unsound, see RUSTSEC-2020-0071"
-[[disallowed-methods]]
-path = "time::at_utc"
-reason = "time::at_utc is unsound, see RUSTSEC-2020-0071"
-
 # See more about RUSTSEC-2023-0072 in deny.toml.
 [[disallowed-methods]]
 path = "openssl::x509::store::X509StoreRef::objects"

--- a/components/backup-stream/src/router.rs
+++ b/components/backup-stream/src/router.rs
@@ -17,7 +17,7 @@ use dashmap::DashMap;
 use encryption::{BackupEncryptionManager, EncrypterReader, Iv, MultiMasterKeyBackend};
 use encryption_export::create_async_backend;
 use engine_traits::{CfName, CF_DEFAULT, CF_LOCK, CF_WRITE};
-use external_storage::{create_storage, BackendConfig, ExternalStorage, UnpinReader};
+use external_storage::{create_storage, BackendConfig, ExternalStorage, HdfsConfig, UnpinReader};
 use file_system::Sha256Reader;
 use futures::io::Cursor;
 use kvproto::{
@@ -343,6 +343,7 @@ pub struct Config {
     pub temp_file_size_limit: u64,
     pub temp_file_memory_quota: u64,
     pub max_flush_interval: Duration,
+    pub s3_multi_part_size: usize,
 }
 
 impl From<BackupStreamConfig> for Config {
@@ -351,11 +352,13 @@ impl From<BackupStreamConfig> for Config {
         let temp_file_size_limit = value.file_size_limit.0;
         let temp_file_memory_quota = value.temp_file_memory_quota.0;
         let max_flush_interval = value.max_flush_interval.0;
+        let s3_multi_part_size = value.s3_multi_part_size.0 as usize;
         Self {
             prefix,
             temp_file_size_limit,
             temp_file_memory_quota,
             max_flush_interval,
+            s3_multi_part_size,
         }
     }
 }
@@ -413,6 +416,9 @@ pub struct RouterInner {
 
     /// Backup encryption manager
     backup_encryption_manager: BackupEncryptionManager,
+
+    /// S3 multi part size
+    s3_multi_part_size: AtomicUsize,
 }
 
 impl std::fmt::Debug for RouterInner {
@@ -440,6 +446,7 @@ impl RouterInner {
             temp_file_memory_quota: AtomicU64::new(config.temp_file_memory_quota),
             max_flush_interval: SyncRwLock::new(config.max_flush_interval),
             backup_encryption_manager,
+            s3_multi_part_size: AtomicUsize::new(config.s3_multi_part_size),
         }
     }
 
@@ -512,12 +519,17 @@ impl RouterInner {
         let cfg = self.tempfile_config_for_task(&task);
         let backup_encryption_manager =
             self.build_backup_encryption_manager_for_task(&task).await?;
+        let backend_config = BackendConfig {
+            s3_multi_part_size: self.s3_multi_part_size.load(Ordering::Relaxed),
+            hdfs_config: HdfsConfig::default(),
+        };
         let stream_task = StreamTaskHandler::new(
             task,
             ranges.clone(),
             merged_file_size_limit,
             cfg,
             backup_encryption_manager,
+            backend_config,
         )
         .await?;
         self.tasks.insert(task_name.clone(), Arc::new(stream_task));
@@ -996,13 +1008,11 @@ impl StreamTaskHandler {
         merged_file_size_limit: u64,
         temp_pool_cfg: tempfiles::Config,
         backup_encryption_manager: BackupEncryptionManager,
+        backend_config: BackendConfig,
     ) -> Result<Self> {
         let temp_dir = &temp_pool_cfg.swap_files;
         tokio::fs::create_dir_all(temp_dir).await?;
-        let storage = Arc::from(create_storage(
-            task.info.get_storage(),
-            BackendConfig::default(),
-        )?);
+        let storage = Arc::from(create_storage(task.info.get_storage(), backend_config)?);
         let start_ts = task.info.get_start_ts();
         Ok(Self {
             task,
@@ -2101,6 +2111,7 @@ mod tests {
                 temp_file_size_limit: 1024,
                 temp_file_memory_quota: 1024 * 2,
                 max_flush_interval: Duration::from_secs(300),
+                s3_multi_part_size: ReadableSize::mb(5).0 as usize,
             },
             BackupEncryptionManager::default(),
         );
@@ -2200,6 +2211,7 @@ mod tests {
                 temp_file_size_limit: 32,
                 temp_file_memory_quota: 32 * 2,
                 max_flush_interval: Duration::from_secs(300),
+                s3_multi_part_size: ReadableSize::mb(5).0 as usize,
             },
             BackupEncryptionManager::default(),
         );
@@ -2345,6 +2357,7 @@ mod tests {
             merged_file_size_limit,
             make_tempfiles_cfg(tmp_dir.path()),
             BackupEncryptionManager::default(),
+            BackendConfig::default(),
         )
         .await
         .unwrap();
@@ -2474,6 +2487,7 @@ mod tests {
                 temp_file_size_limit: 1,
                 temp_file_memory_quota: 2,
                 max_flush_interval: Duration::from_secs(300),
+                s3_multi_part_size: ReadableSize::mb(5).0 as usize,
             },
             BackupEncryptionManager::default(),
         ));
@@ -2513,6 +2527,7 @@ mod tests {
                 temp_file_size_limit: 32,
                 temp_file_memory_quota: 32 * 2,
                 max_flush_interval: Duration::from_secs(300),
+                s3_multi_part_size: ReadableSize::mb(5).0 as usize,
             },
             BackupEncryptionManager::default(),
         );
@@ -2556,6 +2571,7 @@ mod tests {
                 temp_file_size_limit: 1,
                 temp_file_memory_quota: 2,
                 max_flush_interval: Duration::from_secs(300),
+                s3_multi_part_size: ReadableSize::mb(5).0 as usize,
             },
             BackupEncryptionManager::default(),
         ));
@@ -2611,6 +2627,7 @@ mod tests {
                 temp_file_size_limit: 1,
                 temp_file_memory_quota: 2,
                 max_flush_interval: Duration::from_secs(300),
+                s3_multi_part_size: ReadableSize::mb(5).0 as usize,
             },
             BackupEncryptionManager::default(),
         ));
@@ -2748,6 +2765,7 @@ mod tests {
             0x100000,
             make_tempfiles_cfg(tmp_dir.path()),
             backup_encryption_manager,
+            BackendConfig::default(),
         )
         .await
         .unwrap();
@@ -2905,6 +2923,7 @@ mod tests {
                 temp_file_size_limit: 1,
                 temp_file_memory_quota: 2,
                 max_flush_interval: cfg.max_flush_interval.0,
+                s3_multi_part_size: cfg.s3_multi_part_size.0 as usize,
             },
             BackupEncryptionManager::default(),
         ));
@@ -2962,6 +2981,7 @@ mod tests {
                 temp_file_size_limit: 1000,
                 temp_file_memory_quota: 2,
                 max_flush_interval: Duration::from_secs(300),
+                s3_multi_part_size: ReadableSize::mb(5).0 as usize,
             },
             BackupEncryptionManager::default(),
         ));
@@ -3114,6 +3134,7 @@ mod tests {
             merged_file_size_limit,
             make_tempfiles_cfg(tempfile::tempdir().unwrap().path()),
             backup_encryption_manager.clone(),
+            BackendConfig::default(),
         )
         .await
         .unwrap();

--- a/components/backup/src/endpoint.rs
+++ b/components/backup/src/endpoint.rs
@@ -232,7 +232,16 @@ async fn save_backup_file_worker<EK: KvEngine>(
 ) {
     while let Ok(msg) = rx.recv().await {
         let files = if msg.files.need_flush_keys() {
-            match with_resource_limiter(msg.files.save(&storage), msg.limiter.clone()).await {
+            match with_resource_limiter(
+                msg.files.save(&storage),
+                msg.limiter.clone(),
+                false,
+                false,
+                None,
+                0,
+            )
+            .await
+            {
                 Ok(mut split_files) => {
                     let mut has_err = false;
                     for file in split_files.iter_mut() {
@@ -1055,6 +1064,10 @@ impl<E: Engine, R: RegionInfoProvider + Clone + 'static> Endpoint<E, R> {
                                 resource_limiter.clone(),
                             ),
                             resource_limiter.clone(),
+                            false,
+                            false,
+                            None,
+                            0,
                         )
                         .await
                     };

--- a/components/backup/src/endpoint.rs
+++ b/components/backup/src/endpoint.rs
@@ -232,7 +232,15 @@ async fn save_backup_file_worker<EK: KvEngine>(
 ) {
     while let Ok(msg) = rx.recv().await {
         let files = if msg.files.need_flush_keys() {
-            match with_resource_limiter(msg.files.save(&storage), msg.limiter.clone(), false).await
+            match with_resource_limiter(
+                msg.files.save(&storage),
+                msg.limiter.clone(),
+                false,
+                false,
+                None,
+                0,
+            )
+            .await
             {
                 Ok(mut split_files) => {
                     let mut has_err = false;
@@ -1057,6 +1065,9 @@ impl<E: Engine, R: RegionInfoProvider + Clone + 'static> Endpoint<E, R> {
                             ),
                             resource_limiter.clone(),
                             false,
+                            false,
+                            None,
+                            0,
                         )
                         .await
                     };

--- a/components/backup/src/endpoint.rs
+++ b/components/backup/src/endpoint.rs
@@ -232,7 +232,8 @@ async fn save_backup_file_worker<EK: KvEngine>(
 ) {
     while let Ok(msg) = rx.recv().await {
         let files = if msg.files.need_flush_keys() {
-            match with_resource_limiter(msg.files.save(&storage), msg.limiter.clone()).await {
+            match with_resource_limiter(msg.files.save(&storage), msg.limiter.clone(), false).await
+            {
                 Ok(mut split_files) => {
                     let mut has_err = false;
                     for file in split_files.iter_mut() {
@@ -1055,6 +1056,7 @@ impl<E: Engine, R: RegionInfoProvider + Clone + 'static> Endpoint<E, R> {
                                 resource_limiter.clone(),
                             ),
                             resource_limiter.clone(),
+                            false,
                         )
                         .await
                     };

--- a/components/cloud/aws/src/kms.rs
+++ b/components/cloud/aws/src/kms.rs
@@ -12,6 +12,7 @@ use aws_sdk_kms::{
     Client,
 };
 use aws_sdk_s3::config::HttpClient;
+use aws_smithy_types::error::metadata::ProvideErrorMetadata;
 use cloud::{
     error::{Error, KmsError, OtherError, Result},
     kms::{Config, CryptographyType, DataKeyPair, EncryptedKey, KeyId, KmsProvider, PlainKey},
@@ -175,7 +176,9 @@ fn classify_decrypt_error(err: SdkError<DecryptError>) -> Error {
     }
 }
 
-fn classify_error<E: std::error::Error + Send + Sync + 'static>(err: SdkError<E>) -> Error {
+fn classify_error<E: std::error::Error + ProvideErrorMetadata + Send + Sync + 'static>(
+    err: SdkError<E>,
+) -> Error {
     match &err {
         SdkError::DispatchFailure(dispatch_failure) => {
             let maybe_credentials_err = dispatch_failure

--- a/components/cloud/aws/src/s3.rs
+++ b/components/cloud/aws/src/s3.rs
@@ -366,7 +366,9 @@ fn create_error_stream(
 
 /// A helper for uploading a large files to S3 storage.
 ///
-/// Note: this uploader does not support uploading files larger than 19.5 GiB.
+/// The uploader automatically adjusts part size to respect S3's 10000 part
+/// limit. Maximum file size is approximately (part_size * 10000), but the part
+/// size will be increased automatically if needed.
 struct S3Uploader<'client> {
     client: &'client Client,
 
@@ -446,6 +448,8 @@ fn get_content_md5(object_lock_enabled: bool, content: &[u8]) -> Option<String> 
 /// Specifies the minimum size to use multi-part upload.
 /// AWS S3 requires each part to be at least 5 MiB.
 const MINIMUM_PART_SIZE: usize = 5 * 1024 * 1024;
+/// S3 has a maximum of 10000 parts per multipart upload.
+const MAX_PARTS: u64 = 10000;
 
 impl<'client> S3Uploader<'client> {
     /// Creates a new uploader with a given target location and upload
@@ -472,7 +476,26 @@ impl<'client> S3Uploader<'client> {
         reader: &mut (dyn AsyncRead + Unpin + Send),
         est_len: u64,
     ) -> Result<(), UploadError> {
-        if est_len <= self.multi_part_size as u64 {
+        let effective_part_size = if est_len > self.multi_part_size as u64 {
+            let min_part_size_for_limit = est_len.div_ceil(MAX_PARTS);
+            let adjusted_size =
+                std::cmp::max(self.multi_part_size as u64, min_part_size_for_limit) as usize;
+
+            if adjusted_size != self.multi_part_size {
+                debug!(
+                    "adjusted multipart size from {} to {} bytes for file size {} bytes (estimated {} parts)",
+                    self.multi_part_size,
+                    adjusted_size,
+                    est_len,
+                    est_len.div_ceil(adjusted_size as u64)
+                );
+            }
+            adjusted_size
+        } else {
+            self.multi_part_size
+        };
+
+        if est_len <= effective_part_size as u64 {
             // For short files, execute one put_object to upload the entire thing.
             let mut data = Vec::with_capacity(est_len as usize);
             reader.read_to_end(&mut data).await?;
@@ -482,7 +505,7 @@ impl<'client> S3Uploader<'client> {
             // Otherwise, use multipart upload to improve robustness.
             self.upload_id = retry_and_count(|| self.begin(), "begin_upload").await?;
             let upload_res = async {
-                let mut buf = vec![0; self.multi_part_size];
+                let mut buf = vec![0; effective_part_size];
                 let mut part_number = 1;
                 loop {
                     let data_size = try_read_exact(reader, &mut buf).await?;
@@ -1426,5 +1449,42 @@ mod tests {
         assert_matches!(try_read_exact(&mut data, &mut buf).await, Ok(5));
         assert_eq!(&buf[..5], b"ogia.");
         assert_matches!(try_read_exact(&mut data, &mut buf).await, Ok(0));
+    }
+
+    #[test]
+    fn test_multipart_size_adjustment() {
+        const MAX_PARTS: u64 = 10000;
+        let multi_part_size = MINIMUM_PART_SIZE; // 5MB
+
+        // Test case 1: Small file, no adjustment needed
+        let est_len = 10u64 * 1024 * 1024; // 10MB
+        let min_part_size = est_len.div_ceil(MAX_PARTS);
+        let effective_size = std::cmp::max(multi_part_size as u64, min_part_size);
+        assert_eq!(effective_size, multi_part_size as u64);
+
+        // Test case 2: File that would exceed 10000 parts with 5MB part size
+        let est_len = 60u64 * 1024 * 1024 * 1024; // 60GB
+        let min_part_size = est_len.div_ceil(MAX_PARTS);
+        let effective_size = std::cmp::max(multi_part_size as u64, min_part_size);
+        // Should be at least 6MB to fit in 10000 parts
+        assert!(effective_size > multi_part_size as u64);
+        assert!(est_len.div_ceil(effective_size) <= MAX_PARTS);
+
+        // Test case 3: Very large file (100GB)
+        let est_len = 100 * 1024 * 1024 * 1024u64; // 100GB
+        let min_part_size = est_len.div_ceil(MAX_PARTS);
+        let effective_size = std::cmp::max(multi_part_size as u64, min_part_size);
+        // Should be at least ~10MB to fit in 10000 parts
+        assert!(effective_size > multi_part_size as u64);
+        assert!(est_len.div_ceil(effective_size) <= MAX_PARTS);
+
+        // Verify the estimated parts count
+        let estimated_parts = est_len.div_ceil(effective_size);
+        assert!(
+            estimated_parts <= MAX_PARTS,
+            "estimated parts {} exceeds maximum {}",
+            estimated_parts,
+            MAX_PARTS
+        );
     }
 }

--- a/components/cloud/aws/src/s3.rs
+++ b/components/cloud/aws/src/s3.rs
@@ -15,6 +15,7 @@ use aws_sdk_s3::{
     types::{CompletedMultipartUpload, CompletedPart},
     Client,
 };
+use aws_smithy_types::error::metadata::ProvideErrorMetadata;
 use bytes::Bytes;
 use cloud::{
     blob::{
@@ -405,7 +406,7 @@ impl RetryError for UploadError {
     }
 }
 
-impl<T: 'static + StdError> From<SdkError<T>> for UploadError {
+impl<T: 'static + StdError + ProvideErrorMetadata> From<SdkError<T>> for UploadError {
     fn from(err: SdkError<T>) -> Self {
         let msg = format!("{:?}", err);
         Self::Sdk {

--- a/components/cloud/aws/src/util.rs
+++ b/components/cloud/aws/src/util.rs
@@ -14,6 +14,7 @@ use aws_credential_types::provider::{error::CredentialsError, ProvideCredentials
 use aws_sdk_kms::config::SharedHttpClient;
 use aws_sdk_s3::config::HttpClient;
 use aws_smithy_runtime::client::http::hyper_014::HyperClientBuilder;
+use aws_smithy_types::error::metadata::ProvideErrorMetadata;
 use cloud::metrics;
 use futures::{Future, TryFutureExt};
 use hyper::Client;
@@ -66,7 +67,7 @@ pub fn new_credentials_provider(http: impl HttpClient + 'static) -> DefaultCrede
     }
 }
 
-pub fn is_retryable<T>(error: &SdkError<T>) -> bool {
+pub fn is_retryable<T: ProvideErrorMetadata>(error: &SdkError<T>) -> bool {
     match error {
         SdkError::TimeoutError(_) => true,
         SdkError::DispatchFailure(_) => true,
@@ -76,7 +77,18 @@ pub fn is_retryable<T>(error: &SdkError<T>) -> bool {
         }
         SdkError::ServiceError(service_err) => {
             let code = service_err.raw().status();
-            code.is_server_error() || code.as_u16() == http::StatusCode::REQUEST_TIMEOUT.as_u16()
+            if code.is_server_error() || code.as_u16() == http::StatusCode::REQUEST_TIMEOUT.as_u16()
+            {
+                return true;
+            }
+            // S3 can return throttling errors (e.g. SlowDown) as HTTP 200 with
+            // an error code embedded in the XML response body. The SDK detects
+            // this via body_is_error() and routes it through the error path,
+            // producing a ServiceError with raw status 200 but a parsed code.
+            matches!(
+                service_err.err().code(),
+                Some("SlowDown") | Some("RequestThrottled") | Some("RequestTimeout")
+            )
         }
         _ => false,
     }
@@ -204,87 +216,137 @@ impl ProvideCredentials for DefaultCredentialsProvider {
 #[cfg(test)]
 mod tests {
     use aws_smithy_runtime_api::http::StatusCode;
-    use aws_smithy_types::body::SdkBody;
+    use aws_smithy_types::{body::SdkBody, error::ErrorMetadata};
 
     #[allow(unused_imports)]
     use super::*;
 
+    // Minimal error type that satisfies ProvideErrorMetadata for unit tests.
+    #[derive(Debug)]
+    struct TestError {
+        meta: ErrorMetadata,
+    }
+
+    impl TestError {
+        fn with_code(code: &'static str) -> Self {
+            Self {
+                meta: ErrorMetadata::builder().code(code).build(),
+            }
+        }
+
+        fn no_code() -> Self {
+            Self {
+                meta: ErrorMetadata::builder().build(),
+            }
+        }
+    }
+
+    impl std::fmt::Display for TestError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{:?}", self.meta)
+        }
+    }
+
+    impl std::error::Error for TestError {}
+
+    impl ProvideErrorMetadata for TestError {
+        fn meta(&self) -> &ErrorMetadata {
+            &self.meta
+        }
+    }
+
     #[test]
     fn test_is_retryable_response_error_5xx() {
-        // Test that ResponseError with 5xx status codes are retryable
         let response = HttpResponse::new(StatusCode::try_from(503).unwrap(), SdkBody::empty());
-        let err = SdkError::<(), _>::response_error("service unavailable", response);
+        let err = SdkError::<TestError, _>::response_error("service unavailable", response);
         assert!(is_retryable(&err));
 
         let response = HttpResponse::new(StatusCode::try_from(500).unwrap(), SdkBody::empty());
-        let err = SdkError::<(), _>::response_error("internal server error", response);
+        let err = SdkError::<TestError, _>::response_error("internal server error", response);
         assert!(is_retryable(&err));
     }
 
     #[test]
     fn test_is_retryable_response_error_4xx() {
-        // Test that ResponseError with 4xx status codes are not retryable
         let response = HttpResponse::new(StatusCode::try_from(404).unwrap(), SdkBody::empty());
-        let err = SdkError::<(), _>::response_error("not found", response);
+        let err = SdkError::<TestError, _>::response_error("not found", response);
         assert!(!is_retryable(&err));
 
         let response = HttpResponse::new(StatusCode::try_from(400).unwrap(), SdkBody::empty());
-        let err = SdkError::<(), _>::response_error("bad request", response);
+        let err = SdkError::<TestError, _>::response_error("bad request", response);
         assert!(!is_retryable(&err));
     }
 
     #[test]
     fn test_is_retryable_response_error_408() {
-        // Test that ResponseError with 408 Request Timeout is retryable
         let response = HttpResponse::new(StatusCode::try_from(408).unwrap(), SdkBody::empty());
-        let err = SdkError::<(), _>::response_error("request timeout", response);
+        let err = SdkError::<TestError, _>::response_error("request timeout", response);
         assert!(is_retryable(&err));
     }
 
     #[test]
     fn test_is_retryable_service_error_5xx() {
-        // Test that ServiceError with 5xx status codes are retryable (e.g., S3
-        // SlowDown)
         let response = HttpResponse::new(StatusCode::try_from(503).unwrap(), SdkBody::empty());
-        let err = SdkError::<(), _>::service_error((), response);
+        let err = SdkError::service_error(TestError::no_code(), response);
         assert!(is_retryable(&err));
 
         let response = HttpResponse::new(StatusCode::try_from(500).unwrap(), SdkBody::empty());
-        let err = SdkError::<(), _>::service_error((), response);
+        let err = SdkError::service_error(TestError::no_code(), response);
         assert!(is_retryable(&err));
     }
 
     #[test]
     fn test_is_retryable_service_error_4xx() {
-        // Test that ServiceError with 4xx status codes are not retryable
         let response = HttpResponse::new(StatusCode::try_from(404).unwrap(), SdkBody::empty());
-        let err = SdkError::<(), _>::service_error((), response);
+        let err = SdkError::service_error(TestError::no_code(), response);
         assert!(!is_retryable(&err));
 
         let response = HttpResponse::new(StatusCode::try_from(403).unwrap(), SdkBody::empty());
-        let err = SdkError::<(), _>::service_error((), response);
+        let err = SdkError::service_error(TestError::no_code(), response);
         assert!(!is_retryable(&err));
     }
 
     #[test]
     fn test_is_retryable_service_error_408() {
-        // Test that ServiceError with 408 Request Timeout is retryable
         let response = HttpResponse::new(StatusCode::try_from(408).unwrap(), SdkBody::empty());
-        let err = SdkError::<(), _>::service_error((), response);
+        let err = SdkError::service_error(TestError::no_code(), response);
         assert!(is_retryable(&err));
     }
 
     #[test]
+    fn test_is_retryable_service_error_slowdown_http_200() {
+        // S3 SlowDown / throttling can arrive as HTTP 200 with the error code in
+        // the XML body. Verify all three throttling codes are retryable at
+        // status 200.
+        for code in &["SlowDown", "RequestThrottled", "RequestTimeout"] {
+            let response = HttpResponse::new(StatusCode::try_from(200).unwrap(), SdkBody::empty());
+            let err = SdkError::service_error(TestError::with_code(code), response);
+            assert!(
+                is_retryable(&err),
+                "expected HTTP 200 ServiceError with code={} to be retryable",
+                code
+            );
+        }
+    }
+
+    #[test]
+    fn test_is_retryable_service_error_other_200() {
+        // A 200 ServiceError with an unrelated code must not be retried.
+        let response = HttpResponse::new(StatusCode::try_from(200).unwrap(), SdkBody::empty());
+        let err = SdkError::service_error(TestError::with_code("NoSuchKey"), response);
+        assert!(!is_retryable(&err));
+    }
+
+    #[test]
     fn test_is_retryable_timeout_error() {
-        // Test that TimeoutError is retryable
-        let err = SdkError::<(), HttpResponse>::timeout_error("operation timed out");
+        let err = SdkError::<TestError, HttpResponse>::timeout_error("operation timed out");
         assert!(is_retryable(&err));
     }
 
     #[test]
     fn test_is_retryable_construction_failure() {
-        // Test that ConstructionFailure is not retryable
-        let err = SdkError::<(), HttpResponse>::construction_failure("failed to build request");
+        let err =
+            SdkError::<TestError, HttpResponse>::construction_failure("failed to build request");
         assert!(!is_retryable(&err));
     }
 

--- a/components/engine_rocks/src/import.rs
+++ b/components/engine_rocks/src/import.rs
@@ -13,6 +13,9 @@ use crate::{
     r2e, util,
 };
 
+// Temporarily disabled due to https://github.com/tikv/tikv/issues/19891.
+const ENABLE_INGEST_ALLOW_WRITE: bool = false;
+
 impl ImportExt for RocksEngine {
     type IngestExternalFileOptions = RocksIngestExternalFileOptions;
 
@@ -35,7 +38,7 @@ impl ImportExt for RocksEngine {
         let mut opts = RocksIngestExternalFileOptions::new();
         opts.move_files(true);
         opts.set_write_global_seqno(false);
-        let allow_write = range.is_some() || force_allow_write;
+        let allow_write = ENABLE_INGEST_ALLOW_WRITE && (range.is_some() || force_allow_write);
         opts.allow_write(allow_write);
         if allow_write {
             INGEST_EXTERNAL_FILE_ALLOW_WRITE_COUNTER

--- a/components/pd_client/src/client.rs
+++ b/components/pd_client/src/client.rs
@@ -607,6 +607,7 @@ impl PdClient for RpcClient {
         req.set_approximate_size(region_stat.approximate_size);
         req.set_approximate_keys(region_stat.approximate_keys);
         req.set_cpu_usage(region_stat.cpu_usage);
+        req.set_cpu_stats(region_stat.cpu_stats);
         if let Some(s) = replication_status {
             req.set_replication_status(s);
         }

--- a/components/pd_client/src/lib.rs
+++ b/components/pd_client/src/lib.rs
@@ -58,9 +58,13 @@ pub struct RegionStat {
     pub approximate_size: u64,
     pub approximate_keys: u64,
     pub last_report_ts: UnixSecs,
-    // cpu_usage is the CPU time usage of the leader region since the last heartbeat,
-    // which is calculated by cpu_time_delta/heartbeat_reported_interval.
+    // Deprecated in kvproto (`pdpb.RegionHeartbeatRequest.cpu_usage`).
+    // Keep this for backward compatibility while rolling upgrades are in progress.
+    // New PD-side logic should prefer `cpu_stats`.
     pub cpu_usage: u64,
+    // cpu_stats contains detailed CPU usage for the leader and is the preferred
+    // field for PD-side read CPU accounting.
+    pub cpu_stats: pdpb::CpuStats,
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/components/raftstore-v2/Cargo.toml
+++ b/components/raftstore-v2/Cargo.toml
@@ -60,7 +60,7 @@ tikv_util = { workspace = true }
 time = { workspace = true }
 tracker = { workspace = true }
 txn_types = { workspace = true }
-yatp = { git = "https://github.com/tikv/yatp.git", branch = "master" }
+yatp = { workspace = true }
 
 [dev-dependencies]
 engine_rocks = { workspace = true }

--- a/components/raftstore-v2/src/batch/store.rs
+++ b/components/raftstore-v2/src/batch/store.rs
@@ -4,7 +4,7 @@ use std::{
     ops::{Deref, DerefMut},
     path::Path,
     sync::{
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicBool, AtomicU64, Ordering},
         Arc, Mutex,
     },
     time::Duration,
@@ -791,10 +791,19 @@ impl<EK: KvEngine, ER: RaftEngine> StoreSystem<EK, ER> {
             None
         };
 
+        let last_raft_append_success_at_millis = Arc::new(AtomicU64::new(0));
+        let last_kv_sync_success_at_millis = Arc::new(AtomicU64::new(0));
         let mut workers = Workers::new(background, pd_worker, purge_worker, resource_ctl);
-        workers
-            .async_write
-            .spawn(store_id, raft_engine.clone(), None, router, &trans, &cfg)?;
+        workers.async_write.spawn(
+            store_id,
+            raft_engine.clone(),
+            None,
+            router,
+            &trans,
+            &cfg,
+            last_raft_append_success_at_millis.clone(),
+            last_kv_sync_success_at_millis.clone(),
+        )?;
 
         let mut read_runner = ReadRunner::new(router.clone(), raft_engine.clone());
         read_runner.set_snap_mgr(snap_mgr.clone());
@@ -885,6 +894,8 @@ impl<EK: KvEngine, ER: RaftEngine> StoreSystem<EK, ER> {
                 transfer: trans,
                 notifier: router.clone(),
                 cfg: cfg.clone(),
+                last_raft_append_success_at_millis,
+                last_kv_sync_success_at_millis,
             },
             workers.async_write.clone(),
         );

--- a/components/raftstore-v2/src/worker/pd/mod.rs
+++ b/components/raftstore-v2/src/worker/pd/mod.rs
@@ -216,8 +216,12 @@ where
     // For region.
     region_peers: HashMap<u64, region::PeerStat>,
     region_buckets: HashMap<u64, region::ReportBucket>,
-    // region_id -> total_cpu_time_ms (since last region heartbeat)
-    region_cpu_records: HashMap<u64, u32>,
+    // region_id -> total_cpu_time_ms accumulated for RegionHeartbeat reporting.
+    // This map is consumed/cleared by the region-heartbeat path.
+    region_cpu_records_since_region_heartbeat: HashMap<u64, u32>,
+    // region_id -> total_cpu_time_ms accumulated for StoreHeartbeat peer_stats.
+    // This map is consumed/cleared by real store heartbeats (not fake ones).
+    region_cpu_records_since_store_heartbeat: HashMap<u64, u32>,
     is_hb_receiver_scheduled: bool,
 
     // For update_max_timestamp.
@@ -291,7 +295,8 @@ where
             store_stat: store::StoreStat::default(),
             region_peers: HashMap::default(),
             region_buckets: HashMap::default(),
-            region_cpu_records: HashMap::default(),
+            region_cpu_records_since_region_heartbeat: HashMap::default(),
+            region_cpu_records_since_store_heartbeat: HashMap::default(),
             is_hb_receiver_scheduled: false,
             concurrency_manager,
             causal_ts_provider,

--- a/components/raftstore-v2/src/worker/pd/store.rs
+++ b/components/raftstore-v2/src/worker/pd/store.rs
@@ -57,6 +57,12 @@ fn hotspot_query_num_report_threshold() -> u64 {
     HOTSPOT_QUERY_RATE_THRESHOLD * 10
 }
 
+fn hotspot_cpu_usage_report_threshold() -> u64 {
+    const HOTSPOT_CPU_USAGE_THRESHOLD: u64 = 1;
+    fail_point!("mock_hotspot_threshold", |_| { 0 });
+    HOTSPOT_CPU_USAGE_THRESHOLD
+}
+
 pub struct StoreStat {
     pub engine_total_bytes_read: u64,
     pub engine_total_keys_read: u64,
@@ -130,7 +136,7 @@ fn collect_report_read_peer_stats(
     mut report_read_stats: HashMap<u64, pdpb::PeerStat>,
     mut stats: pdpb::StoreStats,
 ) -> pdpb::StoreStats {
-    if report_read_stats.len() < capacity * 3 {
+    if report_read_stats.len() < capacity * 4 {
         for (_, read_stat) in report_read_stats {
             stats.peer_stats.push(read_stat);
         }
@@ -139,6 +145,7 @@ fn collect_report_read_peer_stats(
     let mut keys_topn_report = TopN::new(capacity);
     let mut bytes_topn_report = TopN::new(capacity);
     let mut stats_topn_report = TopN::new(capacity);
+    let mut cpu_topn_report = TopN::new(capacity);
     for read_stat in report_read_stats.values() {
         let mut cmp_stat = PeerCmpReadStat::default();
         cmp_stat.region_id = read_stat.region_id;
@@ -151,6 +158,9 @@ fn collect_report_read_peer_stats(
         let mut query_cmp_stat = cmp_stat.clone();
         query_cmp_stat.report_stat = get_read_query_num(read_stat.get_query_stats());
         stats_topn_report.push(query_cmp_stat);
+        let mut cpu_cmp_stat = cmp_stat;
+        cpu_cmp_stat.report_stat = read_stat.get_cpu_stats().get_unified_read();
+        cpu_topn_report.push(cpu_cmp_stat);
     }
 
     for x in keys_topn_report {
@@ -166,6 +176,12 @@ fn collect_report_read_peer_stats(
     }
 
     for x in stats_topn_report {
+        if let Some(report_stat) = report_read_stats.remove(&x.region_id) {
+            stats.peer_stats.push(report_stat);
+        }
+    }
+
+    for x in cpu_topn_report {
         if let Some(report_stat) = report_read_stats.remove(&x.region_id) {
             stats.peer_stats.push(report_stat);
         }
@@ -189,33 +205,62 @@ where
         is_fake_hb: bool,
         store_report: Option<pdpb::StoreReport>,
     ) {
-        let mut report_peers = HashMap::default();
-        for (region_id, region_peer) in &mut self.region_peers {
-            let read_bytes = region_peer.read_bytes - region_peer.last_store_report_read_bytes;
-            let read_keys = region_peer.read_keys - region_peer.last_store_report_read_keys;
-            let query_stats = region_peer
-                .query_stats
-                .sub_query_stats(&region_peer.last_store_report_query_stats);
-            region_peer.last_store_report_read_bytes = region_peer.read_bytes;
-            region_peer.last_store_report_read_keys = region_peer.read_keys;
-            region_peer
-                .last_store_report_query_stats
-                .fill_query_stats(&region_peer.query_stats);
-            if read_bytes < hotspot_byte_report_threshold()
-                && read_keys < hotspot_key_report_threshold()
-                && query_stats.get_read_query_num() < hotspot_query_num_report_threshold()
-            {
-                continue;
+        let now = UnixSecs::now();
+        if !is_fake_hb {
+            let mut report_peers = HashMap::default();
+            let interval_seconds = now
+                .into_inner()
+                .saturating_sub(self.store_stat.last_report_ts.into_inner());
+            for (region_id, region_peer) in &mut self.region_peers {
+                let read_bytes = region_peer.read_bytes - region_peer.last_store_report_read_bytes;
+                let read_keys = region_peer.read_keys - region_peer.last_store_report_read_keys;
+                let query_stats = region_peer
+                    .query_stats
+                    .sub_query_stats(&region_peer.last_store_report_query_stats);
+                let cpu_usage = if interval_seconds > 0 {
+                    let cpu_time_duration = Duration::from_millis(
+                        self.region_cpu_records_since_store_heartbeat
+                            .remove(region_id)
+                            .unwrap_or(0) as u64,
+                    );
+                    ((cpu_time_duration.as_secs_f64() * 100.0) / interval_seconds as f64) as u64
+                } else {
+                    self.region_cpu_records_since_store_heartbeat
+                        .remove(region_id);
+                    0
+                };
+                let cpu_usage = if cpu_usage < hotspot_cpu_usage_report_threshold() {
+                    0
+                } else {
+                    cpu_usage
+                };
+                region_peer.last_store_report_read_bytes = region_peer.read_bytes;
+                region_peer.last_store_report_read_keys = region_peer.read_keys;
+                region_peer
+                    .last_store_report_query_stats
+                    .fill_query_stats(&region_peer.query_stats);
+                if read_bytes < hotspot_byte_report_threshold()
+                    && read_keys < hotspot_key_report_threshold()
+                    && query_stats.get_read_query_num() < hotspot_query_num_report_threshold()
+                    && cpu_usage < hotspot_cpu_usage_report_threshold()
+                {
+                    continue;
+                }
+                let mut read_stat = pdpb::PeerStat::default();
+                read_stat.set_region_id(*region_id);
+                read_stat.set_read_keys(read_keys);
+                read_stat.set_read_bytes(read_bytes);
+                read_stat.set_query_stats(query_stats.0);
+                let mut cpu_stats = pdpb::CpuStats::default();
+                cpu_stats.set_unified_read(cpu_usage);
+                read_stat.set_cpu_stats(cpu_stats);
+                report_peers.insert(*region_id, read_stat);
             }
-            let mut read_stat = pdpb::PeerStat::default();
-            read_stat.set_region_id(*region_id);
-            read_stat.set_read_keys(read_keys);
-            read_stat.set_read_bytes(read_bytes);
-            read_stat.set_query_stats(query_stats.0);
-            report_peers.insert(*region_id, read_stat);
-        }
 
-        stats = collect_report_read_peer_stats(HOTSPOT_REPORT_CAPACITY, report_peers, stats);
+            // Drain orphan CPU records for regions no longer tracked in `region_peers`.
+            self.region_cpu_records_since_store_heartbeat.clear();
+            stats = collect_report_read_peer_stats(HOTSPOT_REPORT_CAPACITY, report_peers, stats);
+        }
         let (capacity, used_size, available) = self.collect_engine_size();
         if available == 0 {
             warn!(self.logger, "no available space");
@@ -261,7 +306,7 @@ where
             // normal state.
             self.store_stat.last_report_ts
         } else {
-            UnixSecs::now()
+            now
         };
         self.store_stat.region_bytes_written.flush();
         self.store_stat.region_keys_written.flush();

--- a/components/raftstore/src/store/async_io/write.rs
+++ b/components/raftstore/src/store/async_io/write.rs
@@ -10,7 +10,10 @@
 use std::{
     collections::VecDeque,
     fmt, mem,
-    sync::Arc,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
     thread::{self, JoinHandle},
 };
 
@@ -40,7 +43,10 @@ use tikv_util::{
     debug, info, slow_log,
     sys::thread::StdThreadBuildWrapper,
     thd_name,
-    time::{duration_to_sec, setup_for_spin_interval, spin_at_least, Duration, Instant},
+    time::{
+        duration_to_sec, monotonic_raw_now, setup_for_spin_interval, spin_at_least, timespec_to_ns,
+        Duration, Instant,
+    },
     warn,
 };
 use tracker::TrackerTokenArray;
@@ -711,6 +717,8 @@ where
     message_metrics: RaftSendMessageMetrics,
     perf_context: ER::PerfContext,
     pending_latency_inspect: Vec<(Instant, Vec<LatencyInspector>)>,
+    last_raft_append_success_at_millis: Arc<AtomicU64>,
+    last_kv_sync_success_at_millis: Arc<AtomicU64>,
 }
 
 impl<EK, ER, N, T> Worker<EK, ER, N, T>
@@ -729,6 +737,8 @@ where
         notifier: N,
         trans: T,
         cfg: &Arc<VersionTrack<Config>>,
+        last_raft_append_success_at_millis: Arc<AtomicU64>,
+        last_kv_sync_success_at_millis: Arc<AtomicU64>,
     ) -> Self {
         let batch = WriteTaskBatch::new(
             raft_engine.log_batch(RAFT_WB_DEFAULT_SIZE),
@@ -753,6 +763,8 @@ where
             message_metrics: RaftSendMessageMetrics::default(),
             perf_context,
             pending_latency_inspect: vec![],
+            last_raft_append_success_at_millis,
+            last_kv_sync_success_at_millis,
         }
     }
 
@@ -881,6 +893,13 @@ where
                         store_id, tag, e
                     );
                 });
+                // Record this sync-backed kv progress so fail-fast can veto a
+                // kv probe timeout when the same disk is still completing real
+                // sync writes.
+                self.last_kv_sync_success_at_millis.fetch_max(
+                    timespec_to_ns(monotonic_raw_now()) / 1_000_000,
+                    Ordering::Relaxed,
+                );
                 if kv_wb.data_size() > KV_WB_SHRINK_SIZE {
                     *kv_wb = self
                         .kv_engine
@@ -926,6 +945,14 @@ where
             self.perf_context.report_metrics(&trackers);
             write_raft_time = duration_to_sec(now.saturating_elapsed());
             STORE_WRITE_RAFTDB_DURATION_HISTOGRAM.observe(write_raft_time);
+            // Record the last confirmed raft-log append progress on a monotonic
+            // raw clock. Fail-fast reads this timestamp later to answer a very
+            // specific question: "even if the dedicated disk probe is slow, are
+            // real raft appends still succeeding recently?"
+            self.last_raft_append_success_at_millis.fetch_max(
+                timespec_to_ns(monotonic_raw_now()) / 1_000_000,
+                Ordering::Relaxed,
+            );
             debug!("raft log is persisted";
                 "req_info" => TrackerTokenArray::new(trackers.as_slice()));
         }
@@ -1062,6 +1089,8 @@ where
     pub transfer: T,
     pub notifier: N,
     pub cfg: Arc<VersionTrack<Config>>,
+    pub last_raft_append_success_at_millis: Arc<AtomicU64>,
+    pub last_kv_sync_success_at_millis: Arc<AtomicU64>,
 }
 
 #[derive(Clone)]
@@ -1104,6 +1133,8 @@ where
         notifier: &N,
         trans: &T,
         cfg: &Arc<VersionTrack<Config>>,
+        last_raft_append_success_at_millis: Arc<AtomicU64>,
+        last_kv_sync_success_at_millis: Arc<AtomicU64>,
     ) -> Result<()> {
         let pool_size = cfg.value().store_io_pool_size;
         if pool_size > 0 {
@@ -1116,6 +1147,8 @@ where
                     kv_engine,
                     transfer: trans.clone(),
                     cfg: cfg.clone(),
+                    last_raft_append_success_at_millis,
+                    last_kv_sync_success_at_millis,
                 },
             )?;
         }
@@ -1183,6 +1216,8 @@ where
                         writer_meta.notifier.clone(),
                         writer_meta.transfer.clone(),
                         &writer_meta.cfg,
+                        writer_meta.last_raft_append_success_at_millis.clone(),
+                        writer_meta.last_kv_sync_success_at_millis.clone(),
                     );
                     info!("starting store writer {}", i);
                     let t =

--- a/components/raftstore/src/store/async_io/write_tests.rs
+++ b/components/raftstore/src/store/async_io/write_tests.rs
@@ -1,6 +1,9 @@
 // Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::{sync::mpsc, time::Duration};
+use std::{
+    sync::{atomic::AtomicU64, mpsc, Arc},
+    time::Duration,
+};
 
 use collections::HashSet;
 use crossbeam::channel::{unbounded, Receiver, Sender};
@@ -199,6 +202,8 @@ struct TestWorker {
     worker: Worker<KvTestEngine, RaftTestEngine, TestNotifier, TestTransport>,
     msg_rx: Receiver<RaftMessage>,
     notify_rx: Receiver<(u64, (u64, u64))>,
+    last_raft_append_success_at_millis: Arc<AtomicU64>,
+    last_kv_sync_success_at_millis: Arc<AtomicU64>,
 }
 
 impl TestWorker {
@@ -208,6 +213,8 @@ impl TestWorker {
         let trans = TestTransport { tx: msg_tx };
         let (notify_tx, notify_rx) = unbounded();
         let notifier = TestNotifier { tx: notify_tx };
+        let last_raft_append_success_at_millis = Arc::new(AtomicU64::new(0));
+        let last_kv_sync_success_at_millis = Arc::new(AtomicU64::new(0));
         Self {
             worker: Worker::new(
                 1,
@@ -218,9 +225,13 @@ impl TestWorker {
                 notifier,
                 trans,
                 &Arc::new(VersionTrack::new(cfg.clone())),
+                last_raft_append_success_at_millis.clone(),
+                last_kv_sync_success_at_millis.clone(),
             ),
             msg_rx,
             notify_rx,
+            last_raft_append_success_at_millis,
+            last_kv_sync_success_at_millis,
         }
     }
 }
@@ -230,6 +241,7 @@ struct TestWriters {
     msg_rx: Receiver<RaftMessage>,
     notify_rx: Receiver<(u64, (u64, u64))>,
     ctx: TestContext,
+    last_raft_append_success_at_millis: Arc<AtomicU64>,
 }
 
 impl TestWriters {
@@ -247,6 +259,8 @@ impl TestWriters {
                 .as_ref()
                 .map(|m| m.derive_controller("test".into(), false)),
         );
+        let last_raft_append_success_at_millis = Arc::new(AtomicU64::new(0));
+        let last_kv_sync_success_at_millis = Arc::new(AtomicU64::new(0));
         writers
             .spawn(
                 1,
@@ -255,6 +269,8 @@ impl TestWriters {
                 &notifier,
                 &trans,
                 &Arc::new(VersionTrack::new(cfg.clone())),
+                last_raft_append_success_at_millis.clone(),
+                last_kv_sync_success_at_millis.clone(),
             )
             .unwrap();
         Self {
@@ -266,6 +282,7 @@ impl TestWriters {
                 senders: writers.senders(),
             },
             writers,
+            last_raft_append_success_at_millis,
         }
     }
 
@@ -389,6 +406,11 @@ fn test_worker() {
     );
 
     must_have_same_count_msg(5, &t.msg_rx);
+    assert_ne!(
+        t.last_raft_append_success_at_millis.load(Ordering::Relaxed),
+        0
+    );
+    assert_ne!(t.last_kv_sync_success_at_millis.load(Ordering::Relaxed), 0);
 }
 
 #[test]
@@ -495,6 +517,10 @@ fn test_worker_split_raft_wb() {
                 ..Default::default()
             })
         );
+        assert_ne!(
+            t.last_raft_append_success_at_millis.load(Ordering::Relaxed),
+            0
+        );
     };
 
     let mut first_region = 1;
@@ -593,6 +619,10 @@ fn test_basic_flow() {
     );
 
     must_have_same_count_msg(6, &t.msg_rx);
+    assert_ne!(
+        t.last_raft_append_success_at_millis.load(Ordering::Relaxed),
+        0
+    );
     t.writers.shutdown();
 }
 

--- a/components/raftstore/src/store/config.rs
+++ b/components/raftstore/src/store/config.rs
@@ -22,6 +22,8 @@ use time::Duration as TimeDuration;
 use super::worker::{RaftStoreBatchComponent, RefreshConfigTask};
 use crate::{coprocessor::config::RAFTSTORE_V2_SPLIT_SIZE, Result};
 
+const DISK_HANG_TIMEOUT_MIN: ReadableDuration = ReadableDuration::secs(30);
+
 lazy_static! {
     pub static ref CONFIG_RAFTSTORE_GAUGE: prometheus::GaugeVec = register_gauge_vec!(
         "tikv_config_raftstore",
@@ -104,6 +106,13 @@ pub struct Config {
     pub raft_log_reserve_max_ticks: usize,
     // Old logs in Raft engine needs to be purged peridically.
     pub raft_engine_purge_interval: ReadableDuration,
+    /// If set, TiKV exits when a disk probe cannot complete for this long.
+    ///
+    /// This applies to both raft and kv disks (depending on whether they are
+    /// deployed on different mount points). The default is 1 minute. Set it
+    /// to `0s` to disable fail-fast disk hang detection explicitly. Any
+    /// non-zero value must be at least 30 seconds.
+    pub disk_hang_timeout: Option<ReadableDuration>,
     #[doc(hidden)]
     #[online_config(hidden)]
     pub max_manual_flush_rate: f64,
@@ -537,6 +546,7 @@ impl Default for Config {
             follower_read_max_log_gap: 100,
             raft_log_reserve_max_ticks: 6,
             raft_engine_purge_interval: ReadableDuration::secs(10),
+            disk_hang_timeout: Some(ReadableDuration::minutes(1)),
             max_manual_flush_rate: 3.0,
             raft_entry_cache_life_time: ReadableDuration::secs(30),
             raft_reject_transfer_leader_duration: ReadableDuration::secs(3),
@@ -864,6 +874,15 @@ impl Config {
 
         if self.merge_check_tick_interval.as_millis() == 0 {
             return Err(box_err!("raftstore.merge-check-tick-interval can't be 0."));
+        }
+
+        if let Some(timeout) = self.disk_hang_timeout {
+            if !timeout.is_zero() && timeout < DISK_HANG_TIMEOUT_MIN {
+                return Err(box_err!(
+                    "raftstore.disk-hang-timeout must be at least {} ms",
+                    DISK_HANG_TIMEOUT_MIN.as_millis()
+                ));
+            }
         }
 
         let stale_state_check = self.peer_stale_state_check_interval.as_millis();
@@ -1486,6 +1505,30 @@ mod tests {
         cfg.optimize_for(false);
         cfg.validate(split_size, false, ReadableSize(0), false)
             .unwrap_err();
+
+        cfg = Config::new();
+        cfg.disk_hang_timeout = Some(ReadableDuration::millis(999));
+        cfg.optimize_for(false);
+        cfg.validate(split_size, false, ReadableSize(0), false)
+            .unwrap_err();
+
+        cfg = Config::new();
+        cfg.disk_hang_timeout = Some(ReadableDuration::secs(0));
+        cfg.optimize_for(false);
+        cfg.validate(split_size, false, ReadableSize(0), false)
+            .unwrap();
+
+        cfg = Config::new();
+        cfg.disk_hang_timeout = Some(ReadableDuration::secs(29));
+        cfg.optimize_for(false);
+        cfg.validate(split_size, false, ReadableSize(0), false)
+            .unwrap_err();
+
+        cfg = Config::new();
+        cfg.disk_hang_timeout = Some(ReadableDuration::secs(30));
+        cfg.optimize_for(false);
+        cfg.validate(split_size, false, ReadableSize(0), false)
+            .unwrap();
 
         cfg = Config::new();
         cfg.raft_base_tick_interval = ReadableDuration::secs(1);

--- a/components/raftstore/src/store/disk_probe.rs
+++ b/components/raftstore/src/store/disk_probe.rs
@@ -1,0 +1,180 @@
+// Copyright 2026 TiKV Project Authors. Licensed under Apache-2.0.
+
+use std::{
+    fs::OpenOptions,
+    io::Write,
+    path::{Path, PathBuf},
+    sync::Arc,
+    time::Duration,
+};
+
+use parking_lot::Mutex;
+use tikv_util::time::Instant;
+
+/// A tiny disk probe that performs `write + sync` on a dedicated file.
+///
+/// It is intentionally minimal because it is used by multiple subsystems:
+/// - KV disk latency inspection (`disk_check`)
+/// - Raft disk hang fail-fast (`fail_fast`)
+///
+/// Note that this probe is intentionally *blocking*: if the underlying disk or
+/// filesystem is hung, `sync_all()` can block indefinitely. Upper layers rely
+/// on this behavior to detect "no forward progress" via an independent checker
+/// thread.
+pub(crate) fn write_sync_once(path: &Path, payload: &[u8]) -> std::io::Result<Duration> {
+    let start = Instant::now();
+    let mut file = OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .open(path)?;
+    file.write_all(payload)?;
+    file.sync_all()?;
+    Ok(start.saturating_elapsed())
+}
+
+#[derive(Debug)]
+struct ProbeState {
+    current_probe_started_at: Option<Instant>,
+    last_success_at: Option<Instant>,
+    failure_count_since_last_success: u64,
+}
+
+impl ProbeState {
+    fn new() -> Self {
+        Self {
+            current_probe_started_at: None,
+            last_success_at: None,
+            failure_count_since_last_success: 0,
+        }
+    }
+
+    fn mark_probe_start(&mut self) {
+        self.current_probe_started_at = Some(Instant::now());
+    }
+
+    fn try_start_probe(&mut self) -> bool {
+        if self.current_probe_started_at.is_some() {
+            return false;
+        }
+        self.mark_probe_start();
+        true
+    }
+
+    fn finish_probe_success(&mut self) {
+        self.current_probe_started_at = None;
+        self.last_success_at = Some(Instant::now());
+        self.failure_count_since_last_success = 0;
+    }
+
+    fn finish_probe_failure(&mut self) {
+        self.current_probe_started_at = None;
+        self.failure_count_since_last_success += 1;
+    }
+
+    // Tracks whether a probe is in flight and how long it has been blocked.
+    // This is the minimum state needed for hang detection.
+    fn current_probe_elapsed(&self) -> Option<Duration> {
+        self.current_probe_started_at
+            .map(|start| start.saturating_elapsed())
+    }
+
+    fn time_since_last_success(&self) -> Option<Duration> {
+        self.last_success_at.map(|t| t.saturating_elapsed())
+    }
+
+    fn failure_count_since_last_success(&self) -> u64 {
+        self.failure_count_since_last_success
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct ProbeRunner {
+    path: PathBuf,
+    payload: &'static [u8],
+    state: Arc<Mutex<ProbeState>>,
+}
+
+impl ProbeRunner {
+    pub(crate) fn new(path: PathBuf, payload: &'static [u8]) -> Self {
+        Self {
+            path,
+            payload,
+            state: Arc::new(Mutex::new(ProbeState::new())),
+        }
+    }
+
+    pub(crate) fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub(crate) fn probe_once(&self) -> std::io::Result<Duration> {
+        write_sync_once(self.path(), self.payload)
+    }
+
+    pub(crate) fn try_start_probe(&self) -> bool {
+        self.state.lock().try_start_probe()
+    }
+
+    pub(crate) fn finish_probe_success(&self) {
+        self.state.lock().finish_probe_success();
+    }
+
+    pub(crate) fn finish_probe_failure(&self) {
+        self.state.lock().finish_probe_failure();
+    }
+
+    pub(crate) fn current_probe_elapsed(&self) -> Option<Duration> {
+        self.state.lock().current_probe_elapsed()
+    }
+
+    pub(crate) fn time_since_last_success(&self) -> Option<Duration> {
+        self.state.lock().time_since_last_success()
+    }
+
+    pub(crate) fn failure_count_since_last_success(&self) -> u64 {
+        self.state.lock().failure_count_since_last_success()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::tempdir;
+
+    use super::*;
+
+    #[test]
+    fn test_probe_runner_probe_once() {
+        let dir = tempdir().unwrap();
+        let runner = ProbeRunner::new(dir.path().join("probe.tmp"), b"payload");
+
+        let duration = runner.probe_once().unwrap();
+        assert!(duration > Duration::ZERO);
+        assert!(runner.path().exists());
+    }
+
+    #[test]
+    fn test_probe_runner_state() {
+        let dir = tempdir().unwrap();
+        let runner = ProbeRunner::new(dir.path().join("probe.tmp"), b"payload");
+
+        assert!(runner.current_probe_elapsed().is_none());
+        assert!(runner.try_start_probe());
+        assert!(!runner.try_start_probe());
+        assert!(runner.current_probe_elapsed().is_some());
+        runner.finish_probe_failure();
+        assert!(runner.current_probe_elapsed().is_none());
+
+        assert!(runner.try_start_probe());
+        assert!(runner.current_probe_elapsed().is_some());
+        runner.finish_probe_success();
+        assert!(runner.current_probe_elapsed().is_none());
+        assert!(runner.time_since_last_success().is_some());
+        assert_eq!(runner.failure_count_since_last_success(), 0);
+
+        assert!(runner.try_start_probe());
+        runner.finish_probe_failure();
+        assert!(runner.time_since_last_success().is_some());
+        assert_eq!(runner.failure_count_since_last_success(), 1);
+    }
+}

--- a/components/raftstore/src/store/fail_fast.rs
+++ b/components/raftstore/src/store/fail_fast.rs
@@ -1,0 +1,529 @@
+// Copyright 2026 TiKV Project Authors. Licensed under Apache-2.0.
+
+use std::{
+    fs,
+    path::PathBuf,
+    sync::{
+        atomic::{AtomicBool, AtomicU64, Ordering},
+        mpsc::{channel, Receiver},
+        Arc, Mutex,
+    },
+    thread::JoinHandle,
+    time::Duration,
+};
+
+use health_controller::HealthController;
+use prometheus::{exponential_buckets, register_histogram_vec, HistogramVec};
+use tikv_util::{
+    config::VersionTrack,
+    crit, error, logger,
+    metrics::CRITICAL_ERROR,
+    sys::thread::StdThreadBuildWrapper,
+    time::{monotonic_raw_now, timespec_to_ns},
+    warn,
+    worker::Worker,
+};
+
+use super::Config;
+use crate::store::disk_probe::ProbeRunner;
+
+const PROBE_INTERVAL: Duration = Duration::from_secs(1);
+const FAIL_FAST_LOG_FLUSH_TIMEOUT: Duration = Duration::from_secs(2);
+const PROBE_THREAD_STOP_TIMEOUT: Duration = Duration::from_secs(2);
+const PROBE_PAYLOAD: &[u8] = b"tikv disk fail fast probe";
+
+#[derive(Clone, Copy)]
+enum DiskKind {
+    Raft,
+    Kv,
+}
+
+impl DiskKind {
+    fn name(self) -> &'static str {
+        match self {
+            Self::Raft => "raft",
+            Self::Kv => "kv",
+        }
+    }
+
+    fn probe_filename(self) -> &'static str {
+        match self {
+            Self::Raft => ".raft_disk_fail_fast_probe.tmp",
+            Self::Kv => ".kv_disk_fail_fast_probe.tmp",
+        }
+    }
+}
+
+const fn stuck_critical_error_kind(disk: DiskKind) -> &'static str {
+    match disk {
+        DiskKind::Raft => "disk_probe_stuck_raft",
+        DiskKind::Kv => "disk_probe_stuck_kv",
+    }
+}
+
+const fn fail_fast_critical_error_kind(disk: DiskKind) -> &'static str {
+    match disk {
+        DiskKind::Raft => "disk_probe_fail_fast_raft",
+        DiskKind::Kv => "disk_probe_fail_fast_kv",
+    }
+}
+
+lazy_static::lazy_static! {
+    pub static ref DISK_PROBE_DURATION_HISTOGRAM: HistogramVec = register_histogram_vec!(
+        "tikv_raftstore_disk_probe_duration_seconds",
+        "Bucketed histogram of fail-fast disk probe duration.",
+        &["disk", "outcome"],
+        exponential_buckets(0.00001, 2.0, 26).unwrap()
+    ).unwrap();
+}
+
+fn record_probe_duration(disk: &str, outcome: &str, duration: Duration) {
+    DISK_PROBE_DURATION_HISTOGRAM
+        .with_label_values(&[disk, outcome])
+        .observe(duration.as_secs_f64());
+}
+
+fn fail_fast_timeout(cfg: &Config) -> Option<Duration> {
+    // `0s` is treated as explicitly disabled.
+    cfg.disk_hang_timeout
+        .and_then(|timeout| (!timeout.0.is_zero()).then_some(timeout.0))
+}
+
+// Returns false when shutdown is requested.
+fn run_probe(stop: &AtomicBool, disk: DiskKind, probe: &ProbeRunner) -> bool {
+    let started = probe.try_start_probe();
+    debug_assert!(started, "fail-fast probe must not overlap");
+    if !started {
+        return true;
+    }
+
+    match probe.probe_once() {
+        Ok(duration) => {
+            probe.finish_probe_success();
+            if stop.load(Ordering::Acquire) {
+                return false;
+            }
+            record_probe_duration(disk.name(), "success", duration);
+        }
+        Err(e) => {
+            let duration = probe.current_probe_elapsed().unwrap_or_default();
+            probe.finish_probe_failure();
+            if stop.load(Ordering::Acquire) {
+                return false;
+            }
+            record_probe_duration(disk.name(), "failure", duration);
+            warn!(
+                "fail-fast probe failed";
+                "disk" => disk.name(),
+                "path" => %probe.path().display(),
+                "elapsed" => ?duration,
+                "err" => ?e,
+            );
+        }
+    }
+
+    true
+}
+
+fn spawn_probe_thread(
+    name: &'static str,
+    cfg: Arc<VersionTrack<Config>>,
+    stop: Arc<AtomicBool>,
+    raft_probe: ProbeRunner,
+    kv_probe: Option<ProbeRunner>,
+) -> std::io::Result<(JoinHandle<()>, Receiver<()>)> {
+    let (exit_tx, exit_rx) = channel();
+    // A single probe thread alternates raft -> kv.
+    let handle = std::thread::Builder::new()
+        .name(name.to_owned())
+        .spawn_wrapper(move || {
+            while !stop.load(Ordering::Acquire) {
+                // Avoid issuing background IO when fail-fast is disabled.
+                let Some(_) = fail_fast_timeout(&cfg.value()) else {
+                    std::thread::sleep(PROBE_INTERVAL);
+                    continue;
+                };
+
+                if !run_probe(&stop, DiskKind::Raft, &raft_probe) {
+                    return;
+                }
+                if let Some(kv_probe) = kv_probe.as_ref() {
+                    if !run_probe(&stop, DiskKind::Kv, kv_probe) {
+                        return;
+                    }
+                }
+
+                std::thread::sleep(PROBE_INTERVAL);
+            }
+            let _ = exit_tx.send(());
+        })?;
+    Ok((handle, exit_rx))
+}
+
+// Returns the fail-fast decision for one disk probe.
+//
+// The base rule comes from the probe itself:
+// 1. an in-flight `write + sync_all` probe reaches the timeout, or
+// 2. probes have kept failing for a full timeout window after a prior success.
+//
+// Recent successful sync-backed progress on the same disk vetoes that decision
+// to reduce false positives. In other words, if the direct probe looks bad but
+// real sync-backed work has still completed recently on that disk, TiKV treats
+// the disk as still making forward progress and does not fail fast yet.
+fn should_fail_fast(
+    probe: Option<&ProbeRunner>,
+    disk: DiskKind,
+    timeout: Duration,
+    last_sync_success_at_millis: &AtomicU64,
+) -> bool {
+    let Some(probe) = probe else {
+        return false;
+    };
+    let current_probe_elapsed = probe.current_probe_elapsed();
+    // Start surfacing the stuck signal halfway to the fail-fast timeout.
+    let stuck_log_threshold = timeout / 2;
+    if let Some(elapsed) = current_probe_elapsed {
+        if elapsed >= stuck_log_threshold {
+            CRITICAL_ERROR
+                .with_label_values(&[stuck_critical_error_kind(disk)])
+                .inc();
+            error!(
+                "fail-fast probe: disk still not responsive after elapsed";
+                "disk" => disk.name(),
+                "path" => %probe.path().display(),
+                "elapsed" => ?elapsed,
+            );
+        }
+    }
+
+    let last_sync_success_elapsed = last_sync_success_elapsed(last_sync_success_at_millis);
+    let base_signal = current_probe_elapsed.is_some_and(|elapsed| elapsed >= timeout)
+        || should_fail_fast_on_repeated_failures(probe, timeout);
+    if !base_signal {
+        return false;
+    }
+
+    let vetoed_by_recent_progress =
+        last_sync_success_elapsed.is_some_and(|elapsed| elapsed < timeout);
+    if vetoed_by_recent_progress {
+        warn!(
+            "fail-fast vetoed by recent sync-backed progress";
+            "disk" => disk.name(),
+            "timeout" => ?timeout,
+            "current_probe_elapsed" => ?current_probe_elapsed,
+            "last_sync_success_elapsed" => ?last_sync_success_elapsed,
+        );
+        return false;
+    }
+
+    CRITICAL_ERROR
+        .with_label_values(&[fail_fast_critical_error_kind(disk)])
+        .inc();
+    crit!(
+        "fail-fast: disk probe timed out, shutting down to avoid serving on an unhealthy disk";
+        "disk" => disk.name(),
+        "timeout" => ?timeout,
+        "current_probe_elapsed" => ?current_probe_elapsed,
+        "last_sync_success_elapsed" => ?last_sync_success_elapsed,
+    );
+    true
+}
+
+/// Detects one class of TiKV "zombie" failure and chooses to hard-exit.
+///
+/// The target failure mode here is: the process is still alive and may still
+/// hold Raft leadership, but it is no longer truly serviceable because disk IO
+/// on the critical path has stopped making progress. In that state, staying
+/// alive can prolong unavailability and hide the failure from orchestration.
+///
+/// The monitor has two parts:
+/// 1. One dedicated probe thread periodically runs blocking `write + sync_all`
+///    probes, alternating raft -> kv when both disks are configured.
+/// 2. A separate checker worker periodically inspects the probe state, so a
+///    hung blocking probe cannot prevent fail-fast from being triggered.
+///
+/// The checker applies that same rule directly. Raft may veto a probe timeout
+/// if real raft-log appends have still succeeded recently, and kv may veto a
+/// probe timeout if a real kv WAL sync has still succeeded recently.
+///
+/// Once any disk meets the fail-fast rule, TiKV emits the final error, gives
+/// the async logger a brief best-effort flush window, and then panics so the
+/// panic hook can emit the fatal crash log before the process dies. The scope
+/// is intentionally narrow today: disk hang is the first zombie-failure
+/// scenario covered by this monitor.
+pub struct FailFastMonitor {
+    stop: Arc<AtomicBool>,
+    raft_probe: ProbeRunner,
+    kv_probe: Option<ProbeRunner>,
+    probe_thread_handle: Mutex<Option<JoinHandle<()>>>,
+    probe_thread_exit_rx: Mutex<Option<Receiver<()>>>,
+}
+
+impl FailFastMonitor {
+    pub fn new(
+        cfg: Arc<VersionTrack<Config>>,
+        _health_controller: HealthController,
+        raft_probe_dir: PathBuf,
+        kv_probe_dir: Option<PathBuf>,
+        check_worker: Worker,
+        last_raft_append_success_at_millis: Arc<AtomicU64>,
+        last_kv_sync_success_at_millis: Arc<AtomicU64>,
+    ) -> std::io::Result<Self> {
+        let stop = Arc::new(AtomicBool::new(false));
+        let raft_probe = ProbeRunner::new(
+            raft_probe_dir.join(DiskKind::Raft.probe_filename()),
+            PROBE_PAYLOAD,
+        );
+        let kv_probe = kv_probe_dir
+            .map(|dir| ProbeRunner::new(dir.join(DiskKind::Kv.probe_filename()), PROBE_PAYLOAD));
+
+        let (probe_thread_handle, probe_thread_exit_rx) = spawn_probe_thread(
+            "fail-fast-probe",
+            cfg.clone(),
+            stop.clone(),
+            raft_probe.clone(),
+            kv_probe.clone(),
+        )?;
+
+        let stop_for_check = stop.clone();
+        let raft_probe_for_check = raft_probe.clone();
+        let kv_probe_for_check = kv_probe.clone();
+        check_worker.spawn_interval_task(PROBE_INTERVAL, move || {
+            if stop_for_check.load(Ordering::Acquire) {
+                return;
+            }
+
+            let Some(timeout) = fail_fast_timeout(&cfg.value()) else {
+                return;
+            };
+
+            let raft_should_fail_fast = should_fail_fast(
+                Some(&raft_probe_for_check),
+                DiskKind::Raft,
+                timeout,
+                &last_raft_append_success_at_millis,
+            );
+            let kv_should_fail_fast = should_fail_fast(
+                kv_probe_for_check.as_ref(),
+                DiskKind::Kv,
+                timeout,
+                &last_kv_sync_success_at_millis,
+            );
+            if raft_should_fail_fast || kv_should_fail_fast {
+                logger::panic_after_best_effort_flush(
+                    FAIL_FAST_LOG_FLUSH_TIMEOUT,
+                    "fail-fast: TiKV self-killed due to disk unavailability",
+                );
+            }
+        });
+
+        Ok(Self {
+            stop,
+            raft_probe,
+            kv_probe,
+            probe_thread_handle: Mutex::new(Some(probe_thread_handle)),
+            probe_thread_exit_rx: Mutex::new(Some(probe_thread_exit_rx)),
+        })
+    }
+
+    pub fn stop(&self) {
+        self.stop.store(true, Ordering::Release);
+        self.try_join_probe_thread();
+        self.cleanup_probe_file();
+    }
+
+    fn try_join_probe_thread(&self) {
+        let Some(exit_rx) = self.probe_thread_exit_rx.lock().unwrap().take() else {
+            return;
+        };
+        let Some(probe_thread_handle) = self.probe_thread_handle.lock().unwrap().take() else {
+            return;
+        };
+        if exit_rx.recv_timeout(PROBE_THREAD_STOP_TIMEOUT).is_ok() {
+            if let Err(e) = probe_thread_handle.join() {
+                warn!("fail-fast probe thread panicked during shutdown"; "err" => ?e);
+            }
+        }
+    }
+
+    fn cleanup_probe_file(&self) {
+        let kv_path = self.kv_probe.as_ref().map(ProbeRunner::path);
+        for path in std::iter::once(self.raft_probe.path()).chain(kv_path.into_iter()) {
+            if let Err(e) = fs::remove_file(path) {
+                if e.kind() != std::io::ErrorKind::NotFound {
+                    warn!("failed to remove fail-fast probe file"; "err" => ?e, "path" => %path.display());
+                }
+            }
+        }
+    }
+}
+
+// This catches the "not one forever-stuck probe, but no successful probe for a
+// full timeout window" case. We only arm it after a prior success so obvious
+// startup/configuration mistakes do not immediately turn into fail-fast exits.
+fn should_fail_fast_on_repeated_failures(probe: &ProbeRunner, timeout: Duration) -> bool {
+    probe.current_probe_elapsed().is_none()
+        && probe.failure_count_since_last_success() > 0
+        && probe
+            .time_since_last_success()
+            .is_some_and(|elapsed| elapsed >= timeout)
+}
+
+// Returns how long it has been since the last successful sync-backed progress
+// signal on a disk, using the same monotonic raw clock as the producer side.
+fn last_sync_success_elapsed(last_sync_success_at_millis: &AtomicU64) -> Option<Duration> {
+    let last = last_sync_success_at_millis.load(Ordering::Relaxed);
+    if last == 0 {
+        return None;
+    }
+    let now = timespec_to_ns(monotonic_raw_now()) / 1_000_000;
+    Some(Duration::from_millis(now.saturating_sub(last)))
+}
+
+impl Drop for FailFastMonitor {
+    fn drop(&mut self) {
+        self.cleanup_probe_file();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::tempdir;
+
+    use super::*;
+
+    #[test]
+    fn test_probe_once() {
+        let dir = tempdir().unwrap();
+        let raft_probe = ProbeRunner::new(
+            dir.path().join(DiskKind::Raft.probe_filename()),
+            PROBE_PAYLOAD,
+        );
+        let duration = raft_probe.probe_once().unwrap();
+        assert!(duration > Duration::ZERO);
+        assert!(raft_probe.path().exists());
+
+        let kv_probe = ProbeRunner::new(
+            dir.path().join(DiskKind::Kv.probe_filename()),
+            PROBE_PAYLOAD,
+        );
+        let duration = kv_probe.probe_once().unwrap();
+        assert!(duration > Duration::ZERO);
+        assert!(kv_probe.path().exists());
+    }
+
+    #[test]
+    fn test_fail_fast_timeout_none_disables() {
+        let mut cfg = Config::default();
+        cfg.disk_hang_timeout = None;
+        assert_eq!(fail_fast_timeout(&cfg), None);
+    }
+
+    #[test]
+    fn test_should_fail_fast_on_timeout() {
+        let dir = tempdir().unwrap();
+        let probe = ProbeRunner::new(
+            dir.path().join(DiskKind::Raft.probe_filename()),
+            PROBE_PAYLOAD,
+        );
+        let timeout = Duration::from_millis(10);
+
+        assert!(probe.try_start_probe());
+        std::thread::sleep(timeout + Duration::from_millis(5));
+        assert!(should_fail_fast(
+            Some(&probe),
+            DiskKind::Raft,
+            timeout,
+            &AtomicU64::new(0),
+        ));
+    }
+
+    #[test]
+    fn test_should_fail_fast_on_repeated_failures_after_prior_success() {
+        let dir = tempdir().unwrap();
+        let probe = ProbeRunner::new(
+            dir.path().join(DiskKind::Raft.probe_filename()),
+            PROBE_PAYLOAD,
+        );
+        let timeout = Duration::from_millis(10);
+
+        assert!(!should_fail_fast_on_repeated_failures(&probe, timeout));
+        probe.finish_probe_success();
+        assert!(probe.try_start_probe());
+        probe.finish_probe_failure();
+        std::thread::sleep(timeout + Duration::from_millis(5));
+        assert!(should_fail_fast_on_repeated_failures(&probe, timeout));
+    }
+
+    #[test]
+    fn test_should_fail_fast_repeated_failures_respect_raft_progress_veto() {
+        let dir = tempdir().unwrap();
+        let probe = ProbeRunner::new(
+            dir.path().join(DiskKind::Raft.probe_filename()),
+            PROBE_PAYLOAD,
+        );
+        let timeout = Duration::from_millis(10);
+
+        probe.finish_probe_success();
+        assert!(probe.try_start_probe());
+        probe.finish_probe_failure();
+        std::thread::sleep(timeout + Duration::from_millis(5));
+
+        assert!(!should_fail_fast(
+            Some(&probe),
+            DiskKind::Raft,
+            timeout,
+            &AtomicU64::new(timespec_to_ns(monotonic_raw_now()) / 1_000_000),
+        ));
+        assert!(should_fail_fast(
+            Some(&probe),
+            DiskKind::Raft,
+            timeout,
+            &AtomicU64::new(
+                (timespec_to_ns(monotonic_raw_now()) / 1_000_000)
+                    .saturating_sub(timeout.as_millis() as u64 + 1)
+            ),
+        ));
+        assert!(should_fail_fast(
+            Some(&probe),
+            DiskKind::Raft,
+            timeout,
+            &AtomicU64::new(0),
+        ));
+    }
+
+    #[test]
+    fn test_should_fail_fast_respects_kv_sync_veto() {
+        let dir = tempdir().unwrap();
+        let kv_probe = ProbeRunner::new(
+            dir.path().join(DiskKind::Kv.probe_filename()),
+            PROBE_PAYLOAD,
+        );
+        let timeout = Duration::from_millis(10);
+
+        assert!(kv_probe.try_start_probe());
+        std::thread::sleep(timeout + Duration::from_millis(5));
+
+        assert!(!should_fail_fast(
+            Some(&kv_probe),
+            DiskKind::Kv,
+            timeout,
+            &AtomicU64::new(timespec_to_ns(monotonic_raw_now()) / 1_000_000),
+        ));
+        assert!(should_fail_fast(
+            Some(&kv_probe),
+            DiskKind::Kv,
+            timeout,
+            &AtomicU64::new(
+                (timespec_to_ns(monotonic_raw_now()) / 1_000_000)
+                    .saturating_sub(timeout.as_millis() as u64 + 1)
+            ),
+        ));
+        assert!(should_fail_fast(
+            Some(&kv_probe),
+            DiskKind::Kv,
+            timeout,
+            &AtomicU64::new(0),
+        ));
+    }
+}

--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -64,7 +64,7 @@ use tikv_util::{
     mpsc::{loose_bounded, LooseBoundedSender, Receiver},
     safe_panic, slow_log,
     store::{find_peer, find_peer_by_id, find_peer_mut, is_learner, remove_peer},
-    time::{duration_to_sec, Instant},
+    time::{duration_to_sec, monotonic_raw_now, timespec_to_ns, Instant},
     warn,
     worker::Scheduler,
     Either, MustConsumeVec,
@@ -473,6 +473,10 @@ where
     uncommitted_res_count: usize,
 
     enable_v2_compatible_learner: bool,
+    // Records the most recent successful kv write that actually requested
+    // sync=true, so fail-fast can treat recent real kv WAL sync progress as a
+    // veto on the kv probe timeout signal.
+    last_kv_sync_success_at_millis: Arc<AtomicU64>,
 }
 
 impl<EK> ApplyContext<EK>
@@ -491,6 +495,7 @@ where
         store_id: u64,
         pending_create_peers: Arc<Mutex<HashMap<u64, (u64, bool)>>>,
         priority: Priority,
+        last_kv_sync_success_at_millis: Arc<AtomicU64>,
     ) -> ApplyContext<EK> {
         let kv_wb = engine.write_batch_with_cap(DEFAULT_APPLY_WB_SIZE);
         let kv_wb = host.on_create_apply_write_batch(kv_wb);
@@ -534,6 +539,7 @@ where
             disable_wal: false,
             uncommitted_res_count: 0,
             enable_v2_compatible_learner: cfg.enable_v2_compatible_learner,
+            last_kv_sync_success_at_millis,
         }
     }
 
@@ -606,6 +612,15 @@ where
             let seq = self.kv_wb_mut().write_opt(&write_opts).unwrap_or_else(|e| {
                 panic!("failed to write to engine: {:?}", e);
             });
+            if need_sync {
+                // Only sync-backed kv writes count here. Plain kv write success
+                // can still be page-cache progress, which is too weak to veto
+                // a kv probe timeout.
+                self.last_kv_sync_success_at_millis.fetch_max(
+                    timespec_to_ns(monotonic_raw_now()) / 1_000_000,
+                    Ordering::Relaxed,
+                );
+            }
             if let Some(seqno) = seqno.as_mut() {
                 seqno.post_write(seq)
             }
@@ -4815,6 +4830,7 @@ pub struct Builder<EK: KvEngine> {
     router: ApplyRouter<EK>,
     store_id: u64,
     pending_create_peers: Arc<Mutex<HashMap<u64, (u64, bool)>>>,
+    last_kv_sync_success_at_millis: Arc<AtomicU64>,
 }
 
 impl<EK: KvEngine> Builder<EK> {
@@ -4834,6 +4850,7 @@ impl<EK: KvEngine> Builder<EK> {
             router,
             store_id: builder.store.get_id(),
             pending_create_peers: builder.pending_create_peers.clone(),
+            last_kv_sync_success_at_millis: builder.last_kv_sync_success_at_millis.clone(),
         }
     }
 }
@@ -4860,6 +4877,7 @@ where
                 self.store_id,
                 self.pending_create_peers.clone(),
                 priority,
+                self.last_kv_sync_success_at_millis.clone(),
             ),
             messages_per_tick: cfg.messages_per_tick,
             cfg_tracker: self.cfg.clone().tracker(self.tag.clone()),
@@ -4884,6 +4902,7 @@ where
             router: self.router.clone(),
             store_id: self.store_id,
             pending_create_peers: self.pending_create_peers.clone(),
+            last_kv_sync_success_at_millis: self.last_kv_sync_success_at_millis.clone(),
         }
     }
 }
@@ -5541,6 +5560,7 @@ mod tests {
             router: router.clone(),
             store_id: 1,
             pending_create_peers,
+            last_kv_sync_success_at_millis: Arc::new(AtomicU64::new(0)),
         };
         system.spawn("test-basic".to_owned(), builder);
 
@@ -6111,6 +6131,7 @@ mod tests {
             router: router.clone(),
             store_id: 1,
             pending_create_peers,
+            last_kv_sync_success_at_millis: Arc::new(AtomicU64::new(0)),
         };
         system.spawn("test-handle-raft".to_owned(), builder);
 
@@ -6452,6 +6473,7 @@ mod tests {
             router: router.clone(),
             store_id: 1,
             pending_create_peers,
+            last_kv_sync_success_at_millis: Arc::new(AtomicU64::new(0)),
         };
         system.spawn("test-handle-raft".to_owned(), builder);
 
@@ -6795,6 +6817,7 @@ mod tests {
             router: router.clone(),
             store_id: 1,
             pending_create_peers,
+            last_kv_sync_success_at_millis: Arc::new(AtomicU64::new(0)),
         };
         system.spawn("test-handle-raft".to_owned(), builder);
 
@@ -6886,6 +6909,7 @@ mod tests {
             router: router.clone(),
             store_id: 1,
             pending_create_peers,
+            last_kv_sync_success_at_millis: Arc::new(AtomicU64::new(0)),
         };
         system.spawn("test-ingest".to_owned(), builder);
 
@@ -7069,6 +7093,7 @@ mod tests {
             router: router.clone(),
             store_id: 1,
             pending_create_peers,
+            last_kv_sync_success_at_millis: Arc::new(AtomicU64::new(0)),
         };
         system.spawn("test-bucket".to_owned(), builder);
 
@@ -7162,6 +7187,7 @@ mod tests {
             router: router.clone(),
             store_id: 1,
             pending_create_peers,
+            last_kv_sync_success_at_millis: Arc::new(AtomicU64::new(0)),
         };
         system.spawn("test-exec-observer".to_owned(), builder);
 
@@ -7387,6 +7413,7 @@ mod tests {
             router: router.clone(),
             store_id: 1,
             pending_create_peers,
+            last_kv_sync_success_at_millis: Arc::new(AtomicU64::new(0)),
         };
         system.spawn("test-handle-raft".to_owned(), builder);
 
@@ -7667,6 +7694,7 @@ mod tests {
             router: router.clone(),
             store_id: 2,
             pending_create_peers,
+            last_kv_sync_success_at_millis: Arc::new(AtomicU64::new(0)),
         };
         system.spawn("test-split".to_owned(), builder);
 
@@ -7887,6 +7915,7 @@ mod tests {
             router: router.clone(),
             store_id: 2,
             pending_create_peers,
+            last_kv_sync_success_at_millis: Arc::new(AtomicU64::new(0)),
         };
         system.spawn("test-conf-change".to_owned(), builder);
 
@@ -8012,6 +8041,7 @@ mod tests {
             router: router.clone(),
             store_id: 1,
             pending_create_peers,
+            last_kv_sync_success_at_millis: Arc::new(AtomicU64::new(0)),
         };
         system.spawn("flashback_need_to_be_applied".to_owned(), builder);
 

--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -74,7 +74,7 @@ use tikv_util::{
     warn,
     worker::{Builder as WorkerBuilder, LazyWorker, Scheduler, Worker},
     yatp_pool::FuturePool,
-    Either, RingQueue,
+    Either, RingQueue, GLOBAL_SERVER_READINESS,
 };
 use time::{self, Timespec};
 
@@ -2876,13 +2876,26 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> StoreFsmDelegate<'a, EK, ER
             busy_apply_peers_count,
             completed_apply_peers_count,
         );
-        // If the store already pass the check, it should clear the
-        // `completed_apply_peers_count` to skip the check next time.
-        if !busy_on_apply && completed_apply_peers_count.is_some() {
-            let mut meta = self.ctx.store_meta.lock().unwrap();
-            meta.completed_apply_peers_count = None;
-            meta.busy_apply_peers.clear();
+
+        if !busy_on_apply {
+            // If the store already passes the check, it should clear the
+            // `completed_apply_peers_count` to skip the check next time.
+            if completed_apply_peers_count.is_some() {
+                let mut meta = self.ctx.store_meta.lock().unwrap();
+                meta.completed_apply_peers_count = None;
+                meta.busy_apply_peers.clear();
+            }
+
+            if GLOBAL_SERVER_READINESS
+                .raft_peers_caught_up
+                .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed)
+                .is_ok()
+            {
+                // Log when the server readiness condition changes.
+                info!("ServerReadiness: Raft pending peers have caught up applying logs");
+            }
         }
+
         let store_is_busy = self
             .ctx
             .global_stat

--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -10,6 +10,7 @@ use std::{
     },
     mem,
     ops::{Deref, DerefMut},
+    path::PathBuf,
     sync::{
         atomic::{AtomicBool, AtomicU64, Ordering},
         Arc, Mutex,
@@ -1296,6 +1297,10 @@ pub struct RaftPollerBuilder<EK: KvEngine, ER: RaftEngine, T> {
     write_senders: WriteSenders<EK, ER>,
     node_start_time: Timespec, // monotonic_raw_now
     gc_safe_point: Arc<AtomicU64>,
+    // These timestamps feed fail-fast's recent real disk-progress vetoes for
+    // raft and kv respectively.
+    pub(crate) last_raft_append_success_at_millis: Arc<AtomicU64>,
+    pub(crate) last_kv_sync_success_at_millis: Arc<AtomicU64>,
 }
 
 impl<EK: KvEngine, ER: RaftEngine, T> RaftPollerBuilder<EK, ER, T> {
@@ -1502,6 +1507,8 @@ where
                 self.router.clone(),
                 self.trans.clone(),
                 &self.cfg,
+                self.last_raft_append_success_at_millis.clone(),
+                self.last_kv_sync_success_at_millis.clone(),
             ))
         } else {
             None
@@ -1616,6 +1623,8 @@ where
             write_senders: self.write_senders.clone(),
             node_start_time: self.node_start_time,
             gc_safe_point: self.gc_safe_point.clone(),
+            last_raft_append_success_at_millis: self.last_raft_append_success_at_millis.clone(),
+            last_kv_sync_success_at_millis: self.last_kv_sync_success_at_millis.clone(),
         }
     }
 }
@@ -1623,6 +1632,7 @@ where
 struct Workers<EK: KvEngine> {
     pd_worker: LazyWorker<PdTask<EK>>,
     background_worker: Worker,
+    fail_fast_check_worker: Worker,
 
     // Both of cleanup tasks and region tasks get their own workers, instead of reusing
     // background_workers. This is because the underlying compact_range call is a
@@ -1733,6 +1743,8 @@ impl<EK: KvEngine, ER: RaftEngine> RaftBatchSystem<EK, ER> {
             None
         };
         let bgworker_remote = background_worker.remote();
+        let last_raft_append_success_at_millis = Arc::new(AtomicU64::new(0));
+        let last_kv_sync_success_at_millis = Arc::new(AtomicU64::new(0));
         let snap_gen_worker = WorkerBuilder::new("snap-generator")
             .thread_count(cfg.value().snap_generator_pool_size)
             .thread_count_limits(1, SNAP_GENERATOR_MAX_POOL_SIZE)
@@ -1740,6 +1752,9 @@ impl<EK: KvEngine, ER: RaftEngine> RaftBatchSystem<EK, ER> {
         let mut workers = Workers {
             pd_worker,
             background_worker,
+            fail_fast_check_worker: WorkerBuilder::new("fail-fast-check")
+                .thread_count(1)
+                .create(),
             cleanup_worker: Worker::new("cleanup-worker"),
             snap_gen_worker,
             region_worker: Worker::new("region-worker"),
@@ -1838,6 +1853,21 @@ impl<EK: KvEngine, ER: RaftEngine> RaftBatchSystem<EK, ER> {
             .background_worker
             .start("disk-check-worker", disk_check_runner);
 
+        let separated_raft_mount_path =
+            sys_util::path_in_diff_mount_point(engines.kv.path(), engines.raft.get_engine_path());
+        let fail_fast_monitor = crate::store::FailFastMonitor::new(
+            cfg.clone(),
+            health_controller.clone(),
+            PathBuf::from(engines.raft.get_engine_path()),
+            separated_raft_mount_path.then(|| PathBuf::from(engines.kv.path())),
+            workers.fail_fast_check_worker.clone(),
+            last_raft_append_success_at_millis.clone(),
+            last_kv_sync_success_at_millis.clone(),
+        )?;
+        workers.on_stop_hooks.push(Box::new(move || {
+            fail_fast_monitor.stop();
+        }));
+
         self.store_writers.spawn(
             meta.get_id(),
             engines.raft.clone(),
@@ -1845,6 +1875,8 @@ impl<EK: KvEngine, ER: RaftEngine> RaftBatchSystem<EK, ER> {
             &self.router,
             &trans,
             &cfg,
+            last_raft_append_success_at_millis.clone(),
+            last_kv_sync_success_at_millis.clone(),
         )?;
 
         let mut builder = RaftPollerBuilder {
@@ -1872,6 +1904,8 @@ impl<EK: KvEngine, ER: RaftEngine> RaftBatchSystem<EK, ER> {
             pending_create_peers: Arc::new(Mutex::new(HashMap::default())),
             feature_gate: pd_client.feature_gate().clone(),
             write_senders: self.store_writers.senders(),
+            last_raft_append_success_at_millis,
+            last_kv_sync_success_at_millis,
             node_start_time: self.node_start_time,
             gc_safe_point,
         };
@@ -1973,6 +2007,10 @@ impl<EK: KvEngine, ER: RaftEngine> RaftBatchSystem<EK, ER> {
                 kv_engine: Some(raft_builder.engines.kv.clone()),
                 transfer: raft_builder.trans.clone(),
                 cfg: raft_builder.cfg.clone(),
+                last_raft_append_success_at_millis: raft_builder
+                    .last_raft_append_success_at_millis
+                    .clone(),
+                last_kv_sync_success_at_millis: raft_builder.last_kv_sync_success_at_millis.clone(),
             },
             self.store_writers.clone(),
             self.apply_router.router.clone(),
@@ -2035,6 +2073,7 @@ impl<EK: KvEngine, ER: RaftEngine> RaftBatchSystem<EK, ER> {
         workers.cleanup_worker.stop();
         workers.region_worker.stop();
         workers.background_worker.stop();
+        workers.fail_fast_check_worker.stop();
         if let Some(w) = workers.purge_worker {
             w.stop();
         }

--- a/components/raftstore/src/store/metrics.rs
+++ b/components/raftstore/src/store/metrics.rs
@@ -348,6 +348,17 @@ make_static_metric! {
         },
     }
 
+    pub struct StoreCpuPoolGaugeVec: IntGauge {
+        "pool" => {
+            unified_read,
+            scheduler,
+        },
+        "source" => {
+            store_level,
+            region_sum,
+        },
+    }
+
     pub struct SnapshotGenerateBytesTypeVec: IntCounter {
         "type" => SnapshotGenerateBytesType,
     }
@@ -1042,4 +1053,11 @@ lazy_static! {
             "Is raft process busy or not",
             &["type"]
         ).unwrap();
+
+    pub static ref STORE_CPU_POOL_GAUGE_VEC: StoreCpuPoolGaugeVec = register_static_int_gauge_vec!(
+        StoreCpuPoolGaugeVec,
+        "tikv_raftstore_cpu_pool_usage",
+        "CPU usage comparison between store-level (ThreadInfoStatistics) and region-level sum (resource metering) per thread pool.",
+        &["pool", "source"]
+    ).unwrap();
 }

--- a/components/raftstore/src/store/mod.rs
+++ b/components/raftstore/src/store/mod.rs
@@ -19,6 +19,8 @@ pub mod util;
 mod async_io;
 mod bootstrap;
 mod compaction_guard;
+mod disk_probe;
+mod fail_fast;
 mod hibernate_state;
 mod peer_storage;
 mod region_snapshot;
@@ -47,6 +49,7 @@ pub use self::{
     compaction_guard::{CompactionGuardGeneratorFactory, ForcePartitionRangeManager},
     config::Config,
     entry_storage::{EntryStorage, RaftlogFetchResult, MAX_INIT_ENTRY_COUNT},
+    fail_fast::FailFastMonitor,
     fsm::{check_sst_for_ingestion, DestroyPeerJob, RaftRouter},
     hibernate_state::{GroupState, HibernateState},
     memory::*,

--- a/components/raftstore/src/store/worker/disk_check.rs
+++ b/components/raftstore/src/store/worker/disk_check.rs
@@ -2,7 +2,6 @@
 
 use std::{
     fmt::{self, Display, Formatter},
-    io::Write,
     path::PathBuf,
     time::Duration,
 };
@@ -10,10 +9,11 @@ use std::{
 use crossbeam::channel::{bounded, Receiver, Sender};
 use health_controller::types::LatencyInspector;
 use tikv_util::{
-    time::Instant,
     warn,
     worker::{Runnable, Worker},
 };
+
+use crate::store::disk_probe::ProbeRunner;
 
 #[derive(Debug)]
 pub enum Task {
@@ -36,7 +36,7 @@ impl Display for Task {
 /// The inspector writes a file to the disk and measures the time it takes to
 /// complete the write operation.
 pub struct Runner {
-    target: PathBuf,
+    probe: ProbeRunner,
     notifier: Sender<Task>,
     receiver: Receiver<Task>,
     bg_worker: Option<Worker>,
@@ -56,7 +56,7 @@ impl Runner {
         // `capacity` for the disk check worker.
         let (notifier, receiver) = bounded(3);
         Self {
-            target,
+            probe: ProbeRunner::new(target, Self::DISK_IO_LATENCY_INSPECT_FLUSH_STR),
             notifier,
             receiver,
             bg_worker: None,
@@ -81,19 +81,7 @@ impl Runner {
     }
 
     fn inspect(&self) -> Option<Duration> {
-        let mut file = std::fs::OpenOptions::new()
-            .create(true)
-            .write(true)
-            .truncate(true)
-            .open(&self.target)
-            .ok()?;
-
-        let start = Instant::now();
-        // Ignore the error
-        file.write_all(Self::DISK_IO_LATENCY_INSPECT_FLUSH_STR)
-            .ok()?;
-        file.sync_all().ok()?;
-        Some(start.saturating_elapsed())
+        self.probe.probe_once().ok()
     }
 
     fn execute(&self) {
@@ -126,6 +114,14 @@ impl Runnable for Runner {
                     runner.execute();
                 });
             }
+        }
+    }
+}
+
+impl Drop for Runner {
+    fn drop(&mut self) {
+        if let Err(e) = std::fs::remove_file(self.probe.path()) {
+            warn!("remove disk latency inspector file failed"; "err" => ?e);
         }
     }
 }

--- a/components/raftstore/src/store/worker/pd.rs
+++ b/components/raftstore/src/store/worker/pd.rs
@@ -50,6 +50,7 @@ use tikv_util::{
     topn::TopN,
     warn,
     worker::{Runnable, ScheduleError, Scheduler},
+    GLOBAL_SERVER_READINESS,
 };
 use yatp::Remote;
 
@@ -1390,6 +1391,15 @@ where
         let f = async move {
             match resp.await {
                 Ok(mut resp) => {
+                    if GLOBAL_SERVER_READINESS
+                        .connected_to_pd
+                        .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed)
+                        .is_ok()
+                    {
+                        // Log when the server readiness condition changes.
+                        info!("ServerReadiness: connected to PD");
+                    }
+
                     if let Some(status) = resp.replication_status.take() {
                         let _ = router.send_control(StoreMsg::UpdateReplicationMode(status));
                     }

--- a/components/raftstore/src/store/worker/pd.rs
+++ b/components/raftstore/src/store/worker/pd.rs
@@ -37,13 +37,20 @@ use kvproto::{
 use pd_client::{metrics::*, BucketStat, Error, PdClient, RegionStat, RegionWriteCfCopDetail};
 use prometheus::local::LocalHistogram;
 use raft::eraftpb::ConfChangeType;
-use resource_metering::{Collector, CollectorGuard, CollectorRegHandle, RawRecords};
+use resource_metering::{
+    Collector, CollectorGuard, CollectorRegHandle, RawRecords, RegionCpuRecord,
+};
 use service::service_manager::GrpcServiceManager;
 use tikv_util::{
     box_err, debug, error, info,
+    logger::{get_log_level, Level},
     metrics::ThreadInfoStatistics,
     store::QueryStats,
-    sys::{disk, thread::StdThreadBuildWrapper, SysQuota},
+    sys::{
+        disk,
+        thread::{matches_thread_name_prefix, StdThreadBuildWrapper},
+        SysQuota,
+    },
     thd_name,
     time::{Instant as TiInstant, UnixSecs},
     timer::GLOBAL_TIMER_HANDLE,
@@ -904,8 +911,20 @@ const HOTSPOT_KEY_RATE_THRESHOLD: u64 = 128;
 const HOTSPOT_QUERY_RATE_THRESHOLD: u64 = 128;
 const HOTSPOT_BYTE_RATE_THRESHOLD: u64 = 8 * 1024;
 const HOTSPOT_REPORT_CAPACITY: usize = 1000;
+const HOTSPOT_REPORT_METRICS: usize = 5;
+const UNIFIED_READ_POOL_THREAD: &str = "unified-read";
+// Keep scheduler matching broad for CPU attribution. It matches release-8.5's
+// `sched-worker-*` and master's `sched-*`.
+const SCHEDULER_THREAD_PREFIX: &str = "sched";
 
 // TODO: support dynamic configure threshold in future.
+fn hotspot_cpu_usage_report_threshold() -> u64 {
+    const HOTSPOT_CPU_USAGE_THRESHOLD: u64 = 1;
+    fail_point!("mock_hotspot_threshold", |_| { 0 });
+
+    HOTSPOT_CPU_USAGE_THRESHOLD
+}
+
 fn hotspot_key_report_threshold() -> u64 {
     fail_point!("mock_hotspot_threshold", |_| { 0 });
 
@@ -924,8 +943,208 @@ fn hotspot_query_num_report_threshold() -> u64 {
     HOTSPOT_QUERY_RATE_THRESHOLD * 10
 }
 
+#[inline]
+fn should_report_hotspot_read_peer(
+    read_bytes: u64,
+    read_keys: u64,
+    query_stats: &QueryStats,
+    cpu_usage: u64,
+) -> bool {
+    !(read_bytes < hotspot_byte_report_threshold()
+        && read_keys < hotspot_key_report_threshold()
+        && query_stats.get_read_query_num() < hotspot_query_num_report_threshold()
+        && cpu_usage < hotspot_cpu_usage_report_threshold())
+}
+
+#[derive(Default)]
+struct RegionCpuUsage {
+    unified_read_cpu_usage: u64,
+    scheduler_cpu_usage: u64,
+}
+
+fn cpu_usage_from_millis(cpu_time_ms: u64, interval_seconds: u64) -> u64 {
+    if interval_seconds == 0 {
+        return 0;
+    }
+    ((Duration::from_millis(cpu_time_ms).as_secs_f64() * 100.0) / interval_seconds as f64) as u64
+}
+
+fn calculate_region_cpu_usage(
+    cpu_record: RegionCpuRecord,
+    interval_seconds: u64,
+) -> RegionCpuUsage {
+    RegionCpuUsage {
+        unified_read_cpu_usage: cpu_usage_from_millis(
+            cpu_record.unified_read_cpu_time_ms as u64,
+            interval_seconds,
+        ),
+        scheduler_cpu_usage: cpu_usage_from_millis(
+            cpu_record.scheduler_cpu_time_ms as u64,
+            interval_seconds,
+        ),
+    }
+}
+
+fn report_interval_start(start_ts: UnixSecs, last_report_ts: UnixSecs) -> UnixSecs {
+    if last_report_ts.is_zero() {
+        start_ts
+    } else {
+        last_report_ts
+    }
+}
+
+struct StoreHeartbeatPeerReport {
+    report_peers: HashMap<u64, pdpb::PeerStat>,
+    // Keep raw CPU milliseconds here so the store-level region_sum gauges can
+    // convert once after aggregation instead of truncating per region first.
+    region_unified_read_cpu_time_ms_sum: u64,
+    region_scheduler_cpu_time_ms_sum: u64,
+}
+
+fn collect_report_peers_for_store_heartbeat(
+    region_peers: &mut HashMap<u64, PeerStat>,
+    // region_id -> CPU time breakdown accumulated since last store heartbeat.
+    region_cpu_records_since_store_heartbeat: &mut HashMap<u64, RegionCpuRecord>,
+    interval_seconds: u64,
+) -> StoreHeartbeatPeerReport {
+    let has_interval = interval_seconds > 0;
+    let mut report_peers = HashMap::default();
+    let mut region_unified_read_cpu_time_ms_sum = 0;
+    let mut region_scheduler_cpu_time_ms_sum = 0;
+    for (region_id, region_peer) in region_peers.iter_mut() {
+        let read_bytes = region_peer.read_bytes - region_peer.last_store_report_read_bytes;
+        let read_keys = region_peer.read_keys - region_peer.last_store_report_read_keys;
+        let query_stats = region_peer
+            .query_stats
+            .sub_query_stats(&region_peer.last_store_report_query_stats);
+        // Drain the CPU record for this region. The record accumulates since the last
+        // store heartbeat and should be consumed exactly once when reporting.
+        // Using `remove` ensures we report delta values rather than cumulative totals.
+        // If the region is not in the CPU records map (e.g., no CPU activity recorded),
+        // we use a default value of zero.
+        let cpu_record = region_cpu_records_since_store_heartbeat
+            .remove(region_id)
+            .unwrap_or_default();
+        let cpu_usage = if has_interval {
+            calculate_region_cpu_usage(cpu_record, interval_seconds)
+        } else {
+            // `interval_seconds == 0` is unexpected but can happen in corner cases.
+            // Drain the record and report 0 to avoid division by zero.
+            RegionCpuUsage::default()
+        };
+        if has_interval {
+            region_unified_read_cpu_time_ms_sum += cpu_record.unified_read_cpu_time_ms as u64;
+            region_scheduler_cpu_time_ms_sum += cpu_record.scheduler_cpu_time_ms as u64;
+        }
+        region_peer.last_store_report_read_bytes = region_peer.read_bytes;
+        region_peer.last_store_report_read_keys = region_peer.read_keys;
+        region_peer
+            .last_store_report_query_stats
+            .fill_query_stats(&region_peer.query_stats);
+        // Store heartbeat still reports read hotspots, so CPU admission only
+        // uses unified-read pool CPU. If store heartbeat later also reports
+        // write hotspots, scheduler CPU should be folded into this check.
+        if !should_report_hotspot_read_peer(
+            read_bytes,
+            read_keys,
+            &query_stats,
+            cpu_usage.unified_read_cpu_usage,
+        ) {
+            continue;
+        }
+        let mut read_stat = pdpb::PeerStat::default();
+        read_stat.set_region_id(*region_id);
+        read_stat.set_read_keys(read_keys);
+        read_stat.set_read_bytes(read_bytes);
+        read_stat.set_query_stats(query_stats.0);
+        let mut cpu_stats = pdpb::CpuStats::default();
+        cpu_stats.set_unified_read(cpu_usage.unified_read_cpu_usage);
+        cpu_stats.set_scheduler(cpu_usage.scheduler_cpu_usage);
+        read_stat.set_cpu_stats(cpu_stats);
+        report_peers.insert(*region_id, read_stat);
+    }
+    // Drain orphan CPU records for regions that are no longer tracked in
+    // `region_peers`. This can happen when a region is destroyed or merged
+    // between heartbeats. The clear() ensures we don't accumulate stale CPU
+    // records indefinitely.
+    region_cpu_records_since_store_heartbeat.clear();
+    StoreHeartbeatPeerReport {
+        report_peers,
+        region_unified_read_cpu_time_ms_sum,
+        region_scheduler_cpu_time_ms_sum,
+    }
+}
+
 /// Max limitation of delayed store_heartbeat.
 const STORE_HEARTBEAT_DELAY_LIMIT: u64 = 5 * 60;
+const STORE_HEARTBEAT_TOPN_LOG_LIMIT: usize = 5;
+const STORE_HEARTBEAT_TOPN_LOG_MIN_CPU: u64 = 10;
+
+#[derive(Debug)]
+struct TopReadCpuPeer {
+    region_id: u64,
+    read_cpu: u64,
+    sched_cpu: u64,
+}
+
+fn should_log_store_heartbeat_top_read_cpu() -> bool {
+    matches!(get_log_level(), Some(Level::Debug) | Some(Level::Trace))
+}
+
+#[inline]
+fn matches_scheduler_thread_name(thread_name: &str) -> bool {
+    matches_thread_name_prefix(thread_name, SCHEDULER_THREAD_PREFIX)
+}
+
+fn log_store_heartbeat_top_read_cpu(
+    store_id: u64,
+    interval_seconds: u64,
+    report_peers: &HashMap<u64, pdpb::PeerStat>,
+) {
+    if report_peers.is_empty() {
+        return;
+    }
+
+    let mut top_peers: Vec<TopReadCpuPeer> = report_peers
+        .values()
+        .map(|stat| TopReadCpuPeer {
+            region_id: stat.get_region_id(),
+            read_cpu: stat.get_cpu_stats().get_unified_read(),
+            sched_cpu: stat.get_cpu_stats().get_scheduler(),
+        })
+        .collect();
+    top_peers.sort_unstable_by(|lhs, rhs| {
+        rhs.read_cpu
+            .cmp(&lhs.read_cpu)
+            .then_with(|| rhs.sched_cpu.cmp(&lhs.sched_cpu))
+            .then_with(|| lhs.region_id.cmp(&rhs.region_id))
+    });
+    if top_peers[0].read_cpu < STORE_HEARTBEAT_TOPN_LOG_MIN_CPU {
+        return;
+    }
+    top_peers.truncate(STORE_HEARTBEAT_TOPN_LOG_LIMIT);
+    let top_peers_max_cpu = top_peers[0].read_cpu;
+    let top_peers_avg_cpu =
+        top_peers.iter().map(|peer| peer.read_cpu).sum::<u64>() / top_peers.len() as u64;
+    let top_peers_p50_cpu = if top_peers.len() % 2 == 1 {
+        top_peers[top_peers.len() / 2].read_cpu
+    } else {
+        let upper = top_peers[(top_peers.len() / 2) - 1].read_cpu;
+        let lower = top_peers[top_peers.len() / 2].read_cpu;
+        (upper + lower) / 2
+    };
+
+    debug!(
+        "store heartbeat top read cpu peers";
+        "store_id" => store_id,
+        "interval_seconds" => interval_seconds,
+        "reported_peers_count" => report_peers.len(),
+        "top_peers_max_cpu" => top_peers_max_cpu,
+        "top_peers_avg_cpu" => top_peers_avg_cpu,
+        "top_peers_p50_cpu" => top_peers_p50_cpu,
+        "top_peers" => ?top_peers,
+    );
+}
 
 pub struct Runner<EK, ER, T>
 where
@@ -950,8 +1169,12 @@ where
     stats_monitor: StatsMonitor<WrappedScheduler<EK>>,
     store_heartbeat_interval: Duration,
 
-    // region_id -> total_cpu_time_ms (since last region heartbeat)
-    region_cpu_records: HashMap<u64, u32>,
+    // region_id -> CPU time breakdown accumulated for RegionHeartbeat reporting.
+    // This map is consumed/cleared by the region-heartbeat path.
+    region_cpu_records_since_region_heartbeat: HashMap<u64, RegionCpuRecord>,
+    // region_id -> CPU time breakdown accumulated for StoreHeartbeat peer_stats.
+    // This map is consumed/cleared by real store heartbeats (not fake ones).
+    region_cpu_records_since_store_heartbeat: HashMap<u64, RegionCpuRecord>,
 
     concurrency_manager: ConcurrencyManager,
     snap_mgr: SnapManager,
@@ -1056,7 +1279,8 @@ where
             scheduler,
             store_heartbeat_interval,
             stats_monitor,
-            region_cpu_records: HashMap::default(),
+            region_cpu_records_since_region_heartbeat: HashMap::default(),
+            region_cpu_records_since_store_heartbeat: HashMap::default(),
             concurrency_manager,
             snap_mgr,
             remote,
@@ -1274,36 +1498,72 @@ where
         store_report: Option<pdpb::StoreReport>,
         dr_autosync_status: Option<StoreDrAutoSyncStatus>,
     ) {
-        let mut report_peers = HashMap::default();
-        {
-            let mut region_peers = self.region_peers.write().unwrap();
-            for (region_id, region_peer) in region_peers.iter_mut() {
-                let read_bytes = region_peer.read_bytes - region_peer.last_store_report_read_bytes;
-                let read_keys = region_peer.read_keys - region_peer.last_store_report_read_keys;
-                let query_stats = region_peer
-                    .query_stats
-                    .sub_query_stats(&region_peer.last_store_report_query_stats);
-                region_peer.last_store_report_read_bytes = region_peer.read_bytes;
-                region_peer.last_store_report_read_keys = region_peer.read_keys;
-                region_peer
-                    .last_store_report_query_stats
-                    .fill_query_stats(&region_peer.query_stats);
-                if read_bytes < hotspot_byte_report_threshold()
-                    && read_keys < hotspot_key_report_threshold()
-                    && query_stats.get_read_query_num() < hotspot_query_num_report_threshold()
-                {
-                    continue;
-                }
-                let mut read_stat = pdpb::PeerStat::default();
-                read_stat.set_region_id(*region_id);
-                read_stat.set_read_keys(read_keys);
-                read_stat.set_read_bytes(read_bytes);
-                read_stat.set_query_stats(query_stats.0);
-                report_peers.insert(*region_id, read_stat);
+        let now = UnixSecs::now();
+        // For fake heartbeats, keep peer deltas and CPU records untouched so the
+        // next real heartbeat still reports a full interval.
+        if !is_fake_heartbeat {
+            let report_start_ts =
+                report_interval_start(self.start_ts, self.store_stat.last_report_ts);
+            let interval_seconds = now
+                .into_inner()
+                .saturating_sub(report_start_ts.into_inner());
+            let StoreHeartbeatPeerReport {
+                report_peers,
+                region_unified_read_cpu_time_ms_sum,
+                region_scheduler_cpu_time_ms_sum,
+            } = {
+                let mut region_peers = self.region_peers.write().unwrap();
+                collect_report_peers_for_store_heartbeat(
+                    &mut region_peers,
+                    &mut self.region_cpu_records_since_store_heartbeat,
+                    interval_seconds,
+                )
+            };
+            if should_log_store_heartbeat_top_read_cpu() {
+                log_store_heartbeat_top_read_cpu(self.store_id, interval_seconds, &report_peers);
             }
-        }
 
-        stats = collect_report_read_peer_stats(HOTSPOT_REPORT_CAPACITY, report_peers, stats);
+            // Emit per-pool CPU metrics: region-sum vs store-level.
+            {
+                // Region-level sum includes all tracked regions in the interval, not just the
+                // hotspot peers that survive filtering below.
+                // Store-level sum from ThreadInfoStatistics (by thread name prefix).
+                // `store_cpu_usages` is a Vec<RecordPair> where key=thread_name, value=cpu%.
+                let (mut store_unified_read, mut store_scheduler) = (0u64, 0u64);
+                for record in &self.store_stat.store_cpu_usages {
+                    let name = record.get_key();
+                    if matches_thread_name_prefix(name, UNIFIED_READ_POOL_THREAD) {
+                        store_unified_read += record.get_value();
+                    } else if matches_scheduler_thread_name(name) {
+                        store_scheduler += record.get_value();
+                    }
+                }
+                STORE_CPU_POOL_GAUGE_VEC
+                    .unified_read
+                    .store_level
+                    .set(store_unified_read as i64);
+                STORE_CPU_POOL_GAUGE_VEC
+                    .unified_read
+                    .region_sum
+                    .set(cpu_usage_from_millis(
+                        region_unified_read_cpu_time_ms_sum,
+                        interval_seconds,
+                    ) as i64);
+                STORE_CPU_POOL_GAUGE_VEC
+                    .scheduler
+                    .store_level
+                    .set(store_scheduler as i64);
+                STORE_CPU_POOL_GAUGE_VEC
+                    .scheduler
+                    .region_sum
+                    .set(
+                        cpu_usage_from_millis(region_scheduler_cpu_time_ms_sum, interval_seconds)
+                            as i64,
+                    );
+            }
+
+            stats = collect_report_read_peer_stats(HOTSPOT_REPORT_CAPACITY, report_peers, stats);
+        }
         // Fetch all size infos and update last reported infos on engine_size.
         let (capacity, used_size, available) = collect_engine_size(&self.coprocessor_host);
         if available == 0 {
@@ -1338,7 +1598,9 @@ where
         stats.set_write_io_rates(self.store_stat.store_write_io_rates.clone().into());
 
         let mut interval = pdpb::TimeInterval::default();
-        interval.set_start_timestamp(self.store_stat.last_report_ts.into_inner());
+        interval.set_start_timestamp(
+            report_interval_start(self.start_ts, self.store_stat.last_report_ts).into_inner(),
+        );
         stats.set_interval(interval);
         self.store_stat.engine_last_total_bytes_read = self.store_stat.engine_total_bytes_read;
         self.store_stat.engine_last_total_keys_read = self.store_stat.engine_total_keys_read;
@@ -1346,7 +1608,7 @@ where
             .engine_last_query_num
             .fill_query_stats(&self.store_stat.engine_total_query_num);
         self.store_stat.last_report_ts = if !is_fake_heartbeat {
-            UnixSecs::now()
+            now
         } else {
             // If `is_fake_heartbeat == true`, the given Task::StoreHeartbeat should be a
             // fake heartbeat to PD, we won't update the last_report_ts to avoid
@@ -1826,9 +2088,17 @@ where
     }
 
     fn handle_destroy_peer(&mut self, region_id: u64) {
-        match self.region_peers.write().unwrap().remove(&region_id) {
-            None => {}
-            Some(_) => info!("remove peer statistic record in pd"; "region_id" => region_id),
+        let removed = {
+            let mut region_peers = self.region_peers.write().unwrap();
+            remove_peer_stat_from_maps(
+                region_id,
+                &mut region_peers,
+                &mut self.region_cpu_records_since_region_heartbeat,
+                &mut self.region_cpu_records_since_store_heartbeat,
+            )
+        };
+        if removed {
+            info!("remove peer statistic record in pd"; "region_id" => region_id);
         }
     }
 
@@ -1976,7 +2246,16 @@ where
     fn handle_region_cpu_records(&mut self, records: Arc<RawRecords>) {
         // Send Region CPU info to AutoSplitController inside the stats_monitor.
         self.stats_monitor.maybe_send_cpu_stats(&records);
-        calculate_region_cpu_records(self.store_id, records, &mut self.region_cpu_records);
+        calculate_region_cpu_records(
+            self.store_id,
+            records.clone(),
+            &mut self.region_cpu_records_since_region_heartbeat,
+        );
+        calculate_region_cpu_records(
+            self.store_id,
+            records,
+            &mut self.region_cpu_records_since_store_heartbeat,
+        );
     }
 
     fn handle_report_min_resolved_ts(&self, store_id: u64, min_resolved_ts: u64) {
@@ -1995,11 +2274,7 @@ where
         let region_id = region_buckets.meta.region_id;
         self.merge_buckets(region_buckets);
         let report_buckets = self.region_buckets.get_mut(&region_id).unwrap();
-        let last_report_ts = if report_buckets.last_report_ts.is_zero() {
-            self.start_ts
-        } else {
-            report_buckets.last_report_ts
-        };
+        let last_report_ts = report_interval_start(self.start_ts, report_buckets.last_report_ts);
         let now = UnixSecs::now();
         let interval_second = now.into_inner() - last_report_ts.into_inner();
         let delta = report_buckets.new_report(now);
@@ -2210,7 +2485,7 @@ where
 fn calculate_region_cpu_records(
     store_id: u64,
     records: Arc<RawRecords>,
-    region_cpu_records: &mut HashMap<u64, u32>,
+    region_cpu_records: &mut HashMap<u64, RegionCpuRecord>,
 ) {
     for (tag, record) in &records.records {
         let record_store_id = tag.store_id;
@@ -2218,7 +2493,10 @@ fn calculate_region_cpu_records(
             continue;
         }
         // Reporting a region heartbeat later will clear the corresponding record.
-        *region_cpu_records.entry(tag.region_id).or_insert(0) += record.cpu_time;
+        region_cpu_records
+            .entry(tag.region_id)
+            .or_default()
+            .merge_raw_record(record);
     }
 }
 
@@ -2357,6 +2635,7 @@ where
                     query_stats,
                     cop_detail,
                     cpu_usage,
+                    cpu_stats,
                 ) = {
                     let region_id = hb_task.region.get_id();
                     let mut region_peers = self.region_peers.write().unwrap();
@@ -2392,20 +2671,28 @@ where
                         last_report_ts = self.start_ts;
                     }
                     // Calculate the CPU usage since the last region heartbeat.
-                    let cpu_usage = {
+                    let (cpu_usage, cpu_stats) = {
                         // Take out the region CPU record.
-                        let cpu_time_duration = Duration::from_millis(
-                            self.region_cpu_records.remove(&region_id).unwrap_or(0) as u64,
-                        );
+                        let cpu_record = self
+                            .region_cpu_records_since_region_heartbeat
+                            .remove(&region_id)
+                            .unwrap_or_default();
                         let interval_second =
                             unix_secs_now.into_inner() - last_report_ts.into_inner();
                         // Keep consistent with the calculation of cpu_usages in a store heartbeat.
                         // See components/tikv_util/src/metrics/threads_linux.rs for more details.
                         if interval_second > 0 {
-                            ((cpu_time_duration.as_secs_f64() * 100.0) / interval_second as f64)
-                                as u64
+                            let total = cpu_usage_from_millis(
+                                cpu_record.cpu_time_ms as u64,
+                                interval_second,
+                            );
+                            let cpu_usage = calculate_region_cpu_usage(cpu_record, interval_second);
+                            let mut stats = pdpb::CpuStats::default();
+                            stats.set_unified_read(cpu_usage.unified_read_cpu_usage);
+                            stats.set_scheduler(cpu_usage.scheduler_cpu_usage);
+                            (total, stats)
                         } else {
-                            0
+                            (0, pdpb::CpuStats::default())
                         }
                     };
                     (
@@ -2417,6 +2704,7 @@ where
                         query_stats.0,
                         cop_detail,
                         cpu_usage,
+                        cpu_stats,
                     )
                 };
                 self.handle_heartbeat(
@@ -2436,6 +2724,7 @@ where
                         approximate_keys,
                         last_report_ts,
                         cpu_usage,
+                        cpu_stats,
                     },
                     hb_task.replication_status,
                 )
@@ -2658,7 +2947,7 @@ fn collect_report_read_peer_stats(
     mut report_read_stats: HashMap<u64, pdpb::PeerStat>,
     mut stats: pdpb::StoreStats,
 ) -> pdpb::StoreStats {
-    if report_read_stats.len() < capacity * 3 {
+    if report_read_stats.len() < capacity * HOTSPOT_REPORT_METRICS {
         for (_, read_stat) in report_read_stats {
             stats.peer_stats.push(read_stat);
         }
@@ -2667,6 +2956,8 @@ fn collect_report_read_peer_stats(
     let mut keys_topn_report = TopN::new(capacity);
     let mut bytes_topn_report = TopN::new(capacity);
     let mut stats_topn_report = TopN::new(capacity);
+    let mut cpu_topn_report = TopN::new(capacity);
+    let mut scheduler_cpu_topn_report = TopN::new(capacity);
     for read_stat in report_read_stats.values() {
         let mut cmp_stat = PeerCmpReadStat::default();
         cmp_stat.region_id = read_stat.region_id;
@@ -2679,6 +2970,12 @@ fn collect_report_read_peer_stats(
         let mut query_cmp_stat = cmp_stat.clone();
         query_cmp_stat.report_stat = get_read_query_num(read_stat.get_query_stats());
         stats_topn_report.push(query_cmp_stat);
+        let mut cpu_cmp_stat = cmp_stat.clone();
+        cpu_cmp_stat.report_stat = read_stat.get_cpu_stats().get_unified_read();
+        cpu_topn_report.push(cpu_cmp_stat);
+        let mut sched_cmp_stat = cmp_stat;
+        sched_cmp_stat.report_stat = read_stat.get_cpu_stats().get_scheduler();
+        scheduler_cpu_topn_report.push(sched_cmp_stat);
     }
 
     for x in keys_topn_report {
@@ -2698,7 +2995,31 @@ fn collect_report_read_peer_stats(
             stats.peer_stats.push(report_stat);
         }
     }
+
+    for x in cpu_topn_report {
+        if let Some(report_stat) = report_read_stats.remove(&x.region_id) {
+            stats.peer_stats.push(report_stat);
+        }
+    }
+
+    for x in scheduler_cpu_topn_report {
+        if let Some(report_stat) = report_read_stats.remove(&x.region_id) {
+            stats.peer_stats.push(report_stat);
+        }
+    }
     stats
+}
+
+fn remove_peer_stat_from_maps(
+    region_id: u64,
+    region_peers: &mut HashMap<u64, PeerStat>,
+    region_cpu_records_since_region_heartbeat: &mut HashMap<u64, RegionCpuRecord>,
+    region_cpu_records_since_store_heartbeat: &mut HashMap<u64, RegionCpuRecord>,
+) -> bool {
+    let removed = region_peers.remove(&region_id).is_some();
+    region_cpu_records_since_region_heartbeat.remove(&region_id);
+    region_cpu_records_since_store_heartbeat.remove(&region_id);
+    removed
 }
 
 fn collect_engine_size<EK: KvEngine>(coprocessor_host: &CoprocessorHost<EK>) -> (u64, u64, u64) {
@@ -2837,6 +3158,11 @@ mod tests {
             stat.set_read_bytes(6 - i);
             stat.read_keys = i;
             stat.read_bytes = 6 - i;
+            if i == 2 {
+                let mut cpu_stats = pdpb::CpuStats::default();
+                cpu_stats.set_unified_read(10);
+                stat.set_cpu_stats(cpu_stats);
+            }
             let mut query_stat = QueryStats::default();
             if i == 3 {
                 query_stat.add_query_num(QueryKind::Get, 6);
@@ -2848,19 +3174,280 @@ mod tests {
         }
         let mut store_stats = pdpb::StoreStats::default();
         store_stats = collect_report_read_peer_stats(1, report_stats, store_stats);
-        assert_eq!(store_stats.peer_stats.len(), 3)
+        let reported: HashSet<u64> = store_stats
+            .peer_stats
+            .iter()
+            .map(|stat| stat.get_region_id())
+            .collect();
+        assert_eq!(reported.len(), 4);
+        for region_id in 1..5 {
+            assert!(reported.contains(&region_id));
+        }
+    }
+
+    #[test]
+    fn test_should_report_hotspot_read_peer_cpu_threshold() {
+        let query_stats = QueryStats::default();
+        let threshold = hotspot_cpu_usage_report_threshold();
+        if threshold > 0 {
+            assert!(!should_report_hotspot_read_peer(
+                0,
+                0,
+                &query_stats,
+                threshold.saturating_sub(1),
+            ));
+        }
+        assert!(should_report_hotspot_read_peer(
+            0,
+            0,
+            &query_stats,
+            threshold
+        ));
+    }
+
+    #[test]
+    fn test_collect_report_peers_for_store_heartbeat_clears_orphan_cpu_records() {
+        let mut region_peers = HashMap::default();
+        region_peers.insert(1, PeerStat::default());
+        let mut region_cpu_records_since_store_heartbeat: HashMap<u64, RegionCpuRecord> =
+            HashMap::default();
+        region_cpu_records_since_store_heartbeat.insert(
+            1,
+            RegionCpuRecord {
+                cpu_time_ms: 10,
+                ..Default::default()
+            },
+        );
+        region_cpu_records_since_store_heartbeat.insert(
+            2,
+            RegionCpuRecord {
+                cpu_time_ms: 12,
+                ..Default::default()
+            },
+        );
+
+        collect_report_peers_for_store_heartbeat(
+            &mut region_peers,
+            &mut region_cpu_records_since_store_heartbeat,
+            1,
+        );
+
+        assert!(region_cpu_records_since_store_heartbeat.is_empty());
+    }
+
+    #[test]
+    fn test_collect_report_peers_for_store_heartbeat_with_zero_interval() {
+        let mut region_peers = HashMap::default();
+        let peer_stat = PeerStat {
+            read_bytes: hotspot_byte_report_threshold(),
+            ..Default::default()
+        };
+        region_peers.insert(1, peer_stat);
+
+        let mut region_cpu_records_since_store_heartbeat: HashMap<u64, RegionCpuRecord> =
+            HashMap::default();
+        region_cpu_records_since_store_heartbeat.insert(
+            1,
+            RegionCpuRecord {
+                cpu_time_ms: 42,
+                ..Default::default()
+            },
+        );
+
+        let report = collect_report_peers_for_store_heartbeat(
+            &mut region_peers,
+            &mut region_cpu_records_since_store_heartbeat,
+            0,
+        );
+
+        assert!(region_cpu_records_since_store_heartbeat.is_empty());
+        let reported = report.report_peers.get(&1).unwrap();
+        assert_eq!(reported.get_cpu_stats().get_unified_read(), 0);
+        assert_eq!(report.region_unified_read_cpu_time_ms_sum, 0);
+        assert_eq!(report.region_scheduler_cpu_time_ms_sum, 0);
+        assert_eq!(reported.get_read_bytes(), hotspot_byte_report_threshold());
+    }
+
+    #[test]
+    fn test_calculate_region_cpu_usage_converts_pools_independently() {
+        let cpu_usage = calculate_region_cpu_usage(
+            RegionCpuRecord {
+                cpu_time_ms: 12,
+                unified_read_cpu_time_ms: 6,
+                scheduler_cpu_time_ms: 6,
+            },
+            1,
+        );
+
+        assert_eq!(cpu_usage.unified_read_cpu_usage, 0);
+        assert_eq!(cpu_usage.scheduler_cpu_usage, 0);
+    }
+
+    #[test]
+    fn test_collect_report_peers_for_store_heartbeat_ignores_untracked_cpu_for_hotspot() {
+        let mut region_peers = HashMap::default();
+        region_peers.insert(1, PeerStat::default());
+        let mut region_cpu_records_since_store_heartbeat: HashMap<u64, RegionCpuRecord> =
+            HashMap::default();
+        region_cpu_records_since_store_heartbeat.insert(
+            1,
+            RegionCpuRecord {
+                cpu_time_ms: 10,
+                ..Default::default()
+            },
+        );
+
+        let report = collect_report_peers_for_store_heartbeat(
+            &mut region_peers,
+            &mut region_cpu_records_since_store_heartbeat,
+            1,
+        );
+
+        assert!(!report.report_peers.contains_key(&1));
+    }
+
+    #[test]
+    fn test_collect_report_peers_for_store_heartbeat_uses_unified_read_cpu_for_hotspot() {
+        let mut region_peers = HashMap::default();
+        region_peers.insert(1, PeerStat::default());
+        let mut region_cpu_records_since_store_heartbeat: HashMap<u64, RegionCpuRecord> =
+            HashMap::default();
+        region_cpu_records_since_store_heartbeat.insert(
+            1,
+            RegionCpuRecord {
+                cpu_time_ms: 10,
+                unified_read_cpu_time_ms: 10,
+                ..Default::default()
+            },
+        );
+
+        let report = collect_report_peers_for_store_heartbeat(
+            &mut region_peers,
+            &mut region_cpu_records_since_store_heartbeat,
+            1,
+        );
+
+        let reported = report.report_peers.get(&1).unwrap();
+        assert_eq!(reported.get_cpu_stats().get_unified_read(), 1);
+        assert_eq!(reported.get_cpu_stats().get_scheduler(), 0);
+    }
+
+    #[test]
+    fn test_collect_report_peers_for_store_heartbeat_ignores_scheduler_cpu_for_hotspot() {
+        let mut region_peers = HashMap::default();
+        region_peers.insert(1, PeerStat::default());
+        let mut region_cpu_records_since_store_heartbeat: HashMap<u64, RegionCpuRecord> =
+            HashMap::default();
+        region_cpu_records_since_store_heartbeat.insert(
+            1,
+            RegionCpuRecord {
+                cpu_time_ms: 10,
+                scheduler_cpu_time_ms: 10,
+                ..Default::default()
+            },
+        );
+
+        let report = collect_report_peers_for_store_heartbeat(
+            &mut region_peers,
+            &mut region_cpu_records_since_store_heartbeat,
+            1,
+        );
+
+        assert!(!report.report_peers.contains_key(&1));
+    }
+
+    #[test]
+    fn test_collect_report_peers_for_store_heartbeat_accumulates_cpu_time_before_rounding() {
+        let mut region_peers = HashMap::default();
+        region_peers.insert(1, PeerStat::default());
+        region_peers.insert(2, PeerStat::default());
+        let mut region_cpu_records_since_store_heartbeat: HashMap<u64, RegionCpuRecord> =
+            HashMap::default();
+        region_cpu_records_since_store_heartbeat.insert(
+            1,
+            RegionCpuRecord {
+                unified_read_cpu_time_ms: 6,
+                ..Default::default()
+            },
+        );
+        region_cpu_records_since_store_heartbeat.insert(
+            2,
+            RegionCpuRecord {
+                unified_read_cpu_time_ms: 6,
+                ..Default::default()
+            },
+        );
+
+        let report = collect_report_peers_for_store_heartbeat(
+            &mut region_peers,
+            &mut region_cpu_records_since_store_heartbeat,
+            1,
+        );
+
+        assert_eq!(report.region_unified_read_cpu_time_ms_sum, 12);
+        assert_eq!(
+            cpu_usage_from_millis(report.region_unified_read_cpu_time_ms_sum, 1),
+            1
+        );
+    }
+
+    #[test]
+    fn test_report_interval_start_falls_back_to_runner_start_ts() {
+        let start_ts = UnixSecs::now();
+        let last_report_ts = UnixSecs::now();
+
+        assert_eq!(report_interval_start(start_ts, UnixSecs::zero()), start_ts);
+        assert_eq!(
+            report_interval_start(UnixSecs::zero(), last_report_ts),
+            last_report_ts
+        );
+    }
+
+    #[test]
+    fn test_remove_peer_stat_from_maps() {
+        let mut region_peers = HashMap::default();
+        region_peers.insert(1, PeerStat::default());
+        let mut region_cpu_records_since_region_heartbeat: HashMap<u64, RegionCpuRecord> =
+            HashMap::default();
+        region_cpu_records_since_region_heartbeat.insert(
+            1,
+            RegionCpuRecord {
+                cpu_time_ms: 10,
+                ..Default::default()
+            },
+        );
+        let mut region_cpu_records_since_store_heartbeat: HashMap<u64, RegionCpuRecord> =
+            HashMap::default();
+        region_cpu_records_since_store_heartbeat.insert(
+            1,
+            RegionCpuRecord {
+                cpu_time_ms: 12,
+                ..Default::default()
+            },
+        );
+
+        assert!(remove_peer_stat_from_maps(
+            1,
+            &mut region_peers,
+            &mut region_cpu_records_since_region_heartbeat,
+            &mut region_cpu_records_since_store_heartbeat,
+        ));
+        assert!(region_peers.is_empty());
+        assert!(region_cpu_records_since_region_heartbeat.is_empty());
+        assert!(region_cpu_records_since_store_heartbeat.is_empty());
     }
 
     use engine_test::kv::KvTestEngine;
     use metapb::Peer;
-    use resource_metering::{RawRecord, TagInfos};
+    use resource_metering::{RawRecord, RegionCpuRecord, TagInfos};
 
     use crate::coprocessor::{BoxPdTaskObserver, Coprocessor, PdTaskObserver, StoreSizeInfo};
 
     #[test]
     fn test_calculate_region_cpu_records() {
-        // region_id -> total_cpu_time_ms
-        let mut region_cpu_records: HashMap<u64, u32> = HashMap::default();
+        // region_id -> RegionCpuRecord
+        let mut region_cpu_records_since_region_heartbeat: HashMap<u64, RegionCpuRecord> =
+            HashMap::default();
 
         let region_num = 3;
         for i in 0..region_num * 10 {
@@ -2885,6 +3472,8 @@ mod tests {
                         resource_tag,
                         RawRecord {
                             cpu_time: 10,
+                            unified_read_cpu_time: 6,
+                            scheduler_cpu_time: 4,
                             read_keys: 0,
                             write_keys: 0,
                             network_in_bytes: 0,
@@ -2900,14 +3489,19 @@ mod tests {
             calculate_region_cpu_records(
                 DEFAULT_TEST_STORE_ID,
                 cpu_records,
-                &mut region_cpu_records,
+                &mut region_cpu_records_since_region_heartbeat,
             );
 
             sleep(Duration::from_millis(50));
         }
 
         for region_id in 1..region_num + 1 {
-            assert!(*region_cpu_records.get(&region_id).unwrap_or(&0) > 0)
+            let record = region_cpu_records_since_region_heartbeat
+                .get(&region_id)
+                .expect("region should have a CPU record");
+            assert!(record.cpu_time_ms > 0);
+            assert!(record.unified_read_cpu_time_ms > 0);
+            assert!(record.scheduler_cpu_time_ms > 0);
         }
     }
 
@@ -3040,6 +3634,8 @@ mod tests {
                         }),
                         RawRecord {
                             cpu_time: 111,
+                            unified_read_cpu_time: 0,
+                            scheduler_cpu_time: 0,
                             read_keys: 1,
                             write_keys: 0,
                             network_in_bytes: 0,

--- a/components/raftstore/src/store/worker/split_controller.rs
+++ b/components/raftstore/src/store/worker/split_controller.rs
@@ -22,6 +22,7 @@ use tikv_util::{
     debug, info,
     metrics::ThreadInfoStatistics,
     store::{is_read_query, QueryStats},
+    sys::thread::matches_thread_name_prefix,
     time::Instant,
     warn,
 };
@@ -37,6 +38,8 @@ use crate::store::{
 
 const DEFAULT_MAX_SAMPLE_LOOP_COUNT: usize = 10000;
 pub const TOP_N: usize = 10;
+const GRPC_SERVER_THREAD: &str = "grpc-server";
+const UNIFIED_READ_POOL_THREAD: &str = "unified-read";
 
 // It will return prefix sum of the given iter,
 // `read` is a function to process the item from the iter.
@@ -747,7 +750,7 @@ impl AutoSplitController {
         thread_stats
             .get_cpu_usages()
             .iter()
-            .filter(|(thread_name, _)| thread_name.contains(name))
+            .filter(|(thread_name, _)| matches_thread_name_prefix(thread_name, name))
             .fold(0, |cpu_usage_sum, (_, cpu_usage)| {
                 // `cpu_usage` is in [0, 100].
                 cpu_usage_sum + cpu_usage
@@ -772,8 +775,8 @@ impl AutoSplitController {
         // Prepare some diagnostic info.
         thread_stats.record();
         let (grpc_thread_usage, unified_read_pool_thread_usage) = (
-            Self::collect_thread_usage(thread_stats, "grpc-server"),
-            Self::collect_thread_usage(thread_stats, "unified-read-po"),
+            Self::collect_thread_usage(thread_stats, GRPC_SERVER_THREAD),
+            Self::collect_thread_usage(thread_stats, UNIFIED_READ_POOL_THREAD),
         );
         // Update first before calculating the latest average gRPC poll CPU usage.
         self.update_grpc_thread_usage(grpc_thread_usage);
@@ -1430,6 +1433,7 @@ mod tests {
                     network_out_bytes: 0,
                     logical_read_bytes: 0,
                     logical_write_bytes: 0,
+                    ..Default::default()
                 },
             );
         }
@@ -1910,6 +1914,7 @@ mod tests {
                     network_out_bytes: 0,
                     logical_read_bytes: 0,
                     logical_write_bytes: 0,
+                    ..Default::default()
                 },
             );
             // ["c", "d"] with (test_case.1)ms CPU time.
@@ -1923,6 +1928,7 @@ mod tests {
                     network_out_bytes: 0,
                     logical_read_bytes: 0,
                     logical_write_bytes: 0,
+                    ..Default::default()
                 },
             );
             // Multiple key ranges with (test_case.2)ms CPU time.
@@ -1936,6 +1942,7 @@ mod tests {
                     network_out_bytes: 0,
                     logical_read_bytes: 0,
                     logical_write_bytes: 0,
+                    ..Default::default()
                 },
             );
             // Empty key range with (test_case.3)ms CPU time.
@@ -1949,6 +1956,7 @@ mod tests {
                     network_out_bytes: 0,
                     logical_read_bytes: 0,
                     logical_write_bytes: 0,
+                    ..Default::default()
                 },
             );
 

--- a/components/resource_control/Cargo.toml
+++ b/components/resource_control/Cargo.toml
@@ -30,7 +30,7 @@ slog-global = { workspace = true }
 strum = { version = "0.20", features = ["derive"] }
 tikv_util = { workspace = true }
 tokio-timer = { workspace = true }
-yatp = { git = "https://github.com/tikv/yatp.git", branch = "master" }
+yatp = { workspace = true }
 
 [dev-dependencies]
 file_system = { workspace = true, features = ["testexport"] }

--- a/components/resource_control/src/config.rs
+++ b/components/resource_control/src/config.rs
@@ -3,7 +3,7 @@ use std::{fmt, sync::Arc};
 
 use online_config::{ConfigManager, ConfigValue, OnlineConfig};
 use serde::{Deserialize, Serialize};
-use tikv_util::config::VersionTrack;
+use tikv_util::config::{ReadableSize, VersionTrack};
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug, OnlineConfig)]
 #[serde(default)]
@@ -12,6 +12,18 @@ pub struct Config {
     #[online_config(skip)]
     pub enabled: bool,
     pub priority_ctl_strategy: PriorityCtlStrategy,
+    /// Overall resource utilization percentage above which background tasks
+    /// are throttled. Also caps the background utilization limit.
+    pub bg_resource_threshold: f64,
+    /// Compaction pressure percentage at which background write IO throttling
+    /// begins. Dynamically configurable at runtime.
+    pub bg_compaction_pressure_threshold: f64,
+    /// Maximum write IO rate allowed for background tasks when
+    /// compaction pressure is lower than the threshold.
+    pub bg_write_io_ceiling: ReadableSize,
+    /// Minimum write IO rate that background tasks are always allowed,
+    /// even under maximum compaction pressure.
+    pub bg_write_io_floor: ReadableSize,
 }
 
 impl Default for Config {
@@ -19,6 +31,10 @@ impl Default for Config {
         Self {
             enabled: true,
             priority_ctl_strategy: PriorityCtlStrategy::Moderate,
+            bg_resource_threshold: 70.0,
+            bg_compaction_pressure_threshold: 70.0,
+            bg_write_io_ceiling: ReadableSize::gb(100),
+            bg_write_io_floor: ReadableSize::mb(10),
         }
     }
 }

--- a/components/resource_control/src/config.rs
+++ b/components/resource_control/src/config.rs
@@ -3,7 +3,7 @@ use std::{fmt, sync::Arc};
 
 use online_config::{ConfigManager, ConfigValue, OnlineConfig};
 use serde::{Deserialize, Serialize};
-use tikv_util::config::VersionTrack;
+use tikv_util::config::{ReadableSize, VersionTrack};
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug, OnlineConfig)]
 #[serde(default)]
@@ -12,6 +12,55 @@ pub struct Config {
     #[online_config(skip)]
     pub enabled: bool,
     pub priority_ctl_strategy: PriorityCtlStrategy,
+    /// CPU utilization percentage at which background task throttling begins.
+    /// Background budget scales linearly from full down to zero between this
+    /// value and fg_cpu_throttle_threshold.
+    pub bg_cpu_throttle_threshold: f64,
+    /// CPU utilization percentage at which foreground task protection kicks in:
+    /// background tasks are fully throttled to their minimum floor and the
+    /// background utilization limit is capped here.
+    pub fg_cpu_throttle_threshold: f64,
+    /// Compaction pressure percentage at which background write IO throttling
+    /// begins. Dynamically configurable at runtime.
+    pub bg_compaction_pressure_threshold: f64,
+    /// Maximum write IO rate allowed for background tasks when
+    /// compaction pressure is lower than the threshold.
+    pub bg_write_io_ceiling: ReadableSize,
+    /// Minimum write IO rate that background tasks are always allowed,
+    /// even under maximum compaction pressure.
+    pub bg_write_io_floor: ReadableSize,
+    /// When true, enables fair two-phase scheduling for reads: groups whose
+    /// current-minute RU rate exceeds their historical baseline are placed in
+    /// phase 1 (deprioritised in the yatp priority queue) relative to groups
+    /// within their baseline (phase 0). Protects sustained workloads from
+    /// sudden traffic spikes without hard-rejecting requests.
+    pub enable_fair_scheduling: bool,
+    /// When true, enables Tier-1 admission control for reads: high-priority
+    /// read requests from groups that are over their RU baseline are shed
+    /// (SchedTooBusy) when CPU exceeds fg_cpu_throttle_threshold.
+    pub enable_read_admission_control: bool,
+    /// When true, enables Tier-1 admission control for writes: high-priority
+    /// write requests from groups that are over their RU baseline are shed
+    /// (SchedTooBusy) when CPU exceeds fg_cpu_throttle_threshold.
+    pub enable_write_admission_control: bool,
+    /// Size of the sliding window (in minutes) used to compute per-group
+    /// historical RU baselines for fair scheduling and admission control.
+    /// The window is divided into 30-second buckets (2 per minute). Minimum 2,
+    /// maximum 60. Not hot-reloadable; changing requires a restart.
+    #[online_config(skip)]
+    pub historical_usage_window_mins: u64,
+    /// Percentage of headroom above the historical RU baseline before a group
+    /// is considered "over baseline" for two-phase scheduling and CPU
+    /// utilization throttling. For example, 20.0 means a group must exceed
+    /// 1.2× its historical rate to be deprioritized or rate-limited.
+    /// Default: 20.0 (20%).
+    pub baseline_burst_pct: f64,
+    /// Maximum number of requests that can concurrently sit in the admission
+    /// control delay phase (reads and writes combined). When this limit is
+    /// reached, additional over-baseline requests are rejected immediately
+    /// (SchedTooBusy) rather than delayed. Set to 0 to disable the limit
+    /// (unlimited delayed requests). Default: 10_000.
+    pub admission_max_delayed_count: u64,
 }
 
 impl Default for Config {
@@ -19,6 +68,17 @@ impl Default for Config {
         Self {
             enabled: true,
             priority_ctl_strategy: PriorityCtlStrategy::Moderate,
+            bg_cpu_throttle_threshold: 60.0,
+            fg_cpu_throttle_threshold: 70.0,
+            bg_compaction_pressure_threshold: 70.0,
+            bg_write_io_ceiling: ReadableSize::gb(100),
+            bg_write_io_floor: ReadableSize::mb(10),
+            enable_fair_scheduling: false,
+            enable_read_admission_control: false,
+            enable_write_admission_control: false,
+            historical_usage_window_mins: 15,
+            baseline_burst_pct: 20.0,
+            admission_max_delayed_count: 10_000,
         }
     }
 }

--- a/components/resource_control/src/config.rs
+++ b/components/resource_control/src/config.rs
@@ -12,9 +12,14 @@ pub struct Config {
     #[online_config(skip)]
     pub enabled: bool,
     pub priority_ctl_strategy: PriorityCtlStrategy,
-    /// Overall resource utilization percentage above which background tasks
-    /// are throttled. Also caps the background utilization limit.
-    pub bg_resource_threshold: f64,
+    /// CPU utilization percentage at which background task throttling begins.
+    /// Background budget scales linearly from full down to zero between this
+    /// value and fg_cpu_throttle_threshold.
+    pub bg_cpu_throttle_threshold: f64,
+    /// CPU utilization percentage at which foreground task protection kicks in:
+    /// background tasks are fully throttled to their minimum floor and the
+    /// background utilization limit is capped here.
+    pub fg_cpu_throttle_threshold: f64,
     /// Compaction pressure percentage at which background write IO throttling
     /// begins. Dynamically configurable at runtime.
     pub bg_compaction_pressure_threshold: f64,
@@ -24,6 +29,38 @@ pub struct Config {
     /// Minimum write IO rate that background tasks are always allowed,
     /// even under maximum compaction pressure.
     pub bg_write_io_floor: ReadableSize,
+    /// When true, enables fair two-phase scheduling for reads: groups whose
+    /// current-minute RU rate exceeds their historical baseline are placed in
+    /// phase 1 (deprioritised in the yatp priority queue) relative to groups
+    /// within their baseline (phase 0). Protects sustained workloads from
+    /// sudden traffic spikes without hard-rejecting requests.
+    pub enable_fair_scheduling: bool,
+    /// When true, enables Tier-1 admission control for reads: high-priority
+    /// read requests from groups that are over their RU baseline are shed
+    /// (SchedTooBusy) when CPU exceeds fg_cpu_throttle_threshold.
+    pub enable_read_admission_control: bool,
+    /// When true, enables Tier-1 admission control for writes: high-priority
+    /// write requests from groups that are over their RU baseline are shed
+    /// (SchedTooBusy) when CPU exceeds fg_cpu_throttle_threshold.
+    pub enable_write_admission_control: bool,
+    /// Size of the sliding window (in minutes) used to compute per-group
+    /// historical RU baselines for fair scheduling and admission control.
+    /// The window is divided into 30-second buckets (2 per minute). Minimum 2,
+    /// maximum 60. Not hot-reloadable; changing requires a restart.
+    #[online_config(skip)]
+    pub historical_usage_window_mins: u64,
+    /// Percentage of headroom above the historical RU baseline before a group
+    /// is considered "over baseline" for two-phase scheduling and CPU
+    /// utilization throttling. For example, 20.0 means a group must exceed
+    /// 1.2× its historical rate to be deprioritized or rate-limited.
+    /// Default: 20.0 (20%).
+    pub baseline_burst_pct: f64,
+    /// Maximum number of requests that can concurrently sit in the admission
+    /// control delay phase (reads and writes combined). When this limit is
+    /// reached, additional over-baseline requests are rejected immediately
+    /// (SchedTooBusy) rather than delayed. Set to 0 to disable the limit
+    /// (unlimited delayed requests). Default: 10_000.
+    pub admission_max_delayed_count: u64,
 }
 
 impl Default for Config {
@@ -31,10 +68,17 @@ impl Default for Config {
         Self {
             enabled: true,
             priority_ctl_strategy: PriorityCtlStrategy::Moderate,
-            bg_resource_threshold: 70.0,
+            bg_cpu_throttle_threshold: 60.0,
+            fg_cpu_throttle_threshold: 70.0,
             bg_compaction_pressure_threshold: 70.0,
             bg_write_io_ceiling: ReadableSize::gb(100),
             bg_write_io_floor: ReadableSize::mb(10),
+            enable_fair_scheduling: false,
+            enable_read_admission_control: false,
+            enable_write_admission_control: false,
+            historical_usage_window_mins: 15,
+            baseline_burst_pct: 20.0,
+            admission_max_delayed_count: 10_000,
         }
     }
 }

--- a/components/resource_control/src/config.rs
+++ b/components/resource_control/src/config.rs
@@ -3,7 +3,9 @@ use std::{error::Error, fmt, sync::Arc};
 
 use online_config::{ConfigManager, ConfigValue, OnlineConfig};
 use serde::{Deserialize, Serialize};
-use tikv_util::config::{ReadableSize, VersionTrack};
+use tikv_util::config::ReadableSize;
+
+use crate::ResourceGroupManager;
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug, OnlineConfig)]
 #[serde(default)]
@@ -12,6 +14,8 @@ pub struct Config {
     #[online_config(skip)]
     pub enabled: bool,
     pub priority_ctl_strategy: PriorityCtlStrategy,
+    /// How `select_noisy_groups` decides which groups caused an overload.
+    pub noisy_detection: NoisyDetection,
     /// CPU utilization percentage at which background task throttling begins.
     /// Background budget scales linearly from full down to zero between this
     /// value and fg_cpu_throttle_threshold.
@@ -70,6 +74,25 @@ pub struct Config {
     /// (SchedTooBusy) rather than delayed. Set to 0 to disable the limit
     /// (unlimited delayed requests). Default: 10_000.
     pub admission_max_delayed_count: u64,
+    /// RU charged to a group for every request that arrives, on top of the CPU
+    /// that request's execution consumes.
+    ///
+    /// Charged at gRPC handler entry, before admission control, so a rejected
+    /// request pays it too. That is the point: a rejection consumes no read
+    /// pool CPU, so without this it is free, and throttling a group drops its
+    /// measured RU, which relaxes the throttle while the group keeps loading
+    /// the node. No request is free in reality -- each costs the gRPC
+    /// transport a message in and a message out, which resource control
+    /// cannot otherwise see. Foreground RU is CPU microseconds, so this is in
+    /// microseconds. Set to 0 to disable.
+    ///
+    /// The default is taken from published gRPC performance benchmarks: a
+    /// tuned server costs on the order of 45-65us of CPU for a small unary
+    /// call on one allocated core (grpc_bench). That is a floor, not this
+    /// cluster's real cost -- measured client-attributable gRPC CPU is nearer
+    /// 140us per request -- chosen so this term stays small beside the ~180us
+    /// a read already consumes in the read pool.
+    pub request_base_cost_micros: u64,
 }
 
 impl Default for Config {
@@ -77,6 +100,7 @@ impl Default for Config {
         Self {
             enabled: true,
             priority_ctl_strategy: PriorityCtlStrategy::Moderate,
+            noisy_detection: NoisyDetection::Baseline,
             bg_cpu_throttle_threshold: 60.0,
             fg_cpu_throttle_threshold: 70.0,
             bg_compaction_pressure_threshold: 70.0,
@@ -88,6 +112,7 @@ impl Default for Config {
             historical_usage_window_mins: 15,
             baseline_burst_pct: 20.0,
             admission_max_delayed_count: 10_000,
+            request_base_cost_micros: 40,
         }
     }
 }
@@ -96,6 +121,7 @@ const MIN_CPU_PCT: f64 = 1.0;
 const MAX_CPU_PCT: f64 = 99.0;
 const MIN_HISTORICAL_WINDOW_MINS: u64 = 2;
 const MAX_HISTORICAL_WINDOW_MINS: u64 = 60;
+const MAX_REQUEST_BASE_COST_MICROS: u64 = 10_000;
 
 fn validate_cpu_pct(name: &str, value: f64) -> Result<(), Box<dyn Error>> {
     // `!is_finite()` also rejects NaN, which would otherwise compare false
@@ -157,7 +183,63 @@ impl Config {
             .into());
         }
 
+        // Arrival is a fraction of a request's cost, never a multiple of one.
+        // The cap keeps a fat-fingered value from swamping measured execution
+        // CPU, which would throttle every group by request rate alone.
+        if self.request_base_cost_micros > MAX_REQUEST_BASE_COST_MICROS {
+            return Err(format!(
+                "resource-control.request-base-cost-micros must not exceed {}, but got {}",
+                MAX_REQUEST_BASE_COST_MICROS, self.request_base_cost_micros
+            )
+            .into());
+        }
+
         Ok(())
+    }
+}
+
+/// Which signal identifies the groups responsible for an overload.
+#[derive(Clone, Copy, Default, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum NoisyDetection {
+    /// Blame the groups furthest above their own quiet-window baseline. Picks
+    /// out the group that *changed*, so a tenant that is simply large is not
+    /// blamed for an overload someone else caused.
+    #[default]
+    Baseline,
+    /// Blame the groups consuming most right now, ignoring history. No
+    /// baseline to go stale or to be measured wrong, but a tenant that is
+    /// legitimately the largest is the one blamed every time.
+    CurrentUsage,
+}
+
+impl fmt::Display for NoisyDetection {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match *self {
+            Self::Baseline => "baseline",
+            Self::CurrentUsage => "current-usage",
+        })
+    }
+}
+
+impl From<NoisyDetection> for ConfigValue {
+    fn from(v: NoisyDetection) -> Self {
+        ConfigValue::String(format!("{}", v))
+    }
+}
+
+impl TryFrom<ConfigValue> for NoisyDetection {
+    type Error = String;
+    fn try_from(v: ConfigValue) -> Result<Self, Self::Error> {
+        if let ConfigValue::String(s) = v {
+            match s.as_str() {
+                "baseline" => Ok(Self::Baseline),
+                "current-usage" => Ok(Self::CurrentUsage),
+                s => Err(format!("invalid config value: {}", s)),
+            }
+        } else {
+            panic!("expect ConfigValue::String, got: {:?}", v);
+        }
     }
 }
 
@@ -222,12 +304,12 @@ impl TryFrom<ConfigValue> for PriorityCtlStrategy {
 }
 
 pub struct ResourceContrlCfgMgr {
-    config: Arc<VersionTrack<Config>>,
+    resource_ctl: Arc<ResourceGroupManager>,
 }
 
 impl ResourceContrlCfgMgr {
-    pub fn new(config: Arc<VersionTrack<Config>>) -> Self {
-        Self { config }
+    pub fn new(resource_ctl: Arc<ResourceGroupManager>) -> Self {
+        Self { resource_ctl }
     }
 }
 
@@ -236,8 +318,11 @@ impl ConfigManager for ResourceContrlCfgMgr {
         let cfg_str = format!("{:?}", change);
         // `ConfigController::update` already validated the whole TikvConfig,
         // including this submodule, before dispatching.
-        let res = self.config.update(|c| c.update(change));
+        let res = self.resource_ctl.get_config().update(|c| c.update(change));
         if res.is_ok() {
+            // The per-request path reads some of these from a cache outside
+            // the config lock.
+            self.resource_ctl.refresh_cached_config();
             tikv_util::info!("update resource control config"; "change" => cfg_str);
         }
         res
@@ -339,8 +424,8 @@ mod tests {
 
     #[test]
     fn test_config_manager_applies_valid_update() {
-        let tracker = Arc::new(VersionTrack::new(Config::default()));
-        let mut mgr = ResourceContrlCfgMgr::new(tracker.clone());
+        let resource_ctl = Arc::new(ResourceGroupManager::new(Config::default()));
+        let mut mgr = ResourceContrlCfgMgr::new(resource_ctl.clone());
 
         let mut change = ConfigChange::new();
         change.insert(
@@ -349,6 +434,28 @@ mod tests {
         );
         mgr.dispatch(change).unwrap();
 
-        assert_eq!(tracker.value().fg_cpu_throttle_threshold, 90.0);
+        assert_eq!(
+            resource_ctl.get_config().value().fg_cpu_throttle_threshold,
+            90.0
+        );
+    }
+
+    /// The per-request path reads the arrival cost from a cache outside the
+    /// config lock, so dispatching a change has to refresh it -- otherwise the
+    /// knob would not take effect until the next 10s control tick.
+    #[test]
+    fn test_config_manager_refreshes_cached_request_base_cost() {
+        let resource_ctl = Arc::new(ResourceGroupManager::new(Config::default()));
+        let mut mgr = ResourceContrlCfgMgr::new(resource_ctl.clone());
+
+        let mut change = ConfigChange::new();
+        change.insert("request_base_cost_micros".to_owned(), ConfigValue::U64(0));
+        mgr.dispatch(change).unwrap();
+
+        assert_eq!(
+            resource_ctl.get_config().value().request_base_cost_micros,
+            0
+        );
+        assert_eq!(resource_ctl.cached_request_base_cost_micros(), 0);
     }
 }

--- a/components/resource_control/src/config.rs
+++ b/components/resource_control/src/config.rs
@@ -1,5 +1,5 @@
 // Copyright 2024 TiKV Project Authors. Licensed under Apache-2.0.
-use std::{fmt, sync::Arc};
+use std::{error::Error, fmt, sync::Arc};
 
 use online_config::{ConfigManager, ConfigValue, OnlineConfig};
 use serde::{Deserialize, Serialize};
@@ -34,6 +34,13 @@ pub struct Config {
     /// phase 1 (deprioritised in the yatp priority queue) relative to groups
     /// within their baseline (phase 0). Protects sustained workloads from
     /// sudden traffic spikes without hard-rejecting requests.
+    ///
+    /// Requires `readpool.unified.auto-adjust-pool-size` to be enabled, which
+    /// is *not* the default. A group is deprioritised while the unified read
+    /// pool is scaled in and released once the pool recovers to its configured
+    /// size, so with auto-adjustment off the pool never moves and no group is
+    /// ever deprioritised. This is not rejected at config load, for backward
+    /// compatibility, so enabling this alone silently has no effect.
     pub enable_fair_scheduling: bool,
     /// When true, enables Tier-1 admission control for reads: high-priority
     /// read requests from groups that are over their RU baseline are shed
@@ -45,6 +52,8 @@ pub struct Config {
     pub enable_write_admission_control: bool,
     /// Size of the sliding window (in minutes) used to compute per-group
     /// historical RU baselines for fair scheduling and admission control.
+    /// Also sizes the unified read pool's historical CPU-usage tracker, whose
+    /// average is used as a scale-down floor for the pool's thread count.
     /// The window is divided into 30-second buckets (2 per minute). Minimum 2,
     /// maximum 60. Not hot-reloadable; changing requires a restart.
     #[online_config(skip)]
@@ -80,6 +89,75 @@ impl Default for Config {
             baseline_burst_pct: 20.0,
             admission_max_delayed_count: 10_000,
         }
+    }
+}
+
+const MIN_CPU_PCT: f64 = 1.0;
+const MAX_CPU_PCT: f64 = 99.0;
+const MIN_HISTORICAL_WINDOW_MINS: u64 = 2;
+const MAX_HISTORICAL_WINDOW_MINS: u64 = 60;
+
+fn validate_cpu_pct(name: &str, value: f64) -> Result<(), Box<dyn Error>> {
+    // `!is_finite()` also rejects NaN, which would otherwise compare false
+    // against every threshold and silently disable the consumer.
+    if !value.is_finite() || !(MIN_CPU_PCT..=MAX_CPU_PCT).contains(&value) {
+        return Err(format!(
+            "resource-control.{} must be a finite percentage in [{}, {}], but got {}",
+            name, MIN_CPU_PCT, MAX_CPU_PCT, value
+        )
+        .into());
+    }
+    Ok(())
+}
+
+impl Config {
+    pub fn validate(&self) -> Result<(), Box<dyn Error>> {
+        validate_cpu_pct("bg-cpu-throttle-threshold", self.bg_cpu_throttle_threshold)?;
+        validate_cpu_pct("fg-cpu-throttle-threshold", self.fg_cpu_throttle_threshold)?;
+        validate_cpu_pct(
+            "bg-compaction-pressure-threshold",
+            self.bg_compaction_pressure_threshold,
+        )?;
+
+        if self.bg_cpu_throttle_threshold > self.fg_cpu_throttle_threshold {
+            return Err(format!(
+                "resource-control.bg-cpu-throttle-threshold ({}) must not exceed \
+                 fg-cpu-throttle-threshold ({})",
+                self.bg_cpu_throttle_threshold, self.fg_cpu_throttle_threshold
+            )
+            .into());
+        }
+
+        if self.bg_write_io_floor.0 > self.bg_write_io_ceiling.0 {
+            return Err(format!(
+                "resource-control.bg-write-io-floor ({}) must not exceed \
+                 bg-write-io-ceiling ({})",
+                self.bg_write_io_floor, self.bg_write_io_ceiling
+            )
+            .into());
+        }
+
+        if !self.baseline_burst_pct.is_finite() || self.baseline_burst_pct < 0.0 {
+            return Err(format!(
+                "resource-control.baseline-burst-pct must be finite and non-negative, but got {}",
+                self.baseline_burst_pct
+            )
+            .into());
+        }
+
+        if !(MIN_HISTORICAL_WINDOW_MINS..=MAX_HISTORICAL_WINDOW_MINS)
+            .contains(&self.historical_usage_window_mins)
+        {
+            return Err(format!(
+                "resource-control.historical-usage-window-mins must be in [{}, {}], but got {}",
+                MIN_HISTORICAL_WINDOW_MINS,
+                MAX_HISTORICAL_WINDOW_MINS,
+                self.historical_usage_window_mins
+            )
+            .into());
+        }
+
+        Ok(())
     }
 }
 
@@ -156,10 +234,121 @@ impl ResourceContrlCfgMgr {
 impl ConfigManager for ResourceContrlCfgMgr {
     fn dispatch(&mut self, change: online_config::ConfigChange) -> online_config::Result<()> {
         let cfg_str = format!("{:?}", change);
+        // `ConfigController::update` already validated the whole TikvConfig,
+        // including this submodule, before dispatching.
         let res = self.config.update(|c| c.update(change));
         if res.is_ok() {
             tikv_util::info!("update resource control config"; "change" => cfg_str);
         }
         res
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use online_config::{ConfigChange, ConfigValue};
+
+    use super::*;
+
+    #[test]
+    fn test_validate_accepts_defaults() {
+        Config::default().validate().unwrap();
+    }
+
+    #[test]
+    fn test_validate_rejects_out_of_range_cpu_thresholds() {
+        for bad in [0.0, -50.0, 100.0, 150.0, f64::NAN, f64::INFINITY] {
+            let mut cfg = Config::default();
+            cfg.bg_cpu_throttle_threshold = bad;
+            assert!(
+                cfg.validate().is_err(),
+                "bg_cpu_throttle_threshold {} should be rejected",
+                bad
+            );
+
+            let mut cfg = Config::default();
+            cfg.fg_cpu_throttle_threshold = bad;
+            assert!(
+                cfg.validate().is_err(),
+                "fg_cpu_throttle_threshold {} should be rejected",
+                bad
+            );
+
+            let mut cfg = Config::default();
+            cfg.bg_compaction_pressure_threshold = bad;
+            assert!(
+                cfg.validate().is_err(),
+                "bg_compaction_pressure_threshold {} should be rejected",
+                bad
+            );
+        }
+    }
+
+    #[test]
+    fn test_validate_rejects_inverted_cpu_thresholds() {
+        let mut cfg = Config::default();
+        cfg.bg_cpu_throttle_threshold = 80.0;
+        cfg.fg_cpu_throttle_threshold = 20.0;
+        assert!(cfg.validate().is_err());
+
+        // Equal is allowed: background is fully throttled exactly where
+        // foreground protection takes over.
+        cfg.fg_cpu_throttle_threshold = 80.0;
+        cfg.validate().unwrap();
+    }
+
+    #[test]
+    fn test_validate_rejects_inverted_write_io_bounds() {
+        let mut cfg = Config::default();
+        cfg.bg_write_io_floor = ReadableSize::gb(200);
+        cfg.bg_write_io_ceiling = ReadableSize::gb(100);
+        assert!(cfg.validate().is_err());
+
+        cfg.bg_write_io_ceiling = ReadableSize::gb(200);
+        cfg.validate().unwrap();
+    }
+
+    #[test]
+    fn test_validate_rejects_bad_baseline_burst_pct() {
+        for bad in [-1.0, f64::NAN, f64::INFINITY] {
+            let mut cfg = Config::default();
+            cfg.baseline_burst_pct = bad;
+            assert!(cfg.validate().is_err(), "{} should be rejected", bad);
+        }
+
+        // Zero is allowed: no headroom above the baseline.
+        let mut cfg = Config::default();
+        cfg.baseline_burst_pct = 0.0;
+        cfg.validate().unwrap();
+    }
+
+    #[test]
+    fn test_validate_rejects_out_of_range_historical_window() {
+        for bad in [0, 1, 61, u64::MAX] {
+            let mut cfg = Config::default();
+            cfg.historical_usage_window_mins = bad;
+            assert!(cfg.validate().is_err(), "{} should be rejected", bad);
+        }
+
+        for good in [2, 15, 60] {
+            let mut cfg = Config::default();
+            cfg.historical_usage_window_mins = good;
+            cfg.validate().unwrap();
+        }
+    }
+
+    #[test]
+    fn test_config_manager_applies_valid_update() {
+        let tracker = Arc::new(VersionTrack::new(Config::default()));
+        let mut mgr = ResourceContrlCfgMgr::new(tracker.clone());
+
+        let mut change = ConfigChange::new();
+        change.insert(
+            "fg_cpu_throttle_threshold".to_owned(),
+            ConfigValue::F64(90.0),
+        );
+        mgr.dispatch(change).unwrap();
+
+        assert_eq!(tracker.value().fg_cpu_throttle_threshold, 90.0);
     }
 }

--- a/components/resource_control/src/future.rs
+++ b/components/resource_control/src/future.rs
@@ -72,16 +72,24 @@ pub struct LimitedFuture<F: Future> {
     // if the future is first polled, we need to let it consume a 0 value
     // to compensate the debt of previously finished tasks.
     is_first_poll: bool,
+    // Skip the compaction pressure write IO limiter. Set to true for
+    // operations like SST ingestion that don't cause compaction.
+    skip_compaction_pressure: bool,
 }
 
 impl<F: Future> LimitedFuture<F> {
-    pub fn new(f: F, resource_limiter: Arc<ResourceLimiter>) -> Self {
+    pub fn new(
+        f: F,
+        resource_limiter: Arc<ResourceLimiter>,
+        skip_compaction_pressure: bool,
+    ) -> Self {
         Self {
             f,
             pre_delay: None.into(),
             post_delay: None.into(),
             resource_limiter,
             is_first_poll: true,
+            skip_compaction_pressure,
         }
     }
 }
@@ -96,7 +104,12 @@ impl<F: Future> Future for LimitedFuture<F> {
             *this.is_first_poll = false;
             let wait_dur = this
                 .resource_limiter
-                .consume(Duration::ZERO, IoBytes::default(), true)
+                .consume(
+                    Duration::ZERO,
+                    IoBytes::default(),
+                    true,
+                    *this.skip_compaction_pressure,
+                )
                 .min(MAX_WAIT_DURATION);
             if wait_dur > Duration::ZERO {
                 *this.pre_delay = Some(
@@ -136,9 +149,12 @@ impl<F: Future> Future for LimitedFuture<F> {
             .as_mut()
             .and_then(|tracker| tracker.update())
             .unwrap_or_else(IoBytes::default);
-        let mut wait_dur = this
-            .resource_limiter
-            .consume(dur, io_bytes, res.is_pending());
+        let mut wait_dur = this.resource_limiter.consume(
+            dur,
+            io_bytes,
+            res.is_pending(),
+            *this.skip_compaction_pressure,
+        );
         if wait_dur == Duration::ZERO || res.is_ready() {
             return res;
         }
@@ -197,9 +213,10 @@ impl<F: Future> Future for OptionalFuture<F> {
 pub async fn with_resource_limiter<F: Future>(
     f: F,
     limiter: Option<Arc<ResourceLimiter>>,
+    skip_compaction_pressure: bool,
 ) -> F::Output {
     if let Some(limiter) = limiter {
-        LimitedFuture::new(f, limiter).await
+        LimitedFuture::new(f, limiter, skip_compaction_pressure).await
     } else {
         f.await
     }
@@ -264,7 +281,7 @@ mod tests {
             <F as Future>::Output: Send,
         {
             let (sender, receiver) = channel::<()>();
-            let fut = NotifyFuture::new(LimitedFuture::new(f, limiter), sender);
+            let fut = NotifyFuture::new(LimitedFuture::new(f, limiter, false), sender);
             pool.spawn(fut).unwrap();
             receiver.recv().unwrap();
         }

--- a/components/resource_control/src/future.rs
+++ b/components/resource_control/src/future.rs
@@ -15,7 +15,7 @@ use tikv_util::{time::Instant, timer::GLOBAL_TIMER_HANDLE, warn};
 use tokio_timer::Delay;
 
 use crate::{
-    resource_group::{ResourceConsumeType, ResourceController},
+    resource_group::{ResourceConsumeType, ResourceController, ResourceGroupManager},
     resource_limiter::{ResourceLimiter, ResourceType},
 };
 
@@ -69,19 +69,41 @@ pub struct LimitedFuture<F: Future> {
     #[pin]
     post_delay: OptionalFuture<Compat01As03<Delay>>,
     resource_limiter: Arc<ResourceLimiter>,
+    skip_compaction_pressure: bool,
     // if the future is first polled, we need to let it consume a 0 value
     // to compensate the debt of previously finished tasks.
     is_first_poll: bool,
+    // When true: measure CPU/IO and build token-bucket debt, but never sleep.
+    // When false: existing behavior — sleep inside the pool to throttle.
+    measure_only: bool,
+    // For measure-only mode: feed RuTracker + token-bucket via record_ru_consumption.
+    resource_mgr: Option<Arc<ResourceGroupManager>>,
+    // Known write bytes for this request (from cmd.write_bytes()), used as the
+    // write component of io_bytes passed to consume() instead of /proc iostat.
+    // Avoids syscall overhead and thread-level IO noise from compaction on the
+    // same thread. Zero means fall back to IoBytesTracker (e.g. reads, background).
+    write_bytes: u64,
 }
 
 impl<F: Future> LimitedFuture<F> {
-    pub fn new(f: F, resource_limiter: Arc<ResourceLimiter>) -> Self {
+    pub fn new(
+        f: F,
+        resource_limiter: Arc<ResourceLimiter>,
+        skip_compaction_pressure: bool,
+        measure_only: bool,
+        resource_mgr: Option<Arc<ResourceGroupManager>>,
+        write_bytes: u64,
+    ) -> Self {
         Self {
             f,
             pre_delay: None.into(),
             post_delay: None.into(),
             resource_limiter,
+            skip_compaction_pressure,
             is_first_poll: true,
+            measure_only,
+            resource_mgr,
+            write_bytes,
         }
     }
 }
@@ -91,12 +113,20 @@ impl<F: Future> Future for LimitedFuture<F> {
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let mut this = self.project();
-        if *this.is_first_poll {
+
+        // Pre-delay: pay off existing token-bucket debt before starting work.
+        // Skipped in measure-only mode — foreground pools never sleep in-pool.
+        if *this.is_first_poll && !*this.measure_only {
             debug_assert!(this.pre_delay.finished && this.post_delay.finished);
             *this.is_first_poll = false;
             let wait_dur = this
                 .resource_limiter
-                .consume(Duration::ZERO, IoBytes::default(), true)
+                .consume(
+                    Duration::ZERO,
+                    IoBytes::default(),
+                    true,
+                    *this.skip_compaction_pressure,
+                )
                 .min(MAX_WAIT_DURATION);
             if wait_dur > Duration::ZERO {
                 *this.pre_delay = Some(
@@ -106,6 +136,8 @@ impl<F: Future> Future for LimitedFuture<F> {
                 )
                 .into();
             }
+        } else if *this.is_first_poll {
+            *this.is_first_poll = false;
         }
         if !this.post_delay.finished {
             assert!(this.pre_delay.finished);
@@ -117,8 +149,7 @@ impl<F: Future> Future for LimitedFuture<F> {
                 return Poll::Pending;
             }
         }
-        // get io stats is very expensive, so we only do so if only io control is
-        // enabled.
+        // get io stats is very expensive, so we only do so if io control is enabled.
         let mut io_tracker = if this
             .resource_limiter
             .get_limiter(ResourceType::Io)
@@ -132,14 +163,29 @@ impl<F: Future> Future for LimitedFuture<F> {
         let start = Instant::now();
         let res = this.f.poll(cx);
         let dur = start.saturating_elapsed();
-        let io_bytes = io_tracker
+        let mut io_bytes = io_tracker
             .as_mut()
             .and_then(|tracker| tracker.update())
             .unwrap_or_else(IoBytes::default);
-        let mut wait_dur = this
-            .resource_limiter
-            .consume(dur, io_bytes, res.is_pending());
-        if wait_dur == Duration::ZERO || res.is_ready() {
+        // Only count write_bytes when the future completes to avoid
+        // double-counting across multiple pending polls.
+        if *this.write_bytes > 0 && res.is_ready() {
+            io_bytes.write = *this.write_bytes;
+        }
+        let mut wait_dur = this.resource_limiter.consume(
+            dur,
+            io_bytes,
+            res.is_pending(),
+            *this.skip_compaction_pressure,
+        );
+        // Feed RuTracker so admission_decision has baseline data.
+        // Only for foreground limiters — background jobs shouldn't shift the baseline.
+        if !this.resource_limiter.is_background()
+            && let Some(mgr) = &this.resource_mgr
+        {
+            mgr.record_ru_consumption(this.resource_limiter.name(), dur.as_micros() as u64);
+        }
+        if wait_dur == Duration::ZERO || res.is_ready() || *this.measure_only {
             return res;
         }
         if wait_dur > MAX_WAIT_DURATION {
@@ -157,8 +203,8 @@ impl<F: Future> Future for LimitedFuture<F> {
     }
 }
 
-/// `OptionalFuture` is similar to futures::OptionFuture, but provide an extra
-/// `finished` flag to determine if the future requires poll.
+/// `OptionalFuture` is similar to futures::OptionFuture, but provides an extra
+/// `finished` flag to determine if the future requires polling.
 #[pin_project]
 struct OptionalFuture<F> {
     #[pin]
@@ -197,9 +243,21 @@ impl<F: Future> Future for OptionalFuture<F> {
 pub async fn with_resource_limiter<F: Future>(
     f: F,
     limiter: Option<Arc<ResourceLimiter>>,
+    skip_compaction_pressure: bool,
+    measure_only: bool,
+    resource_mgr: Option<Arc<ResourceGroupManager>>,
+    write_bytes: u64,
 ) -> F::Output {
     if let Some(limiter) = limiter {
-        LimitedFuture::new(f, limiter).await
+        LimitedFuture::new(
+            f,
+            limiter,
+            skip_compaction_pressure,
+            measure_only,
+            resource_mgr,
+            write_bytes,
+        )
+        .await
     } else {
         f.await
     }
@@ -264,7 +322,10 @@ mod tests {
             <F as Future>::Output: Send,
         {
             let (sender, receiver) = channel::<()>();
-            let fut = NotifyFuture::new(LimitedFuture::new(f, limiter), sender);
+            let fut = NotifyFuture::new(
+                LimitedFuture::new(f, limiter, false, false, None, 0),
+                sender,
+            );
             pool.spawn(fut).unwrap();
             receiver.recv().unwrap();
         }

--- a/components/resource_control/src/future.rs
+++ b/components/resource_control/src/future.rs
@@ -15,7 +15,7 @@ use tikv_util::{time::Instant, timer::GLOBAL_TIMER_HANDLE, warn};
 use tokio_timer::Delay;
 
 use crate::{
-    resource_group::{ResourceConsumeType, ResourceController},
+    resource_group::{ResourceConsumeType, ResourceController, ResourceGroupManager},
     resource_limiter::{ResourceLimiter, ResourceType},
 };
 
@@ -69,12 +69,20 @@ pub struct LimitedFuture<F: Future> {
     #[pin]
     post_delay: OptionalFuture<Compat01As03<Delay>>,
     resource_limiter: Arc<ResourceLimiter>,
+    skip_compaction_pressure: bool,
     // if the future is first polled, we need to let it consume a 0 value
     // to compensate the debt of previously finished tasks.
     is_first_poll: bool,
-    // Skip the compaction pressure write IO limiter. Set to true for
-    // operations like SST ingestion that don't cause compaction.
-    skip_compaction_pressure: bool,
+    // When true: measure CPU/IO and build token-bucket debt, but never sleep.
+    // When false: existing behavior — sleep inside the pool to throttle.
+    measure_only: bool,
+    // For measure-only mode: feed RuTracker + token-bucket via record_ru_consumption.
+    resource_mgr: Option<Arc<ResourceGroupManager>>,
+    // Known write bytes for this request (from cmd.write_bytes()), used as the
+    // write component of io_bytes passed to consume() instead of /proc iostat.
+    // Avoids syscall overhead and thread-level IO noise from compaction on the
+    // same thread. Zero means fall back to IoBytesTracker (e.g. reads, background).
+    write_bytes: u64,
 }
 
 impl<F: Future> LimitedFuture<F> {
@@ -82,14 +90,20 @@ impl<F: Future> LimitedFuture<F> {
         f: F,
         resource_limiter: Arc<ResourceLimiter>,
         skip_compaction_pressure: bool,
+        measure_only: bool,
+        resource_mgr: Option<Arc<ResourceGroupManager>>,
+        write_bytes: u64,
     ) -> Self {
         Self {
             f,
             pre_delay: None.into(),
             post_delay: None.into(),
             resource_limiter,
-            is_first_poll: true,
             skip_compaction_pressure,
+            is_first_poll: true,
+            measure_only,
+            resource_mgr,
+            write_bytes,
         }
     }
 }
@@ -99,7 +113,10 @@ impl<F: Future> Future for LimitedFuture<F> {
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let mut this = self.project();
-        if *this.is_first_poll {
+
+        // Pre-delay: pay off existing token-bucket debt before starting work.
+        // Skipped in measure-only mode — foreground pools never sleep in-pool.
+        if *this.is_first_poll && !*this.measure_only {
             debug_assert!(this.pre_delay.finished && this.post_delay.finished);
             *this.is_first_poll = false;
             let wait_dur = this
@@ -119,6 +136,8 @@ impl<F: Future> Future for LimitedFuture<F> {
                 )
                 .into();
             }
+        } else if *this.is_first_poll {
+            *this.is_first_poll = false;
         }
         if !this.post_delay.finished {
             assert!(this.pre_delay.finished);
@@ -130,8 +149,7 @@ impl<F: Future> Future for LimitedFuture<F> {
                 return Poll::Pending;
             }
         }
-        // get io stats is very expensive, so we only do so if only io control is
-        // enabled.
+        // get io stats is very expensive, so we only do so if io control is enabled.
         let mut io_tracker = if this
             .resource_limiter
             .get_limiter(ResourceType::Io)
@@ -145,17 +163,29 @@ impl<F: Future> Future for LimitedFuture<F> {
         let start = Instant::now();
         let res = this.f.poll(cx);
         let dur = start.saturating_elapsed();
-        let io_bytes = io_tracker
+        let mut io_bytes = io_tracker
             .as_mut()
             .and_then(|tracker| tracker.update())
             .unwrap_or_else(IoBytes::default);
+        // Only count write_bytes when the future completes to avoid
+        // double-counting across multiple pending polls.
+        if *this.write_bytes > 0 && res.is_ready() {
+            io_bytes.write = *this.write_bytes;
+        }
         let mut wait_dur = this.resource_limiter.consume(
             dur,
             io_bytes,
             res.is_pending(),
             *this.skip_compaction_pressure,
         );
-        if wait_dur == Duration::ZERO || res.is_ready() {
+        // Feed RuTracker so admission_decision has baseline data.
+        // Only for foreground limiters — background jobs shouldn't shift the baseline.
+        if !this.resource_limiter.is_background()
+            && let Some(mgr) = &this.resource_mgr
+        {
+            mgr.record_ru_consumption(this.resource_limiter.name(), dur.as_micros() as u64);
+        }
+        if wait_dur == Duration::ZERO || res.is_ready() || *this.measure_only {
             return res;
         }
         if wait_dur > MAX_WAIT_DURATION {
@@ -173,8 +203,8 @@ impl<F: Future> Future for LimitedFuture<F> {
     }
 }
 
-/// `OptionalFuture` is similar to futures::OptionFuture, but provide an extra
-/// `finished` flag to determine if the future requires poll.
+/// `OptionalFuture` is similar to futures::OptionFuture, but provides an extra
+/// `finished` flag to determine if the future requires polling.
 #[pin_project]
 struct OptionalFuture<F> {
     #[pin]
@@ -214,9 +244,20 @@ pub async fn with_resource_limiter<F: Future>(
     f: F,
     limiter: Option<Arc<ResourceLimiter>>,
     skip_compaction_pressure: bool,
+    measure_only: bool,
+    resource_mgr: Option<Arc<ResourceGroupManager>>,
+    write_bytes: u64,
 ) -> F::Output {
     if let Some(limiter) = limiter {
-        LimitedFuture::new(f, limiter, skip_compaction_pressure).await
+        LimitedFuture::new(
+            f,
+            limiter,
+            skip_compaction_pressure,
+            measure_only,
+            resource_mgr,
+            write_bytes,
+        )
+        .await
     } else {
         f.await
     }
@@ -281,7 +322,10 @@ mod tests {
             <F as Future>::Output: Send,
         {
             let (sender, receiver) = channel::<()>();
-            let fut = NotifyFuture::new(LimitedFuture::new(f, limiter, false), sender);
+            let fut = NotifyFuture::new(
+                LimitedFuture::new(f, limiter, false, false, None, 0),
+                sender,
+            );
             pool.spawn(fut).unwrap();
             receiver.recv().unwrap();
         }

--- a/components/resource_control/src/lib.rs
+++ b/components/resource_control/src/lib.rs
@@ -2,7 +2,7 @@
 #![feature(test)]
 #![feature(let_chains)]
 
-use std::sync::Arc;
+use std::sync::{Arc, atomic::AtomicU32};
 
 use pd_client::RpcClient;
 
@@ -39,6 +39,7 @@ pub fn start_periodic_tasks(
     pd_client: Arc<RpcClient>,
     bg_worker: &Worker,
     io_bandwidth: u64,
+    compaction_pending_bytes_ratio: Arc<AtomicU32>,
 ) {
     let resource_mgr_service = ResourceManagerService::new(mgr.clone(), pd_client);
     // spawn a task to periodically update the minimal virtual time of all resource
@@ -54,7 +55,8 @@ pub fn start_periodic_tasks(
     });
     // spawn a task to auto adjust background quota limiter and priority quota
     // limiter.
-    let mut worker = GroupQuotaAdjustWorker::new(mgr.clone(), io_bandwidth);
+    let mut worker =
+        GroupQuotaAdjustWorker::new(mgr.clone(), io_bandwidth, compaction_pending_bytes_ratio);
     // We disable the priority worker by default because the current adjust
     // algorithm is buggy. We may reenable it only we find a better algorithm.
     // let mut priority_worker = PriorityLimiterAdjustWorker::new(mgr.clone());

--- a/components/resource_control/src/lib.rs
+++ b/components/resource_control/src/lib.rs
@@ -2,13 +2,14 @@
 #![feature(test)]
 #![feature(let_chains)]
 
-use std::sync::Arc;
+use std::sync::{atomic::AtomicU32, Arc};
 
 use pd_client::RpcClient;
 
 mod resource_group;
 pub use resource_group::{
-    ResourceConsumeType, ResourceController, ResourceGroupManager, MIN_PRIORITY_UPDATE_INTERVAL,
+    AdmissionDecision, DelaySlotGuard, ResourceConsumeType, ResourceController,
+    ResourceGroupManager, MIN_PRIORITY_UPDATE_INTERVAL,
 };
 pub use tikv_util::resource_control::*;
 
@@ -29,7 +30,7 @@ pub mod config;
 mod resource_limiter;
 pub use resource_limiter::ResourceLimiter;
 use tikv_util::worker::Worker;
-use worker::{GroupQuotaAdjustWorker, BACKGROUND_LIMIT_ADJUST_DURATION};
+use worker::{GroupQuotaAdjustWorker, QUOTA_ADJUST_DURATION};
 
 mod metrics;
 pub mod worker;
@@ -39,6 +40,7 @@ pub fn start_periodic_tasks(
     pd_client: Arc<RpcClient>,
     bg_worker: &Worker,
     io_bandwidth: u64,
+    compaction_pending_bytes_ratio: Arc<AtomicU32>,
 ) {
     let resource_mgr_service = ResourceManagerService::new(mgr.clone(), pd_client);
     // spawn a task to periodically update the minimal virtual time of all resource
@@ -54,11 +56,12 @@ pub fn start_periodic_tasks(
     });
     // spawn a task to auto adjust background quota limiter and priority quota
     // limiter.
-    let mut worker = GroupQuotaAdjustWorker::new(mgr.clone(), io_bandwidth);
+    let mut worker =
+        GroupQuotaAdjustWorker::new(mgr.clone(), io_bandwidth, compaction_pending_bytes_ratio);
     // We disable the priority worker by default because the current adjust
     // algorithm is buggy. We may reenable it only we find a better algorithm.
     // let mut priority_worker = PriorityLimiterAdjustWorker::new(mgr.clone());
-    bg_worker.spawn_interval_task(BACKGROUND_LIMIT_ADJUST_DURATION, move || {
+    bg_worker.spawn_interval_task(QUOTA_ADJUST_DURATION, move || {
         worker.adjust_quota();
         // priority_worker.adjust();
     });

--- a/components/resource_control/src/lib.rs
+++ b/components/resource_control/src/lib.rs
@@ -9,7 +9,8 @@ use pd_client::RpcClient;
 mod resource_group;
 pub use resource_group::{
     AdmissionDecision, DelaySlotGuard, ResourceConsumeType, ResourceController,
-    ResourceGroupManager, MIN_PRIORITY_UPDATE_INTERVAL,
+    ResourceGroupManager, CONTROL_TICK, LEEWAY_FACTOR, LEEWAY_FRACTION,
+    MIN_PRIORITY_UPDATE_INTERVAL,
 };
 pub use tikv_util::resource_control::*;
 
@@ -30,7 +31,7 @@ pub mod config;
 mod resource_limiter;
 pub use resource_limiter::ResourceLimiter;
 use tikv_util::worker::Worker;
-use worker::{GroupQuotaAdjustWorker, QUOTA_ADJUST_DURATION};
+use worker::GroupQuotaAdjustWorker;
 
 mod metrics;
 pub use metrics::READ_POOL_CPU_VEC;
@@ -73,7 +74,7 @@ pub fn start_periodic_tasks(
     // We disable the priority worker by default because the current adjust
     // algorithm is buggy. We may reenable it only we find a better algorithm.
     // let mut priority_worker = PriorityLimiterAdjustWorker::new(mgr.clone());
-    bg_worker.spawn_interval_task(QUOTA_ADJUST_DURATION, move || {
+    bg_worker.spawn_interval_task(CONTROL_TICK, move || {
         worker.adjust_quota();
         // priority_worker.adjust();
     });

--- a/components/resource_control/src/lib.rs
+++ b/components/resource_control/src/lib.rs
@@ -33,7 +33,14 @@ use tikv_util::worker::Worker;
 use worker::{GroupQuotaAdjustWorker, QUOTA_ADJUST_DURATION};
 
 mod metrics;
+pub use metrics::READ_POOL_CPU_VEC;
+mod score;
 pub mod worker;
+
+pub use score::{
+    compute_resource_scores, ResourceCapacities, ResourceScoreInputs, ResourceScores,
+    ThreadGroupCpuTracker,
+};
 
 pub fn start_periodic_tasks(
     mgr: &Arc<ResourceGroupManager>,
@@ -41,6 +48,7 @@ pub fn start_periodic_tasks(
     bg_worker: &Worker,
     io_bandwidth: u64,
     compaction_pending_bytes_ratio: Arc<AtomicU32>,
+    grpc_concurrency: usize,
 ) {
     let resource_mgr_service = ResourceManagerService::new(mgr.clone(), pd_client);
     // spawn a task to periodically update the minimal virtual time of all resource
@@ -56,8 +64,12 @@ pub fn start_periodic_tasks(
     });
     // spawn a task to auto adjust background quota limiter and priority quota
     // limiter.
-    let mut worker =
-        GroupQuotaAdjustWorker::new(mgr.clone(), io_bandwidth, compaction_pending_bytes_ratio);
+    let mut worker = GroupQuotaAdjustWorker::new(
+        mgr.clone(),
+        io_bandwidth,
+        compaction_pending_bytes_ratio,
+        grpc_concurrency,
+    );
     // We disable the priority worker by default because the current adjust
     // algorithm is buggy. We may reenable it only we find a better algorithm.
     // let mut priority_worker = PriorityLimiterAdjustWorker::new(mgr.clone());

--- a/components/resource_control/src/lib.rs
+++ b/components/resource_control/src/lib.rs
@@ -2,13 +2,14 @@
 #![feature(test)]
 #![feature(let_chains)]
 
-use std::sync::{Arc, atomic::AtomicU32};
+use std::sync::{atomic::AtomicU32, Arc};
 
 use pd_client::RpcClient;
 
 mod resource_group;
 pub use resource_group::{
-    ResourceConsumeType, ResourceController, ResourceGroupManager, MIN_PRIORITY_UPDATE_INTERVAL,
+    AdmissionDecision, DelaySlotGuard, ResourceConsumeType, ResourceController,
+    ResourceGroupManager, MIN_PRIORITY_UPDATE_INTERVAL,
 };
 pub use tikv_util::resource_control::*;
 
@@ -29,7 +30,7 @@ pub mod config;
 mod resource_limiter;
 pub use resource_limiter::ResourceLimiter;
 use tikv_util::worker::Worker;
-use worker::{GroupQuotaAdjustWorker, BACKGROUND_LIMIT_ADJUST_DURATION};
+use worker::{GroupQuotaAdjustWorker, QUOTA_ADJUST_DURATION};
 
 mod metrics;
 pub mod worker;
@@ -60,7 +61,7 @@ pub fn start_periodic_tasks(
     // We disable the priority worker by default because the current adjust
     // algorithm is buggy. We may reenable it only we find a better algorithm.
     // let mut priority_worker = PriorityLimiterAdjustWorker::new(mgr.clone());
-    bg_worker.spawn_interval_task(BACKGROUND_LIMIT_ADJUST_DURATION, move || {
+    bg_worker.spawn_interval_task(QUOTA_ADJUST_DURATION, move || {
         worker.adjust_quota();
         // priority_worker.adjust();
     });

--- a/components/resource_control/src/metrics.rs
+++ b/components/resource_control/src/metrics.rs
@@ -6,20 +6,19 @@ use prometheus::*;
 lazy_static! {
     pub static ref BACKGROUND_QUOTA_LIMIT_VEC: IntGaugeVec = register_int_gauge_vec!(
         "tikv_resource_control_background_quota_limiter",
-        "The quota limiter of background resource groups per resource type",
-        &["resource_group", "type"]
+        "The quota limiter for all background tasks (aggregated across all background resource groups) per resource type",
+        &["type"]
     )
     .unwrap();
     pub static ref BACKGROUND_RESOURCE_CONSUMPTION: IntCounterVec = register_int_counter_vec!(
         "tikv_resource_control_background_resource_consumption",
-        "Total resource consumed of background resource groups per resource type",
-        &["resource_group", "type"]
+        "Total resource consumed by all background tasks (aggregated across all background resource groups) per resource type",
+        &["type"]
     )
     .unwrap();
-    pub static ref BACKGROUND_TASKS_WAIT_DURATION: IntCounterVec = register_int_counter_vec!(
+    pub static ref BACKGROUND_TASKS_WAIT_DURATION: IntCounter = register_int_counter!(
         "tikv_resource_control_background_task_wait_duration",
-        "Total wait duration of background tasks per resource group",
-        &["resource_group"]
+        "Total wait duration of all background tasks (aggregated across all background resource groups)"
     )
     .unwrap();
     pub static ref PRIORITY_QUOTA_LIMIT_VEC: IntGaugeVec = register_int_gauge_vec!(
@@ -48,12 +47,4 @@ lazy_static! {
         &["type"]
     )
     .unwrap();
-}
-
-pub fn deregister_metrics(name: &str) {
-    for ty in ["cpu", "io"] {
-        _ = BACKGROUND_QUOTA_LIMIT_VEC.remove_label_values(&[name, ty]);
-        _ = BACKGROUND_RESOURCE_CONSUMPTION.remove_label_values(&[name, ty]);
-    }
-    _ = BACKGROUND_TASKS_WAIT_DURATION.remove_label_values(&[name]);
 }

--- a/components/resource_control/src/metrics.rs
+++ b/components/resource_control/src/metrics.rs
@@ -6,7 +6,7 @@ use prometheus::*;
 lazy_static! {
     pub static ref BACKGROUND_QUOTA_LIMIT_VEC: IntGaugeVec = register_int_gauge_vec!(
         "tikv_resource_control_background_quota_limiter",
-        "The quota limiter for all background tasks per resource type",
+        "The quota limit for all background tasks per resource type, in centi-cores (cores * 100) for CPU or bytes/s for IO",
         &["type"]
     )
     .unwrap();
@@ -14,11 +14,6 @@ lazy_static! {
         "tikv_resource_control_background_resource_consumption",
         "Total resource consumed by all background tasks (aggregated across all background resource groups) per resource type",
         &["type"]
-    )
-    .unwrap();
-    pub static ref BACKGROUND_TASKS_WAIT_DURATION: IntCounter = register_int_counter!(
-        "tikv_resource_control_background_task_wait_duration",
-        "Total wait duration of all background tasks (aggregated across all background resource groups)"
     )
     .unwrap();
     pub static ref PRIORITY_QUOTA_LIMIT_VEC: IntGaugeVec = register_int_gauge_vec!(
@@ -43,7 +38,7 @@ lazy_static! {
 
     pub static ref BACKGROUND_TASK_RESOURCE_UTILIZATION_VEC: IntGaugeVec = register_int_gauge_vec!(
         "tikv_resource_control_bg_resource_utilization",
-        "The total resource utilization percentage of background tasks",
+        "The total resource consumed by background tasks, in centi-cores (cores * 100) for CPU or bytes/s for IO",
         &["type"]
     )
     .unwrap();
@@ -99,6 +94,20 @@ lazy_static! {
         "Histogram of delay duration imposed by admission control",
         &["resource_group"],
         exponential_buckets(1e-4, 2.0, 20).unwrap() // 100us ~ 52s
+    )
+    .unwrap();
+
+    pub static ref READ_POOL_CPU_VEC: GaugeVec = register_gauge_vec!(
+        "tikv_resource_control_read_pool_cpu_percent",
+        "Unified read pool CPU usage as a percentage of one core (100 = 1 core): historical (floor), current (measured), and target (foreground-pressure-driven ceiling)",
+        &["type"]
+    )
+    .unwrap();
+
+    pub static ref RESOURCE_SCORE_VEC: GaugeVec = register_gauge_vec!(
+        "tikv_resource_control_resource_score",
+        "Common 0-100 resource-pressure score computed by compute_resource_scores, per resource type (cpu, io, compaction)",
+        &["type"]
     )
     .unwrap();
 }

--- a/components/resource_control/src/metrics.rs
+++ b/components/resource_control/src/metrics.rs
@@ -6,20 +6,19 @@ use prometheus::*;
 lazy_static! {
     pub static ref BACKGROUND_QUOTA_LIMIT_VEC: IntGaugeVec = register_int_gauge_vec!(
         "tikv_resource_control_background_quota_limiter",
-        "The quota limiter of background resource groups per resource type",
-        &["resource_group", "type"]
+        "The quota limiter for all background tasks per resource type",
+        &["type"]
     )
     .unwrap();
     pub static ref BACKGROUND_RESOURCE_CONSUMPTION: IntCounterVec = register_int_counter_vec!(
         "tikv_resource_control_background_resource_consumption",
-        "Total resource consumed of background resource groups per resource type",
-        &["resource_group", "type"]
+        "Total resource consumed by all background tasks (aggregated across all background resource groups) per resource type",
+        &["type"]
     )
     .unwrap();
-    pub static ref BACKGROUND_TASKS_WAIT_DURATION: IntCounterVec = register_int_counter_vec!(
+    pub static ref BACKGROUND_TASKS_WAIT_DURATION: IntCounter = register_int_counter!(
         "tikv_resource_control_background_task_wait_duration",
-        "Total wait duration of background tasks per resource group",
-        &["resource_group"]
+        "Total wait duration of all background tasks (aggregated across all background resource groups)"
     )
     .unwrap();
     pub static ref PRIORITY_QUOTA_LIMIT_VEC: IntGaugeVec = register_int_gauge_vec!(
@@ -48,12 +47,71 @@ lazy_static! {
         &["type"]
     )
     .unwrap();
+
+    pub static ref TWO_PHASE_THROTTLED_REQUESTS: IntCounterVec = register_int_counter_vec!(
+        "tikv_resource_control_two_phase_throttled_requests_total",
+        "Total requests assigned to phase 1 (RU rate above 15-min baseline) per resource group",
+        &["resource_group"]
+    )
+    .unwrap();
+
+    pub static ref GROUP_RU_HISTORICAL_RATE: GaugeVec = register_gauge_vec!(
+        "tikv_resource_control_group_ru_historical_rate",
+        "Historical CPU utilization % per resource group (sliding window average)",
+        &["resource_group"]
+    )
+    .unwrap();
+
+    pub static ref GROUP_RU_CURRENT_RATE: GaugeVec = register_gauge_vec!(
+        "tikv_resource_control_group_ru_current_rate",
+        "Current CPU utilization % per resource group (latest bucket)",
+        &["resource_group"]
+    )
+    .unwrap();
+
+    pub static ref GROUP_QUOTA_LIMIT_VEC: GaugeVec = register_gauge_vec!(
+        "tikv_resource_control_group_quota_limit",
+        "Current rate limit per resource group per resource type (CPU as utilization %, 0 means unlimited)",
+        &["resource_group", "type"]
+    )
+    .unwrap();
+
+    pub static ref ADMISSION_CURRENTLY_DELAYED: IntGauge = register_int_gauge!(
+        "tikv_resource_control_admission_currently_delayed",
+        "Current number of requests sitting in admission control delay"
+    )
+    .unwrap();
+
+    pub static ref ADMISSION_DELAYED_REQUESTS: IntCounterVec = register_int_counter_vec!(
+        "tikv_resource_control_admission_delayed_requests_total",
+        "Total requests delayed by admission control per resource group",
+        &["resource_group"]
+    )
+    .unwrap();
+    pub static ref ADMISSION_REJECTED_REQUESTS: IntCounterVec = register_int_counter_vec!(
+        "tikv_resource_control_admission_rejected_requests_total",
+        "Total requests rejected by admission control per resource group",
+        &["resource_group"]
+    )
+    .unwrap();
+    pub static ref ADMISSION_DELAY_DURATION: HistogramVec = register_histogram_vec!(
+        "tikv_resource_control_admission_delay_duration_seconds",
+        "Histogram of delay duration imposed by admission control",
+        &["resource_group"],
+        exponential_buckets(1e-4, 2.0, 20).unwrap() // 100us ~ 52s
+    )
+    .unwrap();
 }
 
 pub fn deregister_metrics(name: &str) {
-    for ty in ["cpu", "io"] {
-        _ = BACKGROUND_QUOTA_LIMIT_VEC.remove_label_values(&[name, ty]);
-        _ = BACKGROUND_RESOURCE_CONSUMPTION.remove_label_values(&[name, ty]);
-    }
-    _ = BACKGROUND_TASKS_WAIT_DURATION.remove_label_values(&[name]);
+    _ = TWO_PHASE_THROTTLED_REQUESTS.remove_label_values(&[name]);
+    _ = GROUP_QUOTA_LIMIT_VEC.remove_label_values(&[name, "cpu"]);
+    _ = GROUP_RU_HISTORICAL_RATE.remove_label_values(&[name]);
+    _ = GROUP_RU_CURRENT_RATE.remove_label_values(&[name]);
+    _ = ADMISSION_DELAYED_REQUESTS.remove_label_values(&[name]);
+    _ = ADMISSION_REJECTED_REQUESTS.remove_label_values(&[name]);
+    _ = ADMISSION_DELAY_DURATION.remove_label_values(&[name]);
+    _ = ADMISSION_DELAYED_REQUESTS.remove_label_values(&["background"]);
+    _ = ADMISSION_REJECTED_REQUESTS.remove_label_values(&["background"]);
+    _ = ADMISSION_DELAY_DURATION.remove_label_values(&["background"]);
 }

--- a/components/resource_control/src/metrics.rs
+++ b/components/resource_control/src/metrics.rs
@@ -6,7 +6,7 @@ use prometheus::*;
 lazy_static! {
     pub static ref BACKGROUND_QUOTA_LIMIT_VEC: IntGaugeVec = register_int_gauge_vec!(
         "tikv_resource_control_background_quota_limiter",
-        "The quota limiter for all background tasks (aggregated across all background resource groups) per resource type",
+        "The quota limiter for all background tasks per resource type",
         &["type"]
     )
     .unwrap();
@@ -47,4 +47,71 @@ lazy_static! {
         &["type"]
     )
     .unwrap();
+
+    pub static ref TWO_PHASE_THROTTLED_REQUESTS: IntCounterVec = register_int_counter_vec!(
+        "tikv_resource_control_two_phase_throttled_requests_total",
+        "Total requests assigned to phase 1 (RU rate above 15-min baseline) per resource group",
+        &["resource_group"]
+    )
+    .unwrap();
+
+    pub static ref GROUP_RU_HISTORICAL_RATE: GaugeVec = register_gauge_vec!(
+        "tikv_resource_control_group_ru_historical_rate",
+        "Historical CPU utilization % per resource group (sliding window average)",
+        &["resource_group"]
+    )
+    .unwrap();
+
+    pub static ref GROUP_RU_CURRENT_RATE: GaugeVec = register_gauge_vec!(
+        "tikv_resource_control_group_ru_current_rate",
+        "Current CPU utilization % per resource group (latest bucket)",
+        &["resource_group"]
+    )
+    .unwrap();
+
+    pub static ref GROUP_QUOTA_LIMIT_VEC: GaugeVec = register_gauge_vec!(
+        "tikv_resource_control_group_quota_limit",
+        "Current rate limit per resource group per resource type (CPU as utilization %, 0 means unlimited)",
+        &["resource_group", "type"]
+    )
+    .unwrap();
+
+    pub static ref ADMISSION_CURRENTLY_DELAYED: IntGauge = register_int_gauge!(
+        "tikv_resource_control_admission_currently_delayed",
+        "Current number of requests sitting in admission control delay"
+    )
+    .unwrap();
+
+    pub static ref ADMISSION_DELAYED_REQUESTS: IntCounterVec = register_int_counter_vec!(
+        "tikv_resource_control_admission_delayed_requests_total",
+        "Total requests delayed by admission control per resource group",
+        &["resource_group"]
+    )
+    .unwrap();
+    pub static ref ADMISSION_REJECTED_REQUESTS: IntCounterVec = register_int_counter_vec!(
+        "tikv_resource_control_admission_rejected_requests_total",
+        "Total requests rejected by admission control per resource group",
+        &["resource_group"]
+    )
+    .unwrap();
+    pub static ref ADMISSION_DELAY_DURATION: HistogramVec = register_histogram_vec!(
+        "tikv_resource_control_admission_delay_duration_seconds",
+        "Histogram of delay duration imposed by admission control",
+        &["resource_group"],
+        exponential_buckets(1e-4, 2.0, 20).unwrap() // 100us ~ 52s
+    )
+    .unwrap();
+}
+
+pub fn deregister_metrics(name: &str) {
+    _ = TWO_PHASE_THROTTLED_REQUESTS.remove_label_values(&[name]);
+    _ = GROUP_QUOTA_LIMIT_VEC.remove_label_values(&[name, "cpu"]);
+    _ = GROUP_RU_HISTORICAL_RATE.remove_label_values(&[name]);
+    _ = GROUP_RU_CURRENT_RATE.remove_label_values(&[name]);
+    _ = ADMISSION_DELAYED_REQUESTS.remove_label_values(&[name]);
+    _ = ADMISSION_REJECTED_REQUESTS.remove_label_values(&[name]);
+    _ = ADMISSION_DELAY_DURATION.remove_label_values(&[name]);
+    _ = ADMISSION_DELAYED_REQUESTS.remove_label_values(&["background"]);
+    _ = ADMISSION_REJECTED_REQUESTS.remove_label_values(&["background"]);
+    _ = ADMISSION_DELAY_DURATION.remove_label_values(&["background"]);
 }

--- a/components/resource_control/src/metrics.rs
+++ b/components/resource_control/src/metrics.rs
@@ -64,6 +64,13 @@ lazy_static! {
     )
     .unwrap();
 
+    pub static ref GROUP_RU_BASELINE: GaugeVec = register_gauge_vec!(
+        "tikv_resource_control_group_ru_baseline",
+        "Quiet-window baseline per resource group, as CPU utilization %. 0 means no quiet window has elapsed yet, which is also what the eligibility gate compares against, so any traffic is over it",
+        &["resource_group"]
+    )
+    .unwrap();
+
     pub static ref GROUP_QUOTA_LIMIT_VEC: GaugeVec = register_gauge_vec!(
         "tikv_resource_control_group_quota_limit",
         "Current rate limit per resource group per resource type (CPU as utilization %, 0 means unlimited)",
@@ -99,7 +106,7 @@ lazy_static! {
 
     pub static ref READ_POOL_CPU_VEC: GaugeVec = register_gauge_vec!(
         "tikv_resource_control_read_pool_cpu_percent",
-        "Unified read pool CPU usage as a percentage of one core (100 = 1 core): historical (floor), current (measured), and target (foreground-pressure-driven ceiling)",
+        "Unified read pool CPU usage as a percentage of one core (100 = 1 core): historical (live sliding average), baseline (floor frozen at overload onset, 0 when not frozen), current (measured), and target (foreground-pressure-driven ceiling)",
         &["type"]
     )
     .unwrap();
@@ -112,11 +119,21 @@ lazy_static! {
     .unwrap();
 }
 
+/// Drops the per-tick gauges for an evicted tracker; without this they keep
+/// reporting its last value. Gauges only, so a returning group is not a reset.
+pub fn deregister_tracker_gauges(name: &str) {
+    _ = GROUP_RU_HISTORICAL_RATE.remove_label_values(&[name]);
+    _ = GROUP_RU_CURRENT_RATE.remove_label_values(&[name]);
+    _ = GROUP_RU_BASELINE.remove_label_values(&[name]);
+    _ = GROUP_QUOTA_LIMIT_VEC.remove_label_values(&[name, "cpu"]);
+}
+
 pub fn deregister_metrics(name: &str) {
     _ = TWO_PHASE_THROTTLED_REQUESTS.remove_label_values(&[name]);
     _ = GROUP_QUOTA_LIMIT_VEC.remove_label_values(&[name, "cpu"]);
     _ = GROUP_RU_HISTORICAL_RATE.remove_label_values(&[name]);
     _ = GROUP_RU_CURRENT_RATE.remove_label_values(&[name]);
+    _ = GROUP_RU_BASELINE.remove_label_values(&[name]);
     _ = ADMISSION_DELAYED_REQUESTS.remove_label_values(&[name]);
     _ = ADMISSION_REJECTED_REQUESTS.remove_label_values(&[name]);
     _ = ADMISSION_DELAY_DURATION.remove_label_values(&[name]);

--- a/components/resource_control/src/resource_group.rs
+++ b/components/resource_control/src/resource_group.rs
@@ -636,12 +636,29 @@ impl ResourceController {
     }
 
     pub fn get_priority(&self, name: &[u8], pri: CommandPri) -> u64 {
-        let level = match pri {
-            CommandPri::Low => 2,
-            CommandPri::Normal => 1,
-            CommandPri::High => 0,
+        let level = Self::command_pri_to_level(pri);
+        self.resource_group(name).get_priority(level, None, true)
+    }
+
+    /// Returns the priority for the given task metadata without incrementing
+    /// virtual time. Used for pre-spawn eviction comparison.
+    pub fn peek_priority_of(&self, metadata: &TaskMetadata<'_>, pri: CommandPri) -> u64 {
+        let level = Self::command_pri_to_level(pri);
+        let group = self.resource_group(metadata.group_name());
+        let override_priority = if metadata.override_priority() == 0 {
+            None
+        } else {
+            Some(metadata.override_priority())
         };
-        self.resource_group(name).get_priority(level, None)
+        group.get_priority(level, override_priority, false)
+    }
+
+    fn command_pri_to_level(pri: CommandPri) -> usize {
+        match pri {
+            CommandPri::High => 0,
+            CommandPri::Normal => 1,
+            CommandPri::Low => 2,
+        }
     }
 }
 
@@ -655,6 +672,7 @@ impl TaskPriorityProvider for ResourceController {
             } else {
                 Some(metadata.override_priority())
             },
+            true,
         )
     }
 }
@@ -679,14 +697,18 @@ struct GroupPriorityTracker {
 }
 
 impl GroupPriorityTracker {
-    fn get_priority(&self, level: usize, override_priority: Option<u32>) -> u64 {
+    /// Computes the scheduling priority for a task at the given level.
+    /// When `advance_vt` is true, atomically increments the virtual time
+    /// (used when actually scheduling a task). When false, reads virtual
+    /// time without advancing it (used for priority comparison only).
+    fn get_priority(&self, level: usize, override_priority: Option<u32>, advance_vt: bool) -> u64 {
         let task_extra_priority = TASK_EXTRA_FACTOR_BY_LEVEL[level] * 1000 * self.weight;
-        let vt = (if self.vt_delta_for_get > 0 {
+        let vt = (if advance_vt && self.vt_delta_for_get > 0 {
             self.virtual_time
                 .fetch_add(self.vt_delta_for_get, Ordering::Relaxed)
                 + self.vt_delta_for_get
         } else {
-            self.virtual_time.load(Ordering::Relaxed)
+            self.virtual_time.load(Ordering::Relaxed) + self.vt_delta_for_get
         }) + task_extra_priority;
         let priority = override_priority.unwrap_or(self.group_priority);
         concat_priority_vt(priority, vt)

--- a/components/resource_control/src/resource_group.rs
+++ b/components/resource_control/src/resource_group.rs
@@ -27,7 +27,7 @@ use tikv_util::{
 };
 use yatp::queue::priority::TaskPriorityProvider;
 
-use crate::{config::Config, metrics::deregister_metrics, resource_limiter::ResourceLimiter};
+use crate::{config::Config, resource_limiter::ResourceLimiter};
 
 // a read task cost at least 50us.
 const DEFAULT_PRIORITY_PER_READ_TASK: u64 = 50;
@@ -62,11 +62,11 @@ pub struct ResourceGroupManager {
     // the count of all groups, a fast path because call `DashMap::len` is a little slower.
     group_count: AtomicU64,
     registry: RwLock<Vec<Arc<ResourceController>>>,
-    // auto incremental version generator used for mark the background
-    // resource limiter has changed.
-    version_generator: AtomicU64,
     // the shared resource limiter of each priority
     priority_limiters: [Arc<ResourceLimiter>; TaskPriority::PRIORITY_COUNT],
+    bg_limiter: Arc<ResourceLimiter>,
+    // cached: true when at least one group has background settings configured.
+    has_background: AtomicBool,
     // lastest config.
     config: Arc<VersionTrack<Config>>,
 }
@@ -88,12 +88,20 @@ impl ResourceGroupManager {
                 false,
             ))
         });
+        let bg_limiter = Arc::new(ResourceLimiter::new(
+            DEFAULT_RESOURCE_GROUP_NAME.to_owned(),
+            f64::INFINITY,
+            f64::INFINITY,
+            0,
+            true,
+        ));
         let manager = Self {
             resource_groups: Default::default(),
             group_count: AtomicU64::new(0),
             registry: Default::default(),
-            version_generator: AtomicU64::new(0),
             priority_limiters,
+            bg_limiter,
+            has_background: AtomicBool::new(false),
             config: Arc::new(VersionTrack::new(config)),
         };
 
@@ -149,12 +157,7 @@ impl ResourceGroupManager {
             controller.add_resource_group(group_name.clone().into_bytes(), ru_quota, rg.priority);
         });
         info!("add resource group"; "name"=> &rg.name, "ru" => rg.get_r_u_settings().get_r_u().get_settings().get_fill_rate());
-        // try to reuse the quota limit when update resource group settings.
-        let prev_limiter = self
-            .resource_groups
-            .get(&rg.name)
-            .and_then(|g| g.limiter.clone());
-        let limiter = self.build_resource_limiter(&rg, prev_limiter);
+        let limiter = self.build_resource_limiter(&rg);
 
         if self
             .resource_groups
@@ -171,27 +174,29 @@ impl ResourceGroupManager {
             .resource_groups
             .iter()
             .any(|g| !g.background_source_types.is_empty());
+        let prev = self.has_background.swap(any_has_bg, Ordering::Release);
+        // When the last background group is removed, reset the shared limiter to
+        // unlimited so that a later re-add does not inherit stale throttled rates.
+        if prev && !any_has_bg {
+            use crate::resource_limiter::ResourceType;
+            self.bg_limiter
+                .get_limiter(ResourceType::Cpu)
+                .set_rate_limit(f64::INFINITY);
+            self.bg_limiter
+                .get_limiter(ResourceType::Io)
+                .set_rate_limit(f64::INFINITY);
+            self.bg_limiter
+                .get_write_io_limiter()
+                .set_rate_limit(f64::INFINITY);
+        }
         self.registry.read().iter().for_each(|controller| {
             controller.set_has_background(any_has_bg);
         });
     }
 
-    fn build_resource_limiter(
-        &self,
-        rg: &PbResourceGroup,
-        old_limiter: Option<Arc<ResourceLimiter>>,
-    ) -> Option<Arc<ResourceLimiter>> {
+    fn build_resource_limiter(&self, rg: &PbResourceGroup) -> Option<Arc<ResourceLimiter>> {
         if !rg.get_background_settings().get_job_types().is_empty() {
-            old_limiter.or_else(|| {
-                let version = self.version_generator.fetch_add(1, Ordering::Relaxed);
-                Some(Arc::new(ResourceLimiter::new(
-                    rg.name.clone(),
-                    f64::INFINITY,
-                    f64::INFINITY,
-                    version,
-                    true,
-                )))
-            })
+            Some(self.bg_limiter.clone())
         } else {
             None
         }
@@ -203,7 +208,6 @@ impl ResourceGroupManager {
             controller.remove_resource_group(group_name.as_bytes());
         });
         if self.resource_groups.remove(&group_name).is_some() {
-            deregister_metrics(name);
             info!("remove resource group"; "name"=> name);
             self.group_count.fetch_sub(1, Ordering::Relaxed);
         }
@@ -220,7 +224,6 @@ impl ResourceGroupManager {
             let ret = f(k, &v.group);
             if !ret {
                 removed_names.push(k.clone());
-                deregister_metrics(k);
             }
             ret
         });
@@ -232,6 +235,7 @@ impl ResourceGroupManager {
             });
             self.group_count
                 .fetch_sub(removed_names.len() as u64, Ordering::Relaxed);
+            self.update_has_background();
         }
     }
 
@@ -257,6 +261,7 @@ impl ResourceGroupManager {
             let ru_quota = Self::get_ru_setting(&g.value().group, controller.is_read);
             controller.add_resource_group(g.key().clone().into_bytes(), ru_quota, g.group.priority);
         }
+        controller.set_has_background(self.has_background.load(Ordering::Acquire));
         controller
     }
 
@@ -368,6 +373,14 @@ impl ResourceGroupManager {
     ) -> &[Arc<ResourceLimiter>; TaskPriority::PRIORITY_COUNT] {
         &self.priority_limiters
     }
+
+    pub fn get_background_limiter(&self) -> Arc<ResourceLimiter> {
+        self.bg_limiter.clone()
+    }
+
+    pub fn has_background_groups(&self) -> bool {
+        self.has_background.load(Ordering::Acquire)
+    }
 }
 
 pub(crate) struct ResourceGroup {
@@ -399,8 +412,8 @@ impl ResourceGroup {
         }
     }
 
-    pub(crate) fn get_ru_quota(&self) -> u64 {
-        assert!(self.group.has_r_u_settings());
+    #[cfg(test)]
+    pub fn get_ru_quota(&self) -> u64 {
         self.group
             .get_r_u_settings()
             .get_r_u()

--- a/components/resource_control/src/resource_group.rs
+++ b/components/resource_control/src/resource_group.rs
@@ -5,10 +5,10 @@ use std::{
     cmp::{max, min},
     collections::HashSet,
     sync::{
-        atomic::{AtomicBool, AtomicU64, Ordering},
+        atomic::{AtomicBool, AtomicI64, AtomicU64, Ordering},
         Arc, Mutex,
     },
-    time::Duration,
+    time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
 use collections::HashMap;
@@ -27,7 +27,12 @@ use tikv_util::{
 };
 use yatp::queue::priority::TaskPriorityProvider;
 
-use crate::{config::Config, metrics::deregister_metrics, resource_limiter::ResourceLimiter};
+use crate::{
+    config::Config,
+    metrics,
+    metrics::{deregister_metrics, TWO_PHASE_THROTTLED_REQUESTS},
+    resource_limiter::{ResourceLimiter, ResourceType},
+};
 
 // a read task cost at least 50us.
 const DEFAULT_PRIORITY_PER_READ_TASK: u64 = 50;
@@ -51,9 +56,259 @@ const HIGH_PRIORITY: u32 = 16;
 // virtual time overflow.
 const RESET_VT_THRESHOLD: u64 = (u64::MAX >> 4) / 2;
 
+/// Duration of each bucket in the RuTracker ring buffer.
+const RU_BUCKET_SECS: u64 = 30;
+
+/// Sliding-window RU consumption tracker for both Tier-1 admission control
+/// and two-phase scheduling phase decisions.
+///
+/// Tracks actual CPU µs consumed (via `consume_penalty`) across reads and
+/// writes in a configurable ring buffer of 30-second buckets. Window size is
+/// set from `historical_usage_window_mins` (× 2 buckets per minute). Using real
+/// RU rather than virtual
+/// time avoids weight-skewing: a high-weight group accumulates VT faster
+/// without necessarily consuming more CPU.
+pub struct RuTracker {
+    /// Ring buffer of completed 30-second bucket totals (oldest at `head`).
+    buckets: Vec<u64>,
+    /// RU accumulated in the currently-open (incomplete) bucket.
+    /// Atomic so that `record_ru_consumption` can add without taking the Mutex.
+    current_bucket: AtomicU64,
+    /// Unix seconds at which the current bucket started.
+    bucket_start_secs: u64,
+    /// Index of the oldest completed bucket.
+    head: usize,
+    /// Number of completed buckets (≤ buckets.len()).
+    completed: usize,
+    /// Cached historical rate (RU/s), updated by `online_adjust_resource_quota`
+    /// every ~10s.
+    cached_historical_rate: f64,
+    /// Consecutive ramp-up epochs where new_limit >= 2x hist. Must reach
+    /// MIN_RAMP_UP_EPOCHS before the limit is fully lifted to INFINITY.
+    ramp_up_epochs: u32,
+}
+
+impl RuTracker {
+    /// Create a new tracker with `num_buckets` 30-second slots.
+    pub fn new(now_secs: u64, num_buckets: usize) -> Self {
+        let num_buckets = num_buckets.max(2); // need at least 2 to warm up
+        Self {
+            buckets: vec![0u64; num_buckets],
+            current_bucket: AtomicU64::new(0),
+            bucket_start_secs: now_secs,
+            head: 0,
+            completed: 0,
+            cached_historical_rate: 0.0,
+            ramp_up_epochs: 0,
+        }
+    }
+
+    pub fn now_secs() -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs()
+    }
+
+    #[inline]
+    fn num_buckets(&self) -> usize {
+        self.buckets.len()
+    }
+
+    /// Record `ru` in the current bucket (lock-free atomic add).
+    pub fn record(&self, ru: u64) {
+        self.current_bucket.fetch_add(ru, Ordering::Relaxed);
+    }
+
+    /// Advance to `now_secs` and record `ru`. Used by tests and callers
+    /// that hold exclusive access.
+    #[cfg(test)]
+    pub fn is_warmed_up(&self) -> bool {
+        self.completed >= 2
+    }
+
+    #[cfg(test)]
+    pub fn record_at(&mut self, ru: u64, now_secs: u64) {
+        self.advance(now_secs);
+        self.current_bucket.fetch_add(ru, Ordering::Relaxed);
+    }
+
+    fn advance(&mut self, now_secs: u64) {
+        let n = self.num_buckets();
+        let elapsed = now_secs.saturating_sub(self.bucket_start_secs);
+        let buckets_to_advance = (elapsed / RU_BUCKET_SECS) as usize;
+        if buckets_to_advance == 0 {
+            return;
+        }
+        if buckets_to_advance >= n {
+            // Gap larger than the window: everything aged out.
+            self.buckets.iter_mut().for_each(|b| *b = 0);
+            self.head = 0;
+            self.completed = 0;
+            self.current_bucket.store(0, Ordering::Relaxed);
+        } else {
+            // Commit the current bucket to the ring, then zero the rest.
+            let write_pos = (self.head + self.completed) % n;
+            self.buckets[write_pos] = self.current_bucket.swap(0, Ordering::Relaxed);
+            if self.completed < n {
+                self.completed += 1;
+            } else {
+                self.head = (self.head + 1) % n;
+            }
+            // Zero out the remaining (buckets_to_advance - 1) slots.
+            for _ in 1..buckets_to_advance {
+                let slot = (self.head + self.completed) % n;
+                self.buckets[slot] = 0;
+                if self.completed < n {
+                    self.completed += 1;
+                } else {
+                    self.head = (self.head + 1) % n;
+                }
+            }
+        }
+        self.bucket_start_secs += buckets_to_advance as u64 * RU_BUCKET_SECS;
+    }
+
+    /// RU/s rate estimated from the current partial bucket and the most recent
+    /// completed bucket. Using both avoids stale readings — the last completed
+    /// bucket alone can be up to 60s old at the end of the current 30s window.
+    ///
+    /// rate = (current_bucket + last_completed) / (elapsed_in_current + 30s)
+    pub fn current_rate(&self, now_secs: u64) -> f64 {
+        let elapsed = now_secs
+            .saturating_sub(self.bucket_start_secs)
+            .min(RU_BUCKET_SECS) as f64;
+        let last_completed = if self.completed > 0 {
+            let newest_slot = (self.head + self.completed - 1) % self.num_buckets();
+            self.buckets[newest_slot]
+        } else {
+            0
+        };
+        let window = elapsed + RU_BUCKET_SECS as f64;
+        (self.current_bucket.load(Ordering::Relaxed) + last_completed) as f64 / window
+    }
+
+    /// Average RU/s rate over all completed buckets (long-term baseline).
+    /// Average RU/s baseline. If the system has been up longer than the full
+    /// historical window, always divide by the full window (not just completed
+    /// buckets). This means a tracker that just started (e.g. spike with no
+    /// prior traffic) has historical=0 and any traffic is immediately detected
+    /// as over baseline, rather than letting new traffic inflate its own
+    /// baseline.
+    pub fn historical_rate(&self, system_start_secs: u64, now_secs: u64) -> f64 {
+        let window_secs = self.num_buckets() as u64 * RU_BUCKET_SECS;
+        let system_uptime = now_secs.saturating_sub(system_start_secs);
+        if system_uptime >= window_secs {
+            // System older than window — use full window as denominator.
+            // Missing buckets count as zero, diluting any fresh traffic.
+            if self.completed == 0 {
+                return 0.0;
+            }
+            let total: u64 = self.buckets.iter().take(self.completed).sum();
+            total as f64 / (self.num_buckets() as f64 * RU_BUCKET_SECS as f64)
+        } else {
+            if self.completed == 0 {
+                return 0.0;
+            }
+            let total: u64 = self.buckets.iter().take(self.completed).sum();
+            // Divide by elapsed system uptime (not just filled buckets) so the
+            // historical rate ramps up smoothly rather than jumping immediately
+            // to the full rate after the first bucket completes.
+            let denom = (system_uptime as f64).max(RU_BUCKET_SECS as f64);
+            total as f64 / denom
+        }
+    }
+
+    /// Returns true if no RU has been recorded: all completed buckets and the
+    /// current bucket are zero. Used to garbage-collect stale ru_trackers
+    /// entries.
+    pub fn is_idle(&self) -> bool {
+        self.current_bucket.load(Ordering::Relaxed) == 0 && self.buckets.iter().all(|&b| b == 0)
+    }
+
+    /// Refresh the cached historical rate. Called periodically from
+    /// `online_adjust_resource_quota` (~every 10s) so the inline hot path
+    /// avoids iterating all buckets.
+    pub fn refresh_cached_historical_rate(&mut self, system_start_secs: u64, now_secs: u64) {
+        self.cached_historical_rate = self.historical_rate(system_start_secs, now_secs);
+    }
+}
+
+/// Encodes a two-phase scheduling priority.
+///
+/// Bit position of the phase bit within the 64-bit encoded priority.
+/// Format: `[4-bit group_priority | 1-bit phase | 59-bit tag]`
+const PRIORITY_TAG_BITS: u32 = 59;
+
+/// Whether a task is within or over its historical RU baseline.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PriorityPhase {
+    /// Within baseline — given scheduling preference over phase-1 tasks.
+    WithinBaseline = 0,
+    /// Over baseline — deprioritised relative to within-baseline tasks.
+    OverBaseline = 1,
+}
+
+/// Format: `[4-bit group_priority | 1-bit phase | 59-bit tag]`
+///
+/// Phase 0 (within baseline) always sorts before phase 1 (over baseline)
+/// within the same group priority tier. Using only 1 bit for phase leaves
+/// 59 bits for the VT tag, matching `RESET_VT_THRESHOLD` (`2^59`).
+fn encode_two_phase_priority(group_priority: u32, phase: PriorityPhase, tag: u64) -> u64 {
+    assert!((1..=16).contains(&group_priority));
+    let tag = tag & ((1u64 << PRIORITY_TAG_BITS) - 1);
+    let phase_bit = (phase as u64) << PRIORITY_TAG_BITS;
+    (!((group_priority - 1) as u64) << 60) | phase_bit | tag
+}
+
+/// Returns true if the encoded priority value represents a phase-1 task.
+#[inline]
+fn is_phase1(priority: u64) -> bool {
+    (priority >> PRIORITY_TAG_BITS) & 1 == 1
+}
 pub enum ResourceConsumeType {
     CpuTime(Duration),
     IoBytes(u64),
+}
+
+/// Result of the Tier-1 admission control check for a single request.
+#[derive(Debug, PartialEq)]
+pub enum AdmissionDecision {
+    /// No throttling needed; let the request proceed immediately.
+    Allow,
+    /// Delay the request by the given duration. The caller **must** call
+    /// [`ResourceGroupManager::release_delay_slot`] once the delay is over
+    /// (or the delayed future is dropped/cancelled).
+    Delay(Duration),
+    /// Reject the request outright (SchedTooBusy). Returned when the number
+    /// of concurrently delayed requests exceeds `admission_max_delayed_count`.
+    Reject,
+}
+
+/// RAII guard that releases an admission-control delay slot on drop.
+/// Ensures the `delayed_req_count` counter is decremented even if the
+/// future is cancelled during the sleep.
+pub struct DelaySlotGuard {
+    mgr: Option<Arc<ResourceGroupManager>>,
+}
+
+impl DelaySlotGuard {
+    fn new(mgr: Arc<ResourceGroupManager>) -> Self {
+        Self { mgr: Some(mgr) }
+    }
+
+    /// Explicitly release the slot and disarm the guard so Drop is a no-op.
+    pub fn release(&mut self) {
+        if let Some(mgr) = self.mgr.take() {
+            mgr.release_delay_slot();
+        }
+    }
+}
+
+impl Drop for DelaySlotGuard {
+    fn drop(&mut self) {
+        self.release();
+    }
 }
 
 /// ResourceGroupManager manages the metadata of each resource group.
@@ -62,13 +317,30 @@ pub struct ResourceGroupManager {
     // the count of all groups, a fast path because call `DashMap::len` is a little slower.
     group_count: AtomicU64,
     registry: RwLock<Vec<Arc<ResourceController>>>,
-    // auto incremental version generator used for mark the background
-    // resource limiter has changed.
-    version_generator: AtomicU64,
     // the shared resource limiter of each priority
     priority_limiters: [Arc<ResourceLimiter>; TaskPriority::PRIORITY_COUNT],
+    bg_limiter: Arc<ResourceLimiter>,
+    // cached: true when at least one group has background settings configured.
+    has_background: AtomicBool,
     // lastest config.
     config: Arc<VersionTrack<Config>>,
+    // Per-group RU consumption trackers for Tier-1 high-priority throttling.
+    // Per-group sliding-window tracker and token-bucket limiter.
+    // Rate on the limiter is set to `fraction × historical_rate` each tick.
+    // The Arc allows handing out limiter references to LimitedFuture wrappers
+    // in the read/write pools without copying the limiter state.
+    ru_trackers: DashMap<String, Mutex<(RuTracker, Arc<ResourceLimiter>)>>,
+    // Number of requests currently held in the admission-control delay phase.
+    delayed_req_count: AtomicI64,
+    // Unix seconds when this manager was created. Used to determine whether
+    // the system has been up long enough that new trackers should be treated
+    // as if they missed the entire historical window (baseline = 0).
+    start_secs: u64,
+    // True when background CPU budget is at the minimum floor (1 core) AND
+    // background consumption is within that floor. Foreground throttling
+    // only engages when this flag is set, ensuring background is fully
+    // squeezed before foreground traffic is touched.
+    bg_cpu_at_floor: AtomicBool,
 }
 
 impl Default for ResourceGroupManager {
@@ -88,13 +360,25 @@ impl ResourceGroupManager {
                 false,
             ))
         });
+        let bg_limiter = Arc::new(ResourceLimiter::new(
+            DEFAULT_RESOURCE_GROUP_NAME.to_owned(),
+            f64::INFINITY,
+            f64::INFINITY,
+            0,
+            true,
+        ));
         let manager = Self {
             resource_groups: Default::default(),
             group_count: AtomicU64::new(0),
             registry: Default::default(),
-            version_generator: AtomicU64::new(0),
+            delayed_req_count: AtomicI64::new(0),
             priority_limiters,
+            bg_limiter,
+            has_background: AtomicBool::new(false),
             config: Arc::new(VersionTrack::new(config)),
+            ru_trackers: Default::default(),
+            start_secs: RuTracker::now_secs(),
+            bg_cpu_at_floor: AtomicBool::new(false),
         };
 
         // init the default resource group by default.
@@ -149,12 +433,7 @@ impl ResourceGroupManager {
             controller.add_resource_group(group_name.clone().into_bytes(), ru_quota, rg.priority);
         });
         info!("add resource group"; "name"=> &rg.name, "ru" => rg.get_r_u_settings().get_r_u().get_settings().get_fill_rate());
-        // try to reuse the quota limit when update resource group settings.
-        let prev_limiter = self
-            .resource_groups
-            .get(&rg.name)
-            .and_then(|g| g.limiter.clone());
-        let limiter = self.build_resource_limiter(&rg, prev_limiter);
+        let limiter = self.build_resource_limiter(&rg);
 
         if self
             .resource_groups
@@ -163,24 +442,37 @@ impl ResourceGroupManager {
         {
             self.group_count.fetch_add(1, Ordering::Relaxed);
         }
+        self.update_has_background();
     }
 
-    fn build_resource_limiter(
-        &self,
-        rg: &PbResourceGroup,
-        old_limiter: Option<Arc<ResourceLimiter>>,
-    ) -> Option<Arc<ResourceLimiter>> {
+    fn update_has_background(&self) {
+        let any_has_bg = self
+            .resource_groups
+            .iter()
+            .any(|g| !g.background_source_types.is_empty());
+        let prev = self.has_background.swap(any_has_bg, Ordering::Release);
+        // When the last background group is removed, reset the shared limiter to
+        // unlimited so that a later re-add does not inherit stale throttled rates.
+        if prev && !any_has_bg {
+            use crate::resource_limiter::ResourceType;
+            self.bg_limiter
+                .get_limiter(ResourceType::Cpu)
+                .set_rate_limit(f64::INFINITY);
+            self.bg_limiter
+                .get_limiter(ResourceType::Io)
+                .set_rate_limit(f64::INFINITY);
+            self.bg_limiter
+                .get_write_io_limiter()
+                .set_rate_limit(f64::INFINITY);
+        }
+        self.registry.read().iter().for_each(|controller| {
+            controller.set_has_background(any_has_bg);
+        });
+    }
+
+    fn build_resource_limiter(&self, rg: &PbResourceGroup) -> Option<Arc<ResourceLimiter>> {
         if !rg.get_background_settings().get_job_types().is_empty() {
-            old_limiter.or_else(|| {
-                let version = self.version_generator.fetch_add(1, Ordering::Relaxed);
-                Some(Arc::new(ResourceLimiter::new(
-                    rg.name.clone(),
-                    f64::INFINITY,
-                    f64::INFINITY,
-                    version,
-                    true,
-                )))
-            })
+            Some(self.bg_limiter.clone())
         } else {
             None
         }
@@ -192,10 +484,11 @@ impl ResourceGroupManager {
             controller.remove_resource_group(group_name.as_bytes());
         });
         if self.resource_groups.remove(&group_name).is_some() {
-            deregister_metrics(name);
             info!("remove resource group"; "name"=> name);
             self.group_count.fetch_sub(1, Ordering::Relaxed);
+            deregister_metrics(&group_name);
         }
+        self.update_has_background();
     }
 
     pub fn retain(&self, mut f: impl FnMut(&String, &PbResourceGroup) -> bool) {
@@ -208,7 +501,6 @@ impl ResourceGroupManager {
             let ret = f(k, &v.group);
             if !ret {
                 removed_names.push(k.clone());
-                deregister_metrics(k);
             }
             ret
         });
@@ -220,6 +512,7 @@ impl ResourceGroupManager {
             });
             self.group_count
                 .fetch_sub(removed_names.len() as u64, Ordering::Relaxed);
+            self.update_has_background();
         }
     }
 
@@ -239,18 +532,47 @@ impl ResourceGroupManager {
     }
 
     pub fn derive_controller(&self, name: String, is_read: bool) -> Arc<ResourceController> {
-        let controller = Arc::new(ResourceController::new(name, is_read));
+        let controller = Arc::new(ResourceController::new(name, is_read, self.config.clone()));
         self.registry.write().push(controller.clone());
         for g in &self.resource_groups {
             let ru_quota = Self::get_ru_setting(&g.value().group, controller.is_read);
             controller.add_resource_group(g.key().clone().into_bytes(), ru_quota, g.group.priority);
         }
+        controller.set_has_background(self.has_background.load(Ordering::Acquire));
         controller
     }
 
     pub fn advance_min_virtual_time(&self) {
+        // Push RU-based phase state into every controller before updating VT,
+        // so get_priority() sees fresh is_over_baseline flags this tick.
+        if self.config.value().enable_fair_scheduling {
+            self.update_group_phases();
+        }
         for controller in self.registry.read().iter() {
             controller.update_min_virtual_time();
+        }
+    }
+
+    /// Iterates all tracked groups and pushes `is_over_baseline` into each
+    /// registered `ResourceController`.  Called every ~1 second from
+    /// `advance_min_virtual_time` when `enable_fair_scheduling` is on.
+    fn update_group_phases(&self) {
+        let now_secs = RuTracker::now_secs();
+        for entry in &self.ru_trackers {
+            let group_bytes = entry.key().as_bytes();
+            let mut guard = entry.value().lock().unwrap();
+            // Roll the ring buffer forward so phase classification uses
+            // up-to-date bucket boundaries, not stale partial data.
+            guard.0.advance(now_secs);
+            let over = guard
+                .1
+                .get_limiter(ResourceType::Cpu)
+                .get_rate_limit()
+                .is_finite();
+            drop(guard);
+            for controller in self.registry.read().iter() {
+                controller.set_group_phase(group_bytes, over);
+            }
         }
     }
 
@@ -271,51 +593,347 @@ impl ResourceGroupManager {
                 ResourceConsumeType::IoBytes(ctx.get_penalty().write_bytes as u64),
             );
         }
+        // RU tracking for foreground admission control is handled by
+        // LimitedFuture (measure-only mode) which calls record_ru_consumption
+        // with actual CPU measured per poll.
     }
 
-    // only enable priority quota limiter when there is at least 1 user-defined
-    // resource group.
-    #[inline]
-    fn enable_priority_limiter(&self) -> bool {
-        // TODO: reenable it once when we fix https://github.com/tikv/tikv/issues/18939
-        // self.get_group_count() > 1
-        false
+    /// Record `ru` units consumed by `group` into the sliding-window tracker
+    /// and consume tokens from the group's rate limiter.
+    pub fn record_ru_consumption(&self, group: &str, ru: u64) {
+        let now = RuTracker::now_secs();
+        // 2 buckets per minute (30s each) to match RU_BUCKET_SECS.
+        let num_buckets = (self.config.value().historical_usage_window_mins.max(2) as usize) * 2;
+        let entry = self.ru_trackers.entry(group.to_owned()).or_insert_with(|| {
+            Mutex::new((
+                RuTracker::new(now, num_buckets),
+                Arc::new(ResourceLimiter::new(
+                    group.to_owned(),
+                    f64::INFINITY,
+                    f64::INFINITY,
+                    0,
+                    false,
+                )),
+            ))
+        });
+        // Lock-free: only atomically adds to current_bucket.
+        // advance() is called separately by online_adjust_resource_quota under the
+        // lock.
+        entry.lock().unwrap().0.record(ru);
     }
 
-    // Always return the background resource limiter if any;
-    // Only return the foregroup limiter when priority is enabled.
+    /// Called by `PriorityLimiterAdjustWorker` every ~1 second with the
+    /// latest process-level CPU utilisation percentage.
+    ///
+    /// Throttle-down: linearly reduces the allowed fraction of historical rate
+    /// for groups that are over their baseline. At `fg_cpu_throttle_threshold`
+    /// (70%) fraction = 1.0 (no throttle), at 90% CPU fraction = 0.8
+    /// (target). Called by the background adjust worker after computing the
+    /// new background CPU budget. `at_floor` should be true when the budget
+    /// has been clamped to the minimum floor AND background consumption
+    /// is within that floor.
+    pub fn set_bg_cpu_at_floor(&self, at_floor: bool) {
+        self.bg_cpu_at_floor.store(at_floor, Ordering::Relaxed);
+    }
+
+    /// Returns true when background CPU is fully throttled (at floor)
+    /// and its consumption is within the floor budget.
+    pub fn is_bg_cpu_at_floor(&self) -> bool {
+        self.bg_cpu_at_floor.load(Ordering::Relaxed)
+    }
+
+    /// Returns true when all foreground groups have unlimited (infinite)
+    /// CPU rate limits, i.e. foreground has fully ramped up.
+    pub fn is_foreground_fully_ramped_up(&self) -> bool {
+        for entry in &self.ru_trackers {
+            let guard = entry.lock().unwrap();
+            if guard
+                .1
+                .get_limiter(ResourceType::Cpu)
+                .get_rate_limit()
+                .is_finite()
+            {
+                return false;
+            }
+        }
+        true
+    }
+
+    /// Only groups whose current rate exceeds their historical rate are
+    /// limited.
+    ///
+    /// Ramp-up: when CPU drops below threshold, recover ×1.1/tick until
+    /// NO_LIMIT is restored.
+    pub fn online_adjust_resource_quota(&self, pct: f64) {
+        const TARGET_CPU: f64 = 90.0;
+        const RAMP_FACTOR: f64 = 1.2;
+        const MIN_RAMP_UP_EPOCHS: u32 = 2;
+
+        let throttle_threshold = self.config.value().fg_cpu_throttle_threshold;
+        let leeway_threshold = throttle_threshold * 0.9;
+        let burst_factor = 1.0 + self.config.value().baseline_burst_pct / 100.0;
+        let now = RuTracker::now_secs();
+
+        // Advance all trackers to `now` and refresh cached historical rates
+        // up front so update_group_phases and the throttling logic below
+        // always see fresh baseline data.
+        for entry in &self.ru_trackers {
+            let mut guard = entry.lock().unwrap();
+            guard.0.advance(now);
+            guard.0.refresh_cached_historical_rate(self.start_secs, now);
+            let name = guard.1.name();
+
+            metrics::GROUP_RU_HISTORICAL_RATE
+                .with_label_values(&[name])
+                .set((guard.0.cached_historical_rate / 1_000_000.0) * 100.0);
+            metrics::GROUP_RU_CURRENT_RATE
+                .with_label_values(&[name])
+                .set((guard.0.current_rate(now) / 1_000_000.0) * 100.0);
+        }
+
+        if pct > throttle_threshold && self.is_bg_cpu_at_floor() {
+            // Linearly scale limit from current rate (at threshold) down to
+            // historical rate (at TARGET_CPU).
+            // pressure: 0.0 at threshold → 1.0 at TARGET_CPU.
+            let pressure =
+                ((pct - throttle_threshold) / (TARGET_CPU - throttle_threshold)).clamp(0.0, 1.0);
+
+            for entry in &self.ru_trackers {
+                let mut guard = entry.lock().unwrap();
+                let hist = guard.0.cached_historical_rate;
+                let current = guard.0.current_rate(now);
+                let burst_target = hist * burst_factor;
+                if hist > 0.0 && current > burst_target {
+                    // rate slides from current (pressure=0) to burst_target (pressure=1).
+                    let rate = current + (burst_target - current) * pressure;
+                    let current_limit = guard.1.get_limiter(ResourceType::Cpu).get_rate_limit();
+                    // Only tighten the limit — never loosen in the throttle branch.
+                    // Ramp-up is the only path that increases limits.
+                    if current_limit.is_infinite() || rate < current_limit {
+                        guard.0.ramp_up_epochs = 0;
+                        guard
+                            .1
+                            .get_limiter(ResourceType::Cpu)
+                            .set_rate_limit(rate.max(1.0));
+                    }
+                }
+            }
+        } else if pct < leeway_threshold {
+            // CPU below start threshold — ramp up by RAMP_FACTOR each tick.
+            // Only lift to INFINITY after MIN_RAMP_UP_EPOCHS consecutive epochs
+            // where the limit has grown past 2x hist, to avoid premature release.
+            for entry in &self.ru_trackers {
+                let mut guard = entry.lock().unwrap();
+                let current_limit = guard.1.get_limiter(ResourceType::Cpu).get_rate_limit();
+                if current_limit.is_finite() {
+                    let hist = guard.0.cached_historical_rate;
+                    let new_limit = current_limit * RAMP_FACTOR;
+                    if hist <= 0.0 || new_limit >= 2.0 * hist {
+                        guard.0.ramp_up_epochs += 1;
+                        if guard.0.ramp_up_epochs >= MIN_RAMP_UP_EPOCHS {
+                            guard.0.ramp_up_epochs = 0;
+                            guard
+                                .1
+                                .get_limiter(ResourceType::Cpu)
+                                .set_rate_limit(f64::INFINITY);
+                        }
+                    } else {
+                        guard.0.ramp_up_epochs = 0;
+                        guard
+                            .1
+                            .get_limiter(ResourceType::Cpu)
+                            .set_rate_limit(new_limit);
+                    }
+                }
+            }
+        }
+
+        // Emit current rate limit per resource group.
+        for entry in &self.ru_trackers {
+            let guard = entry.lock().unwrap();
+            let limit = guard.1.get_limiter(ResourceType::Cpu).get_rate_limit();
+            let val = if limit.is_finite() {
+                (limit / 1_000_000.0) * 100.0
+            } else {
+                0.0
+            };
+            metrics::GROUP_QUOTA_LIMIT_VEC
+                .with_label_values(&[guard.1.name(), "cpu"])
+                .set(val);
+        }
+
+        // Evict idle ru_trackers entries to prevent unbounded growth from
+        // removed or renamed groups. Advance first so stale partial buckets
+        // are flushed before the idle check.
+        self.ru_trackers.retain(|_, entry| {
+            let inner = entry.get_mut().unwrap();
+            inner.0.advance(now);
+            !inner.0.is_idle()
+        });
+    }
+
+    /// Returns the token-bucket debt delay for `group`, or `None` if no
+    /// throttling is active.
+    ///
+    /// Conditions for a non-zero delay (all must hold):
+    ///   1. `enable_read_admission_control` / `enable_write_admission_control`
+    ///      on
+    ///   2. Rate-limit is active (not NO_LIMIT sentinel)
+    ///   3. Tracker has warmed up (≥2 completed 1-min buckets)
+    ///   4. Token-bucket has accumulated debt (group exceeded its allowed rate)
+    pub fn compute_admission_delay(
+        &self,
+        resource_limiter: &ResourceLimiter,
+        is_read: bool,
+    ) -> Option<Duration> {
+        // Always consume tokens so the token-bucket debt stays accurate
+        // for scheduling decisions. Only return the delay when admission
+        // control is enabled (or for background limiters, always).
+        let delay = resource_limiter.admission_delay(is_read);
+        if !resource_limiter.is_background() {
+            let config = self.config.value();
+            let ac_enabled = if is_read {
+                config.enable_read_admission_control
+            } else {
+                config.enable_write_admission_control
+            };
+            if !ac_enabled {
+                return None;
+            }
+        }
+        if delay.is_zero() { None } else { Some(delay) }
+    }
+
+    /// Unified admission-control decision for a request from `group`.
+    ///
+    /// Combines token-bucket rate-limiter debt (`resource_limiter`) with
+    /// RU-baseline overage delay into a single pre-pool sleep duration.
+    /// Covers background, low-priority, and resource-group throttling for
+    /// both reads (`is_read=true`) and writes (`is_read=false`).
+    ///
+    /// Returns:
+    /// - [`AdmissionDecision::Allow`] — no throttling needed.
+    /// - [`AdmissionDecision::Delay(d)`] — caller should sleep `d` then
+    ///   proceed, and **must** call [`release_delay_slot`] afterwards.
+    /// - [`AdmissionDecision::Reject`] — too many requests are already delayed;
+    ///   reject immediately.
+    pub fn admission_decision(
+        &self,
+        is_read: bool,
+        resource_limiter: &ResourceLimiter,
+    ) -> AdmissionDecision {
+        let group = resource_limiter.name();
+        let delay = self
+            .compute_admission_delay(resource_limiter, is_read)
+            .unwrap_or(std::time::Duration::ZERO);
+        if delay.is_zero() {
+            return AdmissionDecision::Allow;
+        }
+        let metric_label = if resource_limiter.is_background() {
+            "background"
+        } else {
+            group
+        };
+        let max = self.config.value().admission_max_delayed_count;
+        let prev = self.delayed_req_count.fetch_add(1, Ordering::Relaxed);
+        metrics::ADMISSION_CURRENTLY_DELAYED.set(prev + 1);
+        if max > 0 && prev >= max as i64 {
+            self.delayed_req_count.fetch_sub(1, Ordering::Relaxed);
+            metrics::ADMISSION_CURRENTLY_DELAYED.set(prev);
+            crate::metrics::ADMISSION_REJECTED_REQUESTS
+                .with_label_values(&[metric_label])
+                .inc();
+            return AdmissionDecision::Reject;
+        }
+        crate::metrics::ADMISSION_DELAYED_REQUESTS
+            .with_label_values(&[metric_label])
+            .inc();
+        crate::metrics::ADMISSION_DELAY_DURATION
+            .with_label_values(&[metric_label])
+            .observe(delay.as_secs_f64());
+        AdmissionDecision::Delay(delay)
+    }
+
+    /// Release a delay slot acquired by [`admission_decision`] returning
+    /// [`AdmissionDecision::Delay`]. Must be called exactly once per `Delay`
+    /// decision, whether the request completes normally or is cancelled.
+    pub fn release_delay_slot(&self) {
+        let prev = self.delayed_req_count.fetch_sub(1, Ordering::Relaxed);
+        metrics::ADMISSION_CURRENTLY_DELAYED.set(prev - 1);
+    }
+
+    /// Returns an RAII guard that calls [`release_delay_slot`] on drop.
+    /// Use this to ensure the slot is released even if the future is
+    /// cancelled during the admission-control sleep.
+    pub fn delay_slot_guard(self: &Arc<Self>) -> DelaySlotGuard {
+        DelaySlotGuard::new(Arc::clone(self))
+    }
+
+    /// Returns the per-group admission-control limiter for `group`, creating
+    /// the entry if it does not yet exist. Used by `with_resource_limiter`
+    /// (measure-only mode) in the read/write pools so `LimitedFuture` can
+    /// build token-bucket debt for pre-pool `admission_decision`.
+    pub fn get_foreground_group_limiter(&self, group: &str) -> Arc<ResourceLimiter> {
+        let now = RuTracker::now_secs();
+        // 2 buckets per minute (30s each) to match RU_BUCKET_SECS.
+        let num_buckets = (self.config.value().historical_usage_window_mins.max(2) as usize) * 2;
+        self.ru_trackers
+            .entry(group.to_owned())
+            .or_insert_with(|| {
+                Mutex::new((
+                    RuTracker::new(now, num_buckets),
+                    Arc::new(ResourceLimiter::new(
+                        group.to_owned(),
+                        f64::INFINITY,
+                        f64::INFINITY,
+                        0,
+                        false,
+                    )),
+                ))
+            })
+            .lock()
+            .unwrap()
+            .1
+            .clone()
+    }
+
+    /// Returns the appropriate `ResourceLimiter` for `with_resource_limiter`:
+    /// - Background tasks → background limiter
+    /// - Foreground tasks (any priority) → per-group limiter from `ru_trackers`
     pub fn get_resource_limiter(
         &self,
         rg: &str,
         request_source: &str,
-        override_priority: u64,
+        _override_priority: u64,
     ) -> Option<Arc<ResourceLimiter>> {
-        let (limiter, group_priority) =
-            self.get_background_resource_limiter_with_priority(rg, request_source);
+        let (limiter, _) = self.get_background_resource_limiter_with_priority(rg, request_source);
         if limiter.is_some() {
             return limiter;
         }
-
-        // if there is only 1 resource group, priority quota limiter is useless so just
-        // return None for better performance.
-        if !self.enable_priority_limiter() {
+        if self.get_group_count() <= 1 {
             return None;
         }
-
-        // request priority has higher priority, 0 means priority is not set.
-        let mut task_priority = override_priority as u32;
-        if task_priority == 0 {
-            task_priority = group_priority;
-        }
-        Some(self.priority_limiters[TaskPriority::from(task_priority) as usize].clone())
+        // Only create a foreground limiter for known groups; unknown or removed
+        // groups fall back to "default" to avoid leaking ru_trackers entries.
+        let group_name = if self.resource_groups.contains_key(rg) {
+            rg
+        } else {
+            DEFAULT_RESOURCE_GROUP_NAME
+        };
+        Some(self.get_foreground_group_limiter(group_name))
     }
 
     // return a ResourceLimiter for background tasks only.
+    // Returns None if request_source does not match a configured background job
+    // type.
     pub fn get_background_resource_limiter(
         &self,
         rg: &str,
         request_source: &str,
     ) -> Option<Arc<ResourceLimiter>> {
+        if request_source.is_empty() {
+            return None;
+        }
         self.get_background_resource_limiter_with_priority(rg, request_source)
             .0
     }
@@ -356,6 +974,14 @@ impl ResourceGroupManager {
     ) -> &[Arc<ResourceLimiter>; TaskPriority::PRIORITY_COUNT] {
         &self.priority_limiters
     }
+
+    pub fn get_background_limiter(&self) -> Arc<ResourceLimiter> {
+        self.bg_limiter.clone()
+    }
+
+    pub fn has_background_groups(&self) -> bool {
+        self.has_background.load(Ordering::Acquire)
+    }
 }
 
 pub(crate) struct ResourceGroup {
@@ -387,8 +1013,8 @@ impl ResourceGroup {
         }
     }
 
-    pub(crate) fn get_ru_quota(&self) -> u64 {
-        assert!(self.group.has_r_u_settings());
+    #[cfg(test)]
+    pub fn get_ru_quota(&self) -> u64 {
         self.group
             .get_r_u_settings()
             .get_r_u()
@@ -442,6 +1068,10 @@ pub struct ResourceController {
     last_rest_vt_time: Cell<Instant>,
     // whether the settings is customized by user
     customized: AtomicBool,
+    // whether any resource group has background settings configured
+    has_background: AtomicBool,
+    // Shared config. Read on the hot path to check enable_fair_scheduling.
+    config: Arc<VersionTrack<Config>>,
 }
 
 // we are ensure to visit the `last_rest_vt_time` by only 1 thread so it's
@@ -450,7 +1080,7 @@ unsafe impl Send for ResourceController {}
 unsafe impl Sync for ResourceController {}
 
 impl ResourceController {
-    fn new(name: String, is_read: bool) -> Self {
+    fn new(name: String, is_read: bool, config: Arc<VersionTrack<Config>>) -> Self {
         Self {
             name,
             is_read,
@@ -459,11 +1089,17 @@ impl ResourceController {
             max_ru_quota: Mutex::new(DEFAULT_MAX_RU_QUOTA),
             last_rest_vt_time: Cell::new(Instant::now_coarse()),
             customized: AtomicBool::new(false),
+            has_background: AtomicBool::new(false),
+            config,
         }
     }
 
     pub fn new_for_test(name: String, is_read: bool) -> Self {
-        let controller = Self::new(name, is_read);
+        let controller = Self::new(
+            name,
+            is_read,
+            Arc::new(VersionTrack::new(Config::default())),
+        );
         // add the "default" resource group.
         controller.add_resource_group(
             DEFAULT_RESOURCE_GROUP_NAME.as_bytes().to_owned(),
@@ -520,6 +1156,9 @@ impl ResourceController {
             weight,
             virtual_time: AtomicU64::new(self.last_min_vt.load(Ordering::Acquire)),
             vt_delta_for_get,
+            // New groups start in phase 0; ResourceGroupManager updates this
+            // each second once the RuTracker has enough history.
+            is_over_baseline: AtomicBool::new(false),
         };
 
         // maybe update existed group
@@ -566,7 +1205,11 @@ impl ResourceController {
     }
 
     pub fn is_customized(&self) -> bool {
-        self.customized.load(Ordering::Acquire)
+        self.customized.load(Ordering::Acquire) || self.has_background.load(Ordering::Acquire)
+    }
+
+    pub fn set_has_background(&self, has_background: bool) {
+        self.has_background.store(has_background, Ordering::Release);
     }
 
     #[inline]
@@ -583,6 +1226,17 @@ impl ResourceController {
 
     pub fn consume(&self, name: &[u8], resource: ResourceConsumeType) {
         self.resource_group(name).consume(resource)
+    }
+
+    /// Updates the two-phase `is_over_baseline` flag for a single group.
+    /// Called each second by `ResourceGroupManager::update_group_phases`.
+    pub fn set_group_phase(&self, group: &[u8], over_baseline: bool) {
+        let consumptions = self.resource_consumptions.read();
+        if let Some(tracker) = consumptions.get(group) {
+            tracker
+                .is_over_baseline
+                .store(over_baseline, Ordering::Relaxed);
+        }
     }
 
     pub fn update_min_virtual_time(&self) {
@@ -636,26 +1290,61 @@ impl ResourceController {
     }
 
     pub fn get_priority(&self, name: &[u8], pri: CommandPri) -> u64 {
-        let level = match pri {
-            CommandPri::Low => 2,
-            CommandPri::Normal => 1,
-            CommandPri::High => 0,
+        let level = Self::command_pri_to_level(pri);
+        self.resource_group(name)
+            .get_priority(level, None, true, self.is_two_phase_enabled())
+    }
+
+    /// Returns the priority for the given task metadata without incrementing
+    /// virtual time. Used for pre-spawn eviction comparison.
+    pub fn peek_priority_of(&self, metadata: &TaskMetadata<'_>, pri: CommandPri) -> u64 {
+        let level = Self::command_pri_to_level(pri);
+        let group = self.resource_group(metadata.group_name());
+        let override_priority = if metadata.override_priority() == 0 {
+            None
+        } else {
+            Some(metadata.override_priority())
         };
-        self.resource_group(name).get_priority(level, None)
+        group.get_priority(level, override_priority, false, self.is_two_phase_enabled())
+    }
+
+    /// Returns true when fair two-phase scheduling is active (read controller
+    /// with enable_fair_scheduling enabled).
+    #[inline]
+    fn is_two_phase_enabled(&self) -> bool {
+        self.is_read && self.config.value().enable_fair_scheduling
+    }
+
+    fn command_pri_to_level(pri: CommandPri) -> usize {
+        match pri {
+            CommandPri::High => 0,
+            CommandPri::Normal => 1,
+            CommandPri::Low => 2,
+        }
     }
 }
 
 impl TaskPriorityProvider for ResourceController {
     fn priority_of(&self, extras: &yatp::queue::Extras) -> u64 {
         let metadata = TaskMetadata::from(extras.metadata());
-        self.resource_group(metadata.group_name()).get_priority(
+        let p = self.resource_group(metadata.group_name()).get_priority(
             extras.current_level() as usize,
             if metadata.override_priority() == 0 {
                 None
             } else {
                 Some(metadata.override_priority())
             },
-        )
+            true,
+            self.is_two_phase_enabled(),
+        );
+        if is_phase1(p)
+            && let Ok(name) = std::str::from_utf8(metadata.group_name())
+        {
+            TWO_PHASE_THROTTLED_REQUESTS
+                .with_label_values(&[name])
+                .inc();
+        }
+        p
     }
 }
 
@@ -676,20 +1365,47 @@ struct GroupPriorityTracker {
     virtual_time: AtomicU64,
     // the constant delta value for each `get_priority` call,
     vt_delta_for_get: u64,
+    // Two-phase scheduling: true when this group's current-minute RU rate
+    // exceeds its historical baseline (set by ResourceGroupManager each second).
+    // Phase 1 tasks are deprioritised relative to phase-0 (within-baseline) tasks.
+    is_over_baseline: AtomicBool,
 }
 
 impl GroupPriorityTracker {
-    fn get_priority(&self, level: usize, override_priority: Option<u32>) -> u64 {
+    /// Computes the scheduling priority for a task at the given level.
+    ///
+    /// When `advance_vt` is true, atomically increments the virtual time
+    /// (used when actually scheduling a task). When false, reads virtual
+    /// time without advancing it (used for priority comparison only).
+    ///
+    /// When `two_phase` is true and `is_over_baseline` is set, the task is
+    /// placed in phase 1 (deprioritised); otherwise it runs in phase 0.
+    /// `is_over_baseline` is updated each second by `ResourceGroupManager`
+    /// from real CPU µs tracked across reads and writes via `consume_penalty`.
+    fn get_priority(
+        &self,
+        level: usize,
+        override_priority: Option<u32>,
+        advance_vt: bool,
+        two_phase: bool,
+    ) -> u64 {
         let task_extra_priority = TASK_EXTRA_FACTOR_BY_LEVEL[level] * 1000 * self.weight;
-        let vt = (if self.vt_delta_for_get > 0 {
-            self.virtual_time
-                .fetch_add(self.vt_delta_for_get, Ordering::Relaxed)
-                + self.vt_delta_for_get
-        } else {
-            self.virtual_time.load(Ordering::Relaxed)
-        }) + task_extra_priority;
         let priority = override_priority.unwrap_or(self.group_priority);
-        concat_priority_vt(priority, vt)
+        let vt_delta = self.vt_delta_for_get;
+
+        let vt = if advance_vt && vt_delta > 0 {
+            self.virtual_time.fetch_add(vt_delta, Ordering::Relaxed) + vt_delta
+        } else {
+            self.virtual_time.load(Ordering::Relaxed) + vt_delta
+        } + task_extra_priority;
+
+        if two_phase && self.is_over_baseline.load(Ordering::Relaxed) {
+            encode_two_phase_priority(priority, PriorityPhase::OverBaseline, vt)
+        } else if two_phase {
+            encode_two_phase_priority(priority, PriorityPhase::WithinBaseline, vt)
+        } else {
+            concat_priority_vt(priority, vt)
+        }
     }
 
     #[inline]
@@ -720,6 +1436,7 @@ impl GroupPriorityTracker {
 
 #[cfg(test)]
 pub(crate) mod tests {
+    use file_system::IoBytes;
     use yatp::queue::Extras;
 
     use super::*;
@@ -1202,6 +1919,150 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn test_encode_two_phase_priority_ordering() {
+        // Phase 0 (reservation) must sort before phase 1 (weight) for the
+        // same group_priority and a larger tag value.
+        let phase0 =
+            encode_two_phase_priority(MEDIUM_PRIORITY, PriorityPhase::WithinBaseline, 9999);
+        let phase1 = encode_two_phase_priority(MEDIUM_PRIORITY, PriorityPhase::OverBaseline, 1);
+        assert!(
+            phase0 < phase1,
+            "phase 0 must be higher priority than phase 1"
+        );
+
+        // Within phase 0, lower tag = higher priority.
+        let p0_low = encode_two_phase_priority(MEDIUM_PRIORITY, PriorityPhase::WithinBaseline, 100);
+        let p0_high =
+            encode_two_phase_priority(MEDIUM_PRIORITY, PriorityPhase::WithinBaseline, 200);
+        assert!(p0_low < p0_high);
+
+        // group_priority still dominates across phases.
+        let high_phase1 =
+            encode_two_phase_priority(HIGH_PRIORITY, PriorityPhase::OverBaseline, u64::MAX >> 8);
+        let low_phase0 = encode_two_phase_priority(LOW_PRIORITY, PriorityPhase::WithinBaseline, 0);
+        assert!(high_phase1 < low_phase0);
+    }
+
+    #[test]
+    fn test_two_phase_scheduling_ru_based() {
+        // Two-phase scheduling driven by real RU (CPU µs) from ResourceGroupManager.
+        let mut cfg = Config::default();
+        cfg.enable_fair_scheduling = true;
+        let mgr = ResourceGroupManager::new(cfg);
+
+        let steady = new_resource_group_ru("steady".into(), 1000, MEDIUM_PRIORITY);
+        let spike = new_resource_group_ru("spike".into(), 1000, MEDIUM_PRIORITY);
+        mgr.add_resource_group(steady);
+        mgr.add_resource_group(spike);
+
+        let ctl = mgr.derive_controller("read".into(), true);
+
+        // Warm up steady's RuTracker: 2 completed 30s buckets with consistent rate.
+        let t0 = RuTracker::now_secs();
+        {
+            let e = mgr
+                .ru_trackers
+                .entry("steady".to_owned())
+                .or_insert_with(|| {
+                    Mutex::new((
+                        RuTracker::new(t0, 30),
+                        Arc::new(ResourceLimiter::new(
+                            "".into(),
+                            f64::INFINITY,
+                            f64::INFINITY,
+                            0,
+                            false,
+                        )),
+                    ))
+                });
+            let mut tr = e.lock().unwrap();
+            tr.0.record_at(6000, t0 + 15);
+            tr.0.record_at(0, t0 + 30); // close bucket 0: 6000 µs
+            tr.0.record_at(6000, t0 + 45);
+            tr.0.record_at(0, t0 + 60); // close bucket 1: 6000 µs → stable baseline
+        }
+        // "spike" has no tracker → is_over_baseline stays false (no history).
+
+        // Push phases into controller.
+        mgr.advance_min_virtual_time();
+
+        // steady: both buckets equal → current_rate == historical_rate → NOT over
+        // baseline. spike: no tracker → also not over baseline.
+        // Neither should be in phase 1 at steady state.
+        {
+            let groups = ctl.resource_consumptions.read();
+            let steady_over = groups
+                .get(b"steady".as_ref())
+                .unwrap()
+                .is_over_baseline
+                .load(Ordering::Relaxed);
+            let spike_over = groups
+                .get(b"spike".as_ref())
+                .unwrap()
+                .is_over_baseline
+                .load(Ordering::Relaxed);
+            assert!(!steady_over, "steady at baseline should be phase 0");
+            assert!(!spike_over, "spike with no history should be phase 0");
+        }
+
+        // Now simulate a spike for "spike": current bucket >> historical.
+        {
+            let e = mgr
+                .ru_trackers
+                .entry("spike".to_owned())
+                .or_insert_with(|| {
+                    Mutex::new((
+                        RuTracker::new(t0, 30),
+                        Arc::new(ResourceLimiter::new(
+                            "".into(),
+                            f64::INFINITY,
+                            f64::INFINITY,
+                            0,
+                            false,
+                        )),
+                    ))
+                });
+            let mut tr = e.lock().unwrap();
+            tr.0.record_at(3000, t0 + 30);
+            tr.0.record_at(0, t0 + 60); // close bucket [t0+30,t0+60): 3000µs baseline
+            tr.0.record_at(12000, t0 + 90); // current open bucket: 12000µs spike (left open)
+        }
+        // Trigger a CPU utilization tick to refresh cached_historical_rate
+        // on all trackers. Set bg_cpu_at_floor so the throttle branch fires
+        // and limits groups that are over baseline.
+        mgr.set_bg_cpu_at_floor(true);
+        mgr.online_adjust_resource_quota(75.0);
+        mgr.advance_min_virtual_time();
+
+        {
+            let groups = ctl.resource_consumptions.read();
+            let spike_over = groups
+                .get(b"spike".as_ref())
+                .unwrap()
+                .is_over_baseline
+                .load(Ordering::Relaxed);
+            assert!(spike_over, "spike bucket1 > bucket0 → should be phase 1");
+        }
+
+        // Phase ordering: steady (phase 0) must sort before spike (phase 1).
+        let groups = ctl.resource_consumptions.read();
+        let steady_pri = groups
+            .get(b"steady".as_ref())
+            .unwrap()
+            .get_priority(1, None, false, true);
+        let spike_pri = groups
+            .get(b"spike".as_ref())
+            .unwrap()
+            .get_priority(1, None, false, true);
+        assert!(!is_phase1(steady_pri), "steady should be phase 0");
+        assert!(is_phase1(spike_pri), "spike should be phase 1");
+        assert!(
+            steady_pri < spike_pri,
+            "phase 0 must schedule before phase 1"
+        );
+    }
+
+    #[test]
     fn test_get_resource_limiter() {
         let mgr = ResourceGroupManager::default();
 
@@ -1219,9 +2080,14 @@ pub(crate) mod tests {
             .clone()
             .unwrap();
 
+        // Only 1 group (default): foreground always returns None.
         assert!(mgr.get_resource_limiter("default", "query", 0).is_none());
         assert!(
             mgr.get_resource_limiter("default", "query", HIGH_PRIORITY as u64)
+                .is_none()
+        );
+        assert!(
+            mgr.get_resource_limiter("default", "query", LOW_PRIORITY as u64)
                 .is_none()
         );
 
@@ -1268,26 +2134,177 @@ pub(crate) mod tests {
             &default_limiter
         ));
 
+        // Background path still takes priority for "stats" source.
         assert!(Arc::ptr_eq(
             &mgr.get_resource_limiter("test1", "stats", 0).unwrap(),
             &default_limiter
         ));
 
-        // test legacy task_type "lightning" can be converted to "import".
-        let lightning_group = new_background_resource_group_ru(
-            "lightning".into(),
-            200,
-            MEDIUM_PRIORITY,
-            vec!["lightning".into()],
+        // Multiple groups: all foreground priorities get the per-group limiter.
+        // The same limiter is returned regardless of priority level.
+        let fg_limiter = mgr
+            .get_resource_limiter("test1", "query", LOW_PRIORITY as u64)
+            .unwrap();
+        assert!(Arc::ptr_eq(
+            &mgr.get_resource_limiter("test1", "query", HIGH_PRIORITY as u64)
+                .unwrap(),
+            &fg_limiter,
+        ));
+        assert!(Arc::ptr_eq(
+            &mgr.get_resource_limiter("test1", "query", 0).unwrap(),
+            &fg_limiter,
+        ));
+    }
+
+    #[test]
+    fn test_ru_tracker() {
+        let t0: u64 = 1_000_000;
+
+        const BUCKETS: usize = 15;
+        let mut tracker = RuTracker::new(t0, BUCKETS);
+        assert!(!tracker.is_warmed_up());
+        // No data at all: current_rate = (0 + 0) / (0 + 60) = 0.
+        assert_eq!(tracker.current_rate(t0), 0.0);
+        assert_eq!(tracker.historical_rate(t0, t0), 0.0);
+
+        // Record 6000 RU in the first 30s bucket.
+        tracker.record_at(6000, t0 + 15);
+
+        // Advance past the first bucket boundary (30s) — completes bucket 0.
+        tracker.record_at(0, t0 + 30);
+        assert_eq!(tracker.completed, 1);
+        // At t0+30: current_bucket=0, elapsed=0, last_completed=6000
+        // rate = (0 + 6000) / (0 + 30) = 200 RU/s
+        assert!((tracker.current_rate(t0 + 30) - 200.0).abs() < 0.01);
+        assert!(!tracker.is_warmed_up()); // needs ≥2 buckets
+
+        // Advance another 30s with 3000 RU — completes bucket 1.
+        tracker.record_at(3000, t0 + 45);
+        tracker.record_at(0, t0 + 60);
+        assert_eq!(tracker.completed, 2);
+        assert!(tracker.is_warmed_up());
+        // At t0+60: current_bucket=0, elapsed=0, last_completed=3000
+        // rate = (0 + 3000) / (0 + 30) = 100 RU/s
+        assert!((tracker.current_rate(t0 + 60) - 100.0).abs() < 0.01);
+        // At t0+75 (15s into next bucket, no new RU): current_bucket=0, elapsed=15
+        // rate = (0 + 3000) / (15 + 30) = 66.67 RU/s
+        assert!((tracker.current_rate(t0 + 75) - 66.67).abs() < 0.1);
+        // historical_rate = (6000+3000) / (2*30) = 150 RU/s
+        assert!((tracker.historical_rate(t0, t0 + 60) - 150.0).abs() < 0.01);
+
+        // Ring buffer: advance 20 more minutes (fully evicts all data).
+        let t_far = t0 + 60 * 20;
+        tracker.record_at(0, t_far);
+        // Gap exceeds window → ring reset, no completed buckets.
+        assert_eq!(tracker.completed, 0);
+        assert_eq!(tracker.current_bucket.load(Ordering::Relaxed), 0);
+
+        // Re-populate after the big gap and fill the entire ring.
+        for i in 1..=BUCKETS {
+            tracker.record_at(100, t_far + (i as u64) * RU_BUCKET_SECS);
+        }
+        assert_eq!(tracker.completed, BUCKETS);
+    }
+
+    #[test]
+    fn test_admission_decision() {
+        let mut cfg = Config::default();
+        cfg.enable_read_admission_control = true;
+        cfg.admission_max_delayed_count = 10; // low limit to test rejection path
+        let mgr = ResourceGroupManager::new(cfg);
+        // Add a second group so the code path is active.
+        mgr.add_resource_group(new_resource_group_ru("spike".into(), 1000, HIGH_PRIORITY));
+        let spike_limiter = mgr.get_foreground_group_limiter("spike");
+
+        // Seed initial RU so the tracker is not idle (prevents eviction by
+        // online_adjust_resource_quota's retain call).
+        let t0 = RuTracker::now_secs();
+        mgr.record_ru_consumption("spike", 1);
+
+        // CPU below threshold → Allow (stays NO_LIMIT, no throttling).
+        mgr.online_adjust_resource_quota(50.0); // below 80%
+        assert_eq!(
+            mgr.admission_decision(true, &spike_limiter),
+            AdmissionDecision::Allow
         );
-        mgr.add_resource_group(lightning_group);
-        assert!(
-            mgr.get_background_resource_limiter("lightning", "lightning")
-                .is_some()
+
+        // CPU above threshold but no warmed-up tracker data → stays NO_LIMIT → Allow.
+        mgr.online_adjust_resource_quota(90.0);
+        assert_eq!(
+            mgr.admission_decision(true, &spike_limiter),
+            AdmissionDecision::Allow
         );
-        assert!(
-            mgr.get_background_resource_limiter("lightning", "import")
-                .is_some()
+
+        // Warm up the tracker: 2 completed buckets. Set up BEFORE calling
+        // online_adjust_resource_quota so historical_rate() is non-zero when the
+        // limiter rate is configured.
+        {
+            let entry = mgr.ru_trackers.get("spike").unwrap();
+            let mut guard = entry.lock().unwrap();
+            guard.0.record_at(6000, t0 + 30);
+            guard.0.record_at(0, t0 + 60); // close bucket 0: 6000 RU (baseline)
+            guard.0.record_at(12000, t0 + 90); // open bucket: 12000 RU spike (left open)
+            // historical ≈ 6000/30 = 200 RU/s (only completed buckets), current
+            // ≈ 400
+        }
+        // Now set CPU — first throttle entry: initializes fraction from spike ratio,
+        // then sets absolute rate = historical × fraction per group.
+        // bg_cpu_at_floor must be true for the throttle branch to fire.
+        mgr.set_bg_cpu_at_floor(true);
+        mgr.online_adjust_resource_quota(90.0);
+        // Consume a burst well above the rate to build token-bucket debt.
+        {
+            let entry = mgr.ru_trackers.get("spike").unwrap();
+            let guard = entry.lock().unwrap();
+            // 10_000 µs consumed against ~133 RU/s rate → several seconds of debt.
+            guard.1.consume(
+                Duration::from_micros(10_000),
+                IoBytes::default(),
+                false,
+                true,
+            );
+        }
+        // Debt is non-zero → Delay.
+        assert!(matches!(
+            mgr.admission_decision(true, &spike_limiter),
+            AdmissionDecision::Delay(_)
+        ));
+        // One slot acquired above; release it.
+        mgr.release_delay_slot();
+
+        // Exhaust the delay slots: acquire 10 (the configured max).
+        for _ in 0..10 {
+            assert!(matches!(
+                mgr.admission_decision(true, &spike_limiter),
+                AdmissionDecision::Delay(_)
+            ));
+        }
+        // 11th request: over the limit → Reject.
+        assert_eq!(
+            mgr.admission_decision(true, &spike_limiter),
+            AdmissionDecision::Reject
+        );
+        // Release all slots.
+        for _ in 0..10 {
+            mgr.release_delay_slot();
+        }
+
+        // Drop CPU into leeway zone (72-80%): multiplier holds, still delays.
+        mgr.online_adjust_resource_quota(75.0);
+        assert!(matches!(
+            mgr.admission_decision(true, &spike_limiter),
+            AdmissionDecision::Delay(_)
+        ));
+
+        // Drop CPU below leeway_start (72%): fraction ramps up ×1.1/tick.
+        // After enough ticks it reaches 5× → NO_LIMIT → rates set to infinity
+        // → token bucket debt clears → Allow.
+        for _ in 0..60 {
+            mgr.online_adjust_resource_quota(50.0);
+        }
+        assert_eq!(
+            mgr.admission_decision(true, &spike_limiter),
+            AdmissionDecision::Allow
         );
     }
 }

--- a/components/resource_control/src/resource_group.rs
+++ b/components/resource_control/src/resource_group.rs
@@ -163,6 +163,17 @@ impl ResourceGroupManager {
         {
             self.group_count.fetch_add(1, Ordering::Relaxed);
         }
+        self.update_has_background();
+    }
+
+    fn update_has_background(&self) {
+        let any_has_bg = self
+            .resource_groups
+            .iter()
+            .any(|g| !g.background_source_types.is_empty());
+        self.registry.read().iter().for_each(|controller| {
+            controller.set_has_background(any_has_bg);
+        });
     }
 
     fn build_resource_limiter(
@@ -196,6 +207,7 @@ impl ResourceGroupManager {
             info!("remove resource group"; "name"=> name);
             self.group_count.fetch_sub(1, Ordering::Relaxed);
         }
+        self.update_has_background();
     }
 
     pub fn retain(&self, mut f: impl FnMut(&String, &PbResourceGroup) -> bool) {
@@ -442,6 +454,8 @@ pub struct ResourceController {
     last_rest_vt_time: Cell<Instant>,
     // whether the settings is customized by user
     customized: AtomicBool,
+    // whether any resource group has background settings configured
+    has_background: AtomicBool,
 }
 
 // we are ensure to visit the `last_rest_vt_time` by only 1 thread so it's
@@ -459,6 +473,7 @@ impl ResourceController {
             max_ru_quota: Mutex::new(DEFAULT_MAX_RU_QUOTA),
             last_rest_vt_time: Cell::new(Instant::now_coarse()),
             customized: AtomicBool::new(false),
+            has_background: AtomicBool::new(false),
         }
     }
 
@@ -566,7 +581,11 @@ impl ResourceController {
     }
 
     pub fn is_customized(&self) -> bool {
-        self.customized.load(Ordering::Acquire)
+        self.customized.load(Ordering::Acquire) || self.has_background.load(Ordering::Acquire)
+    }
+
+    pub fn set_has_background(&self, has_background: bool) {
+        self.has_background.store(has_background, Ordering::Release);
     }
 
     #[inline]

--- a/components/resource_control/src/resource_group.rs
+++ b/components/resource_control/src/resource_group.rs
@@ -56,6 +56,29 @@ const HIGH_PRIORITY: u32 = 16;
 // virtual time overflow.
 const RESET_VT_THRESHOLD: u64 = (u64::MAX >> 4) / 2;
 
+/// Fraction of `fg_cpu_throttle_threshold` below which foreground CPU
+/// pressure counts as cleared — a dead zone so tighten/release don't flap
+/// when `cpu_score` hovers near the threshold. Shared by
+/// [`ResourceGroupManager::adjust_group_throttling`] and
+/// [`ResourceGroupManager::adjust_group_scheduling`].
+///
+/// Must stay strictly less than [`THROTTLE_DECREASE_FACTOR`]: the tighten
+/// step below shrinks whatever's currently enforced by
+/// `1 - THROTTLE_DECREASE_FACTOR` each tick, so the leeway gap
+/// (`1 - LEEWAY_THRESHOLD_RATIO`) must stay larger than that per-tick step —
+/// otherwise a single tick could swing straight through the dead zone and
+/// the engaged/disengaged state — and the throttle it drives — would just
+/// toggle every tick instead of settling.
+const LEEWAY_THRESHOLD_RATIO: f64 = 0.85;
+
+/// Per-tick multiplicative step used to tighten the per-group CPU rate limit
+/// ([`ResourceGroupManager::adjust_group_throttling`]) and to ratchet down
+/// the read pool's CPU ceiling
+/// ([`ResourceGroupManager::compute_read_pool_target_cpu`]) once foreground
+/// CPU pressure is engaged. See [`LEEWAY_THRESHOLD_RATIO`] for the invariant
+/// this must satisfy relative to the leeway threshold.
+const THROTTLE_DECREASE_FACTOR: f64 = 0.9;
+
 /// Duration of each bucket in the RuTracker ring buffer.
 const RU_BUCKET_SECS: u64 = 30;
 
@@ -341,6 +364,19 @@ pub struct ResourceGroupManager {
     // only engages when this flag is set, ensuring background is fully
     // squeezed before foreground traffic is touched.
     bg_cpu_at_floor: AtomicBool,
+    // Latest foreground CPU pressure (0.0-1.0), refreshed every tick by
+    // `online_adjust_resource_quota`. Consumed by the unified read pool to
+    // drive its thread-count scale-down decision. Encoded via `f64::to_bits`.
+    read_pool_cpu_pressure: AtomicU64,
+    // Sliding-window tracker of the unified read pool's actual CPU usage
+    // (in µs of CPU time per tick). Its `historical_rate()` is used as a
+    // floor: the read pool should never be scaled below the thread count
+    // needed to sustain its historical CPU consumption.
+    read_pool_cpu_tracker: Mutex<RuTracker>,
+    // True when the last `adjust_group_scheduling` tick saw cpu_score below
+    // the leeway threshold, i.e. the system is comfortably idle and the
+    // unified read pool may scale its thread count up toward its max.
+    read_pool_scale_up_allowed: AtomicBool,
 }
 
 impl Default for ResourceGroupManager {
@@ -367,6 +403,10 @@ impl ResourceGroupManager {
             0,
             true,
         ));
+        let start_secs = RuTracker::now_secs();
+        // 2 buckets per minute (30s each) to match RU_BUCKET_SECS, mirroring
+        // the per-group ru_trackers window sizing in `record_ru_consumption`.
+        let read_pool_num_buckets = (config.historical_usage_window_mins.max(2) as usize) * 2;
         let manager = Self {
             resource_groups: Default::default(),
             group_count: AtomicU64::new(0),
@@ -377,8 +417,11 @@ impl ResourceGroupManager {
             has_background: AtomicBool::new(false),
             config: Arc::new(VersionTrack::new(config)),
             ru_trackers: Default::default(),
-            start_secs: RuTracker::now_secs(),
+            start_secs,
             bg_cpu_at_floor: AtomicBool::new(false),
+            read_pool_cpu_pressure: AtomicU64::new(0.0f64.to_bits()),
+            read_pool_cpu_tracker: Mutex::new(RuTracker::new(start_secs, read_pool_num_buckets)),
+            read_pool_scale_up_allowed: AtomicBool::new(false),
         };
 
         // init the default resource group by default.
@@ -454,7 +497,6 @@ impl ResourceGroupManager {
         // When the last background group is removed, reset the shared limiter to
         // unlimited so that a later re-add does not inherit stale throttled rates.
         if prev && !any_has_bg {
-            use crate::resource_limiter::ResourceType;
             self.bg_limiter
                 .get_limiter(ResourceType::Cpu)
                 .set_rate_limit(f64::INFINITY);
@@ -543,36 +585,8 @@ impl ResourceGroupManager {
     }
 
     pub fn advance_min_virtual_time(&self) {
-        // Push RU-based phase state into every controller before updating VT,
-        // so get_priority() sees fresh is_over_baseline flags this tick.
-        if self.config.value().enable_fair_scheduling {
-            self.update_group_phases();
-        }
         for controller in self.registry.read().iter() {
             controller.update_min_virtual_time();
-        }
-    }
-
-    /// Iterates all tracked groups and pushes `is_over_baseline` into each
-    /// registered `ResourceController`.  Called every ~1 second from
-    /// `advance_min_virtual_time` when `enable_fair_scheduling` is on.
-    fn update_group_phases(&self) {
-        let now_secs = RuTracker::now_secs();
-        for entry in &self.ru_trackers {
-            let group_bytes = entry.key().as_bytes();
-            let mut guard = entry.value().lock().unwrap();
-            // Roll the ring buffer forward so phase classification uses
-            // up-to-date bucket boundaries, not stale partial data.
-            guard.0.advance(now_secs);
-            let over = guard
-                .1
-                .get_limiter(ResourceType::Cpu)
-                .get_rate_limit()
-                .is_finite();
-            drop(guard);
-            for controller in self.registry.read().iter() {
-                controller.set_group_phase(group_bytes, over);
-            }
         }
     }
 
@@ -642,40 +656,58 @@ impl ResourceGroupManager {
         self.bg_cpu_at_floor.load(Ordering::Relaxed)
     }
 
-    /// Returns true when all foreground groups have unlimited (infinite)
-    /// CPU rate limits, i.e. foreground has fully ramped up.
-    pub fn is_foreground_fully_ramped_up(&self) -> bool {
-        for entry in &self.ru_trackers {
-            let guard = entry.lock().unwrap();
-            if guard
-                .1
-                .get_limiter(ResourceType::Cpu)
-                .get_rate_limit()
-                .is_finite()
-            {
-                return false;
-            }
-        }
-        true
+    fn set_read_pool_cpu_pressure(&self, pressure: f64) {
+        self.read_pool_cpu_pressure
+            .store(pressure.to_bits(), Ordering::Relaxed);
     }
 
-    /// Only groups whose current rate exceeds their historical rate are
-    /// limited.
+    /// Latest foreground CPU pressure (0.0-1.0), refreshed every tick by
+    /// `online_adjust_resource_quota`.
+    pub fn read_pool_cpu_pressure(&self) -> f64 {
+        f64::from_bits(self.read_pool_cpu_pressure.load(Ordering::Relaxed))
+    }
+
+    /// Records `read_pool_cpu` (in cores) into the historical tracker and
+    /// returns the floor CPU:
+    pub fn read_pool_cpu_floor(&self, read_pool_cpu: f64, interval_secs: f64) -> f64 {
+        self.read_pool_cpu_floor_at(read_pool_cpu, interval_secs, RuTracker::now_secs())
+    }
+
+    fn read_pool_cpu_floor_at(&self, read_pool_cpu: f64, interval_secs: f64, now: u64) -> f64 {
+        let mut tracker = self.read_pool_cpu_tracker.lock().unwrap();
+        tracker.advance(now);
+        if interval_secs > 0.0 {
+            let cpu_us = (read_pool_cpu * interval_secs * 1_000_000.0).max(0.0) as u64;
+            tracker.record(cpu_us);
+        }
+        tracker.refresh_cached_historical_rate(self.start_secs, now);
+        tracker.cached_historical_rate / 1_000_000.0
+    }
+
+    /// `cpu_score` is the common CPU-utilization score (0-100) computed by
+    /// [`crate::score::compute_resource_scores`]: the max of process and grpc
+    /// normalized utilization.
+    pub fn online_adjust_resource_quota(&self, cpu_score: f64) {
+        let now = RuTracker::now_secs();
+        self.adjust_group_throttling(cpu_score, now);
+        self.adjust_group_scheduling(cpu_score);
+    }
+
+    /// Per-group CPU rate-limit throttling. Only groups whose current rate
+    /// exceeds their historical rate are limited.
     ///
     /// Ramp-up: when CPU drops below threshold, recover ×1.1/tick until
     /// NO_LIMIT is restored.
-    pub fn online_adjust_resource_quota(&self, pct: f64) {
-        const TARGET_CPU: f64 = 90.0;
-        const RAMP_FACTOR: f64 = 1.2;
+    fn adjust_group_throttling(&self, cpu_score: f64, now: u64) {
+        const RAMP_FACTOR: f64 = 1.1;
         const MIN_RAMP_UP_EPOCHS: u32 = 2;
 
         let throttle_threshold = self.config.value().fg_cpu_throttle_threshold;
-        let leeway_threshold = throttle_threshold * 0.9;
+        let leeway_threshold = throttle_threshold * LEEWAY_THRESHOLD_RATIO;
         let burst_factor = 1.0 + self.config.value().baseline_burst_pct / 100.0;
-        let now = RuTracker::now_secs();
 
         // Advance all trackers to `now` and refresh cached historical rates
-        // up front so update_group_phases and the throttling logic below
+        // up front so adjust_group_scheduling and the throttling logic below
         // always see fresh baseline data.
         for entry in &self.ru_trackers {
             let mut guard = entry.lock().unwrap();
@@ -691,25 +723,21 @@ impl ResourceGroupManager {
                 .set((guard.0.current_rate(now) / 1_000_000.0) * 100.0);
         }
 
-        if pct > throttle_threshold && self.is_bg_cpu_at_floor() {
-            // Linearly scale limit from current rate (at threshold) down to
-            // historical rate (at TARGET_CPU).
-            // pressure: 0.0 at threshold → 1.0 at TARGET_CPU.
-            let pressure =
-                ((pct - throttle_threshold) / (TARGET_CPU - throttle_threshold)).clamp(0.0, 1.0);
-
+        let engaged = cpu_score > throttle_threshold && self.is_bg_cpu_at_floor();
+        if engaged {
             for entry in &self.ru_trackers {
                 let mut guard = entry.lock().unwrap();
                 let hist = guard.0.cached_historical_rate;
-                let current = guard.0.current_rate(now);
                 let burst_target = hist * burst_factor;
-                if hist > 0.0 && current > burst_target {
-                    // rate slides from current (pressure=0) to burst_target (pressure=1).
-                    let rate = current + (burst_target - current) * pressure;
+                if hist > 0.0 {
                     let current_limit = guard.1.get_limiter(ResourceType::Cpu).get_rate_limit();
-                    // Only tighten the limit — never loosen in the throttle branch.
-                    // Ramp-up is the only path that increases limits.
-                    if current_limit.is_infinite() || rate < current_limit {
+                    let base = if current_limit.is_infinite() {
+                        guard.0.current_rate(now)
+                    } else {
+                        current_limit
+                    };
+                    if base > burst_target {
+                        let rate = (base * THROTTLE_DECREASE_FACTOR).max(burst_target);
                         guard.0.ramp_up_epochs = 0;
                         guard
                             .1
@@ -718,7 +746,7 @@ impl ResourceGroupManager {
                     }
                 }
             }
-        } else if pct < leeway_threshold {
+        } else if cpu_score < leeway_threshold {
             // CPU below start threshold — ramp up by RAMP_FACTOR each tick.
             // Only lift to INFINITY after MIN_RAMP_UP_EPOCHS consecutive epochs
             // where the limit has grown past 2x hist, to avoid premature release.
@@ -770,6 +798,109 @@ impl ResourceGroupManager {
             inner.0.advance(now);
             !inner.0.is_idle()
         });
+    }
+
+    fn adjust_group_scheduling(&self, cpu_score: f64) {
+        let throttle_threshold = self.config.value().fg_cpu_throttle_threshold;
+        let leeway_threshold = throttle_threshold * LEEWAY_THRESHOLD_RATIO;
+
+        // Engaged/not-engaged gate consumed by compute_read_pool_target_cpu,
+        // which only ever checks read_pool_cpu_pressure() > 0.0 — so this
+        // stores a plain 1.0/0.0 rather than a continuously-varying
+        // fraction. Reset to 0 whenever foreground is not under CPU
+        // pressure so a transient spike can't pin the read pool down
+        // indefinitely.
+        let engaged = cpu_score > throttle_threshold && self.is_bg_cpu_at_floor();
+        self.set_read_pool_cpu_pressure(if engaged { 1.0 } else { 0.0 });
+
+        // Comfortably idle (below leeway) → allow the read pool to scale its
+        // thread count back up toward its max on the next tick it checks in.
+        self.read_pool_scale_up_allowed
+            .store(cpu_score < leeway_threshold, Ordering::Relaxed);
+    }
+
+    /// Marks resource groups that have exceeded their own quota (current
+    /// rate over their historical baseline by more than `baseline_burst_pct`)
+    /// as over-quota (phase 1), deprioritizing them. A group within its
+    /// baseline is left untouched.
+    ///
+    /// This function only ever sets the over-quota flag, never clears it —
+    /// clearing is the caller's responsibility, once the unified read pool
+    /// has scaled back up to `core_thread_count`, via
+    /// [`Self::reset_group_priorities`]. Otherwise a sustained noisy group's
+    /// own `cached_historical_rate` eventually drifts up to absorb its
+    /// elevated usage, and comparing against it again here would silently
+    /// (and wrongly) release the group early.
+    pub fn deprioritize_over_quota_groups(&self) {
+        if !self.config.value().enable_fair_scheduling {
+            return;
+        }
+        let now = RuTracker::now_secs();
+        let burst_factor = 1.0 + self.config.value().baseline_burst_pct / 100.0;
+        for entry in &self.ru_trackers {
+            let group_bytes = entry.key().as_bytes();
+            let guard = entry.value().lock().unwrap();
+            let hist = guard.0.cached_historical_rate;
+            let current = guard.0.current_rate(now);
+            let over_quota = hist > 0.0 && current > hist * burst_factor;
+            drop(guard);
+            if over_quota {
+                for controller in self.registry.read().iter() {
+                    controller.set_group_phase(group_bytes, true);
+                }
+            }
+        }
+    }
+
+    /// Resets every tracked resource group's two-phase priority back to
+    /// phase 0 (not over-quota). Called once the unified read pool has
+    /// scaled back up to `core_thread_count`, releasing any groups that
+    /// [`Self::deprioritize_over_quota_groups`] had deprioritized.
+    pub fn reset_group_priorities(&self) {
+        for controller in self.registry.read().iter() {
+            controller.reset_all_group_phases();
+        }
+    }
+
+    /// Decides the unified read pool's target CPU (in cores) under
+    /// foreground pressure: once pressure engages, returns
+    /// `THROTTLE_DECREASE_FACTOR` below the currently measured
+    /// `read_pool_cpu`, instead of jumping straight to a computed value. The
+    /// ceiling is clamped to the historical-CPU floor so
+    /// it never drops below what the pool has sustained historically, and
+    /// resets to `f64::INFINITY` (no ceiling) as soon as pressure clears —
+    /// callers that `min()` this into their own ceiling get back exactly
+    /// that ceiling, unaffected. Also records `read_pool_cpu` into the
+    /// historical tracker so the floor stays current.
+    /// [`Self::read_pool_scale_up_allowed`] to know whether it's safe to do
+    /// so.
+    pub fn compute_read_pool_target_cpu(&self, read_pool_cpu: f64, interval_secs: f64) -> f64 {
+        let floor_cpu = self.read_pool_cpu_floor(read_pool_cpu, interval_secs);
+
+        metrics::READ_POOL_CPU_VEC
+            .with_label_values(&["historical"])
+            .set(floor_cpu * 100.0);
+        metrics::READ_POOL_CPU_VEC
+            .with_label_values(&["current"])
+            .set(read_pool_cpu * 100.0);
+
+        // The floor and metrics above are kept current either way, so
+        // re-enabling fair scheduling doesn't start from a stale floor; only
+        // the ceiling itself is gated.
+        if self.config.value().enable_fair_scheduling && self.read_pool_cpu_pressure() > 0.0 {
+            (read_pool_cpu * THROTTLE_DECREASE_FACTOR).max(floor_cpu)
+        } else {
+            f64::INFINITY
+        }
+    }
+
+    /// True when the system was comfortably idle (foreground CPU below the
+    /// leeway threshold) on the last `adjust_group_scheduling` tick, i.e. the
+    /// unified read pool may scale its thread count up toward its max.
+    pub fn read_pool_scale_up_allowed(&self) -> bool {
+        // Without fair scheduling there is nothing holding the pool back.
+        !self.config.value().enable_fair_scheduling
+            || self.read_pool_scale_up_allowed.load(Ordering::Relaxed)
     }
 
     /// Returns the token-bucket debt delay for `group`, or `None` if no
@@ -909,9 +1040,6 @@ impl ResourceGroupManager {
         let (limiter, _) = self.get_background_resource_limiter_with_priority(rg, request_source);
         if limiter.is_some() {
             return limiter;
-        }
-        if self.get_group_count() <= 1 {
-            return None;
         }
         // Only create a foreground limiter for known groups; unknown or removed
         // groups fall back to "default" to avoid leaking ru_trackers entries.
@@ -1072,6 +1200,8 @@ pub struct ResourceController {
     has_background: AtomicBool,
     // Shared config. Read on the hot path to check enable_fair_scheduling.
     config: Arc<VersionTrack<Config>>,
+    // Whether any group is in phase 1, so a reset can skip the sweep.
+    any_group_deprioritized: AtomicBool,
 }
 
 // we are ensure to visit the `last_rest_vt_time` by only 1 thread so it's
@@ -1091,6 +1221,7 @@ impl ResourceController {
             customized: AtomicBool::new(false),
             has_background: AtomicBool::new(false),
             config,
+            any_group_deprioritized: AtomicBool::new(false),
         }
     }
 
@@ -1229,13 +1360,26 @@ impl ResourceController {
     }
 
     /// Updates the two-phase `is_over_baseline` flag for a single group.
-    /// Called each second by `ResourceGroupManager::update_group_phases`.
+    /// Called by `ResourceGroupManager::adjust_group_scheduling`.
     pub fn set_group_phase(&self, group: &[u8], over_baseline: bool) {
         let consumptions = self.resource_consumptions.read();
         if let Some(tracker) = consumptions.get(group) {
             tracker
                 .is_over_baseline
                 .store(over_baseline, Ordering::Relaxed);
+            if over_baseline {
+                self.any_group_deprioritized.store(true, Ordering::Relaxed);
+            }
+        }
+    }
+
+    /// Clears every group's phase-1 flag, or does nothing if none is set.
+    pub fn reset_all_group_phases(&self) {
+        if !self.any_group_deprioritized.swap(false, Ordering::Relaxed) {
+            return;
+        }
+        for tracker in self.resource_consumptions.read().values() {
+            tracker.is_over_baseline.store(false, Ordering::Relaxed);
         }
     }
 
@@ -1440,7 +1584,10 @@ pub(crate) mod tests {
     use yatp::queue::Extras;
 
     use super::*;
-    use crate::resource_limiter::ResourceType::{Cpu, Io};
+    use crate::{
+        resource_limiter::ResourceType::{Cpu, Io},
+        score::TARGET_CPU,
+    };
 
     pub fn new_resource_group_ru(name: String, ru: u64, group_priority: u32) -> PbResourceGroup {
         new_resource_group(name, true, ru, ru, group_priority)
@@ -1944,8 +2091,11 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn test_two_phase_scheduling_ru_based() {
-        // Two-phase scheduling driven by real RU (CPU µs) from ResourceGroupManager.
+    fn test_deprioritize_over_quota_groups_ru_based() {
+        // Two-phase scheduling driven by real RU (CPU µs) from
+        // ResourceGroupManager: only groups that have exceeded their own
+        // historical quota are deprioritized, and only once the caller (the
+        // unified read pool) actually calls deprioritize_over_quota_groups.
         let mut cfg = Config::default();
         cfg.enable_fair_scheduling = true;
         let mgr = ResourceGroupManager::new(cfg);
@@ -1957,7 +2107,8 @@ pub(crate) mod tests {
 
         let ctl = mgr.derive_controller("read".into(), true);
 
-        // Warm up steady's RuTracker: 2 completed 30s buckets with consistent rate.
+        // Warm up steady's RuTracker: 2 completed 30s buckets with consistent
+        // rate (current == historical → within baseline).
         let t0 = RuTracker::now_secs();
         {
             let e = mgr
@@ -1981,31 +2132,7 @@ pub(crate) mod tests {
             tr.0.record_at(6000, t0 + 45);
             tr.0.record_at(0, t0 + 60); // close bucket 1: 6000 µs → stable baseline
         }
-        // "spike" has no tracker → is_over_baseline stays false (no history).
-
-        // Push phases into controller.
-        mgr.advance_min_virtual_time();
-
-        // steady: both buckets equal → current_rate == historical_rate → NOT over
-        // baseline. spike: no tracker → also not over baseline.
-        // Neither should be in phase 1 at steady state.
-        {
-            let groups = ctl.resource_consumptions.read();
-            let steady_over = groups
-                .get(b"steady".as_ref())
-                .unwrap()
-                .is_over_baseline
-                .load(Ordering::Relaxed);
-            let spike_over = groups
-                .get(b"spike".as_ref())
-                .unwrap()
-                .is_over_baseline
-                .load(Ordering::Relaxed);
-            assert!(!steady_over, "steady at baseline should be phase 0");
-            assert!(!spike_over, "spike with no history should be phase 0");
-        }
-
-        // Now simulate a spike for "spike": current bucket >> historical.
+        // Simulate a spike for "spike": current bucket >> historical.
         {
             let e = mgr
                 .ru_trackers
@@ -2027,21 +2154,58 @@ pub(crate) mod tests {
             tr.0.record_at(0, t0 + 60); // close bucket [t0+30,t0+60): 3000µs baseline
             tr.0.record_at(12000, t0 + 90); // current open bucket: 12000µs spike (left open)
         }
-        // Trigger a CPU utilization tick to refresh cached_historical_rate
-        // on all trackers. Set bg_cpu_at_floor so the throttle branch fires
-        // and limits groups that are over baseline.
-        mgr.set_bg_cpu_at_floor(true);
-        mgr.online_adjust_resource_quota(75.0);
-        mgr.advance_min_virtual_time();
 
+        // deprioritize_over_quota_groups reads `cached_historical_rate`,
+        // which is refreshed by `adjust_group_throttling` on
+        // resource_control's own tick (independent of, but still running
+        // alongside, the unified read pool's tick that calls
+        // deprioritize_over_quota_groups in production).
+        mgr.online_adjust_resource_quota(0.0);
+
+        // Before the caller ever deprioritizes, neither group is
+        // deprioritized, even though "spike" is already over its own
+        // baseline.
         {
             let groups = ctl.resource_consumptions.read();
-            let spike_over = groups
-                .get(b"spike".as_ref())
-                .unwrap()
-                .is_over_baseline
-                .load(Ordering::Relaxed);
-            assert!(spike_over, "spike bucket1 > bucket0 → should be phase 1");
+            assert!(
+                !groups
+                    .get(b"steady".as_ref())
+                    .unwrap()
+                    .is_over_baseline
+                    .load(Ordering::Relaxed),
+                "steady should be phase 0 before deprioritize_over_quota_groups runs"
+            );
+            assert!(
+                !groups
+                    .get(b"spike".as_ref())
+                    .unwrap()
+                    .is_over_baseline
+                    .load(Ordering::Relaxed),
+                "spike should be phase 0 before deprioritize_over_quota_groups runs"
+            );
+        }
+
+        // Only "spike" (over its own baseline) is deprioritized; "steady"
+        // (within baseline) is not.
+        mgr.deprioritize_over_quota_groups();
+        {
+            let groups = ctl.resource_consumptions.read();
+            assert!(
+                !groups
+                    .get(b"steady".as_ref())
+                    .unwrap()
+                    .is_over_baseline
+                    .load(Ordering::Relaxed),
+                "steady is within its baseline → should stay phase 0"
+            );
+            assert!(
+                groups
+                    .get(b"spike".as_ref())
+                    .unwrap()
+                    .is_over_baseline
+                    .load(Ordering::Relaxed),
+                "spike exceeded its baseline → should be phase 1"
+            );
         }
 
         // Phase ordering: steady (phase 0) must sort before spike (phase 1).
@@ -2063,6 +2227,368 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn test_deprioritize_over_quota_groups_releases_when_inactive() {
+        // A group over its own quota stays deprioritized until the caller
+        // explicitly calls reset_group_priorities — e.g. once the unified
+        // read pool has scaled back up to core_thread_count.
+        // deprioritize/target-cpu are gated on fair scheduling.
+        let mut cfg = Config::default();
+        cfg.enable_fair_scheduling = true;
+        let mgr = ResourceGroupManager::new(cfg);
+
+        let spike = new_resource_group_ru("spike".into(), 1000, MEDIUM_PRIORITY);
+        mgr.add_resource_group(spike);
+        let ctl = mgr.derive_controller("read".into(), true);
+
+        let t0 = RuTracker::now_secs();
+        {
+            let e = mgr
+                .ru_trackers
+                .entry("spike".to_owned())
+                .or_insert_with(|| {
+                    Mutex::new((
+                        RuTracker::new(t0, 30),
+                        Arc::new(ResourceLimiter::new(
+                            "".into(),
+                            f64::INFINITY,
+                            f64::INFINITY,
+                            0,
+                            false,
+                        )),
+                    ))
+                });
+            let mut tr = e.lock().unwrap();
+            tr.0.record_at(3000, t0 + 30);
+            tr.0.record_at(0, t0 + 60); // close bucket: 3000µs baseline
+            tr.0.record_at(12000, t0 + 90); // open bucket: 12000µs spike
+        }
+
+        // Refresh `cached_historical_rate`, normally done by
+        // `adjust_group_throttling` on resource_control's own tick.
+        mgr.online_adjust_resource_quota(0.0);
+
+        mgr.deprioritize_over_quota_groups();
+        assert!(
+            ctl.resource_consumptions
+                .read()
+                .get(b"spike".as_ref())
+                .unwrap()
+                .is_over_baseline
+                .load(Ordering::Relaxed),
+            "spike exceeded its quota → should be phase 1"
+        );
+
+        // Caller (e.g. the unified read pool, once it has scaled back up to
+        // core_thread_count) calls reset_group_priorities: released
+        // immediately, even though spike's RU history hasn't changed.
+        mgr.reset_group_priorities();
+        assert!(
+            !ctl.resource_consumptions
+                .read()
+                .get(b"spike".as_ref())
+                .unwrap()
+                .is_over_baseline
+                .load(Ordering::Relaxed),
+            "spike should be released once the caller resets priorities"
+        );
+    }
+
+    #[test]
+    fn test_deprioritize_over_quota_groups_does_not_self_release() {
+        // A sustained noisy group must stay deprioritized even once its own
+        // `cached_historical_rate` has drifted up to absorb its elevated
+        // usage (current no longer exceeds hist * burst_factor) — only
+        // reset_group_priorities is allowed to release it.
+        // deprioritize/target-cpu are gated on fair scheduling.
+        let mut cfg = Config::default();
+        cfg.enable_fair_scheduling = true;
+        let mgr = ResourceGroupManager::new(cfg);
+
+        let spike = new_resource_group_ru("spike".into(), 1000, MEDIUM_PRIORITY);
+        mgr.add_resource_group(spike);
+        let ctl = mgr.derive_controller("read".into(), true);
+
+        let t0 = RuTracker::now_secs();
+        {
+            let e = mgr
+                .ru_trackers
+                .entry("spike".to_owned())
+                .or_insert_with(|| {
+                    Mutex::new((
+                        RuTracker::new(t0, 30),
+                        Arc::new(ResourceLimiter::new(
+                            "".into(),
+                            f64::INFINITY,
+                            f64::INFINITY,
+                            0,
+                            false,
+                        )),
+                    ))
+                });
+            let mut tr = e.lock().unwrap();
+            tr.0.record_at(3000, t0 + 30);
+            tr.0.record_at(0, t0 + 60); // close bucket: 3000µs baseline
+            tr.0.record_at(12000, t0 + 90); // open bucket: 12000µs spike
+        }
+        mgr.online_adjust_resource_quota(0.0);
+
+        mgr.deprioritize_over_quota_groups();
+        assert!(
+            ctl.resource_consumptions
+                .read()
+                .get(b"spike".as_ref())
+                .unwrap()
+                .is_over_baseline
+                .load(Ordering::Relaxed),
+            "spike exceeded its quota → should be phase 1"
+        );
+
+        // Simulate the historical baseline catching up to the sustained
+        // elevated rate: overwrite cached_historical_rate directly to match
+        // current, as if enough windows had rolled over.
+        {
+            let e = mgr.ru_trackers.get("spike").unwrap();
+            let mut tr = e.lock().unwrap();
+            let now = RuTracker::now_secs();
+            tr.0.cached_historical_rate = tr.0.current_rate(now);
+        }
+
+        // Calling deprioritize_over_quota_groups again must not clear the
+        // flag just because current no longer exceeds the (now-caught-up)
+        // historical rate.
+        mgr.deprioritize_over_quota_groups();
+        assert!(
+            ctl.resource_consumptions
+                .read()
+                .get(b"spike".as_ref())
+                .unwrap()
+                .is_over_baseline
+                .load(Ordering::Relaxed),
+            "spike must stay deprioritized even after its baseline catches up"
+        );
+
+        // Only an explicit reset releases it.
+        mgr.reset_group_priorities();
+        assert!(
+            !ctl.resource_consumptions
+                .read()
+                .get(b"spike".as_ref())
+                .unwrap()
+                .is_over_baseline
+                .load(Ordering::Relaxed),
+            "spike should be released once the caller resets priorities"
+        );
+    }
+
+    #[test]
+    fn test_read_pool_scale_up_allowed_when_idle() {
+        let mgr = ResourceGroupManager::default();
+        // Drive cpu_score comfortably below the leeway threshold so
+        // adjust_group_scheduling marks the system as idle.
+        mgr.online_adjust_resource_quota(0.0);
+        assert!(mgr.read_pool_scale_up_allowed());
+
+        // With no pressure, compute_read_pool_target_cpu imposes no ceiling
+        // at all — scaling up is the unified read pool's own responsibility.
+        let target_cpu = mgr.compute_read_pool_target_cpu(2.0, 10.0);
+        assert_eq!(target_cpu, f64::INFINITY, "no pressure → no ceiling");
+    }
+
+    #[test]
+    fn test_compute_read_pool_target_cpu_holds_in_leeway_zone() {
+        // deprioritize/target-cpu are gated on fair scheduling.
+        let mut cfg = Config::default();
+        cfg.enable_fair_scheduling = true;
+        let mgr = ResourceGroupManager::new(cfg);
+        // cpu_score in the leeway zone: not engaged (bg not at floor), and
+        // above leeway_threshold, so neither scale-down nor scale-up fires.
+        mgr.online_adjust_resource_quota(65.0);
+        assert!(!mgr.read_pool_scale_up_allowed());
+        assert_eq!(mgr.read_pool_cpu_pressure(), 0.0);
+
+        let target_cpu = mgr.compute_read_pool_target_cpu(2.0, 10.0);
+        assert_eq!(
+            target_cpu,
+            f64::INFINITY,
+            "leeway zone should impose no ceiling"
+        );
+    }
+
+    #[test]
+    fn test_read_pool_entry_points_are_inert_without_fair_scheduling() {
+        // The read pool consults the manager unconditionally and relies on it
+        // to be a no-op while fair scheduling is off, so that gate lives here
+        // rather than at the call site.
+        let mgr = ResourceGroupManager::default();
+        assert!(!mgr.get_config().value().enable_fair_scheduling);
+
+        // Pressure is still tracked (adjust_group_scheduling is not gated)...
+        mgr.set_bg_cpu_at_floor(true);
+        mgr.online_adjust_resource_quota(TARGET_CPU);
+        assert_eq!(mgr.read_pool_cpu_pressure(), 1.0);
+
+        // ...but it must not turn into a ceiling, or hold back scale-out.
+        assert_eq!(
+            mgr.compute_read_pool_target_cpu(4.0, 10.0),
+            f64::INFINITY,
+            "no ceiling should be imposed while fair scheduling is off"
+        );
+        assert!(
+            mgr.read_pool_scale_up_allowed(),
+            "scale-out must not be blocked while fair scheduling is off"
+        );
+
+        // And a group that genuinely is over quota — so that dropping the gate
+        // really would deprioritize it — must be left alone.
+        let spike = new_resource_group_ru("spike".into(), 1000, MEDIUM_PRIORITY);
+        mgr.add_resource_group(spike);
+        let ctl = mgr.derive_controller("read".into(), true);
+        let t0 = RuTracker::now_secs();
+        {
+            let e = mgr
+                .ru_trackers
+                .entry("spike".to_owned())
+                .or_insert_with(|| {
+                    Mutex::new((
+                        RuTracker::new(t0, 30),
+                        Arc::new(ResourceLimiter::new(
+                            "".into(),
+                            f64::INFINITY,
+                            f64::INFINITY,
+                            0,
+                            false,
+                        )),
+                    ))
+                });
+            let mut tr = e.lock().unwrap();
+            tr.0.record_at(3000, t0 + 30);
+            tr.0.record_at(0, t0 + 60); // close bucket: 3000µs baseline
+            tr.0.record_at(12000, t0 + 90); // open bucket: 12000µs spike
+        }
+        // Refresh cached_historical_rate, as resource_control's own tick would.
+        mgr.online_adjust_resource_quota(0.0);
+        mgr.deprioritize_over_quota_groups();
+        assert!(
+            !ctl.resource_consumptions
+                .read()
+                .get(b"spike".as_ref())
+                .unwrap()
+                .is_over_baseline
+                .load(Ordering::Relaxed),
+            "deprioritize must be a no-op while fair scheduling is off"
+        );
+    }
+
+    #[test]
+    fn test_compute_read_pool_target_cpu_scales_down_with_pressure() {
+        // deprioritize/target-cpu are gated on fair scheduling.
+        let mut cfg = Config::default();
+        cfg.enable_fair_scheduling = true;
+        let mgr = ResourceGroupManager::new(cfg);
+        // Seed a historical floor of 0 cores (cold tracker), then engage
+        // pressure (cpu_score == TARGET_CPU).
+        mgr.set_bg_cpu_at_floor(true);
+        mgr.online_adjust_resource_quota(TARGET_CPU);
+        assert_eq!(mgr.read_pool_cpu_pressure(), 1.0);
+
+        // Once engaged, the ceiling is 10% below the currently measured
+        // usage instead of collapsing straight to the (cold, i.e. 0)
+        // historical floor.
+        let target_cpu = mgr.compute_read_pool_target_cpu(4.0, 10.0);
+        assert!(
+            (target_cpu - 3.6).abs() < 1e-9,
+            "should be 10% below measured usage, got {target_cpu}"
+        );
+
+        // Stateless: calling again with the same measured usage gives the
+        // same result rather than ratcheting further down on its own.
+        let target_cpu = mgr.compute_read_pool_target_cpu(4.0, 10.0);
+        assert!(
+            (target_cpu - 3.6).abs() < 1e-9,
+            "repeated calls with unchanged usage should not ratchet further, got {target_cpu}"
+        );
+
+        // It does respond to a drop in measured usage (e.g. after the read
+        // pool itself cut its thread count in response to the previous
+        // tick's lower ceiling).
+        let target_cpu = mgr.compute_read_pool_target_cpu(3.6, 10.0);
+        assert!(
+            (target_cpu - 3.24).abs() < 1e-9,
+            "should track 10% below whatever usage is currently measured, got {target_cpu}"
+        );
+    }
+
+    #[test]
+    fn test_adjust_group_throttling_decreases_by_10_percent_per_tick() {
+        // fg_cpu_throttle_threshold=70, baseline_burst_pct=20 (defaults) ->
+        // burst_factor = 1.2.
+        let mgr = ResourceGroupManager::default();
+        mgr.add_resource_group(new_resource_group_ru("g1".into(), 1000, HIGH_PRIORITY));
+        let limiter = mgr.get_foreground_group_limiter("g1");
+
+        // Seed one completed bucket (historical) and a large spike in the
+        // still-open bucket (current), so hist > 0 and current is well
+        // above burst_target = hist * 1.2.
+        let t0 = RuTracker::now_secs();
+        {
+            let entry = mgr.ru_trackers.get("g1").unwrap();
+            let mut guard = entry.lock().unwrap();
+            guard.0.record_at(6000, t0 + 30);
+            guard.0.record_at(0, t0 + 60); // closes bucket: hist ~= 6000/30 = 200/s
+            guard.0.record_at(120_000, t0 + 65); // open-bucket spike: current >> burst_target
+        }
+        mgr.set_bg_cpu_at_floor(true);
+        let now = t0 + 90;
+
+        // First tick: no limit set yet (starts at INFINITY), so the base is
+        // the measured current rate, tightened by 10% — not an interpolated
+        // jump straight to burst_target.
+        mgr.adjust_group_throttling(90.0, now);
+        let after_tick1 = limiter.get_limiter(ResourceType::Cpu).get_rate_limit();
+        let current_rate = {
+            let entry = mgr.ru_trackers.get("g1").unwrap();
+            let rate = entry.lock().unwrap().0.current_rate(now);
+            rate
+        };
+        assert!(
+            (after_tick1 - current_rate * 0.9).abs() < current_rate * 0.01,
+            "first tick should tighten 10% below measured current rate, got {after_tick1}, \
+             expected ~{}",
+            current_rate * 0.9
+        );
+
+        // Second tick, same inputs: base is now the persisted current_limit
+        // from tick 1 (not a freshly measured/interpolated value), so it
+        // tightens another 10% relative to itself rather than staying put
+        // or jumping to burst_target.
+        mgr.adjust_group_throttling(90.0, now);
+        let after_tick2 = limiter.get_limiter(ResourceType::Cpu).get_rate_limit();
+        assert!(
+            (after_tick2 - after_tick1 * 0.9).abs() < after_tick1 * 0.01,
+            "second tick should tighten another 10% relative to the previous tick's limit, \
+             got {after_tick2}, expected ~{}",
+            after_tick1 * 0.9
+        );
+
+        // Repeated ticks converge to and stop at burst_target = hist * 1.2,
+        // never going below it.
+        for _ in 0..60 {
+            mgr.adjust_group_throttling(90.0, now);
+        }
+        let floored = limiter.get_limiter(ResourceType::Cpu).get_rate_limit();
+        let hist = {
+            let entry = mgr.ru_trackers.get("g1").unwrap();
+            let rate = entry.lock().unwrap().0.cached_historical_rate;
+            rate
+        };
+        let burst_target = hist * 1.2;
+        assert!(
+            (floored - burst_target).abs() < burst_target * 0.01,
+            "should converge to and stop at burst_target ({burst_target}), got {floored}"
+        );
+    }
+
+    #[test]
     fn test_get_resource_limiter() {
         let mgr = ResourceGroupManager::default();
 
@@ -2080,16 +2606,19 @@ pub(crate) mod tests {
             .clone()
             .unwrap();
 
-        // Only 1 group (default): foreground always returns None.
-        assert!(mgr.get_resource_limiter("default", "query", 0).is_none());
-        assert!(
-            mgr.get_resource_limiter("default", "query", HIGH_PRIORITY as u64)
-                .is_none()
-        );
-        assert!(
-            mgr.get_resource_limiter("default", "query", LOW_PRIORITY as u64)
-                .is_none()
-        );
+        // Even with only 1 group (default), foreground returns the
+        // per-group limiter regardless of priority level.
+        let fg_default_limiter = mgr.get_resource_limiter("default", "query", 0).unwrap();
+        assert!(Arc::ptr_eq(
+            &mgr.get_resource_limiter("default", "query", HIGH_PRIORITY as u64)
+                .unwrap(),
+            &fg_default_limiter,
+        ));
+        assert!(Arc::ptr_eq(
+            &mgr.get_resource_limiter("default", "query", LOW_PRIORITY as u64)
+                .unwrap(),
+            &fg_default_limiter,
+        ));
 
         let group1 = new_resource_group("test1".into(), true, 100, 100, HIGH_PRIORITY);
         mgr.add_resource_group(group1);
@@ -2306,5 +2835,45 @@ pub(crate) mod tests {
             mgr.admission_decision(true, &spike_limiter),
             AdmissionDecision::Allow
         );
+    }
+
+    #[test]
+    fn test_read_pool_cpu_floor_cold_tracker() {
+        let mgr = ResourceGroupManager::default();
+        let t0 = RuTracker::now_secs();
+        // Cold tracker → historical rate 0 → floor == 0.0 cores.
+        let floor = mgr.read_pool_cpu_floor_at(8.0, 10.0, t0);
+        assert_eq!(floor, 0.0);
+    }
+
+    #[test]
+    fn test_read_pool_cpu_floor_matches_historical_usage() {
+        // Small window (minimum 2 min = 4 buckets = 120s) so a handful of
+        // directly-seeded buckets fully cover it, giving an exact,
+        // non-ramping historical rate to assert against.
+        let cfg = Config {
+            historical_usage_window_mins: 2,
+            ..Default::default()
+        };
+        let mgr = ResourceGroupManager::new(cfg);
+        let t0 = mgr.start_secs;
+
+        // Seed 4 fully-completed 30s buckets at a sustained 4 cores of usage
+        // (4 cores * 30s * 1_000_000 us/s = 120_000_000 us per bucket). Each
+        // `record_at` call commits the *previous* call's contribution to a
+        // bucket, so a 5th call is needed to flush the 4th bucket closed.
+        {
+            let mut tracker = mgr.read_pool_cpu_tracker.lock().unwrap();
+            tracker.record_at(120_000_000, t0 + 30);
+            tracker.record_at(120_000_000, t0 + 60);
+            tracker.record_at(120_000_000, t0 + 90);
+            tracker.record_at(120_000_000, t0 + 120);
+            tracker.record_at(120_000_000, t0 + 150);
+        }
+        // system_uptime (150s) >= window_secs (120s) → historical_rate uses
+        // the full window as denominator: 480_000_000 / 120 = 4_000_000 us/s
+        // = 4 cores → floor = 4.0.
+        let floor = mgr.read_pool_cpu_floor_at(4.0, 30.0, t0 + 150);
+        assert_eq!(floor, 4.0);
     }
 }

--- a/components/resource_control/src/resource_group.rs
+++ b/components/resource_control/src/resource_group.rs
@@ -6,7 +6,7 @@ use std::{
     collections::HashSet,
     sync::{
         atomic::{AtomicBool, AtomicI64, AtomicU64, Ordering},
-        Arc, Mutex,
+        Arc, LockResult, Mutex, MutexGuard,
     },
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
@@ -28,10 +28,11 @@ use tikv_util::{
 use yatp::queue::priority::TaskPriorityProvider;
 
 use crate::{
-    config::Config,
+    config::{Config, NoisyDetection},
     metrics,
     metrics::{deregister_metrics, TWO_PHASE_THROTTLED_REQUESTS},
     resource_limiter::{ResourceLimiter, ResourceType},
+    score::PEAK_CPU_PCT,
 };
 
 // a read task cost at least 50us.
@@ -56,31 +57,74 @@ const HIGH_PRIORITY: u32 = 16;
 // virtual time overflow.
 const RESET_VT_THRESHOLD: u64 = (u64::MAX >> 4) / 2;
 
-/// Fraction of `fg_cpu_throttle_threshold` below which foreground CPU
-/// pressure counts as cleared — a dead zone so tighten/release don't flap
-/// when `cpu_score` hovers near the threshold. Shared by
-/// [`ResourceGroupManager::adjust_group_throttling`] and
-/// [`ResourceGroupManager::adjust_group_scheduling`].
-///
-/// Must stay strictly less than [`THROTTLE_DECREASE_FACTOR`]: the tighten
-/// step below shrinks whatever's currently enforced by
-/// `1 - THROTTLE_DECREASE_FACTOR` each tick, so the leeway gap
-/// (`1 - LEEWAY_THRESHOLD_RATIO`) must stay larger than that per-tick step —
-/// otherwise a single tick could swing straight through the dead zone and
-/// the engaged/disengaged state — and the throttle it drives — would just
-/// toggle every tick instead of settling.
-const LEEWAY_THRESHOLD_RATIO: f64 = 0.85;
+/// Period of both control loops: the quota worker and the unified read pool's
+/// thread ladder. Independent timers, so the same period but unsynchronised
+/// phase — the read pool acts on a verdict up to one tick stale. Every `*_PCT`
+/// below is per this tick.
+pub const CONTROL_TICK: Duration = Duration::from_secs(10);
 
-/// Per-tick multiplicative step used to tighten the per-group CPU rate limit
-/// ([`ResourceGroupManager::adjust_group_throttling`]) and to ratchet down
-/// the read pool's CPU ceiling
-/// ([`ResourceGroupManager::compute_read_pool_target_cpu`]) once foreground
-/// CPU pressure is engaged. See [`LEEWAY_THRESHOLD_RATIO`] for the invariant
-/// this must satisfy relative to the leeway threshold.
-const THROTTLE_DECREASE_FACTOR: f64 = 0.9;
+/// Margin below a setpoint before a controller trusts there is room to expand:
+/// `measured < LEEWAY_FACTOR * setpoint`. Shared by the foreground throttle's
+/// release gate, the read pool's scale-up permission and scale-out band, and
+/// the background idle gate.
+const LEEWAY_PCT: f64 = 10.0;
+/// The margin itself. Only the scale-*in* band wants it in this form, as
+/// `1 + LEEWAY_FRACTION`; everything comparing downward wants
+/// [`LEEWAY_FACTOR`].
+pub const LEEWAY_FRACTION: f64 = LEEWAY_PCT / 100.0;
+pub const LEEWAY_FACTOR: f64 = 1.0 - LEEWAY_FRACTION;
+
+/// How far below `fg_cpu_throttle_threshold` the node must sit for a group's
+/// sliding average to be trusted as its baseline. Above that mark the baseline
+/// is left alone, so it holds the last quiet reading for the whole episode.
+/// Stricter than [`LEEWAY_FACTOR`]: that decides when to hand capacity back,
+/// this decides when a sample is representative.
+const BASELINE_QUIET_PCT: f64 = 15.0;
+const BASELINE_QUIET_FACTOR: f64 = 1.0 - BASELINE_QUIET_PCT / 100.0;
+// Leeway decides when it is safe to hand capacity back; the quiet gate decides
+// when a sample is representative of normal behaviour. A reference taken at the
+// release point would already include the run-up to the episode, so the quiet
+// gate has to stay the stricter of the two -- checked here so retuning either
+// percentage above cannot silently invert them.
+//
+// `assertions_on_constants` reads this as `assert!(true)` to be optimized out;
+// in a `const` item there is nothing to optimize out, the evaluation *is* the
+// check.
+#[allow(clippy::assertions_on_constants)]
+const _: () = assert!(BASELINE_QUIET_FACTOR < LEEWAY_FACTOR);
+
+/// Per-tick step that tightens an enforced rate while pressure is engaged: the
+/// per-group CPU limit and the read pool's CPU ceiling. Larger than the
+/// increase step on purpose — react fast, restore slowly — so one engaged tick
+/// undoes about 1.7 recovery ticks. The background budget has no equivalent;
+/// it interpolates on pressure instead of stepping.
+const THROTTLE_DECREASE_PCT: f64 = 15.0;
+
+/// Per-tick step that gives an enforced rate back once pressure clears. Held
+/// at 10% so the ramp can finish: ~5 ticks to reach the `2x` baseline that
+/// lifts the limit, and any engaged tick in between resets that progress.
+const THROTTLE_INCREASE_PCT: f64 = 10.0;
+
+const THROTTLE_DECREASE_FACTOR: f64 = 1.0 - THROTTLE_DECREASE_PCT / 100.0;
+pub(crate) const THROTTLE_INCREASE_FACTOR: f64 = 1.0 + THROTTLE_INCREASE_PCT / 100.0;
+
+/// Consecutive loaded ticks a group must be over its own burst target before
+/// `select_noisy_groups` will blame it. The read pool needs no equivalent: its
+/// ceiling moves `THROTTLE_DECREASE_PCT` per tick, which is already gradual.
+const MIN_ENGAGE_TICKS: u32 = 2;
+
+/// A candidate whose excess is under this share of the worst offender's is
+/// tail, not cause. A ratio, so it holds at any scale.
+const TAIL_EXCESS_RATIO: f64 = 0.1;
 
 /// Duration of each bucket in the RuTracker ring buffer.
 const RU_BUCKET_SECS: u64 = 30;
+
+/// Floor the read pool's CPU ceiling never ratchets below, in cores. The
+/// counterpart of the 1 RU/s floor a throttled group gets: without a sampled
+/// quiet floor the target is only `THROTTLE_DECREASE_PCT` below current, which
+/// compounds toward zero and would leave the pool unable to serve anything.
+const MIN_READ_POOL_TARGET_CORES: f64 = 1.0;
 
 /// Sliding-window RU consumption tracker for both Tier-1 admission control
 /// and two-phase scheduling phase decisions.
@@ -95,8 +139,12 @@ pub struct RuTracker {
     /// Ring buffer of completed 30-second bucket totals (oldest at `head`).
     buckets: Vec<u64>,
     /// RU accumulated in the currently-open (incomplete) bucket.
-    /// Atomic so that `record_ru_consumption` can add without taking the Mutex.
-    current_bucket: AtomicU64,
+    /// Atomic, and shared with the enclosing [`RuTrackerSlot`], so that
+    /// `record_ru_consumption` can add without taking the Mutex.
+    current_bucket: Arc<AtomicU64>,
+    /// RU/s over the trailing 30-60 seconds, refreshed once per tick. See
+    /// [`Self::current_rate`].
+    cached_current_rate: f64,
     /// Unix seconds at which the current bucket started.
     bucket_start_secs: u64,
     /// Index of the oldest completed bucket.
@@ -109,6 +157,19 @@ pub struct RuTracker {
     /// Consecutive ramp-up epochs where new_limit >= 2x hist. Must reach
     /// MIN_RAMP_UP_EPOCHS before the limit is fully lifted to INFINITY.
     ramp_up_epochs: u32,
+    /// `cached_historical_rate` as of the last quiet window, in RU/s. The
+    /// clamp-down paths use it; the paths that let go use the live value,
+    /// which has climbed with the load and so keeps release conservative.
+    /// `None` until the first quiet window.
+    quiet_baseline: Option<f64>,
+    /// True while this group is deprioritized in the read scheduler.
+    scheduler_backpressure: bool,
+    /// Consecutive ticks over this group's own burst target, saturating at
+    /// `MIN_ENGAGE_TICKS`. See [`Self::sustained_over_baseline`].
+    over_baseline_ticks: u32,
+    /// When the current run of quiet ticks began, or `u64::MAX` if the last
+    /// tick was not quiet. See [`Self::refresh_quiet_baseline`].
+    quiet_since_secs: u64,
 }
 
 impl RuTracker {
@@ -117,12 +178,17 @@ impl RuTracker {
         let num_buckets = num_buckets.max(2); // need at least 2 to warm up
         Self {
             buckets: vec![0u64; num_buckets],
-            current_bucket: AtomicU64::new(0),
+            current_bucket: Arc::new(AtomicU64::new(0)),
+            cached_current_rate: 0.0,
             bucket_start_secs: now_secs,
             head: 0,
             completed: 0,
             cached_historical_rate: 0.0,
             ramp_up_epochs: 0,
+            quiet_baseline: None,
+            scheduler_backpressure: false,
+            over_baseline_ticks: 0,
+            quiet_since_secs: u64::MAX,
         }
     }
 
@@ -136,6 +202,12 @@ impl RuTracker {
     #[inline]
     fn num_buckets(&self) -> usize {
         self.buckets.len()
+    }
+
+    /// The open-bucket counter, so a holder can add to it without reaching
+    /// through the Mutex. Only [`RuTrackerSlot::new`] needs this.
+    fn open_bucket_counter(&self) -> Arc<AtomicU64> {
+        self.current_bucket.clone()
     }
 
     /// Record `ru` in the current bucket (lock-free atomic add).
@@ -153,7 +225,7 @@ impl RuTracker {
     #[cfg(test)]
     pub fn record_at(&mut self, ru: u64, now_secs: u64) {
         self.advance(now_secs);
-        self.current_bucket.fetch_add(ru, Ordering::Relaxed);
+        self.record(ru);
     }
 
     fn advance(&mut self, now_secs: u64) {
@@ -178,7 +250,6 @@ impl RuTracker {
             } else {
                 self.head = (self.head + 1) % n;
             }
-            // Zero out the remaining (buckets_to_advance - 1) slots.
             for _ in 1..buckets_to_advance {
                 let slot = (self.head + self.completed) % n;
                 self.buckets[slot] = 0;
@@ -192,32 +263,44 @@ impl RuTracker {
         self.bucket_start_secs += buckets_to_advance as u64 * RU_BUCKET_SECS;
     }
 
-    /// RU/s rate estimated from the current partial bucket and the most recent
-    /// completed bucket. Using both avoids stale readings — the last completed
-    /// bucket alone can be up to 60s old at the end of the current 30s window.
-    ///
-    /// rate = (current_bucket + last_completed) / (elapsed_in_current + 30s)
-    pub fn current_rate(&self, now_secs: u64) -> f64 {
-        let elapsed = now_secs
-            .saturating_sub(self.bucket_start_secs)
-            .min(RU_BUCKET_SECS) as f64;
-        let last_completed = if self.completed > 0 {
-            let newest_slot = (self.head + self.completed - 1) % self.num_buckets();
-            self.buckets[newest_slot]
-        } else {
-            0
-        };
-        let window = elapsed + RU_BUCKET_SECS as f64;
-        (self.current_bucket.load(Ordering::Relaxed) + last_completed) as f64 / window
+    /// RU/s over the trailing 30-60 seconds, sampled by
+    /// [`Self::refresh_cached_current_rate`]. A getter, so either clock that
+    /// reaches `select_noisy_groups` may call it freely; the read pool's sees
+    /// it one tick stale, as it already does the baseline.
+    #[inline]
+    pub fn current_rate(&self) -> f64 {
+        self.cached_current_rate
     }
 
-    /// Average RU/s rate over all completed buckets (long-term baseline).
-    /// Average RU/s baseline. If the system has been up longer than the full
-    /// historical window, always divide by the full window (not just completed
-    /// buckets). This means a tracker that just started (e.g. spike with no
-    /// prior traffic) has historical=0 and any traffic is immediately detected
-    /// as over baseline, rather than letting new traffic inflate its own
-    /// baseline.
+    /// The newest closed bucket plus the one still filling, over the time the
+    /// two actually cover. The window slides between 30 and 60 seconds and
+    /// always ends at `now`, so a single tick of traffic cannot swing the
+    /// verdict, and traffic that has not yet closed a bucket is still visible.
+    ///
+    /// Idempotent, unlike the per-tick delta this replaced: a second caller in
+    /// the same tick reads the same value rather than a consumed one.
+    pub fn refresh_cached_current_rate(&mut self, now_secs: u64) {
+        let open = self.current_bucket.load(Ordering::Relaxed);
+        // Clamped because a caller that has not advanced the ring would
+        // otherwise divide by a window the buckets do not cover.
+        let open_secs = now_secs
+            .saturating_sub(self.bucket_start_secs)
+            .min(RU_BUCKET_SECS);
+        self.cached_current_rate = if self.completed == 0 {
+            // No closed bucket yet: measure the open one alone rather than
+            // report zero, so a group's first traffic is not invisible.
+            open as f64 / open_secs.max(1) as f64
+        } else {
+            let n = self.num_buckets();
+            let closed = self.buckets[(self.head + self.completed - 1) % n];
+            (closed + open) as f64 / (RU_BUCKET_SECS + open_secs) as f64
+        };
+    }
+
+    /// Average RU/s baseline. Once the system has been up longer than the
+    /// window, always divides by the full window rather than by the completed
+    /// buckets, so a tracker that just started has historical = 0 and any
+    /// traffic reads as over baseline instead of inflating its own.
     pub fn historical_rate(&self, system_start_secs: u64, now_secs: u64) -> f64 {
         let window_secs = self.num_buckets() as u64 * RU_BUCKET_SECS;
         let system_uptime = now_secs.saturating_sub(system_start_secs);
@@ -247,6 +330,84 @@ impl RuTracker {
     /// entries.
     pub fn is_idle(&self) -> bool {
         self.current_bucket.load(Ordering::Relaxed) == 0 && self.buckets.iter().all(|&b| b == 0)
+    }
+
+    /// Takes the reference the clamp-down paths use, but only after a full
+    /// window of quiet ticks: above the gate the sliding average climbs with
+    /// the load it is used to judge, and for a window after an episode the
+    /// ring buffer still holds it, so a sample would come back inflated.
+    ///
+    /// A cold tracker is skipped: a zero here is indistinguishable from never
+    /// having had a quiet window, and the next quiet tick freezes a real value.
+    fn refresh_quiet_baseline(&mut self, quiet: bool, now: u64) {
+        if !quiet {
+            self.quiet_since_secs = u64::MAX;
+            return;
+        }
+        if self.quiet_since_secs == u64::MAX {
+            self.quiet_since_secs = now;
+        }
+        if now.saturating_sub(self.quiet_since_secs) >= self.window_secs()
+            && self.cached_historical_rate > 0.0
+        {
+            self.quiet_baseline = Some(self.cached_historical_rate);
+        }
+    }
+
+    /// Baseline the eligibility gate compares against: the last quiet reading,
+    /// or zero until there has been one. Zero, not the live sliding average --
+    /// that average climbs with the load it is being used to judge, so a group
+    /// ramping into an overload measures itself against its own spike and
+    /// stays inside the gate. Judged on raw usage instead, it ranks by what it
+    /// is actually consuming, which is what the biggest-mover ranking needs.
+    /// Also what `GROUP_RU_BASELINE` reports, so the panel cannot disagree
+    /// with the gate.
+    fn effective_baseline(&self) -> f64 {
+        self.quiet_baseline.unwrap_or(0.0)
+    }
+
+    /// Whether this group is over its own burst target right now.
+    fn is_over_burst_target(&self, burst_factor: f64) -> bool {
+        let current = self.current_rate();
+        current > 0.0 && current > self.effective_baseline() * burst_factor
+    }
+
+    /// Advances the candidacy counter, once per tick for every group. Load
+    /// matters as well as excess: on excess alone the counter sat saturated,
+    /// since a group above its trailing average stays there for minutes.
+    ///
+    /// `cleared`, not `!loaded`, is what wipes it — a score hovering on the
+    /// threshold would otherwise erase the evidence every other tick. A group
+    /// inside its own target still resets outright: that is evidence about the
+    /// group, not the node. Background reaching its floor is deliberately not a
+    /// condition; it gates whether an actuator may fire, not who is at fault.
+    fn update_over_baseline_ticks(&mut self, burst_factor: f64, loaded: bool, cleared: bool) {
+        if !self.is_over_burst_target(burst_factor) || cleared {
+            self.over_baseline_ticks = 0;
+        } else if loaded {
+            self.over_baseline_ticks = self
+                .over_baseline_ticks
+                .saturating_add(1)
+                .min(MIN_ENGAGE_TICKS);
+        }
+    }
+
+    /// Whether this group has been over its burst target long enough to be
+    /// blamed. One sample is not evidence.
+    fn sustained_over_baseline(&self) -> bool {
+        self.over_baseline_ticks >= MIN_ENGAGE_TICKS
+    }
+
+    /// Records whether a CPU rate limit is applied to this group.
+    /// Records whether this group is deprioritized in the read scheduler.
+    fn set_scheduler_backpressure(&mut self, on: bool) {
+        self.scheduler_backpressure = on;
+    }
+
+    /// Span the ring buffer covers, in seconds: also how long an episode takes
+    /// to age out of it.
+    fn window_secs(&self) -> u64 {
+        self.num_buckets() as u64 * RU_BUCKET_SECS
     }
 
     /// Refresh the cached historical rate. Called periodically from
@@ -335,6 +496,42 @@ impl Drop for DelaySlotGuard {
 }
 
 /// ResourceGroupManager manages the metadata of each resource group.
+/// A group's sliding-window tracker together with its foreground limiter.
+///
+/// `open_bucket` is the tracker's own open-bucket counter, held out here so
+/// `record_ru_consumption` can add to it with a single atomic and no lock --
+/// which is what making that counter atomic was always for. The Mutex is
+/// still what the tick takes to advance buckets and read the derived rates.
+pub(crate) struct RuTrackerSlot {
+    open_bucket: Arc<AtomicU64>,
+    inner: Mutex<(RuTracker, Arc<ResourceLimiter>)>,
+}
+
+impl RuTrackerSlot {
+    fn new(tracker: RuTracker, limiter: Arc<ResourceLimiter>) -> Self {
+        Self {
+            open_bucket: tracker.open_bucket_counter(),
+            inner: Mutex::new((tracker, limiter)),
+        }
+    }
+
+    /// Add to the open bucket without taking the lock.
+    fn record(&self, ru: u64) {
+        self.open_bucket.fetch_add(ru, Ordering::Relaxed);
+    }
+
+    /// Deliberately the same shape as locking the Mutex directly, so every
+    /// caller that needs the tracker itself reads as it did before the
+    /// counter was lifted out.
+    fn lock(&self) -> LockResult<MutexGuard<'_, (RuTracker, Arc<ResourceLimiter>)>> {
+        self.inner.lock()
+    }
+
+    fn get_mut(&mut self) -> LockResult<&mut (RuTracker, Arc<ResourceLimiter>)> {
+        self.inner.get_mut()
+    }
+}
+
 pub struct ResourceGroupManager {
     pub(crate) resource_groups: DashMap<String, ResourceGroup>,
     // the count of all groups, a fast path because call `DashMap::len` is a little slower.
@@ -347,12 +544,10 @@ pub struct ResourceGroupManager {
     has_background: AtomicBool,
     // lastest config.
     config: Arc<VersionTrack<Config>>,
-    // Per-group RU consumption trackers for Tier-1 high-priority throttling.
-    // Per-group sliding-window tracker and token-bucket limiter.
-    // Rate on the limiter is set to `fraction × historical_rate` each tick.
-    // The Arc allows handing out limiter references to LimitedFuture wrappers
-    // in the read/write pools without copying the limiter state.
-    ru_trackers: DashMap<String, Mutex<(RuTracker, Arc<ResourceLimiter>)>>,
+    // Per-group sliding-window tracker and token-bucket limiter. The Arc
+    // allows handing out limiter references to LimitedFuture wrappers in the
+    // read/write pools without copying the limiter state.
+    ru_trackers: DashMap<String, RuTrackerSlot>,
     // Number of requests currently held in the admission-control delay phase.
     delayed_req_count: AtomicI64,
     // Unix seconds when this manager was created. Used to determine whether
@@ -364,24 +559,85 @@ pub struct ResourceGroupManager {
     // only engages when this flag is set, ensuring background is fully
     // squeezed before foreground traffic is touched.
     bg_cpu_at_floor: AtomicBool,
-    // Latest foreground CPU pressure (0.0-1.0), refreshed every tick by
-    // `online_adjust_resource_quota`. Consumed by the unified read pool to
-    // drive its thread-count scale-down decision. Encoded via `f64::to_bits`.
+    // Whether foreground CPU pressure is engaged, refreshed every tick by
+    // `online_adjust_resource_quota`. A plain 1.0/0.0 rather than a varying
+    // fraction, since the read pool only tests it against zero to drive its
+    // thread-count scale-down. Encoded via `f64::to_bits`.
     read_pool_cpu_pressure: AtomicU64,
-    // Sliding-window tracker of the unified read pool's actual CPU usage
-    // (in µs of CPU time per tick). Its `historical_rate()` is used as a
-    // floor: the read pool should never be scaled below the thread count
-    // needed to sustain its historical CPU consumption.
+    // `Config::request_base_cost_micros`, mirrored out of the config lock.
+    // Read once per request on the gRPC handler path, where taking a shared
+    // RwLock read on every gRPC thread is itself the contention. Refreshed by
+    // `refresh_cached_config`.
+    request_base_cost_micros: AtomicU64,
+    // Bucket count for a new per-group tracker. `historical_usage_window_mins`
+    // is not hot-reloadable, so it is resolved once here rather than read off
+    // the config lock on the tracker-creation path.
+    ru_num_buckets: usize,
+    // Sliding-window tracker of the unified read pool's actual CPU usage (in
+    // µs of CPU time per tick). Its `quiet_baseline` is the floor: the pool
+    // should never be scaled below the thread count needed to sustain what it
+    // sustained while the node was quiet.
     read_pool_cpu_tracker: Mutex<RuTracker>,
     // True when the last `adjust_group_scheduling` tick saw cpu_score below
     // the leeway threshold, i.e. the system is comfortably idle and the
     // unified read pool may scale its thread count up toward its max.
     read_pool_scale_up_allowed: AtomicBool,
+    // The groups the last tick blamed. One writer, both actuators reading, so
+    // detection cannot run on two unsynchronised clocks.
+    noisy_groups: RwLock<HashSet<String>>,
 }
 
 impl Default for ResourceGroupManager {
     fn default() -> Self {
         Self::new(Config::default())
+    }
+}
+
+/// A group eligible to be blamed this tick.
+struct Candidate {
+    name: String,
+    /// Rate above its own baseline. What identifies the group that *changed*,
+    /// so it is what the ranking uses.
+    excess: f64,
+    /// Whole share, credited against the target when selected.
+    current: f64,
+}
+
+/// What one pass over the trackers found.
+#[derive(Default)]
+struct GroupSurvey {
+    /// Ranked, biggest mover first.
+    candidates: Vec<Candidate>,
+    /// Every group's rate, whether eligible or not: the target is a share of
+    /// what the node is actually doing.
+    total_usage: f64,
+    /// Load an actuator is already reclaiming, from every held group.
+    relieved: f64,
+    /// Groups the actuators are already holding. Still noisy — they are only
+    /// inside their gate because they are being held there.
+    held: HashSet<String>,
+}
+
+impl GroupSurvey {
+    /// Takes candidates from the top until the relief they provide covers
+    /// `target`, stopping early at the tail cut. Always takes the first unless
+    /// something is already held.
+    fn take_biggest_movers(&self, target: f64) -> Vec<&Candidate> {
+        let tail_floor = self.candidates.first().map_or(0.0, |c| c.excess) * TAIL_EXCESS_RATIO;
+        let mut relieved = self.relieved;
+        let mut noisy_tenants: Vec<&Candidate> = Vec::new();
+        for candidate in &self.candidates {
+            let covered = relieved >= target || candidate.excess < tail_floor;
+            if (!self.held.is_empty() || !noisy_tenants.is_empty()) && covered {
+                break;
+            }
+            // Already in `relieved`, credited when the survey saw it held.
+            if !self.held.contains(&candidate.name) {
+                relieved += candidate.current;
+            }
+            noisy_tenants.push(candidate);
+        }
+        noisy_tenants
     }
 }
 
@@ -404,9 +660,10 @@ impl ResourceGroupManager {
             true,
         ));
         let start_secs = RuTracker::now_secs();
-        // 2 buckets per minute (30s each) to match RU_BUCKET_SECS, mirroring
-        // the per-group ru_trackers window sizing in `record_ru_consumption`.
-        let read_pool_num_buckets = (config.historical_usage_window_mins.max(2) as usize) * 2;
+        // 2 buckets per minute (30s each) to match RU_BUCKET_SECS. Shared with
+        // the per-group ru_trackers, which size their window the same way.
+        let num_buckets = (config.historical_usage_window_mins.max(2) as usize) * 2;
+        let request_base_cost_micros = config.request_base_cost_micros;
         let manager = Self {
             resource_groups: Default::default(),
             group_count: AtomicU64::new(0),
@@ -417,11 +674,14 @@ impl ResourceGroupManager {
             has_background: AtomicBool::new(false),
             config: Arc::new(VersionTrack::new(config)),
             ru_trackers: Default::default(),
+            ru_num_buckets: num_buckets,
             start_secs,
             bg_cpu_at_floor: AtomicBool::new(false),
             read_pool_cpu_pressure: AtomicU64::new(0.0f64.to_bits()),
-            read_pool_cpu_tracker: Mutex::new(RuTracker::new(start_secs, read_pool_num_buckets)),
+            request_base_cost_micros: AtomicU64::new(request_base_cost_micros),
+            read_pool_cpu_tracker: Mutex::new(RuTracker::new(start_secs, num_buckets)),
             read_pool_scale_up_allowed: AtomicBool::new(false),
+            noisy_groups: RwLock::new(HashSet::new()),
         };
 
         // init the default resource group by default.
@@ -590,7 +850,7 @@ impl ResourceGroupManager {
         }
     }
 
-    pub fn consume_penalty(&self, ctx: &ResourceControlContext) {
+    pub fn consume_penalty(&self, ctx: &ResourceControlContext, request_source: &str) {
         for controller in self.registry.read().iter() {
             // FIXME: Should consume CPU time for read controller and write bytes for write
             // controller, once CPU process time of scheduler worker is tracked. Currently,
@@ -610,17 +870,77 @@ impl ResourceGroupManager {
         // RU tracking for foreground admission control is handled by
         // LimitedFuture (measure-only mode) which calls record_ru_consumption
         // with actual CPU measured per poll.
+        //
+        // The fixed arrival cost is charged here because this is the one place
+        // that runs exactly once per request, at gRPC handler entry -- before
+        // admission control, so a request that gets rejected still pays it.
+        //
+        // A request routed to a background limiter is metered there, so it
+        // must not pay into the group's foreground tracker -- the same rule as
+        // the `!is_background()` guard in `future.rs`.
+        if !self.is_background_request(ctx.get_resource_group_name(), request_source) {
+            self.charge_request_base_cost(&ctx.resource_group_name);
+        }
+    }
+
+    /// Map a client-supplied group name onto the bounded set of configured
+    /// groups, so it is safe to use as a metric label or a map key.
+    ///
+    /// The name arrives off the wire and is never validated, so an unknown or
+    /// empty one has to collapse to the default group. Used directly it would
+    /// let a caller mint a new label value -- and so a new permanently
+    /// retained metric series, or a new `ru_trackers` entry -- on every
+    /// request.
+    pub fn bounded_group_name<'a>(&self, group: &'a str) -> &'a str {
+        if self.resource_groups.contains_key(group) {
+            group
+        } else {
+            DEFAULT_RESOURCE_GROUP_NAME
+        }
+    }
+
+    /// Charge `group` the fixed cost of a request arriving, whether or not it
+    /// goes on to run. See `Config::request_base_cost_micros`.
+    fn charge_request_base_cost(&self, group: &str) {
+        let micros = self.request_base_cost_micros.load(Ordering::Relaxed);
+        if micros == 0 {
+            return;
+        }
+        self.record_ru_consumption(self.bounded_group_name(group), micros);
+    }
+
+    /// Re-read the config values the per-request path keeps cached outside the
+    /// config lock. Called from the config dispatcher so a change applies at
+    /// once, and again each tick so a config written straight through
+    /// `VersionTrack` -- tests, and any future path that bypasses the
+    /// dispatcher -- cannot leave the cache stale.
+    /// The cached arrival cost, for asserting the cache tracks the config.
+    #[cfg(test)]
+    pub fn cached_request_base_cost_micros(&self) -> u64 {
+        self.request_base_cost_micros.load(Ordering::Relaxed)
+    }
+
+    pub fn refresh_cached_config(&self) {
+        self.request_base_cost_micros.store(
+            self.config.value().request_base_cost_micros,
+            Ordering::Relaxed,
+        );
     }
 
     /// Record `ru` units consumed by `group` into the sliding-window tracker
     /// and consume tokens from the group's rate limiter.
     pub fn record_ru_consumption(&self, group: &str, ru: u64) {
-        let now = RuTracker::now_secs();
-        // 2 buckets per minute (30s each) to match RU_BUCKET_SECS.
-        let num_buckets = (self.config.value().historical_usage_window_mins.max(2) as usize) * 2;
+        // Fast path: a shared shard read and a single atomic add. `entry()`
+        // below takes the shard exclusively even when the key is already
+        // there, and needs an owned key to do it, so on the hot default group
+        // -- one key, every gRPC thread -- it would serialize this.
+        if let Some(entry) = self.ru_trackers.get(group) {
+            entry.record(ru);
+            return;
+        }
         let entry = self.ru_trackers.entry(group.to_owned()).or_insert_with(|| {
-            Mutex::new((
-                RuTracker::new(now, num_buckets),
+            RuTrackerSlot::new(
+                RuTracker::new(RuTracker::now_secs(), self.ru_num_buckets),
                 Arc::new(ResourceLimiter::new(
                     group.to_owned(),
                     f64::INFINITY,
@@ -628,24 +948,17 @@ impl ResourceGroupManager {
                     0,
                     false,
                 )),
-            ))
+            )
         });
-        // Lock-free: only atomically adds to current_bucket.
-        // advance() is called separately by online_adjust_resource_quota under the
-        // lock.
-        entry.lock().unwrap().0.record(ru);
+        // advance() is called separately by online_adjust_resource_quota
+        // under the lock.
+        entry.record(ru);
     }
 
-    /// Called by `PriorityLimiterAdjustWorker` every ~1 second with the
-    /// latest process-level CPU utilisation percentage.
-    ///
-    /// Throttle-down: linearly reduces the allowed fraction of historical rate
-    /// for groups that are over their baseline. At `fg_cpu_throttle_threshold`
-    /// (70%) fraction = 1.0 (no throttle), at 90% CPU fraction = 0.8
-    /// (target). Called by the background adjust worker after computing the
-    /// new background CPU budget. `at_floor` should be true when the budget
-    /// has been clamped to the minimum floor AND background consumption
-    /// is within that floor.
+    /// Called by the background adjust worker after computing the new
+    /// background CPU budget. `at_floor` should be true when the budget has
+    /// been clamped to the minimum floor AND background consumption is within
+    /// that floor.
     pub fn set_bg_cpu_at_floor(&self, at_floor: bool) {
         self.bg_cpu_at_floor.store(at_floor, Ordering::Relaxed);
     }
@@ -661,19 +974,35 @@ impl ResourceGroupManager {
             .store(pressure.to_bits(), Ordering::Relaxed);
     }
 
-    /// Latest foreground CPU pressure (0.0-1.0), refreshed every tick by
-    /// `online_adjust_resource_quota`.
+    /// Whether foreground CPU pressure is engaged, as 1.0 or 0.0, refreshed
+    /// every tick by `online_adjust_resource_quota`.
     pub fn read_pool_cpu_pressure(&self) -> f64 {
         f64::from_bits(self.read_pool_cpu_pressure.load(Ordering::Relaxed))
     }
 
-    /// Records `read_pool_cpu` (in cores) into the historical tracker and
-    /// returns the floor CPU:
-    pub fn read_pool_cpu_floor(&self, read_pool_cpu: f64, interval_secs: f64) -> f64 {
-        self.read_pool_cpu_floor_at(read_pool_cpu, interval_secs, RuTracker::now_secs())
+    /// Quiet-window floor in cores, or `None` before there has been one. The
+    /// pool's floor is the same mechanism as a group's baseline, so it is the
+    /// same field on the pool's own tracker.
+    fn quiet_read_pool_floor(&self) -> Option<f64> {
+        self.read_pool_cpu_tracker
+            .lock()
+            .unwrap()
+            .quiet_baseline
+            .map(|ru| ru / 1_000_000.0)
     }
 
-    fn read_pool_cpu_floor_at(&self, read_pool_cpu: f64, interval_secs: f64, now: u64) -> f64 {
+    fn refresh_quiet_read_pool_floor(&self, quiet: bool, now: u64) {
+        self.read_pool_cpu_tracker
+            .lock()
+            .unwrap()
+            .refresh_quiet_baseline(quiet, now);
+    }
+
+    /// Records `read_pool_cpu` (in cores) into the historical tracker and
+    /// returns the resulting live average, in cores. Not a floor: the floor is
+    /// `quiet_read_pool_floor`, and the live average is deliberately not used
+    /// as one -- see `compute_read_pool_target_cpu_at`.
+    fn record_read_pool_cpu_at(&self, read_pool_cpu: f64, interval_secs: f64, now: u64) -> f64 {
         let mut tracker = self.read_pool_cpu_tracker.lock().unwrap();
         tracker.advance(now);
         if interval_secs > 0.0 {
@@ -688,31 +1017,77 @@ impl ResourceGroupManager {
     /// [`crate::score::compute_resource_scores`]: the max of process and grpc
     /// normalized utilization.
     pub fn online_adjust_resource_quota(&self, cpu_score: f64) {
-        let now = RuTracker::now_secs();
-        self.adjust_group_throttling(cpu_score, now);
-        self.adjust_group_scheduling(cpu_score);
+        self.online_adjust_resource_quota_at(cpu_score, RuTracker::now_secs());
     }
 
-    /// Per-group CPU rate-limit throttling. Only groups whose current rate
-    /// exceeds their historical rate are limited.
-    ///
-    /// Ramp-up: when CPU drops below threshold, recover ×1.1/tick until
-    /// NO_LIMIT is restored.
-    fn adjust_group_throttling(&self, cpu_score: f64, now: u64) {
-        const RAMP_FACTOR: f64 = 1.1;
-        const MIN_RAMP_UP_EPOCHS: u32 = 2;
+    /// One tick: measure, decide, then actuate. Detection lives here rather
+    /// than inside either actuator, so it runs exactly once per tick against
+    /// one set of measurements, and both actuators act on the same verdict.
+    fn online_adjust_resource_quota_at(&self, cpu_score: f64, now: u64) {
+        self.refresh_cached_config();
+        // Three bands of the same score. Above the threshold is evidence,
+        // below the leeway threshold clears it, and between them the candidacy
+        // counter holds.
+        let threshold = self.config.value().fg_cpu_throttle_threshold;
+        let loaded = cpu_score > threshold;
+        let cleared = cpu_score < threshold * LEEWAY_FACTOR;
+        let quiet = cpu_score < threshold * BASELINE_QUIET_FACTOR;
 
-        let throttle_threshold = self.config.value().fg_cpu_throttle_threshold;
-        let leeway_threshold = throttle_threshold * LEEWAY_THRESHOLD_RATIO;
-        let burst_factor = 1.0 + self.config.value().baseline_burst_pct / 100.0;
+        // A group over its own average is no problem on an idle node, so both
+        // actuators need this, and neither debounces it further. Background
+        // yielding first gates the actuators only — see
+        // `update_over_baseline_ticks`.
+        let under_pressure = loaded && self.is_bg_cpu_at_floor();
 
-        // Advance all trackers to `now` and refresh cached historical rates
-        // up front so adjust_group_scheduling and the throttling logic below
-        // always see fresh baseline data.
+        self.refresh_trackers(now, loaded, cleared, quiet);
+        self.evict_idle_trackers();
+        // Written, never cleared here. The read pool reads this on its own
+        // clock, driven by `busy_cpu_scale_in`, which does not track
+        // `under_pressure` — wiping it on a quiet tick would leave that clock
+        // without a verdict mid-ratchet. `reset_group_priorities` clears it.
+        if under_pressure {
+            *self.noisy_groups.write() = self.select_noisy_groups();
+        }
+
+        self.adjust_group_throttling(cpu_score, under_pressure);
+        self.adjust_group_scheduling_at(cpu_score, under_pressure, now);
+    }
+
+    /// Brings every tracker up to `now` and samples it. Must precede
+    /// detection, which reads what this leaves behind.
+    fn refresh_trackers(&self, now: u64, loaded: bool, cleared: bool, quiet: bool) {
+        let cfg = self.config.value();
+        let burst_factor = 1.0 + cfg.baseline_burst_pct / 100.0;
+        let usage_based = matches!(cfg.noisy_detection, NoisyDetection::CurrentUsage);
         for entry in &self.ru_trackers {
             let mut guard = entry.lock().unwrap();
             guard.0.advance(now);
             guard.0.refresh_cached_historical_rate(self.start_secs, now);
+            // The one place these are sampled, so the read pool's clock can
+            // neither consume the rate delta nor double-count the ticks.
+            guard.0.refresh_cached_current_rate(now);
+            if usage_based {
+                // Judge every group on what it is consuming now. A zero
+                // baseline is all that takes: the eligibility gate reduces to
+                // "has traffic", the candidate ranking is by `excess`, which
+                // becomes the raw rate, and the candidacy counter's target
+                // becomes zero. Nothing else has to know about the mode.
+                guard.0.quiet_baseline = Some(0.0);
+            } else {
+                // Only the branch above ever writes a zero here —
+                // `refresh_quiet_baseline` requires a positive average — so a
+                // zero is a leftover from `current-usage` and has to be
+                // dropped. Left in place, a switch back to `baseline` would
+                // read as a sampled baseline of zero until a full quiet window
+                // has passed, which on a busy node may be never.
+                if guard.0.quiet_baseline == Some(0.0) {
+                    guard.0.quiet_baseline = None;
+                }
+                guard.0.refresh_quiet_baseline(quiet, now);
+            }
+            guard
+                .0
+                .update_over_baseline_ticks(burst_factor, loaded, cleared);
             let name = guard.1.name();
 
             metrics::GROUP_RU_HISTORICAL_RATE
@@ -720,65 +1095,190 @@ impl ResourceGroupManager {
                 .set((guard.0.cached_historical_rate / 1_000_000.0) * 100.0);
             metrics::GROUP_RU_CURRENT_RATE
                 .with_label_values(&[name])
-                .set((guard.0.current_rate(now) / 1_000_000.0) * 100.0);
+                .set((guard.0.current_rate() / 1_000_000.0) * 100.0);
+            // Same `unwrap_or(0.0)` as `effective_baseline`, so the panel
+            // reports the number the gate actually used.
+            metrics::GROUP_RU_BASELINE
+                .with_label_values(&[name])
+                .set(guard.0.quiet_baseline.unwrap_or(0.0) / 1_000_000.0 * 100.0);
         }
+    }
 
-        let engaged = cpu_score > throttle_threshold && self.is_bg_cpu_at_floor();
-        if engaged {
-            for entry in &self.ru_trackers {
-                let mut guard = entry.lock().unwrap();
-                let hist = guard.0.cached_historical_rate;
-                let burst_target = hist * burst_factor;
-                if hist > 0.0 {
-                    let current_limit = guard.1.get_limiter(ResourceType::Cpu).get_rate_limit();
-                    let base = if current_limit.is_infinite() {
-                        guard.0.current_rate(now)
-                    } else {
-                        current_limit
-                    };
-                    if base > burst_target {
-                        let rate = (base * THROTTLE_DECREASE_FACTOR).max(burst_target);
-                        guard.0.ramp_up_epochs = 0;
-                        guard
-                            .1
-                            .get_limiter(ResourceType::Cpu)
-                            .set_rate_limit(rate.max(1.0));
-                    }
-                }
-            }
-        } else if cpu_score < leeway_threshold {
-            // CPU below start threshold — ramp up by RAMP_FACTOR each tick.
-            // Only lift to INFINITY after MIN_RAMP_UP_EPOCHS consecutive epochs
-            // where the limit has grown past 2x hist, to avoid premature release.
-            for entry in &self.ru_trackers {
-                let mut guard = entry.lock().unwrap();
-                let current_limit = guard.1.get_limiter(ResourceType::Cpu).get_rate_limit();
-                if current_limit.is_finite() {
-                    let hist = guard.0.cached_historical_rate;
-                    let new_limit = current_limit * RAMP_FACTOR;
-                    if hist <= 0.0 || new_limit >= 2.0 * hist {
-                        guard.0.ramp_up_epochs += 1;
-                        if guard.0.ramp_up_epochs >= MIN_RAMP_UP_EPOCHS {
-                            guard.0.ramp_up_epochs = 0;
-                            guard
-                                .1
-                                .get_limiter(ResourceType::Cpu)
-                                .set_rate_limit(f64::INFINITY);
-                        }
-                    } else {
-                        guard.0.ramp_up_epochs = 0;
-                        guard
-                            .1
-                            .get_limiter(ResourceType::Cpu)
-                            .set_rate_limit(new_limit);
-                    }
-                }
-            }
+    /// The groups this tick blamed. Read by the actuators; written only by
+    /// [`Self::online_adjust_resource_quota_at`].
+    fn noisy_groups(&self) -> HashSet<String> {
+        self.noisy_groups.read().clone()
+    }
+
+    /// Picks the groups responsible for the current overload: the biggest
+    /// movers, taken until the relief they provide covers the overshoot.
+    fn select_noisy_groups(&self) -> HashSet<String> {
+        let cfg = self.config.value();
+        let survey = self.survey_groups(1.0 + cfg.baseline_burst_pct / 100.0);
+        // Groups already being held stay named. They sit inside their gate
+        // only because an actuator is keeping them there, and the callers
+        // overwrite this wholesale, so dropping them would release them.
+        let mut noisy = survey.held.clone();
+
+        let overshoot_pct = (PEAK_CPU_PCT - cfg.fg_cpu_throttle_threshold).max(0.0);
+        let noisy_tenants = survey.take_biggest_movers(survey.total_usage * overshoot_pct / 100.0);
+
+        for tenant in &noisy_tenants {
+            noisy.insert(tenant.name.clone());
         }
+        noisy
+    }
 
-        // Emit current rate limit per resource group.
+    /// Drops trackers for groups that have gone quiet, so a removed or renamed
+    /// group cannot grow the map without bound. Relies on `refresh_trackers`
+    /// having just advanced them, which flushes partial buckets.
+    fn evict_idle_trackers(&self) {
+        self.ru_trackers.retain(|name, entry| {
+            let inner = entry.get_mut().unwrap();
+            if inner.0.is_idle() {
+                metrics::deregister_tracker_gauges(name);
+                return false;
+            }
+            true
+        });
+    }
+
+    /// One pass over the trackers, reading each group's standing once.
+    /// Candidates come back ranked, biggest mover first.
+    fn survey_groups(&self, burst_factor: f64) -> GroupSurvey {
+        let mut survey = GroupSurvey::default();
         for entry in &self.ru_trackers {
             let guard = entry.lock().unwrap();
+            let baseline = guard.0.effective_baseline();
+            let current = guard.0.current_rate();
+            // A finite CPU rate limit *is* throttle backpressure, so read it
+            // off the limiter rather than a mirror of it that is a tick stale.
+            let throttled = guard
+                .1
+                .get_limiter(ResourceType::Cpu)
+                .get_rate_limit()
+                .is_finite();
+            let held = throttled || guard.0.scheduler_backpressure;
+            let sustained = guard.0.sustained_over_baseline();
+            drop(guard);
+
+            if held {
+                survey.held.insert(entry.key().clone());
+                // An actuator is already reclaiming this load, so it counts
+                // toward the target rather than inflating one the innocent
+                // tail would be taken to meet. Credited here rather than in
+                // the arm below, because whether the group is still above its
+                // gate says nothing about the relief already in flight, and
+                // the ranking would otherwise only credit it at its own
+                // position -- after anything with a larger excess had been
+                // taken. `take_biggest_movers` skips held candidates so this
+                // is not counted twice.
+                survey.relieved += current;
+            }
+            survey.total_usage += current;
+            // No history means any traffic is over baseline. Excluding those
+            // groups hid the culprit during its ramp.
+            let over_gate = current > 0.0 && current > baseline * burst_factor;
+            if over_gate && sustained {
+                survey.candidates.push(Candidate {
+                    name: entry.key().clone(),
+                    excess: current - baseline,
+                    current,
+                });
+            }
+        }
+        survey
+            .candidates
+            .sort_unstable_by(|a, b| b.excess.total_cmp(&a.excess));
+        survey
+    }
+
+    /// Per-group CPU rate-limit throttling. Only the noisy groups picked by
+    /// [`Self::select_noisy_groups`] are limited; a group over its own
+    /// baseline that is not among the biggest movers is left alone.
+    ///
+    /// Ramp-up: once CPU drops below the leeway threshold, recover one step
+    /// per tick until the limit is infinite again.
+    fn adjust_group_throttling(&self, cpu_score: f64, under_pressure: bool) {
+        const MIN_RAMP_UP_EPOCHS: u32 = 2;
+
+        let throttle_threshold = self.config.value().fg_cpu_throttle_threshold;
+        let leeway_threshold = throttle_threshold * LEEWAY_FACTOR;
+        let burst_factor = 1.0 + self.config.value().baseline_burst_pct / 100.0;
+
+        // Live pressure, not the cache being non-empty: the cache outlives the
+        // episode and says only *whom* to act on.
+        if under_pressure {
+            for name in self.noisy_groups() {
+                // Gone if its tracker was evicted between the tick that named
+                // it and now.
+                let Some(entry) = self.ru_trackers.get(&name) else {
+                    continue;
+                };
+                let mut guard = entry.lock().unwrap();
+                // The quiet-tick baseline, so the throttle floor cannot drift
+                // up with the load being shed.
+                let hist = guard.0.effective_baseline();
+                // No zero special case: a zero baseline is a target of zero,
+                // not a reason to skip. A group with no history of its own,
+                // and every group under `current-usage` detection, is
+                // throttled on this same path -- the target simply stops
+                // clamping the decrease, so a named group keeps being cut
+                // while it stays named.
+                let burst_target = hist * burst_factor;
+                let current_limit = guard.1.get_limiter(ResourceType::Cpu).get_rate_limit();
+                let base = if current_limit.is_infinite() {
+                    guard.0.current_rate()
+                } else {
+                    current_limit
+                };
+                if base > burst_target {
+                    let rate = (base * THROTTLE_DECREASE_FACTOR).max(burst_target);
+                    guard.0.ramp_up_epochs = 0;
+                    guard
+                        .1
+                        .get_limiter(ResourceType::Cpu)
+                        .set_rate_limit(rate.max(1.0));
+                }
+            }
+        }
+
+        // One pass over every group, not just the named ones: a group that
+        // has left the verdict still needs its capacity handed back. Skipping
+        // it would strand a finite limit and freeze its baseline for good.
+        let recovering = !under_pressure && cpu_score < leeway_threshold;
+        for entry in &self.ru_trackers {
+            let mut guard = entry.lock().unwrap();
+            // Ramp up one step per tick, lifting to INFINITY only after
+            // MIN_RAMP_UP_EPOCHS epochs past 2x hist so release is not
+            // premature. Against the live average, not the quiet baseline:
+            // recovery hands capacity back relative to what it consumes now,
+            // and the live one has climbed, which keeps release conservative.
+            let current_limit = guard.1.get_limiter(ResourceType::Cpu).get_rate_limit();
+            if recovering && current_limit.is_finite() {
+                let hist = guard.0.cached_historical_rate;
+                let new_limit = current_limit * THROTTLE_INCREASE_FACTOR;
+                // No zero special case: at `hist == 0` the comparison is
+                // already true, so a zero takes the same path as any other
+                // value.
+                if new_limit >= 2.0 * hist {
+                    guard.0.ramp_up_epochs += 1;
+                    if guard.0.ramp_up_epochs >= MIN_RAMP_UP_EPOCHS {
+                        guard.0.ramp_up_epochs = 0;
+                        guard
+                            .1
+                            .get_limiter(ResourceType::Cpu)
+                            .set_rate_limit(f64::INFINITY);
+                    }
+                } else {
+                    guard.0.ramp_up_epochs = 0;
+                    guard
+                        .1
+                        .get_limiter(ResourceType::Cpu)
+                        .set_rate_limit(new_limit);
+                }
+            }
+
             let limit = guard.1.get_limiter(ResourceType::Cpu).get_rate_limit();
             let val = if limit.is_finite() {
                 (limit / 1_000_000.0) * 100.0
@@ -789,29 +1289,20 @@ impl ResourceGroupManager {
                 .with_label_values(&[guard.1.name(), "cpu"])
                 .set(val);
         }
-
-        // Evict idle ru_trackers entries to prevent unbounded growth from
-        // removed or renamed groups. Advance first so stale partial buckets
-        // are flushed before the idle check.
-        self.ru_trackers.retain(|_, entry| {
-            let inner = entry.get_mut().unwrap();
-            inner.0.advance(now);
-            !inner.0.is_idle()
-        });
     }
 
-    fn adjust_group_scheduling(&self, cpu_score: f64) {
+    fn adjust_group_scheduling_at(&self, cpu_score: f64, engaged: bool, now: u64) {
         let throttle_threshold = self.config.value().fg_cpu_throttle_threshold;
-        let leeway_threshold = throttle_threshold * LEEWAY_THRESHOLD_RATIO;
+        let leeway_threshold = throttle_threshold * LEEWAY_FACTOR;
 
-        // Engaged/not-engaged gate consumed by compute_read_pool_target_cpu,
-        // which only ever checks read_pool_cpu_pressure() > 0.0 — so this
-        // stores a plain 1.0/0.0 rather than a continuously-varying
-        // fraction. Reset to 0 whenever foreground is not under CPU
-        // pressure so a transient spike can't pin the read pool down
-        // indefinitely.
-        let engaged = cpu_score > throttle_threshold && self.is_bg_cpu_at_floor();
+        // Reset to 0 whenever foreground is not under CPU pressure, so a
+        // transient spike cannot pin the read pool down indefinitely.
         self.set_read_pool_cpu_pressure(if engaged { 1.0 } else { 0.0 });
+
+        self.refresh_quiet_read_pool_floor(
+            cpu_score < throttle_threshold * BASELINE_QUIET_FACTOR,
+            now,
+        );
 
         // Comfortably idle (below leeway) → allow the read pool to scale its
         // thread count back up toward its max on the next tick it checks in.
@@ -819,35 +1310,27 @@ impl ResourceGroupManager {
             .store(cpu_score < leeway_threshold, Ordering::Relaxed);
     }
 
-    /// Marks resource groups that have exceeded their own quota (current
-    /// rate over their historical baseline by more than `baseline_burst_pct`)
-    /// as over-quota (phase 1), deprioritizing them. A group within its
-    /// baseline is left untouched.
+    /// Marks the noisy resource groups picked by
+    /// [`Self::select_noisy_groups`] as over-quota (phase 1), deprioritizing
+    /// them. A group within its baseline — or over it but not among the
+    /// biggest movers — is left untouched.
     ///
-    /// This function only ever sets the over-quota flag, never clears it —
-    /// clearing is the caller's responsibility, once the unified read pool
-    /// has scaled back up to `core_thread_count`, via
-    /// [`Self::reset_group_priorities`]. Otherwise a sustained noisy group's
-    /// own `cached_historical_rate` eventually drifts up to absorb its
-    /// elevated usage, and comparing against it again here would silently
-    /// (and wrongly) release the group early.
+    /// Only ever sets the flag, never clears it: the release signal is the
+    /// unified read pool recovering to `core_thread_count`, which this path
+    /// cannot see, so clearing is the caller's job via
+    /// [`Self::reset_group_priorities`].
     pub fn deprioritize_over_quota_groups(&self) {
         if !self.config.value().enable_fair_scheduling {
             return;
         }
-        let now = RuTracker::now_secs();
-        let burst_factor = 1.0 + self.config.value().baseline_burst_pct / 100.0;
-        for entry in &self.ru_trackers {
-            let group_bytes = entry.key().as_bytes();
-            let guard = entry.value().lock().unwrap();
-            let hist = guard.0.cached_historical_rate;
-            let current = guard.0.current_rate(now);
-            let over_quota = hist > 0.0 && current > hist * burst_factor;
-            drop(guard);
-            if over_quota {
-                for controller in self.registry.read().iter() {
-                    controller.set_group_phase(group_bytes, true);
-                }
+        // The quota-worker tick decided this; recomputing here would run
+        // detection on a second, unsynchronised clock.
+        for name in self.noisy_groups() {
+            for controller in self.registry.read().iter() {
+                controller.set_group_phase(name.as_bytes(), true);
+            }
+            if let Some(entry) = self.ru_trackers.get(&name) {
+                entry.lock().unwrap().0.set_scheduler_backpressure(true);
             }
         }
     }
@@ -860,26 +1343,46 @@ impl ResourceGroupManager {
         for controller in self.registry.read().iter() {
             controller.reset_all_group_phases();
         }
+        self.noisy_groups.write().clear();
+        for entry in &self.ru_trackers {
+            entry.lock().unwrap().0.set_scheduler_backpressure(false);
+        }
     }
 
-    /// Decides the unified read pool's target CPU (in cores) under
-    /// foreground pressure: once pressure engages, returns
-    /// `THROTTLE_DECREASE_FACTOR` below the currently measured
-    /// `read_pool_cpu`, instead of jumping straight to a computed value. The
-    /// ceiling is clamped to the historical-CPU floor so
-    /// it never drops below what the pool has sustained historically, and
-    /// resets to `f64::INFINITY` (no ceiling) as soon as pressure clears —
-    /// callers that `min()` this into their own ceiling get back exactly
-    /// that ceiling, unaffected. Also records `read_pool_cpu` into the
-    /// historical tracker so the floor stays current.
-    /// [`Self::read_pool_scale_up_allowed`] to know whether it's safe to do
-    /// so.
+    /// The unified read pool's target CPU in cores, while foreground pressure
+    /// is engaged: one `THROTTLE_DECREASE_PCT` step below the measured
+    /// `read_pool_cpu`, floored at the quiet-window baseline so it never drops
+    /// below what the pool sustained while the node was quiet, and never below
+    /// `MIN_READ_POOL_TARGET_CORES` whether or not there is one. Returns
+    /// `f64::INFINITY` once pressure clears, so callers that `min()` it into
+    /// their own ceiling get that ceiling back unaffected. Also records
+    /// `read_pool_cpu`, keeping the floor current.
     pub fn compute_read_pool_target_cpu(&self, read_pool_cpu: f64, interval_secs: f64) -> f64 {
-        let floor_cpu = self.read_pool_cpu_floor(read_pool_cpu, interval_secs);
+        self.compute_read_pool_target_cpu_at(read_pool_cpu, interval_secs, RuTracker::now_secs())
+    }
+
+    fn compute_read_pool_target_cpu_at(
+        &self,
+        read_pool_cpu: f64,
+        interval_secs: f64,
+        now: u64,
+    ) -> f64 {
+        let historical_cpu = self.record_read_pool_cpu_at(read_pool_cpu, interval_secs, now);
+        // The quiet-tick floor, or a fixed one core until there has been a
+        // quiet tick -- not the live average, which keeps recording the
+        // overload and so rises in step with the load being shed, floating the
+        // floor up under the ratchet. Same rule as a group's baseline, and
+        // `MIN_READ_POOL_TARGET_CORES` is what stops the unfloored ratchet
+        // compounding to zero.
+        let quiet_cpu = self.quiet_read_pool_floor();
+        let floor_cpu = quiet_cpu.unwrap_or(0.0).max(MIN_READ_POOL_TARGET_CORES);
 
         metrics::READ_POOL_CPU_VEC
             .with_label_values(&["historical"])
-            .set(floor_cpu * 100.0);
+            .set(historical_cpu * 100.0);
+        metrics::READ_POOL_CPU_VEC
+            .with_label_values(&["baseline"])
+            .set(quiet_cpu.unwrap_or(0.0) * 100.0);
         metrics::READ_POOL_CPU_VEC
             .with_label_values(&["current"])
             .set(read_pool_cpu * 100.0);
@@ -909,8 +1412,8 @@ impl ResourceGroupManager {
     /// Conditions for a non-zero delay (all must hold):
     ///   1. `enable_read_admission_control` / `enable_write_admission_control`
     ///      on
-    ///   2. Rate-limit is active (not NO_LIMIT sentinel)
-    ///   3. Tracker has warmed up (≥2 completed 1-min buckets)
+    ///   2. Rate-limit is active (finite)
+    ///   3. Tracker has warmed up (≥2 completed 30s buckets)
     ///   4. Token-bucket has accumulated debt (group exceeded its allowed rate)
     pub fn compute_admission_delay(
         &self,
@@ -1006,13 +1509,11 @@ impl ResourceGroupManager {
     /// build token-bucket debt for pre-pool `admission_decision`.
     pub fn get_foreground_group_limiter(&self, group: &str) -> Arc<ResourceLimiter> {
         let now = RuTracker::now_secs();
-        // 2 buckets per minute (30s each) to match RU_BUCKET_SECS.
-        let num_buckets = (self.config.value().historical_usage_window_mins.max(2) as usize) * 2;
         self.ru_trackers
             .entry(group.to_owned())
             .or_insert_with(|| {
-                Mutex::new((
-                    RuTracker::new(now, num_buckets),
+                RuTrackerSlot::new(
+                    RuTracker::new(now, self.ru_num_buckets),
                     Arc::new(ResourceLimiter::new(
                         group.to_owned(),
                         f64::INFINITY,
@@ -1020,7 +1521,7 @@ impl ResourceGroupManager {
                         0,
                         false,
                     )),
-                ))
+                )
             })
             .lock()
             .unwrap()
@@ -1043,12 +1544,7 @@ impl ResourceGroupManager {
         }
         // Only create a foreground limiter for known groups; unknown or removed
         // groups fall back to "default" to avoid leaking ru_trackers entries.
-        let group_name = if self.resource_groups.contains_key(rg) {
-            rg
-        } else {
-            DEFAULT_RESOURCE_GROUP_NAME
-        };
-        Some(self.get_foreground_group_limiter(group_name))
+        Some(self.get_foreground_group_limiter(self.bounded_group_name(rg)))
     }
 
     // return a ResourceLimiter for background tasks only.
@@ -1064,6 +1560,25 @@ impl ResourceGroupManager {
         }
         self.get_background_resource_limiter_with_priority(rg, request_source)
             .0
+    }
+
+    /// Whether a request from `rg` with `request_source` is routed to a
+    /// background limiter, without building one. Resolves the group the same
+    /// way `get_background_resource_limiter_with_priority` does, and returns
+    /// on the atomic before touching the map when no group configures
+    /// background job types at all.
+    pub fn is_background_request(&self, rg: &str, request_source: &str) -> bool {
+        if request_source.is_empty() || !self.has_background_groups() {
+            return false;
+        }
+        if let Some(group) = self.resource_groups.get(rg) {
+            if !group.fallback_default {
+                return group.is_background_source(request_source);
+            }
+        }
+        self.resource_groups
+            .get(DEFAULT_RESOURCE_GROUP_NAME)
+            .is_some_and(|g| g.is_background_source(request_source))
     }
 
     fn get_background_resource_limiter_with_priority(
@@ -1150,23 +1665,28 @@ impl ResourceGroup {
             .get_fill_rate()
     }
 
+    /// Whether `request_source` routes to this group's background limiter.
+    /// The one copy of the rule: `is_background_request` needs the verdict
+    /// without materializing the limiter.
+    fn is_background_source(&self, request_source: &str) -> bool {
+        // the source task name is the last part of `request_source` separated by "_"
+        // the request_source is
+        // {extrenal|internal}_{tidb_req_source}_{source_task_name}
+        self.limiter.is_some() && {
+            let source_task_name = request_source.rsplit('_').next().unwrap_or("");
+            !source_task_name.is_empty() && self.background_source_types.contains(source_task_name)
+        }
+    }
+
     fn get_background_resource_limiter(
         &self,
         request_source: &str,
     ) -> Option<Arc<ResourceLimiter>> {
-        self.limiter.as_ref().and_then(|limiter| {
-            // the source task name is the last part of `request_source` separated by "_"
-            // the request_source is
-            // {extrenal|internal}_{tidb_req_source}_{source_task_name}
-            let source_task_name = request_source.rsplit('_').next().unwrap_or("");
-            if !source_task_name.is_empty()
-                && self.background_source_types.contains(source_task_name)
-            {
-                Some(limiter.clone())
-            } else {
-                None
-            }
-        })
+        if self.is_background_source(request_source) {
+            self.limiter.clone()
+        } else {
+            None
+        }
     }
 }
 
@@ -1584,10 +2104,7 @@ pub(crate) mod tests {
     use yatp::queue::Extras;
 
     use super::*;
-    use crate::{
-        resource_limiter::ResourceType::{Cpu, Io},
-        score::TARGET_CPU,
-    };
+    use crate::resource_limiter::ResourceType::{Cpu, Io};
 
     pub fn new_resource_group_ru(name: String, ru: u64, group_priority: u32) -> PbResourceGroup {
         new_resource_group(name, true, ru, ru, group_priority)
@@ -2090,6 +2607,536 @@ pub(crate) mod tests {
         assert!(high_phase1 < low_phase0);
     }
 
+    // Inserts a tracker whose current rate is `current` and whose cached
+    // baseline is `hist`, both in RU/s.
+    fn seed_tracker(mgr: &ResourceGroupManager, name: &str, hist: f64, current: f64, t0: u64) {
+        let e = mgr.ru_trackers.entry(name.to_owned()).or_insert_with(|| {
+            RuTrackerSlot::new(
+                RuTracker::new(t0 - RU_BUCKET_SECS, 30),
+                Arc::new(ResourceLimiter::new(
+                    name.into(),
+                    f64::INFINITY,
+                    f64::INFINITY,
+                    0,
+                    false,
+                )),
+            )
+        });
+        let mut tr = e.lock().unwrap();
+        // Recorded so the tracker is not idle, and so `retain` keeps it. The
+        // two rates are then stated directly, as a tick would have sampled them.
+        tr.0.record_at(
+            (current * RU_BUCKET_SECS as f64) as u64,
+            t0 - RU_BUCKET_SECS,
+        );
+        tr.0.advance(t0);
+        tr.0.cached_historical_rate = hist;
+        tr.0.cached_current_rate = current;
+        // A group that has been running has had quiet ticks to sample.
+        tr.0.quiet_baseline = Some(hist);
+        // The fixture states the group is already running at `current`, so it
+        // has been over its target for as long as it needs to be blamed.
+        tr.0.over_baseline_ticks = MIN_ENGAGE_TICKS;
+        assert!((tr.0.current_rate() - current).abs() < 1.0);
+    }
+
+    /// States the rate the quota-worker tick would have sampled for `name`.
+    /// Needed by tests that reach selection without a tick — as the read pool
+    /// does — since that path samples nothing.
+    fn set_sampled_rate(mgr: &ResourceGroupManager, name: &str, rate: f64) {
+        mgr.ru_trackers
+            .get(name)
+            .unwrap()
+            .lock()
+            .unwrap()
+            .0
+            .cached_current_rate = rate;
+    }
+
+    /// Records `ru` into the still-open bucket: traffic the ring has not
+    /// absorbed yet, so it raises the current rate while leaving the closed
+    /// buckets — and so the baseline — untouched.
+    fn stage_open_bucket(mgr: &ResourceGroupManager, name: &str, ru: u64) {
+        let entry = mgr.ru_trackers.get(name).unwrap();
+        let guard = entry.lock().unwrap();
+        guard.0.record(ru);
+    }
+
+    /// One tick with the sampled rates stated rather than measured, so a
+    /// scenario reads as the story it tests instead of ring-buffer
+    /// bookkeeping. Mirrors `online_adjust_resource_quota_at` without the part
+    /// of `refresh_trackers` that recomputes the rates, and without the quiet
+    /// baseline refresh: no time passes here for a quiet window to elapse.
+    fn tick(mgr: &ResourceGroupManager, cpu_score: f64) {
+        let cfg = mgr.get_config().value();
+        let loaded = cpu_score > cfg.fg_cpu_throttle_threshold;
+        let cleared = cpu_score < cfg.fg_cpu_throttle_threshold * LEEWAY_FACTOR;
+        let under_pressure = loaded && mgr.is_bg_cpu_at_floor();
+        let burst_factor = 1.0 + cfg.baseline_burst_pct / 100.0;
+        for entry in &mgr.ru_trackers {
+            let mut guard = entry.lock().unwrap();
+            guard
+                .0
+                .update_over_baseline_ticks(burst_factor, loaded, cleared);
+        }
+        if under_pressure {
+            *mgr.noisy_groups.write() = mgr.select_noisy_groups();
+        }
+        mgr.adjust_group_throttling(cpu_score, under_pressure);
+    }
+
+    /// States the pool's sampled quiet floor, in cores.
+    fn set_quiet_read_pool_floor(mgr: &ResourceGroupManager, cores: f64) {
+        mgr.read_pool_cpu_tracker.lock().unwrap().quiet_baseline = Some(cores * 1_000_000.0);
+    }
+
+    fn limit_of(mgr: &ResourceGroupManager, name: &str) -> f64 {
+        mgr.ru_trackers
+            .get(name)
+            .unwrap()
+            .lock()
+            .unwrap()
+            .1
+            .get_limiter(ResourceType::Cpu)
+            .get_rate_limit()
+    }
+
+    fn set_baseline(mgr: &ResourceGroupManager, name: &str, hist: f64) {
+        mgr.ru_trackers
+            .get(name)
+            .unwrap()
+            .lock()
+            .unwrap()
+            .0
+            .cached_historical_rate = hist;
+    }
+
+    /// Runs detection and stores its verdict as a tick would, but without the
+    /// tracker refresh, which would overwrite a staged rate.
+    fn stage_noisy(mgr: &ResourceGroupManager) {
+        *mgr.noisy_groups.write() = mgr.select_noisy_groups();
+    }
+
+    /// Marks `name` as having been over its target for long enough to be
+    /// blamed. The quota-worker tick counts this; a test that calls
+    /// `deprioritize_over_quota_groups` directly, as the read pool does, has
+    /// to state it.
+    fn mark_sustained(mgr: &ResourceGroupManager, name: &str) {
+        mgr.ru_trackers
+            .get(name)
+            .unwrap()
+            .lock()
+            .unwrap()
+            .0
+            .over_baseline_ticks = MIN_ENGAGE_TICKS;
+    }
+
+    /// Ticks the manager until the per-group counter has been satisfied.
+    fn tick_until_engaged(mgr: &ResourceGroupManager, cpu_score: f64) {
+        for _ in 0..MIN_ENGAGE_TICKS {
+            mgr.online_adjust_resource_quota(cpu_score);
+        }
+    }
+
+    fn baseline_of(mgr: &ResourceGroupManager, name: &str) -> Option<f64> {
+        mgr.ru_trackers
+            .get(name)
+            .unwrap()
+            .lock()
+            .unwrap()
+            .0
+            .quiet_baseline
+    }
+
+    fn set_backpressure(mgr: &ResourceGroupManager, name: &str, throttle: bool, scheduler: bool) {
+        let e = mgr.ru_trackers.get(name).unwrap();
+        let mut tr = e.lock().unwrap();
+        // Throttle backpressure is the limiter's own state: a finite CPU
+        // rate limit is what being throttled means.
+        tr.1.get_limiter(ResourceType::Cpu)
+            .set_rate_limit(if throttle { 1_000_000.0 } else { f64::INFINITY });
+        tr.0.set_scheduler_backpressure(scheduler);
+    }
+
+    // seed_tracker builds a 30-bucket tracker, so one window is 15 minutes.
+    const TEST_WINDOW_SECS: u64 = 30 * RU_BUCKET_SECS;
+
+    #[test]
+    fn test_held_load_counts_toward_the_target_instead_of_inflating_it() {
+        // The tikv-50 case at 19:56:30. uds_006's baseline is 783 and it has been
+        // throttled down to 464, so 464 > 783 * 1.2 is false and it dropped out
+        // of the candidates -- while its 464 still set the target, and default
+        // (spiking 25.6 -> 50.8) plus two negligible groups were taken to meet
+        // a target none of them could reach.
+        let mgr = ResourceGroupManager::new(Config::default());
+        let t0 = RuTracker::now_secs();
+        seed_tracker(&mgr, "uds_006", 783.0, 464.0, t0);
+        seed_tracker(&mgr, "default", 25.6, 50.8, t0);
+        seed_tracker(&mgr, "uds_000", 0.1, 0.9, t0);
+        seed_tracker(&mgr, "uds_008", 0.0, 0.3, t0);
+        // uds_006 is the group already under backpressure.
+        set_backpressure(&mgr, "uds_006", true, true);
+
+        let selected = mgr.select_noisy_groups();
+        assert!(
+            selected.contains("uds_006") && selected.len() == 1,
+            "only the group already held is named: the load it is giving back \
+             covers the target, so nothing new is taken: {selected:?}"
+        );
+    }
+
+    #[test]
+    fn test_held_group_still_over_its_gate_covers_the_target() {
+        // The tikv-24-1b case at 16:12. uds_006 is throttled to its burst
+        // target, which is the same 239.8 * 1.2 the gate uses, so it sits on
+        // the gate and a one-minute burst to 294 put it over. That took its
+        // 294 of already-reclaimed load out of `relieved` and made it a
+        // candidate instead -- ranked second, behind default spiking 25.4 ->
+        // 118.2 -- so the loop reached default before ever crediting it.
+        let mgr = ResourceGroupManager::new(Config::default());
+        let t0 = RuTracker::now_secs();
+        seed_tracker(&mgr, "uds_006", 239.8, 294.3, t0);
+        seed_tracker(&mgr, "default", 25.4, 118.2, t0);
+        set_backpressure(&mgr, "uds_006", true, true);
+
+        let selected = mgr.select_noisy_groups();
+        assert!(
+            selected.contains("uds_006") && selected.len() == 1,
+            "the held group covers the target whether or not it is still over \
+             its gate, so default is not taken with it: {selected:?}"
+        );
+    }
+
+    #[test]
+    fn test_tail_groups_below_the_head_ratio_are_spared() {
+        // Nothing is held and the head cannot reach the target on its own, so
+        // the loop used to walk the whole list. Groups an order of magnitude
+        // below the worst offender are tail, not cause.
+        let mgr = ResourceGroupManager::new(Config::default());
+        let t0 = RuTracker::now_secs();
+        seed_tracker(&mgr, "quiet", 900.0, 800.0, t0); // under its gate
+        seed_tracker(&mgr, "head", 25.6, 50.8, t0); // excess 25.2
+        seed_tracker(&mgr, "tail_a", 0.1, 0.9, t0); // excess 0.8
+        seed_tracker(&mgr, "tail_b", 0.0, 0.3, t0); // excess 0.3
+
+        let selected = mgr.select_noisy_groups();
+        assert_eq!(
+            selected.iter().map(String::as_str).collect::<Vec<_>>(),
+            vec!["head"],
+            "only the head is a plausible cause: {:?}",
+            selected
+        );
+    }
+
+    #[test]
+    fn test_ramping_group_with_no_history_is_selected_alone() {
+        // The tikv-48 case: the culprit ramped 0 -> 5428 with historical still
+        // 0, so it was excluded and every small jittering group was taken.
+        let mgr = ResourceGroupManager::new(Config::default());
+        let t0 = RuTracker::now_secs();
+        seed_tracker(&mgr, "ramping", 0.0, 5428.0, t0);
+        seed_tracker(&mgr, "default", 7.40, 9.31, t0);
+        seed_tracker(&mgr, "small_a", 0.235, 0.288, t0);
+        seed_tracker(&mgr, "small_b", 0.187, 0.225, t0);
+
+        let selected = mgr.select_noisy_groups();
+        assert!(selected.contains("ramping"), "{:?}", selected);
+        assert_eq!(
+            selected.len(),
+            1,
+            "the ramping group covers the target alone, sparing the rest: {:?}",
+            selected
+        );
+        assert_eq!(baseline_of(&mgr, "ramping"), Some(0.0));
+    }
+
+    #[test]
+    fn test_zero_baseline_is_frozen_and_keeps_the_group_selected() {
+        let mgr = ResourceGroupManager::new(Config::default());
+        let t0 = RuTracker::now_secs();
+        seed_tracker(&mgr, "fresh", 0.0, 500.0, t0);
+        assert!(mgr.select_noisy_groups().contains("fresh"));
+        assert_eq!(baseline_of(&mgr, "fresh"), Some(0.0));
+
+        // First selection wins; a later historical does not displace it.
+        mgr.ru_trackers
+            .get("fresh")
+            .unwrap()
+            .lock()
+            .unwrap()
+            .0
+            .cached_historical_rate = 100.0;
+        assert!(mgr.select_noisy_groups().contains("fresh"));
+        assert_eq!(baseline_of(&mgr, "fresh"), Some(0.0));
+    }
+
+    #[test]
+    fn test_idle_eviction_clears_the_group_gauges() {
+        // An evicted tracker's gauges keep reporting their last value -- a
+        // stale baseline then reads as still noisy.
+        //
+        // The gauge registry is global to the test binary, so this group name
+        // must not be shared with a test that could run alongside it.
+        let mgr = ResourceGroupManager::new(Config::default());
+        let t0 = RuTracker::now_secs();
+        seed_tracker(&mgr, "evicted", 100.0, 1000.0, t0);
+        mgr.select_noisy_groups();
+        assert_eq!(baseline_of(&mgr, "evicted"), Some(100.0));
+        metrics::GROUP_RU_BASELINE
+            .with_label_values(&["evicted"])
+            .set(100.0);
+
+        // Traffic stops: advance past the window so every bucket is zero.
+        mgr.online_adjust_resource_quota_at(0.0, t0 + 2 * TEST_WINDOW_SECS);
+
+        assert!(
+            mgr.ru_trackers.get("evicted").is_none(),
+            "an idle tracker should be evicted"
+        );
+        assert_eq!(
+            metrics::GROUP_RU_BASELINE
+                .get_metric_with_label_values(&["evicted"])
+                .unwrap()
+                .get(),
+            0.0,
+            "the gauge must be dropped on eviction, not left holding its last value"
+        );
+    }
+
+    #[test]
+    fn test_select_noisy_groups_leaves_the_quiet_baseline_alone() {
+        // The reference comes from the last quiet tick, so naming a group is
+        // not what establishes it and must not disturb it.
+        let mgr = ResourceGroupManager::new(Config::default());
+        let t0 = RuTracker::now_secs();
+        seed_tracker(&mgr, "noisy", 100.0, 1000.0, t0);
+        seed_tracker(&mgr, "small", 100.0, 130.0, t0);
+
+        let selected = mgr.select_noisy_groups();
+        assert!(
+            selected.contains("noisy") && !selected.contains("small"),
+            "{selected:?}"
+        );
+
+        assert_eq!(baseline_of(&mgr, "noisy"), Some(100.0));
+        assert_eq!(baseline_of(&mgr, "small"), Some(100.0));
+    }
+
+    #[test]
+    fn test_named_group_survives_baseline_drift() {
+        // The failure this prevents: the live baseline absorbs the spike, the
+        // gate stops matching, and the culprit is released.
+        let mgr = ResourceGroupManager::new(Config::default());
+        let t0 = RuTracker::now_secs();
+        seed_tracker(&mgr, "noisy", 100.0, 1000.0, t0);
+
+        assert!(mgr.select_noisy_groups().contains("noisy"));
+        assert_eq!(baseline_of(&mgr, "noisy"), Some(100.0));
+        set_backpressure(&mgr, "noisy", true, true);
+
+        // current == hist, so the gate can no longer match.
+        mgr.ru_trackers
+            .get("noisy")
+            .unwrap()
+            .lock()
+            .unwrap()
+            .0
+            .cached_historical_rate = 1000.0;
+
+        assert!(
+            mgr.select_noisy_groups().contains("noisy"),
+            "latched group must stay selected after its baseline drifts up"
+        );
+        assert_eq!(baseline_of(&mgr, "noisy"), Some(100.0));
+    }
+
+    #[test]
+    fn test_a_group_back_at_its_frozen_baseline_takes_nobody_with_it() {
+        // The actuators have driven the group back to the baseline it was
+        // selected against. It stays named, since it is inside its gate only
+        // because they are holding it there, but the load it has given back
+        // must not pull anyone else in.
+        let mgr = ResourceGroupManager::new(Config::default());
+        let t0 = RuTracker::now_secs();
+        seed_tracker(&mgr, "noisy", 100.0, 1000.0, t0);
+        assert!(mgr.select_noisy_groups().contains("noisy"));
+        assert_eq!(baseline_of(&mgr, "noisy"), Some(100.0));
+        set_backpressure(&mgr, "noisy", true, true);
+
+        // Rate back at its baseline, and the live average has drifted up to
+        // meet it — neither can keep the group selected.
+        let t1 = t0 + 10 * RU_BUCKET_SECS;
+        seed_tracker(&mgr, "quiet", 100.0, 100.0, t1);
+        {
+            let e = mgr.ru_trackers.get("noisy").unwrap();
+            let mut tr = e.lock().unwrap();
+            tr.0.record_at(100 * RU_BUCKET_SECS, t1);
+            tr.0.cached_historical_rate = 900.0;
+            tr.0.cached_current_rate = 100.0;
+        }
+        let noisy = mgr.select_noisy_groups();
+        assert!(
+            noisy.contains("noisy"),
+            "a held group stays named however far its rate has come back down"
+        );
+        assert!(
+            !noisy.contains("quiet"),
+            "and the load it returned must not drag in a group inside its gate"
+        );
+    }
+
+    #[test]
+    fn test_quiet_baseline_needs_a_full_window_of_quiet() {
+        let mut tr = RuTracker::new(0, 30);
+        let window = tr.window_secs();
+        tr.cached_historical_rate = 200.0;
+
+        tr.refresh_quiet_baseline(true, 0);
+        assert_eq!(tr.quiet_baseline, None, "one quiet tick is not a window");
+        tr.refresh_quiet_baseline(true, window - 1);
+        assert_eq!(tr.quiet_baseline, None);
+        tr.refresh_quiet_baseline(true, window);
+        assert_eq!(tr.quiet_baseline, Some(200.0));
+
+        // The sliding average climbs as the overload is recorded. A tick above
+        // the gate must not take it, or the reference would drift up to absorb
+        // the very load it is used to judge.
+        tr.cached_historical_rate = 900.0;
+        tr.refresh_quiet_baseline(false, window + 10);
+        assert_eq!(tr.quiet_baseline, Some(200.0));
+        assert_eq!(
+            tr.effective_baseline(),
+            200.0,
+            "the clamp-down paths must see the pre-overload value"
+        );
+
+        // Quiet again, but the run restarts: for a window yet the ring buffer
+        // still holds the episode, so a sample would come back inflated.
+        tr.cached_historical_rate = 250.0;
+        tr.refresh_quiet_baseline(true, window + 20);
+        assert_eq!(tr.quiet_baseline, Some(200.0), "the run restarted");
+        tr.refresh_quiet_baseline(true, 2 * window + 19);
+        assert_eq!(tr.quiet_baseline, Some(200.0));
+        tr.refresh_quiet_baseline(true, 2 * window + 20);
+        assert_eq!(
+            tr.quiet_baseline,
+            Some(250.0),
+            "a full quiet window re-takes it, with no latch to drop"
+        );
+    }
+
+    #[test]
+    fn test_baseline_is_zero_before_any_quiet_window() {
+        // A tracker created mid-overload, or one on a node that never goes
+        // quiet, has no sample yet, and is judged on raw usage rather than
+        // against a live average that has already absorbed its own spike.
+        let mut tr = RuTracker::new(0, 30);
+        tr.cached_historical_rate = 400.0;
+        tr.refresh_quiet_baseline(false, 0);
+        assert_eq!(tr.quiet_baseline, None);
+        assert_eq!(tr.effective_baseline(), 0.0);
+        // Any traffic clears a zero gate, so such a group is always eligible.
+        tr.current_bucket.store(10, Ordering::Relaxed);
+        tr.refresh_cached_current_rate(1);
+        assert!(tr.is_over_burst_target(1.2));
+    }
+
+    #[test]
+    fn test_a_cold_tracker_never_takes_a_zero_baseline() {
+        // A zero would outlast the warm-up and, since the throttle needs a
+        // positive baseline, leave the group permanently unthrottleable.
+        let mut tr = RuTracker::new(0, 30);
+        let window = tr.window_secs();
+        tr.refresh_quiet_baseline(true, 0);
+        tr.refresh_quiet_baseline(true, window);
+        assert_eq!(tr.quiet_baseline, None, "nothing to sample yet");
+
+        tr.cached_historical_rate = 150.0;
+        tr.refresh_quiet_baseline(true, 2 * window);
+        assert_eq!(
+            tr.quiet_baseline,
+            Some(150.0),
+            "taken once there is history"
+        );
+    }
+
+    #[test]
+    fn test_held_credit_covers_target_and_spares_new_candidates() {
+        // A held group's credit keeps covering the target, sparing a small
+        // group that drifts over its gate.
+        let mgr = ResourceGroupManager::new(Config::default());
+        let t0 = RuTracker::now_secs();
+        seed_tracker(&mgr, "noisy", 100.0, 1000.0, t0);
+        assert!(mgr.select_noisy_groups().contains("noisy"));
+        set_backpressure(&mgr, "noisy", true, true);
+
+        // A small group is now marginally over its own baseline.
+        seed_tracker(&mgr, "small", 10.0, 20.0, t0);
+
+        let selected = mgr.select_noisy_groups();
+        assert!(selected.contains("noisy"), "{:?}", selected);
+        assert!(
+            !selected.contains("small"),
+            "latched credit should already cover the target: {:?}",
+            selected
+        );
+    }
+
+    #[test]
+    fn test_select_noisy_groups_credits_whole_share() {
+        // Four groups each 1.25x their own baseline: excess 20 apiece, current
+        // 100 apiece, total usage 400. Default threshold 70 → target is 20% of
+        // 400 = 80. A selected group is credited with its whole share, so one
+        // covers the target; crediting only the excess would have taken all four.
+        let mgr = ResourceGroupManager::new(Config::default());
+        let t0 = RuTracker::now_secs();
+        for name in ["g1", "g2", "g3", "g4"] {
+            seed_tracker(&mgr, name, 80.0, 100.0, t0);
+        }
+
+        assert_eq!(mgr.select_noisy_groups().len(), 1);
+    }
+
+    #[test]
+    fn test_select_noisy_groups_prefers_biggest_movers() {
+        // Default threshold 70 → target reduction is 20% of total usage.
+        // "noisy" alone covers that, so "mild" is spared even though it is
+        // over its own burst target.
+        let mgr = ResourceGroupManager::new(Config::default());
+        let t0 = RuTracker::now_secs();
+        seed_tracker(&mgr, "noisy", 100.0, 3000.0, t0);
+        seed_tracker(&mgr, "mild", 500.0, 1000.0, t0);
+        seed_tracker(&mgr, "steady", 1000.0, 1000.0, t0);
+
+        let selected = mgr.select_noisy_groups();
+        assert!(selected.contains("noisy"), "biggest mover must be selected");
+        assert!(
+            !selected.contains("mild"),
+            "2x mover must be spared once the 10x mover covers the target"
+        );
+        assert!(
+            !selected.contains("steady"),
+            "within burst target → never a candidate"
+        );
+    }
+
+    #[test]
+    fn test_select_noisy_groups_always_takes_top_candidate() {
+        // No single group can cover the target, so selection walks down the
+        // sorted list; the group within its burst target stays out.
+        let mgr = ResourceGroupManager::new(Config::default());
+        let t0 = RuTracker::now_secs();
+        seed_tracker(&mgr, "mild", 500.0, 1000.0, t0);
+        seed_tracker(&mgr, "steady", 1000.0, 1000.0, t0);
+
+        let selected = mgr.select_noisy_groups();
+        assert!(
+            selected.contains("mild"),
+            "the only candidate must still be penalized"
+        );
+        assert!(!selected.contains("steady"));
+    }
+
     #[test]
     fn test_deprioritize_over_quota_groups_ru_based() {
         // Two-phase scheduling driven by real RU (CPU µs) from
@@ -2115,7 +3162,7 @@ pub(crate) mod tests {
                 .ru_trackers
                 .entry("steady".to_owned())
                 .or_insert_with(|| {
-                    Mutex::new((
+                    RuTrackerSlot::new(
                         RuTracker::new(t0, 30),
                         Arc::new(ResourceLimiter::new(
                             "".into(),
@@ -2124,7 +3171,7 @@ pub(crate) mod tests {
                             0,
                             false,
                         )),
-                    ))
+                    )
                 });
             let mut tr = e.lock().unwrap();
             tr.0.record_at(6000, t0 + 15);
@@ -2138,7 +3185,7 @@ pub(crate) mod tests {
                 .ru_trackers
                 .entry("spike".to_owned())
                 .or_insert_with(|| {
-                    Mutex::new((
+                    RuTrackerSlot::new(
                         RuTracker::new(t0, 30),
                         Arc::new(ResourceLimiter::new(
                             "".into(),
@@ -2147,7 +3194,7 @@ pub(crate) mod tests {
                             0,
                             false,
                         )),
-                    ))
+                    )
                 });
             let mut tr = e.lock().unwrap();
             tr.0.record_at(3000, t0 + 30);
@@ -2187,6 +3234,9 @@ pub(crate) mod tests {
 
         // Only "spike" (over its own baseline) is deprioritized; "steady"
         // (within baseline) is not.
+        set_sampled_rate(&mgr, "spike", 400.0);
+        mark_sustained(&mgr, "spike");
+        stage_noisy(&mgr);
         mgr.deprioritize_over_quota_groups();
         {
             let groups = ctl.resource_consumptions.read();
@@ -2246,7 +3296,7 @@ pub(crate) mod tests {
                 .ru_trackers
                 .entry("spike".to_owned())
                 .or_insert_with(|| {
-                    Mutex::new((
+                    RuTrackerSlot::new(
                         RuTracker::new(t0, 30),
                         Arc::new(ResourceLimiter::new(
                             "".into(),
@@ -2255,7 +3305,7 @@ pub(crate) mod tests {
                             0,
                             false,
                         )),
-                    ))
+                    )
                 });
             let mut tr = e.lock().unwrap();
             tr.0.record_at(3000, t0 + 30);
@@ -2267,6 +3317,9 @@ pub(crate) mod tests {
         // `adjust_group_throttling` on resource_control's own tick.
         mgr.online_adjust_resource_quota(0.0);
 
+        set_sampled_rate(&mgr, "spike", 400.0);
+        mark_sustained(&mgr, "spike");
+        stage_noisy(&mgr);
         mgr.deprioritize_over_quota_groups();
         assert!(
             ctl.resource_consumptions
@@ -2314,7 +3367,7 @@ pub(crate) mod tests {
                 .ru_trackers
                 .entry("spike".to_owned())
                 .or_insert_with(|| {
-                    Mutex::new((
+                    RuTrackerSlot::new(
                         RuTracker::new(t0, 30),
                         Arc::new(ResourceLimiter::new(
                             "".into(),
@@ -2323,7 +3376,7 @@ pub(crate) mod tests {
                             0,
                             false,
                         )),
-                    ))
+                    )
                 });
             let mut tr = e.lock().unwrap();
             tr.0.record_at(3000, t0 + 30);
@@ -2332,6 +3385,9 @@ pub(crate) mod tests {
         }
         mgr.online_adjust_resource_quota(0.0);
 
+        set_sampled_rate(&mgr, "spike", 400.0);
+        mark_sustained(&mgr, "spike");
+        stage_noisy(&mgr);
         mgr.deprioritize_over_quota_groups();
         assert!(
             ctl.resource_consumptions
@@ -2349,8 +3405,7 @@ pub(crate) mod tests {
         {
             let e = mgr.ru_trackers.get("spike").unwrap();
             let mut tr = e.lock().unwrap();
-            let now = RuTracker::now_secs();
-            tr.0.cached_historical_rate = tr.0.current_rate(now);
+            tr.0.cached_historical_rate = tr.0.current_rate();
         }
 
         // Calling deprioritize_over_quota_groups again must not clear the
@@ -2424,7 +3479,7 @@ pub(crate) mod tests {
 
         // Pressure is still tracked (adjust_group_scheduling is not gated)...
         mgr.set_bg_cpu_at_floor(true);
-        mgr.online_adjust_resource_quota(TARGET_CPU);
+        tick_until_engaged(&mgr, PEAK_CPU_PCT);
         assert_eq!(mgr.read_pool_cpu_pressure(), 1.0);
 
         // ...but it must not turn into a ceiling, or hold back scale-out.
@@ -2449,7 +3504,7 @@ pub(crate) mod tests {
                 .ru_trackers
                 .entry("spike".to_owned())
                 .or_insert_with(|| {
-                    Mutex::new((
+                    RuTrackerSlot::new(
                         RuTracker::new(t0, 30),
                         Arc::new(ResourceLimiter::new(
                             "".into(),
@@ -2458,7 +3513,7 @@ pub(crate) mod tests {
                             0,
                             false,
                         )),
-                    ))
+                    )
                 });
             let mut tr = e.lock().unwrap();
             tr.0.record_at(3000, t0 + 30);
@@ -2486,40 +3541,190 @@ pub(crate) mod tests {
         cfg.enable_fair_scheduling = true;
         let mgr = ResourceGroupManager::new(cfg);
         // Seed a historical floor of 0 cores (cold tracker), then engage
-        // pressure (cpu_score == TARGET_CPU).
+        // pressure (cpu_score == PEAK_CPU_PCT).
         mgr.set_bg_cpu_at_floor(true);
-        mgr.online_adjust_resource_quota(TARGET_CPU);
+        tick_until_engaged(&mgr, PEAK_CPU_PCT);
         assert_eq!(mgr.read_pool_cpu_pressure(), 1.0);
 
-        // Once engaged, the ceiling is 10% below the currently measured
+        // Once engaged, the ceiling is one step below the currently measured
         // usage instead of collapsing straight to the (cold, i.e. 0)
         // historical floor.
         let target_cpu = mgr.compute_read_pool_target_cpu(4.0, 10.0);
         assert!(
-            (target_cpu - 3.6).abs() < 1e-9,
-            "should be 10% below measured usage, got {target_cpu}"
+            (target_cpu - 3.4).abs() < 1e-9,
+            "should be 15% below measured usage, got {target_cpu}"
         );
 
         // Stateless: calling again with the same measured usage gives the
         // same result rather than ratcheting further down on its own.
         let target_cpu = mgr.compute_read_pool_target_cpu(4.0, 10.0);
         assert!(
-            (target_cpu - 3.6).abs() < 1e-9,
+            (target_cpu - 3.4).abs() < 1e-9,
             "repeated calls with unchanged usage should not ratchet further, got {target_cpu}"
         );
 
         // It does respond to a drop in measured usage (e.g. after the read
         // pool itself cut its thread count in response to the previous
         // tick's lower ceiling).
-        let target_cpu = mgr.compute_read_pool_target_cpu(3.6, 10.0);
+        let target_cpu = mgr.compute_read_pool_target_cpu(3.4, 10.0);
         assert!(
-            (target_cpu - 3.24).abs() < 1e-9,
-            "should track 10% below whatever usage is currently measured, got {target_cpu}"
+            (target_cpu - 2.89).abs() < 1e-9,
+            "should track 15% below whatever usage is currently measured, got {target_cpu}"
+        );
+    }
+
+    /// The pool gets at least one core, the counterpart of the 1 RU/s floor a
+    /// throttled group gets. Without it the ceiling is only 15% below current
+    /// on every tick, which compounds: the pool follows its own ceiling down
+    /// and the two spiral toward zero.
+    #[test]
+    fn test_read_pool_target_never_goes_below_one_core() {
+        let mut cfg = Config::default();
+        cfg.enable_fair_scheduling = true;
+        let mgr = ResourceGroupManager::new(cfg);
+        mgr.set_bg_cpu_at_floor(true);
+        tick_until_engaged(&mgr, PEAK_CPU_PCT);
+
+        // No quiet window has elapsed, so there is no sampled floor.
+        assert_eq!(mgr.quiet_read_pool_floor(), None);
+        // 15% below 1.0 would be 0.85; the floor holds it at one core.
+        let target = mgr.compute_read_pool_target_cpu(1.0, 10.0);
+        assert!(
+            (target - 1.0).abs() < 1e-9,
+            "should hold at one core, got {target}"
+        );
+        // And it does not spiral: feeding the target back in as the measured
+        // usage leaves it where it is.
+        let target = mgr.compute_read_pool_target_cpu(target, 10.0);
+        assert!(
+            (target - 1.0).abs() < 1e-9,
+            "should not ratchet, got {target}"
+        );
+
+        // Nor does the live average serve as the floor: build one well above a
+        // core and the target still comes down to the minimum. The average is
+        // computed over the overload being shed, so using it would float the
+        // floor up under the ratchet and stall the shedding.
+        let t0 = RuTracker::now_secs();
+        for i in 0..12 {
+            mgr.compute_read_pool_target_cpu_at(8.0, 10.0, t0 + 10 * i);
+        }
+        assert!(
+            mgr.record_read_pool_cpu_at(0.0, 0.0, RuTracker::now_secs()) > 1.0,
+            "the live average should exceed a core for this to prove anything"
+        );
+        let target = mgr.compute_read_pool_target_cpu_at(1.0, 10.0, t0 + 120);
+        assert!(
+            (target - 1.0).abs() < 1e-9,
+            "the live average must not act as the floor, got {target}"
+        );
+
+        // A sampled floor under one core does not lower the floor either --
+        // this node's was 0.075 cores.
+        set_quiet_read_pool_floor(&mgr, 0.075);
+        let target = mgr.compute_read_pool_target_cpu(1.0, 10.0);
+        assert!(
+            (target - 1.0).abs() < 1e-9,
+            "a sub-core sampled floor is still one core, got {target}"
+        );
+
+        // A sampled floor above it still wins, which is the whole point of
+        // sampling one.
+        set_quiet_read_pool_floor(&mgr, 3.0);
+        let target = mgr.compute_read_pool_target_cpu(2.0, 10.0);
+        assert!(
+            (target - 3.0).abs() < 1e-9,
+            "the sampled floor should hold above the minimum, got {target}"
+        );
+    }
+
+    /// The release path measures against the live average, not the baseline,
+    /// and a group with no history at all reads zero there. Zero must still
+    /// reach INFINITY: a throttled group that has since gone idle would
+    /// otherwise ramp 10% a tick forever and never be handed back its limit.
+    #[test]
+    fn test_a_zero_history_group_is_still_released() {
+        let mgr = ResourceGroupManager::default();
+        mgr.add_resource_group(new_resource_group_ru("g1".into(), 1000, HIGH_PRIORITY));
+        let limiter = mgr.get_foreground_group_limiter("g1");
+        let now = RuTracker::now_secs();
+        // Traffic in the open bucket only: enough to keep the tracker from
+        // being evicted as idle, not enough to complete a bucket, so the
+        // historical rate stays at zero.
+        stage_open_bucket(&mgr, "g1", 1_000);
+        limiter.get_limiter(ResourceType::Cpu).set_rate_limit(500.0);
+        assert_eq!(
+            mgr.ru_trackers
+                .get("g1")
+                .unwrap()
+                .lock()
+                .unwrap()
+                .0
+                .cached_historical_rate,
+            0.0,
+            "no traffic has ever been recorded"
+        );
+
+        // Quiet enough to be recovering: below the leeway threshold.
+        // MIN_RAMP_UP_EPOCHS is local to the actuator, hence the literal.
+        for _ in 0..2 {
+            assert!(
+                limit_of(&mgr, "g1").is_finite(),
+                "not released before the epochs elapse"
+            );
+            mgr.online_adjust_resource_quota_at(10.0, now);
+        }
+        assert!(
+            limit_of(&mgr, "g1").is_infinite(),
+            "a zero live average releases on the same path as any other"
+        );
+    }
+
+    /// A group that has never had a quiet window has a baseline of zero, so
+    /// its burst target is zero and nothing clamps the decrease: it descends
+    /// to the 1 RU/s floor for as long as it stays named. On a node that is
+    /// never quiet, that is every group.
+    #[test]
+    fn test_a_zero_baseline_ratchets_to_the_floor() {
+        let mgr = ResourceGroupManager::default();
+        mgr.add_resource_group(new_resource_group_ru("g1".into(), 1000, HIGH_PRIORITY));
+        let limiter = mgr.get_foreground_group_limiter("g1");
+        let t0 = RuTracker::now_secs();
+        {
+            let entry = mgr.ru_trackers.get("g1").unwrap();
+            let mut guard = entry.lock().unwrap();
+            guard.0.record_at(6000, t0 + 30);
+            guard.0.record_at(0, t0 + 60);
+        }
+        mgr.set_bg_cpu_at_floor(true);
+        let now = t0 + 85;
+        stage_open_bucket(&mgr, "g1", 20_000);
+
+        assert_eq!(
+            mgr.ru_trackers
+                .get("g1")
+                .unwrap()
+                .lock()
+                .unwrap()
+                .0
+                .quiet_baseline,
+            None,
+            "no quiet window has elapsed"
+        );
+
+        mark_sustained(&mgr, "g1");
+        for _ in 0..120 {
+            mgr.online_adjust_resource_quota_at(90.0, now);
+        }
+        assert_eq!(
+            limiter.get_limiter(ResourceType::Cpu).get_rate_limit(),
+            1.0,
+            "a zero target leaves nothing to stop the ratchet"
         );
     }
 
     #[test]
-    fn test_adjust_group_throttling_decreases_by_10_percent_per_tick() {
+    fn test_adjust_group_throttling_decreases_by_15_percent_per_tick() {
         // fg_cpu_throttle_threshold=70, baseline_burst_pct=20 (defaults) ->
         // burst_factor = 1.2.
         let mgr = ResourceGroupManager::default();
@@ -2534,54 +3739,65 @@ pub(crate) mod tests {
             let entry = mgr.ru_trackers.get("g1").unwrap();
             let mut guard = entry.lock().unwrap();
             guard.0.record_at(6000, t0 + 30);
-            guard.0.record_at(0, t0 + 60); // closes bucket: hist ~= 6000/30 = 200/s
-            guard.0.record_at(120_000, t0 + 65); // open-bucket spike: current >> burst_target
+            guard.0.record_at(0, t0 + 60); // closes bucket, so hist is non-zero
         }
         mgr.set_bg_cpu_at_floor(true);
-        let now = t0 + 90;
+        let now = t0 + 85;
+        // Spike confined to the last tick, so it does not also raise hist.
+        stage_open_bucket(&mgr, "g1", 20_000);
+        // A target now comes only from a sampled quiet window, so freeze one:
+        // with no baseline the ratchet has nothing to stop at and runs to the
+        // floor, which `test_a_zero_baseline_ratchets_to_the_floor` covers.
+        let quiet_baseline = {
+            let entry = mgr.ru_trackers.get("g1").unwrap();
+            let mut guard = entry.lock().unwrap();
+            guard.0.refresh_cached_historical_rate(t0, now);
+            let hist = guard.0.cached_historical_rate;
+            guard.0.quiet_baseline = Some(hist);
+            hist
+        };
 
         // First tick: no limit set yet (starts at INFINITY), so the base is
-        // the measured current rate, tightened by 10% — not an interpolated
-        // jump straight to burst_target.
-        mgr.adjust_group_throttling(90.0, now);
+        // the measured current rate, tightened by one step — not an
+        // interpolated jump straight to burst_target.
+        mark_sustained(&mgr, "g1");
+        mgr.online_adjust_resource_quota_at(90.0, now);
         let after_tick1 = limiter.get_limiter(ResourceType::Cpu).get_rate_limit();
-        let current_rate = {
-            let entry = mgr.ru_trackers.get("g1").unwrap();
-            let rate = entry.lock().unwrap().0.current_rate(now);
-            rate
-        };
+        let current_rate = mgr
+            .ru_trackers
+            .get("g1")
+            .unwrap()
+            .lock()
+            .unwrap()
+            .0
+            .current_rate();
         assert!(
-            (after_tick1 - current_rate * 0.9).abs() < current_rate * 0.01,
-            "first tick should tighten 10% below measured current rate, got {after_tick1}, \
+            (after_tick1 - current_rate * 0.85).abs() < current_rate * 0.01,
+            "first tick should tighten 15% below measured current rate, got {after_tick1}, \
              expected ~{}",
-            current_rate * 0.9
+            current_rate * 0.85
         );
 
         // Second tick, same inputs: base is now the persisted current_limit
         // from tick 1 (not a freshly measured/interpolated value), so it
-        // tightens another 10% relative to itself rather than staying put
+        // tightens another step relative to itself rather than staying put
         // or jumping to burst_target.
-        mgr.adjust_group_throttling(90.0, now);
+        mgr.online_adjust_resource_quota_at(90.0, now);
         let after_tick2 = limiter.get_limiter(ResourceType::Cpu).get_rate_limit();
         assert!(
-            (after_tick2 - after_tick1 * 0.9).abs() < after_tick1 * 0.01,
-            "second tick should tighten another 10% relative to the previous tick's limit, \
+            (after_tick2 - after_tick1 * 0.85).abs() < after_tick1 * 0.01,
+            "second tick should tighten another 15% relative to the previous tick's limit, \
              got {after_tick2}, expected ~{}",
-            after_tick1 * 0.9
+            after_tick1 * 0.85
         );
 
         // Repeated ticks converge to and stop at burst_target = hist * 1.2,
         // never going below it.
         for _ in 0..60 {
-            mgr.adjust_group_throttling(90.0, now);
+            mgr.online_adjust_resource_quota_at(90.0, now);
         }
         let floored = limiter.get_limiter(ResourceType::Cpu).get_rate_limit();
-        let hist = {
-            let entry = mgr.ru_trackers.get("g1").unwrap();
-            let rate = entry.lock().unwrap().0.cached_historical_rate;
-            rate
-        };
-        let burst_target = hist * 1.2;
+        let burst_target = quiet_baseline * 1.2;
         assert!(
             (floored - burst_target).abs() < burst_target * 0.01,
             "should converge to and stop at burst_target ({burst_target}), got {floored}"
@@ -2692,8 +3908,9 @@ pub(crate) mod tests {
         const BUCKETS: usize = 15;
         let mut tracker = RuTracker::new(t0, BUCKETS);
         assert!(!tracker.is_warmed_up());
-        // No data at all: current_rate = (0 + 0) / (0 + 60) = 0.
-        assert_eq!(tracker.current_rate(t0), 0.0);
+        // No data at all, and no elapsed time to divide by.
+        tracker.refresh_cached_current_rate(t0);
+        assert_eq!(tracker.current_rate(), 0.0);
         assert_eq!(tracker.historical_rate(t0, t0), 0.0);
 
         // Record 6000 RU in the first 30s bucket.
@@ -2702,9 +3919,9 @@ pub(crate) mod tests {
         // Advance past the first bucket boundary (30s) — completes bucket 0.
         tracker.record_at(0, t0 + 30);
         assert_eq!(tracker.completed, 1);
-        // At t0+30: current_bucket=0, elapsed=0, last_completed=6000
-        // rate = (0 + 6000) / (0 + 30) = 200 RU/s
-        assert!((tracker.current_rate(t0 + 30) - 200.0).abs() < 0.01);
+        // 6000 RU over the 30s since the last sample = 200 RU/s.
+        tracker.refresh_cached_current_rate(t0 + 30);
+        assert!((tracker.current_rate() - 200.0).abs() < 0.01);
         assert!(!tracker.is_warmed_up()); // needs ≥2 buckets
 
         // Advance another 30s with 3000 RU — completes bucket 1.
@@ -2712,12 +3929,14 @@ pub(crate) mod tests {
         tracker.record_at(0, t0 + 60);
         assert_eq!(tracker.completed, 2);
         assert!(tracker.is_warmed_up());
-        // At t0+60: current_bucket=0, elapsed=0, last_completed=3000
-        // rate = (0 + 3000) / (0 + 30) = 100 RU/s
-        assert!((tracker.current_rate(t0 + 60) - 100.0).abs() < 0.01);
-        // At t0+75 (15s into next bucket, no new RU): current_bucket=0, elapsed=15
-        // rate = (0 + 3000) / (15 + 30) = 66.67 RU/s
-        assert!((tracker.current_rate(t0 + 75) - 66.67).abs() < 0.1);
+        // A further 3000 RU over the next 30s = 100 RU/s.
+        tracker.refresh_cached_current_rate(t0 + 60);
+        assert!((tracker.current_rate() - 100.0).abs() < 0.01);
+        // Nothing recorded since: the trailing window still holds the closed
+        // bucket, so the rate decays rather than dropping to zero on the tick
+        // traffic stops -- 3000 RU over the 45s the window now covers.
+        tracker.refresh_cached_current_rate(t0 + 75);
+        assert!((tracker.current_rate() - 66.667).abs() < 0.01);
         // historical_rate = (6000+3000) / (2*30) = 150 RU/s
         assert!((tracker.historical_rate(t0, t0 + 60) - 150.0).abs() < 0.01);
 
@@ -2750,15 +3969,16 @@ pub(crate) mod tests {
         let t0 = RuTracker::now_secs();
         mgr.record_ru_consumption("spike", 1);
 
-        // CPU below threshold → Allow (stays NO_LIMIT, no throttling).
+        // CPU below threshold → Allow (limit stays infinite, no throttling).
         mgr.online_adjust_resource_quota(50.0); // below 80%
         assert_eq!(
             mgr.admission_decision(true, &spike_limiter),
             AdmissionDecision::Allow
         );
 
-        // CPU above threshold but no warmed-up tracker data → stays NO_LIMIT → Allow.
-        mgr.online_adjust_resource_quota(90.0);
+        // CPU above threshold but no warmed-up tracker data → limit stays
+        // infinite → Allow.
+        tick_until_engaged(&mgr, 90.0);
         assert_eq!(
             mgr.admission_decision(true, &spike_limiter),
             AdmissionDecision::Allow
@@ -2773,14 +3993,13 @@ pub(crate) mod tests {
             guard.0.record_at(6000, t0 + 30);
             guard.0.record_at(0, t0 + 60); // close bucket 0: 6000 RU (baseline)
             guard.0.record_at(12000, t0 + 90); // open bucket: 12000 RU spike (left open)
-            // historical ≈ 6000/30 = 200 RU/s (only completed buckets), current
-            // ≈ 400
+            // historical ≈ 6000/30 = 200 RU/s (only completed buckets)
         }
-        // Now set CPU — first throttle entry: initializes fraction from spike ratio,
-        // then sets absolute rate = historical × fraction per group.
+        // ...and a spike in the last tick, giving current ≈ 400 RU/s.
+        stage_open_bucket(&mgr, "spike", 4_000);
         // bg_cpu_at_floor must be true for the throttle branch to fire.
         mgr.set_bg_cpu_at_floor(true);
-        mgr.online_adjust_resource_quota(90.0);
+        tick_until_engaged(&mgr, 90.0);
         // Consume a burst well above the rate to build token-bucket debt.
         {
             let entry = mgr.ru_trackers.get("spike").unwrap();
@@ -2818,16 +4037,16 @@ pub(crate) mod tests {
             mgr.release_delay_slot();
         }
 
-        // Drop CPU into leeway zone (72-80%): multiplier holds, still delays.
+        // Above the leeway threshold: no recovery, so the multiplier holds
+        // and requests still delay.
         mgr.online_adjust_resource_quota(75.0);
         assert!(matches!(
             mgr.admission_decision(true, &spike_limiter),
             AdmissionDecision::Delay(_)
         ));
 
-        // Drop CPU below leeway_start (72%): fraction ramps up ×1.1/tick.
-        // After enough ticks it reaches 5× → NO_LIMIT → rates set to infinity
-        // → token bucket debt clears → Allow.
+        // Drop CPU below the leeway threshold: the limit ramps up a step per
+        // tick until it is lifted to infinity, clearing the token-bucket debt.
         for _ in 0..60 {
             mgr.online_adjust_resource_quota(50.0);
         }
@@ -2838,16 +4057,703 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn test_read_pool_cpu_floor_cold_tracker() {
-        let mgr = ResourceGroupManager::default();
-        let t0 = RuTracker::now_secs();
-        // Cold tracker → historical rate 0 → floor == 0.0 cores.
-        let floor = mgr.read_pool_cpu_floor_at(8.0, 10.0, t0);
-        assert_eq!(floor, 0.0);
+    fn test_current_rate_needs_no_warm_up() {
+        let t0: u64 = 1_000_000;
+        let mut tr = RuTracker::new(t0, 30);
+        // A steady 100 RU/s from the moment the tracker exists. With no closed
+        // bucket the open one is measured over its own elapsed time, so the
+        // first tick already reports the real rate instead of half of it.
+        for i in 0..10 {
+            tr.record_at(100, t0 + i);
+        }
+        tr.refresh_cached_current_rate(t0 + 10);
+        assert_eq!(tr.current_rate(), 100.0);
+        assert_eq!(tr.completed, 0, "no bucket needs to have closed");
+
+        // Reading or refreshing it again inside the same tick is free and
+        // stable: the window is derived from the ring, not consumed from it.
+        assert_eq!(tr.current_rate(), 100.0);
+        tr.refresh_cached_current_rate(t0 + 10);
+        assert_eq!(tr.current_rate(), 100.0, "a refresh must be idempotent");
     }
 
     #[test]
-    fn test_read_pool_cpu_floor_matches_historical_usage() {
+    fn test_current_rate_does_not_follow_a_single_tick_of_traffic() {
+        let t0: u64 = 1_000_000;
+        let mut tr = RuTracker::new(t0, 30);
+        // One closed bucket at a steady 100 RU/s.
+        tr.record_at(3000, t0 + 15);
+        tr.record_at(0, t0 + 30);
+        tr.refresh_cached_current_rate(t0 + 30);
+        assert!((tr.current_rate() - 100.0).abs() < 0.01);
+
+        // Then a burst running at 200 RU/s for one 10s tick. The window is the
+        // closed bucket plus the open one over the 40s they cover, so the rate
+        // moves to 125, not to the 200 the burst is running at.
+        tr.record(2_000);
+        tr.refresh_cached_current_rate(t0 + 40);
+        assert!(
+            (tr.current_rate() - 125.0).abs() < 0.01,
+            "expected the 40s average, got {}",
+            tr.current_rate()
+        );
+    }
+
+    #[test]
+    fn test_lifecycle_zero_history_tenant_spikes_alone_and_both_recover() {
+        // tenant1 idle, tenant2 steady at 100. tenant1 jumps to 1000.
+        let mgr = ResourceGroupManager::new(Config::default());
+        let t0 = RuTracker::now_secs();
+        mgr.set_bg_cpu_at_floor(true);
+        seed_tracker(&mgr, "tenant1", 0.0, 1000.0, t0);
+        seed_tracker(&mgr, "tenant2", 100.0, 100.0, t0);
+
+        tick(&mgr, 90.0);
+        let noisy = mgr.noisy_groups();
+        assert!(
+            noisy.contains("tenant1") && noisy.len() == 1,
+            "the spike is tenant1's alone: {noisy:?}"
+        );
+        // Throttled off what it is consuming. With no history its target is
+        // zero, so the decrease step is unclamped — a first-ever spike is cut
+        // by the full step rather than being left alone.
+        assert!(
+            (limit_of(&mgr, "tenant1") - 1000.0 * THROTTLE_DECREASE_FACTOR).abs() < 1.0,
+            "one decrease step off 1000: {}",
+            limit_of(&mgr, "tenant1")
+        );
+        assert!(
+            limit_of(&mgr, "tenant2").is_infinite(),
+            "not named, untouched"
+        );
+
+        // It slows down, and its trailing average has now absorbed the spike.
+        set_sampled_rate(&mgr, "tenant1", 10.0);
+        set_baseline(&mgr, "tenant1", 500.0);
+        for _ in 1..=3 {
+            tick(&mgr, 50.0);
+        }
+        assert!(
+            mgr.select_noisy_groups().is_empty(),
+            "neither tenant is noisy once the load is back down"
+        );
+        assert!(limit_of(&mgr, "tenant1").is_infinite());
+        assert!(limit_of(&mgr, "tenant2").is_infinite());
+    }
+
+    #[test]
+    fn test_zero_baseline_tenant_is_both_throttled_and_deprioritized() {
+        // A first-ever spike has no baseline, which is a target of zero rather
+        // than an exemption: both actuators reach it.
+        let mut cfg = Config::default();
+        cfg.enable_fair_scheduling = true;
+        let mgr = ResourceGroupManager::new(cfg);
+        mgr.add_resource_group(new_resource_group_ru("fresh".into(), 1000, MEDIUM_PRIORITY));
+        let ctl = mgr.derive_controller("read".into(), true);
+        let t0 = RuTracker::now_secs();
+        mgr.set_bg_cpu_at_floor(true);
+        seed_tracker(&mgr, "fresh", 0.0, 1000.0, t0);
+
+        tick(&mgr, 90.0);
+        assert!(mgr.noisy_groups().contains("fresh"), "named");
+        assert!(
+            limit_of(&mgr, "fresh").is_finite(),
+            "and throttled: a zero target does not clamp the decrease"
+        );
+
+        mgr.deprioritize_over_quota_groups();
+        assert!(
+            ctl.resource_consumptions
+                .read()
+                .get(b"fresh".as_ref())
+                .unwrap()
+                .is_over_baseline
+                .load(Ordering::Relaxed),
+            "the scheduler is the one actuator that does reach it"
+        );
+    }
+
+    #[test]
+    fn test_lifecycle_baseline_catching_up_does_not_release_the_culprit() {
+        // Three tenants, one spikes. Its own trailing average then rises to
+        // absorb the spike, which is exactly when the live baseline would let
+        // it go while it is still the cause.
+        let mgr = ResourceGroupManager::new(Config::default());
+        let t0 = RuTracker::now_secs();
+        mgr.set_bg_cpu_at_floor(true);
+        seed_tracker(&mgr, "tenant1", 100.0, 1000.0, t0);
+        seed_tracker(&mgr, "tenant2", 200.0, 200.0, t0);
+        seed_tracker(&mgr, "tenant3", 300.0, 300.0, t0);
+
+        tick(&mgr, 90.0);
+        assert!(mgr.noisy_groups().contains("tenant1"));
+        assert_eq!(
+            baseline_of(&mgr, "tenant1"),
+            Some(100.0),
+            "frozen pre-spike"
+        );
+        let first = limit_of(&mgr, "tenant1");
+        assert!(first.is_finite(), "throttled, since it has history");
+
+        // The live average catches up to the elevated rate.
+        set_baseline(&mgr, "tenant1", 1000.0);
+        tick(&mgr, 90.0);
+        assert!(
+            mgr.noisy_groups().contains("tenant1"),
+            "the frozen baseline keeps it named while its rate is still up"
+        );
+        assert!(limit_of(&mgr, "tenant1") < first, "and it keeps tightening");
+        assert!(!mgr.noisy_groups().contains("tenant2"));
+        assert!(!mgr.noisy_groups().contains("tenant3"));
+
+        // Recovery: load back to its (now higher) baseline, CPU below leeway.
+        set_sampled_rate(&mgr, "tenant1", 1000.0);
+        for _ in 2..=40 {
+            tick(&mgr, 50.0);
+        }
+        assert!(
+            limit_of(&mgr, "tenant1").is_infinite(),
+            "the limit is handed back"
+        );
+        assert!(
+            mgr.select_noisy_groups().is_empty(),
+            "and nobody is noisy any more"
+        );
+    }
+
+    #[test]
+    fn test_lifecycle_a_throttled_culprit_keeps_the_blame_off_a_small_spike() {
+        // tenant1 spikes and is held. Its load comes back down, and tenant2
+        // then rises slightly. The relief tenant1 is already giving covers the
+        // target, so tenant2 must not be taken in its place.
+        let mgr = ResourceGroupManager::new(Config::default());
+        let t0 = RuTracker::now_secs();
+        mgr.set_bg_cpu_at_floor(true);
+        seed_tracker(&mgr, "tenant1", 300.0, 3000.0, t0);
+        seed_tracker(&mgr, "tenant2", 100.0, 100.0, t0);
+
+        tick(&mgr, 90.0);
+        assert!(
+            mgr.noisy_groups().contains("tenant1") && mgr.noisy_groups().len() == 1,
+            "tenant1 alone"
+        );
+
+        // The throttle has worked: tenant1 back inside its gate. tenant2 edges
+        // up just past its own.
+        set_sampled_rate(&mgr, "tenant1", 300.0);
+        set_sampled_rate(&mgr, "tenant2", 130.0);
+        tick(&mgr, 90.0);
+
+        let noisy = mgr.noisy_groups();
+        assert!(
+            noisy.contains("tenant1"),
+            "still held, so still named: {noisy:?}"
+        );
+        // Spared by the counter on this tick: one tick over its gate is not
+        // evidence, whatever else is going on.
+        assert!(!noisy.contains("tenant2"), "{noisy:?}");
+
+        // A second tick over its gate confirms it, so now it is a genuine
+        // candidate -- and must still be spared, because the relief tenant1 is
+        // already giving back covers the whole target.
+        tick(&mgr, 90.0);
+        let noisy = mgr.noisy_groups();
+        assert!(noisy.contains("tenant1"), "{noisy:?}");
+        assert!(
+            !noisy.contains("tenant2"),
+            "tenant1's relief covers the target, so the small riser is not \
+             taken to meet it: {noisy:?}"
+        );
+        assert!(limit_of(&mgr, "tenant2").is_infinite(), "and not throttled");
+    }
+
+    #[test]
+    fn test_the_cached_verdict_keeps_a_group_the_throttle_has_pushed_back_down() {
+        // The callers overwrite the cache wholesale each pressured tick, so a
+        // group dropping out of the verdict silently unnames it. Once the
+        // throttle has driven it back inside its gate that is exactly when it
+        // must stay named.
+        let mgr = ResourceGroupManager::new(Config::default());
+        let t0 = RuTracker::now_secs();
+        seed_tracker(&mgr, "spike", 100.0, 1000.0, t0);
+
+        *mgr.noisy_groups.write() = mgr.select_noisy_groups();
+        assert!(
+            mgr.noisy_groups().contains("spike"),
+            "named on the first tick"
+        );
+        set_backpressure(&mgr, "spike", true, true);
+
+        // Next tick: the throttle has worked and it is back inside its gate.
+        set_sampled_rate(&mgr, "spike", 100.0);
+        *mgr.noisy_groups.write() = mgr.select_noisy_groups();
+        assert!(
+            mgr.noisy_groups().contains("spike"),
+            "still held, so the cache must still name it"
+        );
+    }
+
+    #[test]
+    fn test_a_held_group_still_over_its_gate_is_credited_not_ignored() {
+        // A held group whose counter has been cleared -- by a tick inside its
+        // gate, or by one without node pressure -- while it is still above
+        // that gate. The actuators are on it, so its rate has to count toward
+        // the target; otherwise a confirmed neighbour is taken to make up a
+        // difference that is already being reclaimed.
+        let mgr = ResourceGroupManager::new(Config::default());
+        let t0 = RuTracker::now_secs();
+        seed_tracker(&mgr, "culprit", 300.0, 3000.0, t0);
+        seed_tracker(&mgr, "neighbour", 100.0, 130.0, t0);
+        {
+            let entry = mgr.ru_trackers.get("culprit").unwrap();
+            let mut guard = entry.lock().unwrap();
+            guard.0.over_baseline_ticks = 0;
+        }
+        set_backpressure(&mgr, "culprit", true, true);
+
+        let noisy = mgr.select_noisy_groups();
+        assert!(noisy.contains("culprit"), "held, so named: {noisy:?}");
+        assert!(
+            !noisy.contains("neighbour"),
+            "the held group's rate covers the target, so the neighbour is not \
+             taken to meet it: {noisy:?}"
+        );
+    }
+
+    /// Same fixture for both detection modes: `small` has moved 10x above its
+    /// own history but is tiny; `big` is the largest consumer but sits just
+    /// above its own history.
+    fn seed_mover_and_hog(mgr: &ResourceGroupManager, t0: u64) {
+        seed_tracker(mgr, "big", 990.0, 1000.0, t0);
+        seed_tracker(mgr, "small", 10.0, 100.0, t0);
+        mgr.set_bg_cpu_at_floor(true);
+    }
+
+    #[test]
+    fn test_baseline_detection_blames_the_group_that_moved() {
+        let mgr = ResourceGroupManager::new(Config::default());
+        let t0 = RuTracker::now_secs();
+        seed_mover_and_hog(&mgr, t0);
+
+        mgr.online_adjust_resource_quota_at(90.0, t0);
+        assert!(
+            mgr.noisy_groups().contains("small"),
+            "10x its own baseline outranks a larger group sitting on its: {:?}",
+            mgr.noisy_groups()
+        );
+    }
+
+    #[test]
+    fn test_current_usage_detection_blames_the_biggest_consumer() {
+        // Zeroing the baseline is the whole mode: the eligibility gate reduces
+        // to "has traffic" and `excess` becomes the raw rate, so the ranking is
+        // by consumption and the small mover is spared.
+        let cfg = Config {
+            noisy_detection: NoisyDetection::CurrentUsage,
+            ..Default::default()
+        };
+        let mgr = ResourceGroupManager::new(cfg);
+        let t0 = RuTracker::now_secs();
+        seed_mover_and_hog(&mgr, t0);
+
+        mgr.online_adjust_resource_quota_at(90.0, t0);
+        assert_eq!(baseline_of(&mgr, "big"), Some(0.0));
+        assert_eq!(
+            baseline_of(&mgr, "small"),
+            Some(0.0),
+            "the mode discards whatever history the fixture stated"
+        );
+
+        let noisy = mgr.noisy_groups();
+        assert!(
+            noisy.contains("big") && !noisy.contains("small"),
+            "the biggest consumer is blamed, not the biggest mover: {noisy:?}"
+        );
+
+        // The zero baseline does not exempt it from the throttle: one
+        // decrease step off what it is consuming, with nothing below to clamp
+        // at but the 1 RU/s minimum.
+        let limit = limit_of(&mgr, "big");
+        assert!(
+            (limit - 1000.0 * THROTTLE_DECREASE_FACTOR).abs() < 1.0,
+            "expected one decrease step off the sampled rate, got {limit}"
+        );
+        assert!(limit_of(&mgr, "small").is_infinite());
+    }
+
+    #[test]
+    fn test_switching_back_to_baseline_drops_the_stated_zero() {
+        let cfg = Config {
+            noisy_detection: NoisyDetection::CurrentUsage,
+            ..Default::default()
+        };
+        let mgr = ResourceGroupManager::new(cfg);
+        let t0 = RuTracker::now_secs();
+        seed_mover_and_hog(&mgr, t0);
+
+        mgr.online_adjust_resource_quota_at(90.0, t0);
+        assert_eq!(baseline_of(&mgr, "big"), Some(0.0));
+
+        // Switched back mid-episode, so the tick that follows is far too
+        // loaded to sample a replacement baseline. The zero still has to go:
+        // `None` records that this group has never had a quiet window, which
+        // a zero stated by the other mode does not.
+        mgr.get_config()
+            .update(|c| -> Result<(), ()> {
+                c.noisy_detection = NoisyDetection::Baseline;
+                Ok(())
+            })
+            .unwrap();
+        mgr.online_adjust_resource_quota_at(90.0, t0 + 10);
+
+        assert_eq!(
+            baseline_of(&mgr, "big"),
+            None,
+            "the zero was stated by the other mode, not sampled"
+        );
+    }
+
+    #[test]
+    fn test_a_group_over_its_target_for_one_tick_is_not_blamed() {
+        let mgr = ResourceGroupManager::default();
+        let t0 = RuTracker::now_secs();
+        seed_tracker(&mgr, "spike", 100.0, 1000.0, t0);
+        let burst_factor = 1.0 + mgr.get_config().value().baseline_burst_pct / 100.0;
+        let tick = || {
+            mgr.ru_trackers
+                .get("spike")
+                .unwrap()
+                .lock()
+                .unwrap()
+                .0
+                .update_over_baseline_ticks(burst_factor, true, false)
+        };
+        // Undo the fixture's claim, so the counter starts cold as it would on
+        // the first tick a group runs hot.
+        mgr.ru_trackers
+            .get("spike")
+            .unwrap()
+            .lock()
+            .unwrap()
+            .0
+            .over_baseline_ticks = 0;
+
+        tick();
+        assert!(
+            mgr.select_noisy_groups().is_empty(),
+            "one tick over target is not evidence"
+        );
+
+        tick();
+        let noisy = mgr.select_noisy_groups();
+        assert!(
+            noisy.contains("spike") && noisy.len() == 1,
+            "two consecutive ticks must blame the group, got {noisy:?}"
+        );
+    }
+
+    #[test]
+    fn test_a_score_hovering_on_the_threshold_keeps_the_evidence() {
+        // The failure this prevents: cpu_score alternating either side of the
+        // threshold wiped the count every other tick, so a node overloaded half
+        // the time never reached two and blamed nobody.
+        let mgr = ResourceGroupManager::default();
+        let t0 = RuTracker::now_secs();
+        seed_tracker(&mgr, "spike", 100.0, 1000.0, t0);
+        let burst_factor = 1.0 + mgr.get_config().value().baseline_burst_pct / 100.0;
+        let entry = mgr.ru_trackers.get("spike").unwrap();
+        let mut guard = entry.lock().unwrap();
+        guard.0.over_baseline_ticks = 0;
+
+        // Above the threshold: evidence.
+        guard
+            .0
+            .update_over_baseline_ticks(burst_factor, true, false);
+        assert_eq!(guard.0.over_baseline_ticks, 1);
+
+        // Below the threshold but above the leeway threshold: hold.
+        guard
+            .0
+            .update_over_baseline_ticks(burst_factor, false, false);
+        assert_eq!(
+            guard.0.over_baseline_ticks, 1,
+            "the band between the thresholds must hold, not wipe"
+        );
+
+        guard
+            .0
+            .update_over_baseline_ticks(burst_factor, true, false);
+        assert!(
+            guard.0.sustained_over_baseline(),
+            "so the next loaded tick confirms instead of starting over"
+        );
+    }
+
+    #[test]
+    fn test_pressure_clearing_wipes_the_evidence() {
+        let mgr = ResourceGroupManager::default();
+        let t0 = RuTracker::now_secs();
+        seed_tracker(&mgr, "spike", 100.0, 1000.0, t0);
+        let burst_factor = 1.0 + mgr.get_config().value().baseline_burst_pct / 100.0;
+        let entry = mgr.ru_trackers.get("spike").unwrap();
+        let mut guard = entry.lock().unwrap();
+        assert!(guard.0.sustained_over_baseline(), "fixture starts blamed");
+
+        // Below the leeway threshold the node is genuinely fine, so whatever
+        // the group is doing is not a problem worth blaming it for.
+        guard
+            .0
+            .update_over_baseline_ticks(burst_factor, false, true);
+        assert_eq!(guard.0.over_baseline_ticks, 0);
+    }
+
+    #[test]
+    fn test_the_tick_wires_the_load_bands_into_the_candidacy_counter() {
+        // Drives the real entry point, since the wiring is what is under test:
+        // that the counter keys off the load bands and not off the background
+        // gate. Threshold 70, so the leeway threshold is 63.
+        let mgr = ResourceGroupManager::default();
+        let t0 = RuTracker::now_secs();
+        seed_tracker(&mgr, "spike", 100.0, 1000.0, t0);
+        let count = |mgr: &ResourceGroupManager| {
+            mgr.ru_trackers
+                .get("spike")
+                .unwrap()
+                .lock()
+                .unwrap()
+                .0
+                .over_baseline_ticks
+        };
+        mgr.ru_trackers
+            .get("spike")
+            .unwrap()
+            .lock()
+            .unwrap()
+            .0
+            .over_baseline_ticks = 0;
+
+        // Background has not yielded yet, so nothing may be acted on — but the
+        // evidence has to accrue anyway. Folding `is_bg_cpu_at_floor` into the
+        // counter meant every tick of the background squeeze wiped it, making
+        // the engage delay the whole squeeze plus MIN_ENGAGE_TICKS.
+        mgr.set_bg_cpu_at_floor(false);
+        mgr.online_adjust_resource_quota_at(90.0, t0);
+        assert_eq!(count(&mgr), 1);
+        mgr.online_adjust_resource_quota_at(90.0, t0);
+        assert_eq!(
+            count(&mgr),
+            MIN_ENGAGE_TICKS,
+            "the background squeeze must not wipe the evidence"
+        );
+        assert!(
+            mgr.noisy_groups().is_empty(),
+            "but no group may be blamed before background is at its floor"
+        );
+
+        // Between the two thresholds: held, so a score hovering on the
+        // threshold cannot erase the evidence every other tick.
+        mgr.online_adjust_resource_quota_at(66.0, t0);
+        assert_eq!(count(&mgr), MIN_ENGAGE_TICKS, "the band must hold");
+
+        // Below the leeway threshold the node is genuinely fine.
+        mgr.online_adjust_resource_quota_at(50.0, t0);
+        assert_eq!(count(&mgr), 0);
+    }
+
+    #[test]
+    fn test_a_tick_inside_the_target_restarts_the_group_count() {
+        let mgr = ResourceGroupManager::default();
+        let t0 = RuTracker::now_secs();
+        seed_tracker(&mgr, "spike", 100.0, 1000.0, t0);
+        let burst_factor = 1.0 + mgr.get_config().value().baseline_burst_pct / 100.0;
+
+        let entry = mgr.ru_trackers.get("spike").unwrap();
+        let mut guard = entry.lock().unwrap();
+        assert!(guard.0.sustained_over_baseline(), "fixture starts blamed");
+        // A quiet tick has since raised its baseline, so this tick is inside
+        // the target.
+        guard.0.quiet_baseline = Some(10_000.0);
+        guard
+            .0
+            .update_over_baseline_ticks(burst_factor, true, false);
+        assert_eq!(
+            guard.0.over_baseline_ticks, 0,
+            "a tick inside the target must clear the count outright"
+        );
+    }
+
+    #[test]
+    fn test_read_pool_historical_cpu_cold_tracker() {
+        let mgr = ResourceGroupManager::default();
+        let t0 = RuTracker::now_secs();
+        // Cold tracker → historical rate 0 → 0.0 cores.
+        let historical = mgr.record_read_pool_cpu_at(8.0, 10.0, t0);
+        assert_eq!(historical, 0.0);
+    }
+
+    /// A quiet period of a sustained 1 core, then the pool's own window
+    /// (2 min = 4 x 30s) of quiet ticks so the floor is established.
+    fn seed_read_pool_floor(mgr: &ResourceGroupManager, t0: u64) -> (f64, u64) {
+        {
+            let mut tracker = mgr.read_pool_cpu_tracker.lock().unwrap();
+            for i in 1..=5 {
+                tracker.record_at(30_000_000, t0 + 30 * i);
+            }
+            tracker.refresh_cached_historical_rate(t0, t0 + 150);
+        }
+        let quiet = mgr
+            .read_pool_cpu_tracker
+            .lock()
+            .unwrap()
+            .cached_historical_rate
+            / 1e6;
+        assert!(quiet > 0.0 && quiet < 6.8, "{}", quiet);
+        let now = t0 + 150;
+        mgr.adjust_group_scheduling_at(10.0, false, now);
+        assert_eq!(
+            mgr.quiet_read_pool_floor(),
+            None,
+            "one quiet tick is not a window"
+        );
+        mgr.adjust_group_scheduling_at(10.0, false, now + 120);
+        let floor = mgr
+            .quiet_read_pool_floor()
+            .expect("a full quiet window establishes the floor");
+        assert!(
+            (floor - quiet).abs() < 1e-9,
+            "floor {} should be the pre-overload {}",
+            floor,
+            quiet
+        );
+        (floor, now + 120)
+    }
+
+    fn read_pool_live_floor(mgr: &ResourceGroupManager) -> f64 {
+        mgr.read_pool_cpu_tracker
+            .lock()
+            .unwrap()
+            .cached_historical_rate
+            / 1e6
+    }
+
+    #[test]
+    fn test_read_pool_floor_holds_through_an_overload() {
+        // Without the gate the floor climbs with the load and the ratchet
+        // stalls, since the tracker keeps recording the overload.
+        let cfg = Config {
+            historical_usage_window_mins: 2,
+            enable_fair_scheduling: true,
+            ..Default::default()
+        };
+        let mgr = ResourceGroupManager::new(cfg);
+        let (floor, engaged) = seed_read_pool_floor(&mgr, mgr.start_secs);
+
+        mgr.set_bg_cpu_at_floor(true);
+        mgr.adjust_group_scheduling_at(95.0, true, engaged);
+        assert!(mgr.read_pool_cpu_pressure() > 0.0);
+
+        // 8 cores through the pool: the live average climbs, the floor does
+        // not, so the ratchet keeps stepping down.
+        let mut target = f64::INFINITY;
+        for i in 1..=6 {
+            target = mgr.compute_read_pool_target_cpu_at(8.0, 10.0, engaged + 10 * i);
+        }
+        assert!(
+            (target - 6.8).abs() < 0.01,
+            "ratchet should hold at 0.85 * 8.0 above the floor, got {}",
+            target
+        );
+        assert!(
+            read_pool_live_floor(&mgr) > floor,
+            "the live average should have absorbed the overload"
+        );
+        assert_eq!(
+            mgr.quiet_read_pool_floor(),
+            Some(floor),
+            "the floor must not move while overload is engaged"
+        );
+    }
+
+    #[test]
+    fn test_read_pool_floor_is_not_re_taken_until_the_episode_ages_out() {
+        // The window after recovery is the hazard: the tracker still holds the
+        // episode, so re-taking the floor there would come back inflated by
+        // the very load that was shed.
+        let cfg = Config {
+            historical_usage_window_mins: 2,
+            enable_fair_scheduling: true,
+            ..Default::default()
+        };
+        let mgr = ResourceGroupManager::new(cfg);
+        let (floor, engaged) = seed_read_pool_floor(&mgr, mgr.start_secs);
+
+        mgr.set_bg_cpu_at_floor(true);
+        mgr.adjust_group_scheduling_at(95.0, true, engaged);
+        for i in 1..=6 {
+            mgr.compute_read_pool_target_cpu_at(8.0, 10.0, engaged + 10 * i);
+        }
+        let contaminated = read_pool_live_floor(&mgr);
+        assert!(contaminated > floor, "tracker should be contaminated");
+
+        let recovered = engaged + 60;
+        mgr.adjust_group_scheduling_at(10.0, false, recovered);
+        assert_eq!(
+            mgr.quiet_read_pool_floor(),
+            Some(floor),
+            "the contaminated average must not be taken at the moment of recovery"
+        );
+        mgr.adjust_group_scheduling_at(10.0, false, recovered + 119);
+        assert_eq!(mgr.quiet_read_pool_floor(), Some(floor));
+
+        mgr.adjust_group_scheduling_at(10.0, false, recovered + 120);
+        assert_ne!(
+            mgr.quiet_read_pool_floor(),
+            Some(floor),
+            "a full quiet window re-takes it, with no latch to drop"
+        );
+    }
+
+    #[test]
+    fn test_read_pool_floor_is_not_taken_in_the_mid_range_band() {
+        // Between the quiet gate (59.5) and the throttle threshold (70) the
+        // node is not engaged but not quiet either, and the tracker is still
+        // recording load. The run of quiet must not start there.
+        let cfg = Config {
+            historical_usage_window_mins: 2,
+            enable_fair_scheduling: true,
+            ..Default::default()
+        };
+        let mgr = ResourceGroupManager::new(cfg);
+        let t0 = mgr.start_secs;
+        {
+            let mut tracker = mgr.read_pool_cpu_tracker.lock().unwrap();
+            for i in 1..=5 {
+                tracker.record_at(30_000_000, t0 + 30 * i);
+            }
+            tracker.refresh_cached_historical_rate(t0, t0 + 150);
+        }
+        let now = t0 + 150;
+
+        mgr.adjust_group_scheduling_at(65.0, false, now);
+        mgr.adjust_group_scheduling_at(65.0, false, now + 1000);
+        assert_eq!(
+            mgr.quiet_read_pool_floor(),
+            None,
+            "the mid-range band is not quiet, however long it lasts"
+        );
+
+        // The run starts here, not before.
+        mgr.adjust_group_scheduling_at(10.0, false, now + 1000);
+        assert_eq!(mgr.quiet_read_pool_floor(), None);
+        mgr.adjust_group_scheduling_at(10.0, false, now + 1120);
+        assert!(
+            mgr.quiet_read_pool_floor().is_some(),
+            "a window of quiet from that point establishes it"
+        );
+    }
+
+    #[test]
+    fn test_read_pool_historical_cpu_matches_usage() {
         // Small window (minimum 2 min = 4 buckets = 120s) so a handful of
         // directly-seeded buckets fully cover it, giving an exact,
         // non-ramping historical rate to assert against.
@@ -2872,8 +4778,143 @@ pub(crate) mod tests {
         }
         // system_uptime (150s) >= window_secs (120s) → historical_rate uses
         // the full window as denominator: 480_000_000 / 120 = 4_000_000 us/s
-        // = 4 cores → floor = 4.0.
-        let floor = mgr.read_pool_cpu_floor_at(4.0, 30.0, t0 + 150);
-        assert_eq!(floor, 4.0);
+        // = 4 cores.
+        let historical = mgr.record_read_pool_cpu_at(4.0, 30.0, t0 + 150);
+        assert_eq!(historical, 4.0);
+    }
+
+    /// RU sitting in the still-open bucket, which is where an arrival charge
+    /// lands before any tick closes the bucket.
+    fn open_bucket(mgr: &ResourceGroupManager, name: &str) -> u64 {
+        mgr.ru_trackers
+            .get(name)
+            .unwrap()
+            .lock()
+            .unwrap()
+            .0
+            .current_bucket
+            .load(Ordering::Relaxed)
+    }
+
+    /// The arrival cost is read from an `AtomicU64` cache rather than the
+    /// config lock, so the cache has to actually track the config.
+    #[test]
+    fn test_request_base_cost_follows_config() {
+        let mut cfg = Config::default();
+        cfg.request_base_cost_micros = 70;
+        let mgr = ResourceGroupManager::new(cfg);
+
+        let mut ctx = ResourceControlContext::default();
+        ctx.resource_group_name = DEFAULT_RESOURCE_GROUP_NAME.to_owned();
+        mgr.consume_penalty(&ctx, "");
+        assert_eq!(open_bucket(&mgr, DEFAULT_RESOURCE_GROUP_NAME), 70);
+
+        mgr.get_config()
+            .update::<_, _, ()>(|c| {
+                c.request_base_cost_micros = 0;
+                Ok(())
+            })
+            .unwrap();
+        mgr.refresh_cached_config();
+        mgr.consume_penalty(&ctx, "");
+        assert_eq!(
+            open_bucket(&mgr, DEFAULT_RESOURCE_GROUP_NAME),
+            70,
+            "0 disables the charge"
+        );
+    }
+
+    /// A background-routed request is metered by its background limiter, so
+    /// it must not also pay the arrival cost into the group's foreground
+    /// tracker -- the same rule `future.rs` applies to measured CPU.
+    #[test]
+    fn test_request_base_cost_skips_background_requests() {
+        let mut cfg = Config::default();
+        cfg.request_base_cost_micros = 50;
+        let mgr = ResourceGroupManager::new(cfg);
+        mgr.add_resource_group(new_background_resource_group_ru(
+            "bg".into(),
+            1000,
+            LOW_PRIORITY,
+            vec!["br".into()],
+        ));
+
+        let mut ctx = ResourceControlContext::default();
+        ctx.resource_group_name = "bg".to_owned();
+
+        // The source task name is the last `_`-separated segment, so this
+        // routes to the group's background limiter.
+        mgr.consume_penalty(&ctx, "external_Br_br");
+        assert!(
+            mgr.ru_trackers.get("bg").is_none(),
+            "a background request must not open a foreground tracker"
+        );
+
+        // Same group, a source that matches no configured job type.
+        mgr.consume_penalty(&ctx, "external_Select_stmt");
+        assert_eq!(open_bucket(&mgr, "bg"), 50);
+    }
+
+    /// A name that is not a configured group must not open a tracker of its
+    /// own, or every request can mint one.
+    #[test]
+    fn test_request_base_cost_of_unknown_group_lands_on_default() {
+        let mut cfg = Config::default();
+        cfg.request_base_cost_micros = 40;
+        let mgr = ResourceGroupManager::new(cfg);
+
+        let mut ctx = ResourceControlContext::default();
+        ctx.resource_group_name = "never-configured".to_owned();
+        mgr.consume_penalty(&ctx, "");
+
+        assert!(mgr.ru_trackers.get("never-configured").is_none());
+        assert_eq!(open_bucket(&mgr, DEFAULT_RESOURCE_GROUP_NAME), 40);
+    }
+
+    /// The slot's lock-free counter and the tracker inside its Mutex have to
+    /// be the same counter, or a tick would flush a bucket that never saw the
+    /// arrival charges.
+    #[test]
+    fn test_slot_counter_is_the_trackers_own() {
+        let mgr = ResourceGroupManager::default();
+        mgr.record_ru_consumption("g", 9);
+
+        let entry = mgr.ru_trackers.get("g").unwrap();
+        // Written without the lock, read through it.
+        assert_eq!(
+            entry
+                .lock()
+                .unwrap()
+                .0
+                .current_bucket
+                .load(Ordering::Relaxed),
+            9
+        );
+        // And the other way round.
+        entry.lock().unwrap().0.record(5);
+        assert_eq!(entry.open_bucket.load(Ordering::Relaxed), 14);
+
+        // A tick flushing the bucket must see both.
+        entry
+            .lock()
+            .unwrap()
+            .0
+            .advance(RuTracker::now_secs() + RU_BUCKET_SECS);
+        assert_eq!(entry.open_bucket.load(Ordering::Relaxed), 0);
+    }
+
+    /// `record_ru_consumption` takes a shared-read fast path when the group is
+    /// already there and falls back to `entry()` only to create one. Both
+    /// paths must accumulate into the same bucket.
+    #[test]
+    fn test_record_ru_consumption_creates_then_reuses_tracker() {
+        let mgr = ResourceGroupManager::default();
+        assert!(mgr.ru_trackers.get("g").is_none());
+
+        mgr.record_ru_consumption("g", 5);
+        assert_eq!(open_bucket(&mgr, "g"), 5);
+
+        mgr.record_ru_consumption("g", 7);
+        assert_eq!(open_bucket(&mgr, "g"), 12);
     }
 }

--- a/components/resource_control/src/resource_group.rs
+++ b/components/resource_control/src/resource_group.rs
@@ -5,10 +5,10 @@ use std::{
     cmp::{max, min},
     collections::HashSet,
     sync::{
-        atomic::{AtomicBool, AtomicU64, Ordering},
+        atomic::{AtomicBool, AtomicI64, AtomicU64, Ordering},
         Arc, Mutex,
     },
-    time::Duration,
+    time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
 use collections::HashMap;
@@ -27,7 +27,12 @@ use tikv_util::{
 };
 use yatp::queue::priority::TaskPriorityProvider;
 
-use crate::{config::Config, resource_limiter::ResourceLimiter};
+use crate::{
+    config::Config,
+    metrics,
+    metrics::{deregister_metrics, TWO_PHASE_THROTTLED_REQUESTS},
+    resource_limiter::{ResourceLimiter, ResourceType},
+};
 
 // a read task cost at least 50us.
 const DEFAULT_PRIORITY_PER_READ_TASK: u64 = 50;
@@ -51,9 +56,259 @@ const HIGH_PRIORITY: u32 = 16;
 // virtual time overflow.
 const RESET_VT_THRESHOLD: u64 = (u64::MAX >> 4) / 2;
 
+/// Duration of each bucket in the RuTracker ring buffer.
+const RU_BUCKET_SECS: u64 = 30;
+
+/// Sliding-window RU consumption tracker for both Tier-1 admission control
+/// and two-phase scheduling phase decisions.
+///
+/// Tracks actual CPU µs consumed (via `consume_penalty`) across reads and
+/// writes in a configurable ring buffer of 30-second buckets. Window size is
+/// set from `historical_usage_window_mins` (× 2 buckets per minute). Using real
+/// RU rather than virtual
+/// time avoids weight-skewing: a high-weight group accumulates VT faster
+/// without necessarily consuming more CPU.
+pub struct RuTracker {
+    /// Ring buffer of completed 30-second bucket totals (oldest at `head`).
+    buckets: Vec<u64>,
+    /// RU accumulated in the currently-open (incomplete) bucket.
+    /// Atomic so that `record_ru_consumption` can add without taking the Mutex.
+    current_bucket: AtomicU64,
+    /// Unix seconds at which the current bucket started.
+    bucket_start_secs: u64,
+    /// Index of the oldest completed bucket.
+    head: usize,
+    /// Number of completed buckets (≤ buckets.len()).
+    completed: usize,
+    /// Cached historical rate (RU/s), updated by `online_adjust_resource_quota`
+    /// every ~10s.
+    cached_historical_rate: f64,
+    /// Consecutive ramp-up epochs where new_limit >= 2x hist. Must reach
+    /// MIN_RAMP_UP_EPOCHS before the limit is fully lifted to INFINITY.
+    ramp_up_epochs: u32,
+}
+
+impl RuTracker {
+    /// Create a new tracker with `num_buckets` 30-second slots.
+    pub fn new(now_secs: u64, num_buckets: usize) -> Self {
+        let num_buckets = num_buckets.max(2); // need at least 2 to warm up
+        Self {
+            buckets: vec![0u64; num_buckets],
+            current_bucket: AtomicU64::new(0),
+            bucket_start_secs: now_secs,
+            head: 0,
+            completed: 0,
+            cached_historical_rate: 0.0,
+            ramp_up_epochs: 0,
+        }
+    }
+
+    pub fn now_secs() -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs()
+    }
+
+    #[inline]
+    fn num_buckets(&self) -> usize {
+        self.buckets.len()
+    }
+
+    /// Record `ru` in the current bucket (lock-free atomic add).
+    pub fn record(&self, ru: u64) {
+        self.current_bucket.fetch_add(ru, Ordering::Relaxed);
+    }
+
+    /// Advance to `now_secs` and record `ru`. Used by tests and callers
+    /// that hold exclusive access.
+    #[cfg(test)]
+    pub fn is_warmed_up(&self) -> bool {
+        self.completed >= 2
+    }
+
+    #[cfg(test)]
+    pub fn record_at(&mut self, ru: u64, now_secs: u64) {
+        self.advance(now_secs);
+        self.current_bucket.fetch_add(ru, Ordering::Relaxed);
+    }
+
+    fn advance(&mut self, now_secs: u64) {
+        let n = self.num_buckets();
+        let elapsed = now_secs.saturating_sub(self.bucket_start_secs);
+        let buckets_to_advance = (elapsed / RU_BUCKET_SECS) as usize;
+        if buckets_to_advance == 0 {
+            return;
+        }
+        if buckets_to_advance >= n {
+            // Gap larger than the window: everything aged out.
+            self.buckets.iter_mut().for_each(|b| *b = 0);
+            self.head = 0;
+            self.completed = 0;
+            self.current_bucket.store(0, Ordering::Relaxed);
+        } else {
+            // Commit the current bucket to the ring, then zero the rest.
+            let write_pos = (self.head + self.completed) % n;
+            self.buckets[write_pos] = self.current_bucket.swap(0, Ordering::Relaxed);
+            if self.completed < n {
+                self.completed += 1;
+            } else {
+                self.head = (self.head + 1) % n;
+            }
+            // Zero out the remaining (buckets_to_advance - 1) slots.
+            for _ in 1..buckets_to_advance {
+                let slot = (self.head + self.completed) % n;
+                self.buckets[slot] = 0;
+                if self.completed < n {
+                    self.completed += 1;
+                } else {
+                    self.head = (self.head + 1) % n;
+                }
+            }
+        }
+        self.bucket_start_secs += buckets_to_advance as u64 * RU_BUCKET_SECS;
+    }
+
+    /// RU/s rate estimated from the current partial bucket and the most recent
+    /// completed bucket. Using both avoids stale readings — the last completed
+    /// bucket alone can be up to 60s old at the end of the current 30s window.
+    ///
+    /// rate = (current_bucket + last_completed) / (elapsed_in_current + 30s)
+    pub fn current_rate(&self, now_secs: u64) -> f64 {
+        let elapsed = now_secs
+            .saturating_sub(self.bucket_start_secs)
+            .min(RU_BUCKET_SECS) as f64;
+        let last_completed = if self.completed > 0 {
+            let newest_slot = (self.head + self.completed - 1) % self.num_buckets();
+            self.buckets[newest_slot]
+        } else {
+            0
+        };
+        let window = elapsed + RU_BUCKET_SECS as f64;
+        (self.current_bucket.load(Ordering::Relaxed) + last_completed) as f64 / window
+    }
+
+    /// Average RU/s rate over all completed buckets (long-term baseline).
+    /// Average RU/s baseline. If the system has been up longer than the full
+    /// historical window, always divide by the full window (not just completed
+    /// buckets). This means a tracker that just started (e.g. spike with no
+    /// prior traffic) has historical=0 and any traffic is immediately detected
+    /// as over baseline, rather than letting new traffic inflate its own
+    /// baseline.
+    pub fn historical_rate(&self, system_start_secs: u64, now_secs: u64) -> f64 {
+        let window_secs = self.num_buckets() as u64 * RU_BUCKET_SECS;
+        let system_uptime = now_secs.saturating_sub(system_start_secs);
+        if system_uptime >= window_secs {
+            // System older than window — use full window as denominator.
+            // Missing buckets count as zero, diluting any fresh traffic.
+            if self.completed == 0 {
+                return 0.0;
+            }
+            let total: u64 = self.buckets.iter().take(self.completed).sum();
+            total as f64 / (self.num_buckets() as f64 * RU_BUCKET_SECS as f64)
+        } else {
+            if self.completed == 0 {
+                return 0.0;
+            }
+            let total: u64 = self.buckets.iter().take(self.completed).sum();
+            // Divide by elapsed system uptime (not just filled buckets) so the
+            // historical rate ramps up smoothly rather than jumping immediately
+            // to the full rate after the first bucket completes.
+            let denom = (system_uptime as f64).max(RU_BUCKET_SECS as f64);
+            total as f64 / denom
+        }
+    }
+
+    /// Returns true if no RU has been recorded: all completed buckets and the
+    /// current bucket are zero. Used to garbage-collect stale ru_trackers
+    /// entries.
+    pub fn is_idle(&self) -> bool {
+        self.current_bucket.load(Ordering::Relaxed) == 0 && self.buckets.iter().all(|&b| b == 0)
+    }
+
+    /// Refresh the cached historical rate. Called periodically from
+    /// `online_adjust_resource_quota` (~every 10s) so the inline hot path
+    /// avoids iterating all buckets.
+    pub fn refresh_cached_historical_rate(&mut self, system_start_secs: u64, now_secs: u64) {
+        self.cached_historical_rate = self.historical_rate(system_start_secs, now_secs);
+    }
+}
+
+/// Encodes a two-phase scheduling priority.
+///
+/// Bit position of the phase bit within the 64-bit encoded priority.
+/// Format: `[4-bit group_priority | 1-bit phase | 59-bit tag]`
+const PRIORITY_TAG_BITS: u32 = 59;
+
+/// Whether a task is within or over its historical RU baseline.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PriorityPhase {
+    /// Within baseline — given scheduling preference over phase-1 tasks.
+    WithinBaseline = 0,
+    /// Over baseline — deprioritised relative to within-baseline tasks.
+    OverBaseline = 1,
+}
+
+/// Format: `[4-bit group_priority | 1-bit phase | 59-bit tag]`
+///
+/// Phase 0 (within baseline) always sorts before phase 1 (over baseline)
+/// within the same group priority tier. Using only 1 bit for phase leaves
+/// 59 bits for the VT tag, matching `RESET_VT_THRESHOLD` (`2^59`).
+fn encode_two_phase_priority(group_priority: u32, phase: PriorityPhase, tag: u64) -> u64 {
+    assert!((1..=16).contains(&group_priority));
+    let tag = tag & ((1u64 << PRIORITY_TAG_BITS) - 1);
+    let phase_bit = (phase as u64) << PRIORITY_TAG_BITS;
+    (!((group_priority - 1) as u64) << 60) | phase_bit | tag
+}
+
+/// Returns true if the encoded priority value represents a phase-1 task.
+#[inline]
+fn is_phase1(priority: u64) -> bool {
+    (priority >> PRIORITY_TAG_BITS) & 1 == 1
+}
 pub enum ResourceConsumeType {
     CpuTime(Duration),
     IoBytes(u64),
+}
+
+/// Result of the Tier-1 admission control check for a single request.
+#[derive(Debug, PartialEq)]
+pub enum AdmissionDecision {
+    /// No throttling needed; let the request proceed immediately.
+    Allow,
+    /// Delay the request by the given duration. The caller **must** call
+    /// [`ResourceGroupManager::release_delay_slot`] once the delay is over
+    /// (or the delayed future is dropped/cancelled).
+    Delay(Duration),
+    /// Reject the request outright (SchedTooBusy). Returned when the number
+    /// of concurrently delayed requests exceeds `admission_max_delayed_count`.
+    Reject,
+}
+
+/// RAII guard that releases an admission-control delay slot on drop.
+/// Ensures the `delayed_req_count` counter is decremented even if the
+/// future is cancelled during the sleep.
+pub struct DelaySlotGuard {
+    mgr: Option<Arc<ResourceGroupManager>>,
+}
+
+impl DelaySlotGuard {
+    fn new(mgr: Arc<ResourceGroupManager>) -> Self {
+        Self { mgr: Some(mgr) }
+    }
+
+    /// Explicitly release the slot and disarm the guard so Drop is a no-op.
+    pub fn release(&mut self) {
+        if let Some(mgr) = self.mgr.take() {
+            mgr.release_delay_slot();
+        }
+    }
+}
+
+impl Drop for DelaySlotGuard {
+    fn drop(&mut self) {
+        self.release();
+    }
 }
 
 /// ResourceGroupManager manages the metadata of each resource group.
@@ -69,6 +324,23 @@ pub struct ResourceGroupManager {
     has_background: AtomicBool,
     // lastest config.
     config: Arc<VersionTrack<Config>>,
+    // Per-group RU consumption trackers for Tier-1 high-priority throttling.
+    // Per-group sliding-window tracker and token-bucket limiter.
+    // Rate on the limiter is set to `fraction × historical_rate` each tick.
+    // The Arc allows handing out limiter references to LimitedFuture wrappers
+    // in the read/write pools without copying the limiter state.
+    ru_trackers: DashMap<String, Mutex<(RuTracker, Arc<ResourceLimiter>)>>,
+    // Number of requests currently held in the admission-control delay phase.
+    delayed_req_count: AtomicI64,
+    // Unix seconds when this manager was created. Used to determine whether
+    // the system has been up long enough that new trackers should be treated
+    // as if they missed the entire historical window (baseline = 0).
+    start_secs: u64,
+    // True when background CPU budget is at the minimum floor (1 core) AND
+    // background consumption is within that floor. Foreground throttling
+    // only engages when this flag is set, ensuring background is fully
+    // squeezed before foreground traffic is touched.
+    bg_cpu_at_floor: AtomicBool,
 }
 
 impl Default for ResourceGroupManager {
@@ -99,10 +371,14 @@ impl ResourceGroupManager {
             resource_groups: Default::default(),
             group_count: AtomicU64::new(0),
             registry: Default::default(),
+            delayed_req_count: AtomicI64::new(0),
             priority_limiters,
             bg_limiter,
             has_background: AtomicBool::new(false),
             config: Arc::new(VersionTrack::new(config)),
+            ru_trackers: Default::default(),
+            start_secs: RuTracker::now_secs(),
+            bg_cpu_at_floor: AtomicBool::new(false),
         };
 
         // init the default resource group by default.
@@ -210,6 +486,7 @@ impl ResourceGroupManager {
         if self.resource_groups.remove(&group_name).is_some() {
             info!("remove resource group"; "name"=> name);
             self.group_count.fetch_sub(1, Ordering::Relaxed);
+            deregister_metrics(&group_name);
         }
         self.update_has_background();
     }
@@ -255,7 +532,7 @@ impl ResourceGroupManager {
     }
 
     pub fn derive_controller(&self, name: String, is_read: bool) -> Arc<ResourceController> {
-        let controller = Arc::new(ResourceController::new(name, is_read));
+        let controller = Arc::new(ResourceController::new(name, is_read, self.config.clone()));
         self.registry.write().push(controller.clone());
         for g in &self.resource_groups {
             let ru_quota = Self::get_ru_setting(&g.value().group, controller.is_read);
@@ -266,8 +543,36 @@ impl ResourceGroupManager {
     }
 
     pub fn advance_min_virtual_time(&self) {
+        // Push RU-based phase state into every controller before updating VT,
+        // so get_priority() sees fresh is_over_baseline flags this tick.
+        if self.config.value().enable_fair_scheduling {
+            self.update_group_phases();
+        }
         for controller in self.registry.read().iter() {
             controller.update_min_virtual_time();
+        }
+    }
+
+    /// Iterates all tracked groups and pushes `is_over_baseline` into each
+    /// registered `ResourceController`.  Called every ~1 second from
+    /// `advance_min_virtual_time` when `enable_fair_scheduling` is on.
+    fn update_group_phases(&self) {
+        let now_secs = RuTracker::now_secs();
+        for entry in &self.ru_trackers {
+            let group_bytes = entry.key().as_bytes();
+            let mut guard = entry.value().lock().unwrap();
+            // Roll the ring buffer forward so phase classification uses
+            // up-to-date bucket boundaries, not stale partial data.
+            guard.0.advance(now_secs);
+            let over = guard
+                .1
+                .get_limiter(ResourceType::Cpu)
+                .get_rate_limit()
+                .is_finite();
+            drop(guard);
+            for controller in self.registry.read().iter() {
+                controller.set_group_phase(group_bytes, over);
+            }
         }
     }
 
@@ -288,51 +593,347 @@ impl ResourceGroupManager {
                 ResourceConsumeType::IoBytes(ctx.get_penalty().write_bytes as u64),
             );
         }
+        // RU tracking for foreground admission control is handled by
+        // LimitedFuture (measure-only mode) which calls record_ru_consumption
+        // with actual CPU measured per poll.
     }
 
-    // only enable priority quota limiter when there is at least 1 user-defined
-    // resource group.
-    #[inline]
-    fn enable_priority_limiter(&self) -> bool {
-        // TODO: reenable it once when we fix https://github.com/tikv/tikv/issues/18939
-        // self.get_group_count() > 1
-        false
+    /// Record `ru` units consumed by `group` into the sliding-window tracker
+    /// and consume tokens from the group's rate limiter.
+    pub fn record_ru_consumption(&self, group: &str, ru: u64) {
+        let now = RuTracker::now_secs();
+        // 2 buckets per minute (30s each) to match RU_BUCKET_SECS.
+        let num_buckets = (self.config.value().historical_usage_window_mins.max(2) as usize) * 2;
+        let entry = self.ru_trackers.entry(group.to_owned()).or_insert_with(|| {
+            Mutex::new((
+                RuTracker::new(now, num_buckets),
+                Arc::new(ResourceLimiter::new(
+                    group.to_owned(),
+                    f64::INFINITY,
+                    f64::INFINITY,
+                    0,
+                    false,
+                )),
+            ))
+        });
+        // Lock-free: only atomically adds to current_bucket.
+        // advance() is called separately by online_adjust_resource_quota under the
+        // lock.
+        entry.lock().unwrap().0.record(ru);
     }
 
-    // Always return the background resource limiter if any;
-    // Only return the foregroup limiter when priority is enabled.
+    /// Called by `PriorityLimiterAdjustWorker` every ~1 second with the
+    /// latest process-level CPU utilisation percentage.
+    ///
+    /// Throttle-down: linearly reduces the allowed fraction of historical rate
+    /// for groups that are over their baseline. At `fg_cpu_throttle_threshold`
+    /// (70%) fraction = 1.0 (no throttle), at 90% CPU fraction = 0.8
+    /// (target). Called by the background adjust worker after computing the
+    /// new background CPU budget. `at_floor` should be true when the budget
+    /// has been clamped to the minimum floor AND background consumption
+    /// is within that floor.
+    pub fn set_bg_cpu_at_floor(&self, at_floor: bool) {
+        self.bg_cpu_at_floor.store(at_floor, Ordering::Relaxed);
+    }
+
+    /// Returns true when background CPU is fully throttled (at floor)
+    /// and its consumption is within the floor budget.
+    pub fn is_bg_cpu_at_floor(&self) -> bool {
+        self.bg_cpu_at_floor.load(Ordering::Relaxed)
+    }
+
+    /// Returns true when all foreground groups have unlimited (infinite)
+    /// CPU rate limits, i.e. foreground has fully ramped up.
+    pub fn is_foreground_fully_ramped_up(&self) -> bool {
+        for entry in &self.ru_trackers {
+            let guard = entry.lock().unwrap();
+            if guard
+                .1
+                .get_limiter(ResourceType::Cpu)
+                .get_rate_limit()
+                .is_finite()
+            {
+                return false;
+            }
+        }
+        true
+    }
+
+    /// Only groups whose current rate exceeds their historical rate are
+    /// limited.
+    ///
+    /// Ramp-up: when CPU drops below threshold, recover ×1.1/tick until
+    /// NO_LIMIT is restored.
+    pub fn online_adjust_resource_quota(&self, pct: f64) {
+        const TARGET_CPU: f64 = 90.0;
+        const RAMP_FACTOR: f64 = 1.2;
+        const MIN_RAMP_UP_EPOCHS: u32 = 2;
+
+        let throttle_threshold = self.config.value().fg_cpu_throttle_threshold;
+        let leeway_threshold = throttle_threshold * 0.9;
+        let burst_factor = 1.0 + self.config.value().baseline_burst_pct / 100.0;
+        let now = RuTracker::now_secs();
+
+        // Advance all trackers to `now` and refresh cached historical rates
+        // up front so update_group_phases and the throttling logic below
+        // always see fresh baseline data.
+        for entry in &self.ru_trackers {
+            let mut guard = entry.lock().unwrap();
+            guard.0.advance(now);
+            guard.0.refresh_cached_historical_rate(self.start_secs, now);
+            let name = guard.1.name();
+
+            metrics::GROUP_RU_HISTORICAL_RATE
+                .with_label_values(&[name])
+                .set((guard.0.cached_historical_rate / 1_000_000.0) * 100.0);
+            metrics::GROUP_RU_CURRENT_RATE
+                .with_label_values(&[name])
+                .set((guard.0.current_rate(now) / 1_000_000.0) * 100.0);
+        }
+
+        if pct > throttle_threshold && self.is_bg_cpu_at_floor() {
+            // Linearly scale limit from current rate (at threshold) down to
+            // historical rate (at TARGET_CPU).
+            // pressure: 0.0 at threshold → 1.0 at TARGET_CPU.
+            let pressure =
+                ((pct - throttle_threshold) / (TARGET_CPU - throttle_threshold)).clamp(0.0, 1.0);
+
+            for entry in &self.ru_trackers {
+                let mut guard = entry.lock().unwrap();
+                let hist = guard.0.cached_historical_rate;
+                let current = guard.0.current_rate(now);
+                let burst_target = hist * burst_factor;
+                if hist > 0.0 && current > burst_target {
+                    // rate slides from current (pressure=0) to burst_target (pressure=1).
+                    let rate = current + (burst_target - current) * pressure;
+                    let current_limit = guard.1.get_limiter(ResourceType::Cpu).get_rate_limit();
+                    // Only tighten the limit — never loosen in the throttle branch.
+                    // Ramp-up is the only path that increases limits.
+                    if current_limit.is_infinite() || rate < current_limit {
+                        guard.0.ramp_up_epochs = 0;
+                        guard
+                            .1
+                            .get_limiter(ResourceType::Cpu)
+                            .set_rate_limit(rate.max(1.0));
+                    }
+                }
+            }
+        } else if pct < leeway_threshold {
+            // CPU below start threshold — ramp up by RAMP_FACTOR each tick.
+            // Only lift to INFINITY after MIN_RAMP_UP_EPOCHS consecutive epochs
+            // where the limit has grown past 2x hist, to avoid premature release.
+            for entry in &self.ru_trackers {
+                let mut guard = entry.lock().unwrap();
+                let current_limit = guard.1.get_limiter(ResourceType::Cpu).get_rate_limit();
+                if current_limit.is_finite() {
+                    let hist = guard.0.cached_historical_rate;
+                    let new_limit = current_limit * RAMP_FACTOR;
+                    if hist <= 0.0 || new_limit >= 2.0 * hist {
+                        guard.0.ramp_up_epochs += 1;
+                        if guard.0.ramp_up_epochs >= MIN_RAMP_UP_EPOCHS {
+                            guard.0.ramp_up_epochs = 0;
+                            guard
+                                .1
+                                .get_limiter(ResourceType::Cpu)
+                                .set_rate_limit(f64::INFINITY);
+                        }
+                    } else {
+                        guard.0.ramp_up_epochs = 0;
+                        guard
+                            .1
+                            .get_limiter(ResourceType::Cpu)
+                            .set_rate_limit(new_limit);
+                    }
+                }
+            }
+        }
+
+        // Emit current rate limit per resource group.
+        for entry in &self.ru_trackers {
+            let guard = entry.lock().unwrap();
+            let limit = guard.1.get_limiter(ResourceType::Cpu).get_rate_limit();
+            let val = if limit.is_finite() {
+                (limit / 1_000_000.0) * 100.0
+            } else {
+                0.0
+            };
+            metrics::GROUP_QUOTA_LIMIT_VEC
+                .with_label_values(&[guard.1.name(), "cpu"])
+                .set(val);
+        }
+
+        // Evict idle ru_trackers entries to prevent unbounded growth from
+        // removed or renamed groups. Advance first so stale partial buckets
+        // are flushed before the idle check.
+        self.ru_trackers.retain(|_, entry| {
+            let inner = entry.get_mut().unwrap();
+            inner.0.advance(now);
+            !inner.0.is_idle()
+        });
+    }
+
+    /// Returns the token-bucket debt delay for `group`, or `None` if no
+    /// throttling is active.
+    ///
+    /// Conditions for a non-zero delay (all must hold):
+    ///   1. `enable_read_admission_control` / `enable_write_admission_control`
+    ///      on
+    ///   2. Rate-limit is active (not NO_LIMIT sentinel)
+    ///   3. Tracker has warmed up (≥2 completed 1-min buckets)
+    ///   4. Token-bucket has accumulated debt (group exceeded its allowed rate)
+    pub fn compute_admission_delay(
+        &self,
+        resource_limiter: &ResourceLimiter,
+        is_read: bool,
+    ) -> Option<Duration> {
+        // Always consume tokens so the token-bucket debt stays accurate
+        // for scheduling decisions. Only return the delay when admission
+        // control is enabled (or for background limiters, always).
+        let delay = resource_limiter.admission_delay(is_read);
+        if !resource_limiter.is_background() {
+            let config = self.config.value();
+            let ac_enabled = if is_read {
+                config.enable_read_admission_control
+            } else {
+                config.enable_write_admission_control
+            };
+            if !ac_enabled {
+                return None;
+            }
+        }
+        if delay.is_zero() { None } else { Some(delay) }
+    }
+
+    /// Unified admission-control decision for a request from `group`.
+    ///
+    /// Combines token-bucket rate-limiter debt (`resource_limiter`) with
+    /// RU-baseline overage delay into a single pre-pool sleep duration.
+    /// Covers background, low-priority, and resource-group throttling for
+    /// both reads (`is_read=true`) and writes (`is_read=false`).
+    ///
+    /// Returns:
+    /// - [`AdmissionDecision::Allow`] — no throttling needed.
+    /// - [`AdmissionDecision::Delay(d)`] — caller should sleep `d` then
+    ///   proceed, and **must** call [`release_delay_slot`] afterwards.
+    /// - [`AdmissionDecision::Reject`] — too many requests are already delayed;
+    ///   reject immediately.
+    pub fn admission_decision(
+        &self,
+        is_read: bool,
+        resource_limiter: &ResourceLimiter,
+    ) -> AdmissionDecision {
+        let group = resource_limiter.name();
+        let delay = self
+            .compute_admission_delay(resource_limiter, is_read)
+            .unwrap_or(std::time::Duration::ZERO);
+        if delay.is_zero() {
+            return AdmissionDecision::Allow;
+        }
+        let metric_label = if resource_limiter.is_background() {
+            "background"
+        } else {
+            group
+        };
+        let max = self.config.value().admission_max_delayed_count;
+        let prev = self.delayed_req_count.fetch_add(1, Ordering::Relaxed);
+        metrics::ADMISSION_CURRENTLY_DELAYED.set(prev + 1);
+        if max > 0 && prev >= max as i64 {
+            self.delayed_req_count.fetch_sub(1, Ordering::Relaxed);
+            metrics::ADMISSION_CURRENTLY_DELAYED.set(prev);
+            crate::metrics::ADMISSION_REJECTED_REQUESTS
+                .with_label_values(&[metric_label])
+                .inc();
+            return AdmissionDecision::Reject;
+        }
+        crate::metrics::ADMISSION_DELAYED_REQUESTS
+            .with_label_values(&[metric_label])
+            .inc();
+        crate::metrics::ADMISSION_DELAY_DURATION
+            .with_label_values(&[metric_label])
+            .observe(delay.as_secs_f64());
+        AdmissionDecision::Delay(delay)
+    }
+
+    /// Release a delay slot acquired by [`admission_decision`] returning
+    /// [`AdmissionDecision::Delay`]. Must be called exactly once per `Delay`
+    /// decision, whether the request completes normally or is cancelled.
+    pub fn release_delay_slot(&self) {
+        let prev = self.delayed_req_count.fetch_sub(1, Ordering::Relaxed);
+        metrics::ADMISSION_CURRENTLY_DELAYED.set(prev - 1);
+    }
+
+    /// Returns an RAII guard that calls [`release_delay_slot`] on drop.
+    /// Use this to ensure the slot is released even if the future is
+    /// cancelled during the admission-control sleep.
+    pub fn delay_slot_guard(self: &Arc<Self>) -> DelaySlotGuard {
+        DelaySlotGuard::new(Arc::clone(self))
+    }
+
+    /// Returns the per-group admission-control limiter for `group`, creating
+    /// the entry if it does not yet exist. Used by `with_resource_limiter`
+    /// (measure-only mode) in the read/write pools so `LimitedFuture` can
+    /// build token-bucket debt for pre-pool `admission_decision`.
+    pub fn get_foreground_group_limiter(&self, group: &str) -> Arc<ResourceLimiter> {
+        let now = RuTracker::now_secs();
+        // 2 buckets per minute (30s each) to match RU_BUCKET_SECS.
+        let num_buckets = (self.config.value().historical_usage_window_mins.max(2) as usize) * 2;
+        self.ru_trackers
+            .entry(group.to_owned())
+            .or_insert_with(|| {
+                Mutex::new((
+                    RuTracker::new(now, num_buckets),
+                    Arc::new(ResourceLimiter::new(
+                        group.to_owned(),
+                        f64::INFINITY,
+                        f64::INFINITY,
+                        0,
+                        false,
+                    )),
+                ))
+            })
+            .lock()
+            .unwrap()
+            .1
+            .clone()
+    }
+
+    /// Returns the appropriate `ResourceLimiter` for `with_resource_limiter`:
+    /// - Background tasks → background limiter
+    /// - Foreground tasks (any priority) → per-group limiter from `ru_trackers`
     pub fn get_resource_limiter(
         &self,
         rg: &str,
         request_source: &str,
-        override_priority: u64,
+        _override_priority: u64,
     ) -> Option<Arc<ResourceLimiter>> {
-        let (limiter, group_priority) =
-            self.get_background_resource_limiter_with_priority(rg, request_source);
+        let (limiter, _) = self.get_background_resource_limiter_with_priority(rg, request_source);
         if limiter.is_some() {
             return limiter;
         }
-
-        // if there is only 1 resource group, priority quota limiter is useless so just
-        // return None for better performance.
-        if !self.enable_priority_limiter() {
+        if self.get_group_count() <= 1 {
             return None;
         }
-
-        // request priority has higher priority, 0 means priority is not set.
-        let mut task_priority = override_priority as u32;
-        if task_priority == 0 {
-            task_priority = group_priority;
-        }
-        Some(self.priority_limiters[TaskPriority::from(task_priority) as usize].clone())
+        // Only create a foreground limiter for known groups; unknown or removed
+        // groups fall back to "default" to avoid leaking ru_trackers entries.
+        let group_name = if self.resource_groups.contains_key(rg) {
+            rg
+        } else {
+            DEFAULT_RESOURCE_GROUP_NAME
+        };
+        Some(self.get_foreground_group_limiter(group_name))
     }
 
     // return a ResourceLimiter for background tasks only.
+    // Returns None if request_source does not match a configured background job
+    // type.
     pub fn get_background_resource_limiter(
         &self,
         rg: &str,
         request_source: &str,
     ) -> Option<Arc<ResourceLimiter>> {
+        if request_source.is_empty() {
+            return None;
+        }
         self.get_background_resource_limiter_with_priority(rg, request_source)
             .0
     }
@@ -469,6 +1070,8 @@ pub struct ResourceController {
     customized: AtomicBool,
     // whether any resource group has background settings configured
     has_background: AtomicBool,
+    // Shared config. Read on the hot path to check enable_fair_scheduling.
+    config: Arc<VersionTrack<Config>>,
 }
 
 // we are ensure to visit the `last_rest_vt_time` by only 1 thread so it's
@@ -477,7 +1080,7 @@ unsafe impl Send for ResourceController {}
 unsafe impl Sync for ResourceController {}
 
 impl ResourceController {
-    fn new(name: String, is_read: bool) -> Self {
+    fn new(name: String, is_read: bool, config: Arc<VersionTrack<Config>>) -> Self {
         Self {
             name,
             is_read,
@@ -487,11 +1090,16 @@ impl ResourceController {
             last_rest_vt_time: Cell::new(Instant::now_coarse()),
             customized: AtomicBool::new(false),
             has_background: AtomicBool::new(false),
+            config,
         }
     }
 
     pub fn new_for_test(name: String, is_read: bool) -> Self {
-        let controller = Self::new(name, is_read);
+        let controller = Self::new(
+            name,
+            is_read,
+            Arc::new(VersionTrack::new(Config::default())),
+        );
         // add the "default" resource group.
         controller.add_resource_group(
             DEFAULT_RESOURCE_GROUP_NAME.as_bytes().to_owned(),
@@ -548,6 +1156,9 @@ impl ResourceController {
             weight,
             virtual_time: AtomicU64::new(self.last_min_vt.load(Ordering::Acquire)),
             vt_delta_for_get,
+            // New groups start in phase 0; ResourceGroupManager updates this
+            // each second once the RuTracker has enough history.
+            is_over_baseline: AtomicBool::new(false),
         };
 
         // maybe update existed group
@@ -617,6 +1228,17 @@ impl ResourceController {
         self.resource_group(name).consume(resource)
     }
 
+    /// Updates the two-phase `is_over_baseline` flag for a single group.
+    /// Called each second by `ResourceGroupManager::update_group_phases`.
+    pub fn set_group_phase(&self, group: &[u8], over_baseline: bool) {
+        let consumptions = self.resource_consumptions.read();
+        if let Some(tracker) = consumptions.get(group) {
+            tracker
+                .is_over_baseline
+                .store(over_baseline, Ordering::Relaxed);
+        }
+    }
+
     pub fn update_min_virtual_time(&self) {
         let start = Instant::now_coarse();
         let mut min_vt = u64::MAX;
@@ -669,7 +1291,8 @@ impl ResourceController {
 
     pub fn get_priority(&self, name: &[u8], pri: CommandPri) -> u64 {
         let level = Self::command_pri_to_level(pri);
-        self.resource_group(name).get_priority(level, None, true)
+        self.resource_group(name)
+            .get_priority(level, None, true, self.is_two_phase_enabled())
     }
 
     /// Returns the priority for the given task metadata without incrementing
@@ -682,7 +1305,14 @@ impl ResourceController {
         } else {
             Some(metadata.override_priority())
         };
-        group.get_priority(level, override_priority, false)
+        group.get_priority(level, override_priority, false, self.is_two_phase_enabled())
+    }
+
+    /// Returns true when fair two-phase scheduling is active (read controller
+    /// with enable_fair_scheduling enabled).
+    #[inline]
+    fn is_two_phase_enabled(&self) -> bool {
+        self.is_read && self.config.value().enable_fair_scheduling
     }
 
     fn command_pri_to_level(pri: CommandPri) -> usize {
@@ -697,7 +1327,7 @@ impl ResourceController {
 impl TaskPriorityProvider for ResourceController {
     fn priority_of(&self, extras: &yatp::queue::Extras) -> u64 {
         let metadata = TaskMetadata::from(extras.metadata());
-        self.resource_group(metadata.group_name()).get_priority(
+        let p = self.resource_group(metadata.group_name()).get_priority(
             extras.current_level() as usize,
             if metadata.override_priority() == 0 {
                 None
@@ -705,7 +1335,16 @@ impl TaskPriorityProvider for ResourceController {
                 Some(metadata.override_priority())
             },
             true,
-        )
+            self.is_two_phase_enabled(),
+        );
+        if is_phase1(p)
+            && let Ok(name) = std::str::from_utf8(metadata.group_name())
+        {
+            TWO_PHASE_THROTTLED_REQUESTS
+                .with_label_values(&[name])
+                .inc();
+        }
+        p
     }
 }
 
@@ -726,24 +1365,47 @@ struct GroupPriorityTracker {
     virtual_time: AtomicU64,
     // the constant delta value for each `get_priority` call,
     vt_delta_for_get: u64,
+    // Two-phase scheduling: true when this group's current-minute RU rate
+    // exceeds its historical baseline (set by ResourceGroupManager each second).
+    // Phase 1 tasks are deprioritised relative to phase-0 (within-baseline) tasks.
+    is_over_baseline: AtomicBool,
 }
 
 impl GroupPriorityTracker {
     /// Computes the scheduling priority for a task at the given level.
+    ///
     /// When `advance_vt` is true, atomically increments the virtual time
     /// (used when actually scheduling a task). When false, reads virtual
     /// time without advancing it (used for priority comparison only).
-    fn get_priority(&self, level: usize, override_priority: Option<u32>, advance_vt: bool) -> u64 {
+    ///
+    /// When `two_phase` is true and `is_over_baseline` is set, the task is
+    /// placed in phase 1 (deprioritised); otherwise it runs in phase 0.
+    /// `is_over_baseline` is updated each second by `ResourceGroupManager`
+    /// from real CPU µs tracked across reads and writes via `consume_penalty`.
+    fn get_priority(
+        &self,
+        level: usize,
+        override_priority: Option<u32>,
+        advance_vt: bool,
+        two_phase: bool,
+    ) -> u64 {
         let task_extra_priority = TASK_EXTRA_FACTOR_BY_LEVEL[level] * 1000 * self.weight;
-        let vt = (if advance_vt && self.vt_delta_for_get > 0 {
-            self.virtual_time
-                .fetch_add(self.vt_delta_for_get, Ordering::Relaxed)
-                + self.vt_delta_for_get
-        } else {
-            self.virtual_time.load(Ordering::Relaxed) + self.vt_delta_for_get
-        }) + task_extra_priority;
         let priority = override_priority.unwrap_or(self.group_priority);
-        concat_priority_vt(priority, vt)
+        let vt_delta = self.vt_delta_for_get;
+
+        let vt = if advance_vt && vt_delta > 0 {
+            self.virtual_time.fetch_add(vt_delta, Ordering::Relaxed) + vt_delta
+        } else {
+            self.virtual_time.load(Ordering::Relaxed) + vt_delta
+        } + task_extra_priority;
+
+        if two_phase && self.is_over_baseline.load(Ordering::Relaxed) {
+            encode_two_phase_priority(priority, PriorityPhase::OverBaseline, vt)
+        } else if two_phase {
+            encode_two_phase_priority(priority, PriorityPhase::WithinBaseline, vt)
+        } else {
+            concat_priority_vt(priority, vt)
+        }
     }
 
     #[inline]
@@ -774,6 +1436,7 @@ impl GroupPriorityTracker {
 
 #[cfg(test)]
 pub(crate) mod tests {
+    use file_system::IoBytes;
     use yatp::queue::Extras;
 
     use super::*;
@@ -1256,6 +1919,150 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn test_encode_two_phase_priority_ordering() {
+        // Phase 0 (reservation) must sort before phase 1 (weight) for the
+        // same group_priority and a larger tag value.
+        let phase0 =
+            encode_two_phase_priority(MEDIUM_PRIORITY, PriorityPhase::WithinBaseline, 9999);
+        let phase1 = encode_two_phase_priority(MEDIUM_PRIORITY, PriorityPhase::OverBaseline, 1);
+        assert!(
+            phase0 < phase1,
+            "phase 0 must be higher priority than phase 1"
+        );
+
+        // Within phase 0, lower tag = higher priority.
+        let p0_low = encode_two_phase_priority(MEDIUM_PRIORITY, PriorityPhase::WithinBaseline, 100);
+        let p0_high =
+            encode_two_phase_priority(MEDIUM_PRIORITY, PriorityPhase::WithinBaseline, 200);
+        assert!(p0_low < p0_high);
+
+        // group_priority still dominates across phases.
+        let high_phase1 =
+            encode_two_phase_priority(HIGH_PRIORITY, PriorityPhase::OverBaseline, u64::MAX >> 8);
+        let low_phase0 = encode_two_phase_priority(LOW_PRIORITY, PriorityPhase::WithinBaseline, 0);
+        assert!(high_phase1 < low_phase0);
+    }
+
+    #[test]
+    fn test_two_phase_scheduling_ru_based() {
+        // Two-phase scheduling driven by real RU (CPU µs) from ResourceGroupManager.
+        let mut cfg = Config::default();
+        cfg.enable_fair_scheduling = true;
+        let mgr = ResourceGroupManager::new(cfg);
+
+        let steady = new_resource_group_ru("steady".into(), 1000, MEDIUM_PRIORITY);
+        let spike = new_resource_group_ru("spike".into(), 1000, MEDIUM_PRIORITY);
+        mgr.add_resource_group(steady);
+        mgr.add_resource_group(spike);
+
+        let ctl = mgr.derive_controller("read".into(), true);
+
+        // Warm up steady's RuTracker: 2 completed 30s buckets with consistent rate.
+        let t0 = RuTracker::now_secs();
+        {
+            let e = mgr
+                .ru_trackers
+                .entry("steady".to_owned())
+                .or_insert_with(|| {
+                    Mutex::new((
+                        RuTracker::new(t0, 30),
+                        Arc::new(ResourceLimiter::new(
+                            "".into(),
+                            f64::INFINITY,
+                            f64::INFINITY,
+                            0,
+                            false,
+                        )),
+                    ))
+                });
+            let mut tr = e.lock().unwrap();
+            tr.0.record_at(6000, t0 + 15);
+            tr.0.record_at(0, t0 + 30); // close bucket 0: 6000 µs
+            tr.0.record_at(6000, t0 + 45);
+            tr.0.record_at(0, t0 + 60); // close bucket 1: 6000 µs → stable baseline
+        }
+        // "spike" has no tracker → is_over_baseline stays false (no history).
+
+        // Push phases into controller.
+        mgr.advance_min_virtual_time();
+
+        // steady: both buckets equal → current_rate == historical_rate → NOT over
+        // baseline. spike: no tracker → also not over baseline.
+        // Neither should be in phase 1 at steady state.
+        {
+            let groups = ctl.resource_consumptions.read();
+            let steady_over = groups
+                .get(b"steady".as_ref())
+                .unwrap()
+                .is_over_baseline
+                .load(Ordering::Relaxed);
+            let spike_over = groups
+                .get(b"spike".as_ref())
+                .unwrap()
+                .is_over_baseline
+                .load(Ordering::Relaxed);
+            assert!(!steady_over, "steady at baseline should be phase 0");
+            assert!(!spike_over, "spike with no history should be phase 0");
+        }
+
+        // Now simulate a spike for "spike": current bucket >> historical.
+        {
+            let e = mgr
+                .ru_trackers
+                .entry("spike".to_owned())
+                .or_insert_with(|| {
+                    Mutex::new((
+                        RuTracker::new(t0, 30),
+                        Arc::new(ResourceLimiter::new(
+                            "".into(),
+                            f64::INFINITY,
+                            f64::INFINITY,
+                            0,
+                            false,
+                        )),
+                    ))
+                });
+            let mut tr = e.lock().unwrap();
+            tr.0.record_at(3000, t0 + 30);
+            tr.0.record_at(0, t0 + 60); // close bucket [t0+30,t0+60): 3000µs baseline
+            tr.0.record_at(12000, t0 + 90); // current open bucket: 12000µs spike (left open)
+        }
+        // Trigger a CPU utilization tick to refresh cached_historical_rate
+        // on all trackers. Set bg_cpu_at_floor so the throttle branch fires
+        // and limits groups that are over baseline.
+        mgr.set_bg_cpu_at_floor(true);
+        mgr.online_adjust_resource_quota(75.0);
+        mgr.advance_min_virtual_time();
+
+        {
+            let groups = ctl.resource_consumptions.read();
+            let spike_over = groups
+                .get(b"spike".as_ref())
+                .unwrap()
+                .is_over_baseline
+                .load(Ordering::Relaxed);
+            assert!(spike_over, "spike bucket1 > bucket0 → should be phase 1");
+        }
+
+        // Phase ordering: steady (phase 0) must sort before spike (phase 1).
+        let groups = ctl.resource_consumptions.read();
+        let steady_pri = groups
+            .get(b"steady".as_ref())
+            .unwrap()
+            .get_priority(1, None, false, true);
+        let spike_pri = groups
+            .get(b"spike".as_ref())
+            .unwrap()
+            .get_priority(1, None, false, true);
+        assert!(!is_phase1(steady_pri), "steady should be phase 0");
+        assert!(is_phase1(spike_pri), "spike should be phase 1");
+        assert!(
+            steady_pri < spike_pri,
+            "phase 0 must schedule before phase 1"
+        );
+    }
+
+    #[test]
     fn test_get_resource_limiter() {
         let mgr = ResourceGroupManager::default();
 
@@ -1273,9 +2080,14 @@ pub(crate) mod tests {
             .clone()
             .unwrap();
 
+        // Only 1 group (default): foreground always returns None.
         assert!(mgr.get_resource_limiter("default", "query", 0).is_none());
         assert!(
             mgr.get_resource_limiter("default", "query", HIGH_PRIORITY as u64)
+                .is_none()
+        );
+        assert!(
+            mgr.get_resource_limiter("default", "query", LOW_PRIORITY as u64)
                 .is_none()
         );
 
@@ -1322,26 +2134,177 @@ pub(crate) mod tests {
             &default_limiter
         ));
 
+        // Background path still takes priority for "stats" source.
         assert!(Arc::ptr_eq(
             &mgr.get_resource_limiter("test1", "stats", 0).unwrap(),
             &default_limiter
         ));
 
-        // test legacy task_type "lightning" can be converted to "import".
-        let lightning_group = new_background_resource_group_ru(
-            "lightning".into(),
-            200,
-            MEDIUM_PRIORITY,
-            vec!["lightning".into()],
+        // Multiple groups: all foreground priorities get the per-group limiter.
+        // The same limiter is returned regardless of priority level.
+        let fg_limiter = mgr
+            .get_resource_limiter("test1", "query", LOW_PRIORITY as u64)
+            .unwrap();
+        assert!(Arc::ptr_eq(
+            &mgr.get_resource_limiter("test1", "query", HIGH_PRIORITY as u64)
+                .unwrap(),
+            &fg_limiter,
+        ));
+        assert!(Arc::ptr_eq(
+            &mgr.get_resource_limiter("test1", "query", 0).unwrap(),
+            &fg_limiter,
+        ));
+    }
+
+    #[test]
+    fn test_ru_tracker() {
+        let t0: u64 = 1_000_000;
+
+        const BUCKETS: usize = 15;
+        let mut tracker = RuTracker::new(t0, BUCKETS);
+        assert!(!tracker.is_warmed_up());
+        // No data at all: current_rate = (0 + 0) / (0 + 60) = 0.
+        assert_eq!(tracker.current_rate(t0), 0.0);
+        assert_eq!(tracker.historical_rate(t0, t0), 0.0);
+
+        // Record 6000 RU in the first 30s bucket.
+        tracker.record_at(6000, t0 + 15);
+
+        // Advance past the first bucket boundary (30s) — completes bucket 0.
+        tracker.record_at(0, t0 + 30);
+        assert_eq!(tracker.completed, 1);
+        // At t0+30: current_bucket=0, elapsed=0, last_completed=6000
+        // rate = (0 + 6000) / (0 + 30) = 200 RU/s
+        assert!((tracker.current_rate(t0 + 30) - 200.0).abs() < 0.01);
+        assert!(!tracker.is_warmed_up()); // needs ≥2 buckets
+
+        // Advance another 30s with 3000 RU — completes bucket 1.
+        tracker.record_at(3000, t0 + 45);
+        tracker.record_at(0, t0 + 60);
+        assert_eq!(tracker.completed, 2);
+        assert!(tracker.is_warmed_up());
+        // At t0+60: current_bucket=0, elapsed=0, last_completed=3000
+        // rate = (0 + 3000) / (0 + 30) = 100 RU/s
+        assert!((tracker.current_rate(t0 + 60) - 100.0).abs() < 0.01);
+        // At t0+75 (15s into next bucket, no new RU): current_bucket=0, elapsed=15
+        // rate = (0 + 3000) / (15 + 30) = 66.67 RU/s
+        assert!((tracker.current_rate(t0 + 75) - 66.67).abs() < 0.1);
+        // historical_rate = (6000+3000) / (2*30) = 150 RU/s
+        assert!((tracker.historical_rate(t0, t0 + 60) - 150.0).abs() < 0.01);
+
+        // Ring buffer: advance 20 more minutes (fully evicts all data).
+        let t_far = t0 + 60 * 20;
+        tracker.record_at(0, t_far);
+        // Gap exceeds window → ring reset, no completed buckets.
+        assert_eq!(tracker.completed, 0);
+        assert_eq!(tracker.current_bucket.load(Ordering::Relaxed), 0);
+
+        // Re-populate after the big gap and fill the entire ring.
+        for i in 1..=BUCKETS {
+            tracker.record_at(100, t_far + (i as u64) * RU_BUCKET_SECS);
+        }
+        assert_eq!(tracker.completed, BUCKETS);
+    }
+
+    #[test]
+    fn test_admission_decision() {
+        let mut cfg = Config::default();
+        cfg.enable_read_admission_control = true;
+        cfg.admission_max_delayed_count = 10; // low limit to test rejection path
+        let mgr = ResourceGroupManager::new(cfg);
+        // Add a second group so the code path is active.
+        mgr.add_resource_group(new_resource_group_ru("spike".into(), 1000, HIGH_PRIORITY));
+        let spike_limiter = mgr.get_foreground_group_limiter("spike");
+
+        // Seed initial RU so the tracker is not idle (prevents eviction by
+        // online_adjust_resource_quota's retain call).
+        let t0 = RuTracker::now_secs();
+        mgr.record_ru_consumption("spike", 1);
+
+        // CPU below threshold → Allow (stays NO_LIMIT, no throttling).
+        mgr.online_adjust_resource_quota(50.0); // below 80%
+        assert_eq!(
+            mgr.admission_decision(true, &spike_limiter),
+            AdmissionDecision::Allow
         );
-        mgr.add_resource_group(lightning_group);
-        assert!(
-            mgr.get_background_resource_limiter("lightning", "lightning")
-                .is_some()
+
+        // CPU above threshold but no warmed-up tracker data → stays NO_LIMIT → Allow.
+        mgr.online_adjust_resource_quota(90.0);
+        assert_eq!(
+            mgr.admission_decision(true, &spike_limiter),
+            AdmissionDecision::Allow
         );
-        assert!(
-            mgr.get_background_resource_limiter("lightning", "import")
-                .is_some()
+
+        // Warm up the tracker: 2 completed buckets. Set up BEFORE calling
+        // online_adjust_resource_quota so historical_rate() is non-zero when the
+        // limiter rate is configured.
+        {
+            let entry = mgr.ru_trackers.get("spike").unwrap();
+            let mut guard = entry.lock().unwrap();
+            guard.0.record_at(6000, t0 + 30);
+            guard.0.record_at(0, t0 + 60); // close bucket 0: 6000 RU (baseline)
+            guard.0.record_at(12000, t0 + 90); // open bucket: 12000 RU spike (left open)
+            // historical ≈ 6000/30 = 200 RU/s (only completed buckets), current
+            // ≈ 400
+        }
+        // Now set CPU — first throttle entry: initializes fraction from spike ratio,
+        // then sets absolute rate = historical × fraction per group.
+        // bg_cpu_at_floor must be true for the throttle branch to fire.
+        mgr.set_bg_cpu_at_floor(true);
+        mgr.online_adjust_resource_quota(90.0);
+        // Consume a burst well above the rate to build token-bucket debt.
+        {
+            let entry = mgr.ru_trackers.get("spike").unwrap();
+            let guard = entry.lock().unwrap();
+            // 10_000 µs consumed against ~133 RU/s rate → several seconds of debt.
+            guard.1.consume(
+                Duration::from_micros(10_000),
+                IoBytes::default(),
+                false,
+                true,
+            );
+        }
+        // Debt is non-zero → Delay.
+        assert!(matches!(
+            mgr.admission_decision(true, &spike_limiter),
+            AdmissionDecision::Delay(_)
+        ));
+        // One slot acquired above; release it.
+        mgr.release_delay_slot();
+
+        // Exhaust the delay slots: acquire 10 (the configured max).
+        for _ in 0..10 {
+            assert!(matches!(
+                mgr.admission_decision(true, &spike_limiter),
+                AdmissionDecision::Delay(_)
+            ));
+        }
+        // 11th request: over the limit → Reject.
+        assert_eq!(
+            mgr.admission_decision(true, &spike_limiter),
+            AdmissionDecision::Reject
+        );
+        // Release all slots.
+        for _ in 0..10 {
+            mgr.release_delay_slot();
+        }
+
+        // Drop CPU into leeway zone (72-80%): multiplier holds, still delays.
+        mgr.online_adjust_resource_quota(75.0);
+        assert!(matches!(
+            mgr.admission_decision(true, &spike_limiter),
+            AdmissionDecision::Delay(_)
+        ));
+
+        // Drop CPU below leeway_start (72%): fraction ramps up ×1.1/tick.
+        // After enough ticks it reaches 5× → NO_LIMIT → rates set to infinity
+        // → token bucket debt clears → Allow.
+        for _ in 0..60 {
+            mgr.online_adjust_resource_quota(50.0);
+        }
+        assert_eq!(
+            mgr.admission_decision(true, &spike_limiter),
+            AdmissionDecision::Allow
         );
     }
 }

--- a/components/resource_control/src/resource_limiter.rs
+++ b/components/resource_control/src/resource_limiter.rs
@@ -40,6 +40,10 @@ pub struct ResourceLimiter {
     _name: String,
     version: u64,
     limiters: [QuotaLimiter; ResourceType::COUNT],
+    // Dedicated write-only IO limiter for compaction pressure throttling.
+    // Independent from the combined IO limiter; rate is set by do_adjust
+    // based on compaction pressure. Defaults to f64::INFINITY (no throttle).
+    write_io_limiter: QuotaLimiter,
     // whether the resource limiter is a background limiter or priority limiter.
     is_background: bool,
     // the wait duration histogram for prioitry limiter.
@@ -77,6 +81,7 @@ impl ResourceLimiter {
             _name: name,
             version,
             limiters: [cpu_limiter, io_limiter],
+            write_io_limiter: QuotaLimiter::new(f64::INFINITY),
             is_background,
             wait_histogram,
         }
@@ -86,11 +91,22 @@ impl ResourceLimiter {
         self.is_background
     }
 
-    pub fn consume(&self, cpu_time: Duration, io_bytes: IoBytes, wait: bool) -> Duration {
+    pub fn consume(
+        &self,
+        cpu_time: Duration,
+        io_bytes: IoBytes,
+        wait: bool,
+        skip_compaction_pressure: bool,
+    ) -> Duration {
         let cpu_dur =
             self.limiters[ResourceType::Cpu as usize].consume(cpu_time.as_micros() as u64, wait);
         let io_dur = self.limiters[ResourceType::Io as usize].consume_io(io_bytes, wait);
-        let wait_dur = cpu_dur.max(io_dur);
+        let write_io_dur = if skip_compaction_pressure {
+            Duration::ZERO
+        } else {
+            self.write_io_limiter.consume(io_bytes.write, wait)
+        };
+        let wait_dur = cpu_dur.max(io_dur).max(write_io_dur);
         if !wait_dur.is_zero()
             && let Some(h) = &self.wait_histogram
         {
@@ -99,8 +115,13 @@ impl ResourceLimiter {
         wait_dur
     }
 
-    pub async fn async_consume(&self, cpu_time: Duration, io_bytes: IoBytes) -> Duration {
-        let dur = self.consume(cpu_time, io_bytes, true);
+    pub async fn async_consume(
+        &self,
+        cpu_time: Duration,
+        io_bytes: IoBytes,
+        skip_compaction_pressure: bool,
+    ) -> Duration {
+        let dur = self.consume(cpu_time, io_bytes, true, skip_compaction_pressure);
         if !dur.is_zero() {
             _ = GLOBAL_TIMER_HANDLE
                 .delay(Instant::now() + dur)
@@ -113,6 +134,11 @@ impl ResourceLimiter {
     #[inline]
     pub(crate) fn get_limiter(&self, ty: ResourceType) -> &QuotaLimiter {
         &self.limiters[ty as usize]
+    }
+
+    #[inline]
+    pub(crate) fn get_write_io_limiter(&self) -> &QuotaLimiter {
+        &self.write_io_limiter
     }
 
     pub(crate) fn get_limit_statistics(&self, ty: ResourceType) -> GroupStatistics {
@@ -179,7 +205,7 @@ impl QuotaLimiter {
     }
 
     fn consume(&self, value: u64, wait: bool) -> Duration {
-        if value == 0 && self.limiter.speed_limit().is_infinite() {
+        if value == 0 {
             return Duration::ZERO;
         }
         let mut dur = self.limiter.consume_duration(value as usize);

--- a/components/resource_control/src/resource_limiter.rs
+++ b/components/resource_control/src/resource_limiter.rs
@@ -37,9 +37,13 @@ impl fmt::Debug for ResourceType {
 }
 
 pub struct ResourceLimiter {
-    _name: String,
+    name: String,
     version: u64,
     limiters: [QuotaLimiter; ResourceType::COUNT],
+    // Dedicated write-only IO limiter for compaction pressure throttling.
+    // Independent from the combined IO limiter; rate is set by do_adjust
+    // based on compaction pressure. Defaults to f64::INFINITY (no throttle).
+    write_io_limiter: QuotaLimiter,
     // whether the resource limiter is a background limiter or priority limiter.
     is_background: bool,
     // the wait duration histogram for prioitry limiter.
@@ -74,23 +78,39 @@ impl ResourceLimiter {
             None
         };
         Self {
-            _name: name,
+            name,
             version,
             limiters: [cpu_limiter, io_limiter],
+            write_io_limiter: QuotaLimiter::new(f64::INFINITY),
             is_background,
             wait_histogram,
         }
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
     }
 
     pub fn is_background(&self) -> bool {
         self.is_background
     }
 
-    pub fn consume(&self, cpu_time: Duration, io_bytes: IoBytes, wait: bool) -> Duration {
+    pub fn consume(
+        &self,
+        cpu_time: Duration,
+        io_bytes: IoBytes,
+        wait: bool,
+        skip_compaction_pressure: bool,
+    ) -> Duration {
         let cpu_dur =
             self.limiters[ResourceType::Cpu as usize].consume(cpu_time.as_micros() as u64, wait);
         let io_dur = self.limiters[ResourceType::Io as usize].consume_io(io_bytes, wait);
-        let wait_dur = cpu_dur.max(io_dur);
+        let write_io_dur = if skip_compaction_pressure {
+            Duration::ZERO
+        } else {
+            self.write_io_limiter.consume(io_bytes.write, wait)
+        };
+        let wait_dur = cpu_dur.max(io_dur).max(write_io_dur);
         if !wait_dur.is_zero()
             && let Some(h) = &self.wait_histogram
         {
@@ -99,8 +119,34 @@ impl ResourceLimiter {
         wait_dur
     }
 
-    pub async fn async_consume(&self, cpu_time: Duration, io_bytes: IoBytes) -> Duration {
-        let dur = self.consume(cpu_time, io_bytes, true);
+    /// Returns the current token-bucket debt the caller should wait before
+    /// entering the thread pool. Reads accumulated debt via `consume(0, ...)`
+    /// which returns the existing debt when the rate limit is finite, without
+    /// adding new token consumption.
+    ///
+    /// For write requests (`is_read = false`), the write-specific IO limiter
+    /// debt is also considered alongside CPU and combined IO debt.
+    ///
+    /// Note: `write_io_limiter` and the combined IO limiter are only rate-set
+    /// for background limiters (via `do_adjust`); for foreground per-group
+    /// limiters their rates remain at `f64::INFINITY`, so their debt is
+    /// always zero and only CPU debt drives the delay in practice.
+    pub fn admission_delay(&self, is_read: bool) -> Duration {
+        self.consume(
+            Duration::ZERO,
+            IoBytes::default(),
+            true,
+            is_read, // skip_compaction_pressure = true for reads (skip write_io_limiter)
+        )
+    }
+
+    pub async fn async_consume(
+        &self,
+        cpu_time: Duration,
+        io_bytes: IoBytes,
+        skip_compaction_pressure: bool,
+    ) -> Duration {
+        let dur = self.consume(cpu_time, io_bytes, true, skip_compaction_pressure);
         if !dur.is_zero() {
             _ = GLOBAL_TIMER_HANDLE
                 .delay(Instant::now() + dur)
@@ -113,6 +159,11 @@ impl ResourceLimiter {
     #[inline]
     pub(crate) fn get_limiter(&self, ty: ResourceType) -> &QuotaLimiter {
         &self.limiters[ty as usize]
+    }
+
+    #[inline]
+    pub(crate) fn get_write_io_limiter(&self) -> &QuotaLimiter {
+        &self.write_io_limiter
     }
 
     pub(crate) fn get_limit_statistics(&self, ty: ResourceType) -> GroupStatistics {

--- a/components/resource_control/src/resource_limiter.rs
+++ b/components/resource_control/src/resource_limiter.rs
@@ -37,7 +37,7 @@ impl fmt::Debug for ResourceType {
 }
 
 pub struct ResourceLimiter {
-    _name: String,
+    name: String,
     version: u64,
     limiters: [QuotaLimiter; ResourceType::COUNT],
     // Dedicated write-only IO limiter for compaction pressure throttling.
@@ -78,13 +78,17 @@ impl ResourceLimiter {
             None
         };
         Self {
-            _name: name,
+            name,
             version,
             limiters: [cpu_limiter, io_limiter],
             write_io_limiter: QuotaLimiter::new(f64::INFINITY),
             is_background,
             wait_histogram,
         }
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
     }
 
     pub fn is_background(&self) -> bool {
@@ -113,6 +117,27 @@ impl ResourceLimiter {
             h.observe(wait_dur.as_secs_f64());
         }
         wait_dur
+    }
+
+    /// Returns the current token-bucket debt the caller should wait before
+    /// entering the thread pool. Reads accumulated debt via `consume(0, ...)`
+    /// which returns the existing debt when the rate limit is finite, without
+    /// adding new token consumption.
+    ///
+    /// For write requests (`is_read = false`), the write-specific IO limiter
+    /// debt is also considered alongside CPU and combined IO debt.
+    ///
+    /// Note: `write_io_limiter` and the combined IO limiter are only rate-set
+    /// for background limiters (via `do_adjust`); for foreground per-group
+    /// limiters their rates remain at `f64::INFINITY`, so their debt is
+    /// always zero and only CPU debt drives the delay in practice.
+    pub fn admission_delay(&self, is_read: bool) -> Duration {
+        self.consume(
+            Duration::ZERO,
+            IoBytes::default(),
+            true,
+            is_read, // skip_compaction_pressure = true for reads (skip write_io_limiter)
+        )
     }
 
     pub async fn async_consume(
@@ -205,7 +230,7 @@ impl QuotaLimiter {
     }
 
     fn consume(&self, value: u64, wait: bool) -> Duration {
-        if value == 0 {
+        if value == 0 && self.limiter.speed_limit().is_infinite() {
             return Duration::ZERO;
         }
         let mut dur = self.limiter.consume_duration(value as usize);

--- a/components/resource_control/src/score.rs
+++ b/components/resource_control/src/score.rs
@@ -25,11 +25,12 @@ use tikv_util::{
     time::Instant,
 };
 
-/// Test-only: a cpu_score high enough to guarantee maximum pressure
-/// regardless of configured thresholds, used to drive foreground/read-pool
-/// throttling tests unconditionally into their "fully engaged" branch.
-#[cfg(test)]
-pub(crate) const TARGET_CPU: f64 = 90.0;
+/// CPU utilization a node is assumed to reach once foreground pressure is
+/// engaged. `resource_group.rs` measures the overshoot from
+/// `fg_cpu_throttle_threshold` up to this when sizing the noisy group set,
+/// and tests pass it as a `cpu_score` guaranteed to engage regardless of the
+/// configured threshold.
+pub(crate) const PEAK_CPU_PCT: f64 = 90.0;
 
 /// Shortest interval [`ThreadGroupCpuTracker::measure_cpu_cores`] will measure
 /// over; below this the tick count is too small to be meaningful and the cached

--- a/components/resource_control/src/score.rs
+++ b/components/resource_control/src/score.rs
@@ -1,0 +1,295 @@
+// Copyright 2026 TiKV Project Authors. Licensed under Apache-2.0.
+
+//! Common resource-pressure scoring shared by background quota adjustment
+//! (`worker.rs`) and foreground/read-pool throttling (`resource_group.rs`).
+//!
+//! `compute_resource_scores` produces three independent 0-100 scores —
+//! `cpu_score`, `io_score`, `compaction_score` — each simply the resource's
+//! utilization percentage, clamped to `[0, 100]`. The CPU score is the max of
+//! whole-process and grpc normalized utilization, so pressure is detected on
+//! whichever signal is hottest.
+//!
+//! Background quota adjustment turns its score into a `[0, 1]` pressure
+//! fraction via [`pressure_fraction`], over its own
+//! `(bg_cpu_throttle_threshold, fg_cpu_throttle_threshold)` range.
+//! Foreground/read-pool throttling instead just tightens whatever's currently
+//! in effect by a fixed percentage per tick once engaged — see
+//! `resource_group.rs::adjust_group_throttling` and
+//! `compute_read_pool_target_cpu`.
+
+use std::time::Duration;
+
+use tikv_util::{
+    sys::thread::{full_thread_stat, process_id, thread_ids, ticks_per_second},
+    thread_name_prefix::matches_thread_name_prefix,
+    time::Instant,
+};
+
+/// Test-only: a cpu_score high enough to guarantee maximum pressure
+/// regardless of configured thresholds, used to drive foreground/read-pool
+/// throttling tests unconditionally into their "fully engaged" branch.
+#[cfg(test)]
+pub(crate) const TARGET_CPU: f64 = 90.0;
+
+/// Shortest interval [`ThreadGroupCpuTracker::measure_cpu_cores`] will measure
+/// over; below this the tick count is too small to be meaningful and the cached
+/// value is returned instead. Mirrors
+/// `ReadPoolCpuTimeTracker::get_unified_read_pool_cpu`.
+const MIN_MEASURE_INTERVAL: Duration = Duration::from_millis(500);
+
+/// Maps `score` onto a `[0, 1]` pressure fraction: `0` at `start`, `1` at
+/// `end`, linear in between, clamped.
+pub(crate) fn pressure_fraction(score: f64, start: f64, end: f64) -> f64 {
+    let range = (end - start).max(1.0);
+    ((score - start) / range).clamp(0.0, 1.0)
+}
+
+/// Raw measurements feeding [`compute_resource_scores`].
+pub struct ResourceScoreInputs {
+    /// Whole-process CPU utilization percentage
+    /// (`cpu_stats.current_used / cpu_stats.total_quota * 100`).
+    pub process_cpu_util: f64,
+    /// Measured grpc-server CPU usage, in cores.
+    pub grpc_cpu_cores: f64,
+    /// IO utilization percentage (`io_stats.current_used /
+    /// io_stats.total_quota * 100`); 0 when IO quota is unlimited.
+    pub io_util: f64,
+    /// Raw compaction pending-bytes ratio, range `[0, 100+]`.
+    pub compaction_pending_ratio: f64,
+}
+
+/// Static capacities used to normalize per-pool CPU measurements into
+/// utilization percentages, comparable to whole-process CPU utilization.
+pub struct ResourceCapacities {
+    /// `SysQuota::cpu_cores_quota()`.
+    pub total_cpu_cores: f64,
+    /// `config.server.grpc_concurrency`.
+    pub grpc_concurrency: f64,
+}
+
+/// Output of [`compute_resource_scores`]: three independent 0-100 scores,
+/// each a plain utilization percentage clamped to `[0, 100]`.
+pub struct ResourceScores {
+    /// CPU utilization score: the max of process and grpc normalized
+    /// utilization.
+    pub cpu_score: f64,
+    /// IO utilization score (background-only).
+    pub io_score: f64,
+    /// Compaction pending-bytes score (background-only); the input ratio
+    /// clamped to `[0, 100]`.
+    pub compaction_score: f64,
+}
+
+/// Computes the three resource-utilization scores from raw measurements.
+/// Each score is a plain percentage in `[0, 100]` — 100% CPU utilization
+/// yields `cpu_score == 100.0`, 10% yields `10.0`.
+pub fn compute_resource_scores(
+    inputs: &ResourceScoreInputs,
+    caps: &ResourceCapacities,
+) -> ResourceScores {
+    let grpc_util = if caps.grpc_concurrency > 0.0 {
+        inputs.grpc_cpu_cores / caps.grpc_concurrency * 100.0
+    } else {
+        0.0
+    };
+    let max_cpu_util = inputs.process_cpu_util.max(grpc_util);
+
+    ResourceScores {
+        cpu_score: max_cpu_util.clamp(0.0, 100.0),
+        io_score: inputs.io_util.clamp(0.0, 100.0),
+        compaction_score: inputs.compaction_pending_ratio.clamp(0.0, 100.0),
+    }
+}
+
+/// Tracks CPU usage (in cores) of all threads whose name matches a given
+/// prefix, e.g. `UNIFIED_READ_POOL_THREAD` or `GRPC_SERVER_THREAD`. Generalizes
+/// the `/proc`-based scan originally written for the unified read pool alone.
+pub struct ThreadGroupCpuTracker {
+    name_prefix: &'static str,
+    prev_total_cpu_ticks: i64,
+    prev_check_time: Instant,
+    prev_cpu_cores: f64,
+    // Whether a baseline has been established yet. `utime`/`stime` are
+    // cumulative since thread start, so the first scan can't compute a
+    // meaningful delta — it only records the baseline.
+    initialized: bool,
+}
+
+impl ThreadGroupCpuTracker {
+    pub fn new(name_prefix: &'static str) -> Self {
+        Self {
+            name_prefix,
+            prev_total_cpu_ticks: 0,
+            prev_check_time: Instant::now_coarse(),
+            prev_cpu_cores: 0.0,
+            initialized: false,
+        }
+    }
+
+    /// Returns the average CPU usage (in cores) of threads matching
+    /// `name_prefix` since the previous call.
+    pub fn measure_cpu_cores(&mut self) -> f64 {
+        let check_time = Instant::now_coarse();
+        let duration = check_time.saturating_duration_since(self.prev_check_time);
+        if duration < MIN_MEASURE_INTERVAL {
+            return self.prev_cpu_cores;
+        }
+
+        let pid = process_id();
+        let tids = match thread_ids::<Vec<_>>(pid) {
+            Ok(tids) => tids,
+            Err(_) => {
+                // Transient /proc read failure: keep the previous cached
+                // value instead of treating it as zero CPU usage. Otherwise
+                // this tick would spuriously report 0 cores, and the next
+                // successful read would compute tick_diff against a reset
+                // baseline of 0, producing an artificial spike.
+                return self.prev_cpu_cores;
+            }
+        };
+
+        let mut current_total_cpu_ticks = 0i64;
+        for tid in tids {
+            if let Ok(stat) = full_thread_stat(pid, tid)
+                && matches_thread_name_prefix(&stat.command, self.name_prefix)
+            {
+                current_total_cpu_ticks += stat.utime + stat.stime;
+            }
+        }
+
+        if !self.initialized {
+            // First successful scan: establish the baseline rather than
+            // treating the thread's entire historical CPU-tick count as this
+            // tick's delta, which would report a false spike.
+            self.initialized = true;
+            self.prev_total_cpu_ticks = current_total_cpu_ticks;
+            self.prev_check_time = check_time;
+            self.prev_cpu_cores = 0.0;
+            return 0.0;
+        }
+
+        let tick_diff = current_total_cpu_ticks.saturating_sub(self.prev_total_cpu_ticks);
+        let cpu_cores = if duration.as_secs_f64() > 0.0 && tick_diff > 0 {
+            let cpu_seconds = tick_diff as f64 / ticks_per_second() as f64;
+            cpu_seconds / duration.as_secs_f64()
+        } else {
+            0.0
+        };
+
+        self.prev_total_cpu_ticks = current_total_cpu_ticks;
+        self.prev_check_time = check_time;
+        self.prev_cpu_cores = cpu_cores;
+        cpu_cores
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_pressure_fraction_boundaries_and_clamp() {
+        assert_eq!(pressure_fraction(60.0, 60.0, 90.0), 0.0);
+        assert_eq!(pressure_fraction(90.0, 60.0, 90.0), 1.0);
+        assert_eq!(pressure_fraction(75.0, 60.0, 90.0), 0.5);
+        assert_eq!(pressure_fraction(200.0, 60.0, 90.0), 1.0);
+        assert_eq!(pressure_fraction(0.0, 60.0, 90.0), 0.0);
+    }
+
+    fn base_inputs() -> ResourceScoreInputs {
+        ResourceScoreInputs {
+            process_cpu_util: 0.0,
+            grpc_cpu_cores: 0.0,
+            io_util: 0.0,
+            compaction_pending_ratio: 0.0,
+        }
+    }
+
+    fn base_caps() -> ResourceCapacities {
+        ResourceCapacities {
+            total_cpu_cores: 8.0,
+            grpc_concurrency: 8.0,
+        }
+    }
+
+    #[test]
+    fn test_cpu_score_is_plain_utilization() {
+        let mut inputs = base_inputs();
+        inputs.process_cpu_util = 100.0;
+        assert_eq!(
+            compute_resource_scores(&inputs, &base_caps()).cpu_score,
+            100.0
+        );
+        inputs.process_cpu_util = 10.0;
+        assert_eq!(
+            compute_resource_scores(&inputs, &base_caps()).cpu_score,
+            10.0
+        );
+    }
+
+    #[test]
+    fn test_cpu_score_process_dominant() {
+        let mut inputs = base_inputs();
+        inputs.process_cpu_util = 75.0;
+        let scores = compute_resource_scores(&inputs, &base_caps());
+        assert_eq!(scores.cpu_score, 75.0);
+    }
+
+    #[test]
+    fn test_cpu_score_grpc_dominant() {
+        let mut inputs = base_inputs();
+        inputs.process_cpu_util = 30.0;
+        inputs.grpc_cpu_cores = 7.2; // 7.2/8*100 = 90% util
+        let scores = compute_resource_scores(&inputs, &base_caps());
+        assert_eq!(scores.cpu_score, 90.0);
+    }
+
+    #[test]
+    fn test_io_score_independent_of_cpu() {
+        let mut inputs = base_inputs();
+        inputs.process_cpu_util = 100.0;
+        inputs.grpc_cpu_cores = 8.0;
+        inputs.io_util = 65.0;
+        let scores = compute_resource_scores(&inputs, &base_caps());
+        assert_eq!(scores.io_score, 65.0);
+
+        // Unlimited IO quota is represented as io_util = 0 by the caller.
+        inputs.io_util = 0.0;
+        let scores = compute_resource_scores(&inputs, &base_caps());
+        assert_eq!(scores.io_score, 0.0);
+    }
+
+    #[test]
+    fn test_compaction_score_clamp() {
+        let mut inputs = base_inputs();
+        inputs.compaction_pending_ratio = 150.0;
+        assert_eq!(
+            compute_resource_scores(&inputs, &base_caps()).compaction_score,
+            100.0
+        );
+        inputs.compaction_pending_ratio = 55.0;
+        assert_eq!(
+            compute_resource_scores(&inputs, &base_caps()).compaction_score,
+            55.0
+        );
+        inputs.compaction_pending_ratio = 0.0;
+        assert_eq!(
+            compute_resource_scores(&inputs, &base_caps()).compaction_score,
+            0.0
+        );
+    }
+
+    #[test]
+    fn test_zero_grpc_capacity_guard() {
+        let mut inputs = base_inputs();
+        inputs.process_cpu_util = 50.0;
+        inputs.grpc_cpu_cores = 100.0; // would dominate if normalized
+        let caps = ResourceCapacities {
+            total_cpu_cores: 8.0,
+            grpc_concurrency: 0.0,
+        };
+        // Zero grpc capacity => grpc signal contributes 0 util, no div-by-zero.
+        let scores = compute_resource_scores(&inputs, &caps);
+        assert_eq!(scores.cpu_score, 50.0);
+    }
+}

--- a/components/resource_control/src/service.rs
+++ b/components/resource_control/src/service.rs
@@ -554,6 +554,7 @@ pub mod tests {
                 write: 1000,
             },
             true,
+            false,
         );
         // Wait for report ru metrics.
         std::thread::sleep(Duration::from_millis(100));
@@ -575,6 +576,7 @@ pub mod tests {
                 write: 2000,
             },
             true,
+            false,
         );
         // Wait for report ru metrics.
         std::thread::sleep(Duration::from_millis(100));

--- a/components/resource_control/src/service.rs
+++ b/components/resource_control/src/service.rs
@@ -1,10 +1,6 @@
 // Copyright 2023 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::{
-    collections::{HashMap, HashSet},
-    sync::Arc,
-    time::Duration,
-};
+use std::{collections::HashSet, sync::Arc, time::Duration};
 
 use futures::{compat::Future01CompatExt, stream, StreamExt};
 use kvproto::{
@@ -17,7 +13,9 @@ use pd_client::{
     RESOURCE_CONTROL_CONTROLLER_CONFIG_PATH,
 };
 use serde::{Deserialize, Serialize};
-use tikv_util::{error, info, timer::GLOBAL_TIMER_HANDLE, warn};
+use tikv_util::{
+    error, info, resource_control::DEFAULT_RESOURCE_GROUP_NAME, timer::GLOBAL_TIMER_HANDLE, warn,
+};
 
 use crate::{resource_limiter::ResourceType, ResourceGroupManager};
 
@@ -187,37 +185,13 @@ impl ResourceManagerService {
 
     // report ru metrics periodically.
     pub async fn report_ru_metrics(&self) {
-        let mut last_group_statistics_map: HashMap<String, ReportStatistic> = HashMap::new();
+        let mut last_bg_statistics: Option<ReportStatistic> = None;
         // load controller config firstly.
         let config = self.load_controller_config().await;
         info!("load controller config"; "config" => ?config);
 
         loop {
-            let background_groups: Vec<_> = self
-                .manager
-                .resource_groups
-                .iter()
-                .filter_map(|kv| {
-                    let g = kv.value();
-                    g.limiter.clone().map(|limiter| {
-                        let io_statistics = limiter.get_limit_statistics(ResourceType::Io);
-                        let cpu_statistics = limiter.get_limit_statistics(ResourceType::Cpu);
-
-                        (
-                            g.group.name.clone(),
-                            ReportStatistic {
-                                // io statistics and cpu statistics should have the same version.
-                                version: io_statistics.version,
-                                read_bytes_consumed: io_statistics.read_consumed,
-                                write_bytes_consumed: io_statistics.write_consumed,
-                                cpu_consumed: cpu_statistics.total_consumed,
-                            },
-                        )
-                    })
-                })
-                .collect();
-
-            if background_groups.is_empty() {
+            if !self.manager.has_background_groups() {
                 let _ = GLOBAL_TIMER_HANDLE
                     .delay(std::time::Instant::now() + BACKGROUND_RU_REPORT_DURATION)
                     .compat()
@@ -225,55 +199,69 @@ impl ResourceManagerService {
                 continue;
             }
 
+            // All background groups share a single limiter; read it once and
+            // report under the fixed label "background".
+            let limiter = self.manager.get_background_limiter();
+            let io_statistics = limiter.get_limit_statistics(ResourceType::Io);
+            let cpu_statistics = limiter.get_limit_statistics(ResourceType::Cpu);
+            let statistic = ReportStatistic {
+                // io statistics and cpu statistics should have the same version.
+                version: io_statistics.version,
+                read_bytes_consumed: io_statistics.read_consumed,
+                write_bytes_consumed: io_statistics.write_consumed,
+                cpu_consumed: cpu_statistics.total_consumed,
+            };
+
+            // Non-existence or version change means this is a brand new limiter,
+            // so no need to sub the old statistics.
+            let (cpu_consumed, io_consumed) = if let Some(last_stats) = last_bg_statistics
+                .as_ref()
+                .filter(|s| s.version == statistic.version)
+            {
+                if statistic == *last_stats {
+                    let _ = GLOBAL_TIMER_HANDLE
+                        .delay(std::time::Instant::now() + BACKGROUND_RU_REPORT_DURATION)
+                        .compat()
+                        .await;
+                    continue;
+                }
+                (
+                    statistic.cpu_consumed - last_stats.cpu_consumed,
+                    (
+                        statistic.read_bytes_consumed - last_stats.read_bytes_consumed,
+                        statistic.write_bytes_consumed - last_stats.write_bytes_consumed,
+                    ),
+                )
+            } else {
+                (
+                    statistic.cpu_consumed,
+                    (
+                        statistic.read_bytes_consumed,
+                        statistic.write_bytes_consumed,
+                    ),
+                )
+            };
+            last_bg_statistics = Some(statistic);
+
             let mut req = TokenBucketsRequest::default();
             let all_reqs = req.mut_requests();
-            for (name, statistic) in background_groups.into_iter() {
-                // Non-existence or version change means this is a brand new limiter, so no need
-                // to sub the old statistics.
-                let (cpu_consumed, io_consumed) = if let Some(last_stats) =
-                    last_group_statistics_map
-                        .get(&name)
-                        .filter(|stats| statistic.version == stats.version)
-                {
-                    if statistic == *last_stats {
-                        continue;
-                    }
-                    (
-                        statistic.cpu_consumed - last_stats.cpu_consumed,
-                        (
-                            statistic.read_bytes_consumed - last_stats.read_bytes_consumed,
-                            statistic.write_bytes_consumed - last_stats.write_bytes_consumed,
-                        ),
-                    )
-                } else {
-                    (
-                        statistic.cpu_consumed,
-                        (
-                            statistic.read_bytes_consumed,
-                            statistic.write_bytes_consumed,
-                        ),
-                    )
-                };
-                // replace the previous statistics.
-                last_group_statistics_map.insert(name.clone(), statistic);
-                // report ru statistics.
-                let mut req = TokenBucketRequest::default();
-                req.set_resource_group_name(name.clone());
-                req.set_is_background(true);
-                let report_consumption = req.mut_consumption_since_last_request();
+            // report ru statistics.
+            let mut bucket_req = TokenBucketRequest::default();
+            bucket_req.set_resource_group_name(DEFAULT_RESOURCE_GROUP_NAME.to_owned());
+            bucket_req.set_is_background(true);
+            let report_consumption = bucket_req.mut_consumption_since_last_request();
 
-                let read_total = config.read_cpu_ms_cost * cpu_consumed as f64
-                    + config.read_cost_per_byte * io_consumed.0 as f64;
-                let write_total = config.write_cost_per_byte * io_consumed.1 as f64;
+            let read_total = config.read_cpu_ms_cost * cpu_consumed as f64
+                + config.read_cost_per_byte * io_consumed.0 as f64;
+            let write_total = config.write_cost_per_byte * io_consumed.1 as f64;
 
-                report_consumption.set_r_r_u(read_total);
-                report_consumption.set_w_r_u(write_total);
-                report_consumption.set_read_bytes(io_consumed.0 as f64);
-                report_consumption.set_write_bytes(io_consumed.1 as f64);
-                report_consumption.set_total_cpu_time_ms(cpu_consumed as f64);
+            report_consumption.set_r_r_u(read_total);
+            report_consumption.set_w_r_u(write_total);
+            report_consumption.set_read_bytes(io_consumed.0 as f64);
+            report_consumption.set_write_bytes(io_consumed.1 as f64);
+            report_consumption.set_total_cpu_time_ms(cpu_consumed as f64);
 
-                all_reqs.push(req);
-            }
+            all_reqs.push(bucket_req);
 
             if !all_reqs.is_empty() {
                 if let Err(e) = self.pd_client.report_ru_metrics(req).await {
@@ -542,7 +530,7 @@ pub mod tests {
         background_worker.spawn_async_task(async move {
             s_clone.report_ru_metrics().await;
         });
-        // Mock consume.
+        // Mock consume on the shared background limiter.
         let bg_limiter = s
             .manager
             .get_background_resource_limiter("background", "br")
@@ -554,27 +542,29 @@ pub mod tests {
                 write: 1000,
             },
             true,
+            false,
         );
         // Wait for report ru metrics.
         std::thread::sleep(Duration::from_millis(100));
-        // Mock update version.
-        let bg = new_resource_group_ru("background".into(), 1000, 15);
-        s.manager.add_resource_group(bg);
 
-        let background_group =
-            new_background_resource_group_ru("background".into(), 500, 8, vec!["lightning".into()]);
+        // Add a second background group; all groups share the same limiter.
+        let background_group = new_background_resource_group_ru(
+            "lightning_group".into(),
+            500,
+            8,
+            vec!["lightning".into()],
+        );
         s.manager.add_resource_group(background_group);
-        let new_bg_limiter = s
-            .manager
-            .get_background_resource_limiter("background", "lightning")
-            .unwrap();
-        new_bg_limiter.consume(
+        // Consuming through either group's limiter goes to the same shared
+        // limiter; the next report will reflect the delta.
+        bg_limiter.consume(
             Duration::from_secs(5),
             IoBytes {
                 read: 2000,
                 write: 2000,
             },
             true,
+            false,
         );
         // Wait for report ru metrics.
         std::thread::sleep(Duration::from_millis(100));

--- a/components/resource_control/src/service.rs
+++ b/components/resource_control/src/service.rs
@@ -1,10 +1,6 @@
 // Copyright 2023 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::{
-    collections::{HashMap, HashSet},
-    sync::Arc,
-    time::Duration,
-};
+use std::{collections::HashSet, sync::Arc, time::Duration};
 
 use futures::{compat::Future01CompatExt, stream, StreamExt};
 use kvproto::{
@@ -17,7 +13,9 @@ use pd_client::{
     RESOURCE_CONTROL_CONTROLLER_CONFIG_PATH,
 };
 use serde::{Deserialize, Serialize};
-use tikv_util::{error, info, timer::GLOBAL_TIMER_HANDLE, warn};
+use tikv_util::{
+    error, info, resource_control::DEFAULT_RESOURCE_GROUP_NAME, timer::GLOBAL_TIMER_HANDLE, warn,
+};
 
 use crate::{resource_limiter::ResourceType, ResourceGroupManager};
 
@@ -187,37 +185,13 @@ impl ResourceManagerService {
 
     // report ru metrics periodically.
     pub async fn report_ru_metrics(&self) {
-        let mut last_group_statistics_map: HashMap<String, ReportStatistic> = HashMap::new();
+        let mut last_bg_statistics: Option<ReportStatistic> = None;
         // load controller config firstly.
         let config = self.load_controller_config().await;
         info!("load controller config"; "config" => ?config);
 
         loop {
-            let background_groups: Vec<_> = self
-                .manager
-                .resource_groups
-                .iter()
-                .filter_map(|kv| {
-                    let g = kv.value();
-                    g.limiter.clone().map(|limiter| {
-                        let io_statistics = limiter.get_limit_statistics(ResourceType::Io);
-                        let cpu_statistics = limiter.get_limit_statistics(ResourceType::Cpu);
-
-                        (
-                            g.group.name.clone(),
-                            ReportStatistic {
-                                // io statistics and cpu statistics should have the same version.
-                                version: io_statistics.version,
-                                read_bytes_consumed: io_statistics.read_consumed,
-                                write_bytes_consumed: io_statistics.write_consumed,
-                                cpu_consumed: cpu_statistics.total_consumed,
-                            },
-                        )
-                    })
-                })
-                .collect();
-
-            if background_groups.is_empty() {
+            if !self.manager.has_background_groups() {
                 let _ = GLOBAL_TIMER_HANDLE
                     .delay(std::time::Instant::now() + BACKGROUND_RU_REPORT_DURATION)
                     .compat()
@@ -225,55 +199,69 @@ impl ResourceManagerService {
                 continue;
             }
 
+            // All background groups share a single limiter; read it once and
+            // report under the fixed label "background".
+            let limiter = self.manager.get_background_limiter();
+            let io_statistics = limiter.get_limit_statistics(ResourceType::Io);
+            let cpu_statistics = limiter.get_limit_statistics(ResourceType::Cpu);
+            let statistic = ReportStatistic {
+                // io statistics and cpu statistics should have the same version.
+                version: io_statistics.version,
+                read_bytes_consumed: io_statistics.read_consumed,
+                write_bytes_consumed: io_statistics.write_consumed,
+                cpu_consumed: cpu_statistics.total_consumed,
+            };
+
+            // Non-existence or version change means this is a brand new limiter,
+            // so no need to sub the old statistics.
+            let (cpu_consumed, io_consumed) = if let Some(last_stats) = last_bg_statistics
+                .as_ref()
+                .filter(|s| s.version == statistic.version)
+            {
+                if statistic == *last_stats {
+                    let _ = GLOBAL_TIMER_HANDLE
+                        .delay(std::time::Instant::now() + BACKGROUND_RU_REPORT_DURATION)
+                        .compat()
+                        .await;
+                    continue;
+                }
+                (
+                    statistic.cpu_consumed - last_stats.cpu_consumed,
+                    (
+                        statistic.read_bytes_consumed - last_stats.read_bytes_consumed,
+                        statistic.write_bytes_consumed - last_stats.write_bytes_consumed,
+                    ),
+                )
+            } else {
+                (
+                    statistic.cpu_consumed,
+                    (
+                        statistic.read_bytes_consumed,
+                        statistic.write_bytes_consumed,
+                    ),
+                )
+            };
+            last_bg_statistics = Some(statistic);
+
             let mut req = TokenBucketsRequest::default();
             let all_reqs = req.mut_requests();
-            for (name, statistic) in background_groups.into_iter() {
-                // Non-existence or version change means this is a brand new limiter, so no need
-                // to sub the old statistics.
-                let (cpu_consumed, io_consumed) = if let Some(last_stats) =
-                    last_group_statistics_map
-                        .get(&name)
-                        .filter(|stats| statistic.version == stats.version)
-                {
-                    if statistic == *last_stats {
-                        continue;
-                    }
-                    (
-                        statistic.cpu_consumed - last_stats.cpu_consumed,
-                        (
-                            statistic.read_bytes_consumed - last_stats.read_bytes_consumed,
-                            statistic.write_bytes_consumed - last_stats.write_bytes_consumed,
-                        ),
-                    )
-                } else {
-                    (
-                        statistic.cpu_consumed,
-                        (
-                            statistic.read_bytes_consumed,
-                            statistic.write_bytes_consumed,
-                        ),
-                    )
-                };
-                // replace the previous statistics.
-                last_group_statistics_map.insert(name.clone(), statistic);
-                // report ru statistics.
-                let mut req = TokenBucketRequest::default();
-                req.set_resource_group_name(name.clone());
-                req.set_is_background(true);
-                let report_consumption = req.mut_consumption_since_last_request();
+            // report ru statistics.
+            let mut bucket_req = TokenBucketRequest::default();
+            bucket_req.set_resource_group_name(DEFAULT_RESOURCE_GROUP_NAME.to_owned());
+            bucket_req.set_is_background(true);
+            let report_consumption = bucket_req.mut_consumption_since_last_request();
 
-                let read_total = config.read_cpu_ms_cost * cpu_consumed as f64
-                    + config.read_cost_per_byte * io_consumed.0 as f64;
-                let write_total = config.write_cost_per_byte * io_consumed.1 as f64;
+            let read_total = config.read_cpu_ms_cost * cpu_consumed as f64
+                + config.read_cost_per_byte * io_consumed.0 as f64;
+            let write_total = config.write_cost_per_byte * io_consumed.1 as f64;
 
-                report_consumption.set_r_r_u(read_total);
-                report_consumption.set_w_r_u(write_total);
-                report_consumption.set_read_bytes(io_consumed.0 as f64);
-                report_consumption.set_write_bytes(io_consumed.1 as f64);
-                report_consumption.set_total_cpu_time_ms(cpu_consumed as f64);
+            report_consumption.set_r_r_u(read_total);
+            report_consumption.set_w_r_u(write_total);
+            report_consumption.set_read_bytes(io_consumed.0 as f64);
+            report_consumption.set_write_bytes(io_consumed.1 as f64);
+            report_consumption.set_total_cpu_time_ms(cpu_consumed as f64);
 
-                all_reqs.push(req);
-            }
+            all_reqs.push(bucket_req);
 
             if !all_reqs.is_empty() {
                 if let Err(e) = self.pd_client.report_ru_metrics(req).await {
@@ -542,7 +530,7 @@ pub mod tests {
         background_worker.spawn_async_task(async move {
             s_clone.report_ru_metrics().await;
         });
-        // Mock consume.
+        // Mock consume on the shared background limiter.
         let bg_limiter = s
             .manager
             .get_background_resource_limiter("background", "br")
@@ -558,18 +546,18 @@ pub mod tests {
         );
         // Wait for report ru metrics.
         std::thread::sleep(Duration::from_millis(100));
-        // Mock update version.
-        let bg = new_resource_group_ru("background".into(), 1000, 15);
-        s.manager.add_resource_group(bg);
 
-        let background_group =
-            new_background_resource_group_ru("background".into(), 500, 8, vec!["lightning".into()]);
+        // Add a second background group; all groups share the same limiter.
+        let background_group = new_background_resource_group_ru(
+            "lightning_group".into(),
+            500,
+            8,
+            vec!["lightning".into()],
+        );
         s.manager.add_resource_group(background_group);
-        let new_bg_limiter = s
-            .manager
-            .get_background_resource_limiter("background", "lightning")
-            .unwrap();
-        new_bg_limiter.consume(
+        // Consuming through either group's limiter goes to the same shared
+        // limiter; the next report will reflect the delta.
+        bg_limiter.consume(
             Duration::from_secs(5),
             IoBytes {
                 read: 2000,

--- a/components/resource_control/src/worker.rs
+++ b/components/resource_control/src/worker.rs
@@ -4,7 +4,10 @@ use std::{
     array,
     collections::{HashMap, HashSet},
     io::Result as IoResult,
-    sync::Arc,
+    sync::{
+        Arc,
+        atomic::{AtomicU32, Ordering},
+    },
     time::Duration,
 };
 
@@ -95,19 +98,28 @@ pub struct GroupQuotaAdjustWorker<R> {
     prev_stats_by_group: [HashMap<String, GroupStatistics>; ResourceType::COUNT],
     last_adjust_time: Instant,
     resource_ctl: Arc<ResourceGroupManager>,
-    is_last_time_low_load: [bool; ResourceType::COUNT],
     resource_quota_getter: R,
+    // Shared compaction pressure (0-100+) written by EnginesResourceInfo::update().
+    compaction_pending_bytes_ratio: Arc<AtomicU32>,
 }
 
 impl GroupQuotaAdjustWorker<SysQuotaGetter> {
-    pub fn new(resource_ctl: Arc<ResourceGroupManager>, io_bandwidth: u64) -> Self {
+    pub fn new(
+        resource_ctl: Arc<ResourceGroupManager>,
+        io_bandwidth: u64,
+        compaction_pending_bytes_ratio: Arc<AtomicU32>,
+    ) -> Self {
         let resource_quota_getter = SysQuotaGetter {
             process_stat: ProcessStat::cur_proc_stat().unwrap(),
             prev_io_stats: [IoBytes::default(); IoType::COUNT],
             prev_io_ts: Instant::now_coarse(),
             io_bandwidth: io_bandwidth as f64,
         };
-        Self::with_quota_getter(resource_ctl, resource_quota_getter)
+        Self::with_quota_getter(
+            resource_ctl,
+            resource_quota_getter,
+            compaction_pending_bytes_ratio,
+        )
     }
 }
 
@@ -115,6 +127,7 @@ impl<R: ResourceStatsProvider> GroupQuotaAdjustWorker<R> {
     pub fn with_quota_getter(
         resource_ctl: Arc<ResourceGroupManager>,
         resource_quota_getter: R,
+        compaction_pending_bytes_ratio: Arc<AtomicU32>,
     ) -> Self {
         let prev_stats_by_group = array::from_fn(|_| HashMap::default());
         Self {
@@ -122,7 +135,7 @@ impl<R: ResourceStatsProvider> GroupQuotaAdjustWorker<R> {
             last_adjust_time: Instant::now_coarse(),
             resource_ctl,
             resource_quota_getter,
-            is_last_time_low_load: array::from_fn(|_| false),
+            compaction_pending_bytes_ratio,
         }
     }
 
@@ -137,19 +150,30 @@ impl<R: ResourceStatsProvider> GroupQuotaAdjustWorker<R> {
         }
         self.last_adjust_time = now;
 
-        let mut background_util_limit = self
+        let mut bg_util_limit = self
             .resource_ctl
             .get_resource_group(DEFAULT_RESOURCE_GROUP_NAME)
             .map_or(0, |r| {
                 r.group.get_background_settings().get_utilization_limit()
             });
-        if background_util_limit == 0 {
-            background_util_limit = 100;
+        if bg_util_limit == 0 {
+            bg_util_limit = 100;
         }
+        let bg_resource_threshold = self
+            .resource_ctl
+            .get_config()
+            .value()
+            .bg_resource_threshold
+            .clamp(1.0, 99.0);
+        // Cap utilization limit to bg_resource_threshold. Background
+        // tasks should never consume more than this fraction of total resources.
+        // When CPU utilization exceeds the threshold, the headroom goes negative
+        // and the background rate limit is reduced.
+        bg_util_limit = bg_util_limit.min(bg_resource_threshold as u64);
 
         BACKGROUND_TASK_RESOURCE_UTILIZATION_VEC
             .with_label_values(&["limit"])
-            .set(background_util_limit as i64);
+            .set(bg_util_limit as i64);
 
         let mut background_groups: Vec<_> = self
             .resource_ctl
@@ -161,8 +185,6 @@ impl<R: ResourceStatsProvider> GroupQuotaAdjustWorker<R> {
                     name: g.group.name.clone(),
                     ru_quota: g.get_ru_quota() as f64,
                     limiter: limiter.clone(),
-                    stats_per_sec: GroupStatistics::default(),
-                    expect_cost_rate: 0.0,
                 })
             })
             .collect();
@@ -173,15 +195,20 @@ impl<R: ResourceStatsProvider> GroupQuotaAdjustWorker<R> {
         self.do_adjust(
             ResourceType::Cpu,
             dur_secs,
-            background_util_limit,
+            bg_util_limit,
+            bg_resource_threshold,
             &mut background_groups,
         );
         self.do_adjust(
             ResourceType::Io,
             dur_secs,
-            background_util_limit,
+            bg_util_limit,
+            bg_resource_threshold,
             &mut background_groups,
         );
+
+        // Adjust write IO limiter based on compaction pressure.
+        self.adjust_write_io_by_compaction_pressure(&background_groups, dur_secs);
 
         // clean up deleted group stats
         if self.prev_stats_by_group[0].len() != background_groups.len() {
@@ -198,6 +225,7 @@ impl<R: ResourceStatsProvider> GroupQuotaAdjustWorker<R> {
         resource_type: ResourceType,
         dur_secs: f64,
         utilization_limit: u64,
+        bg_resource_threshold: f64,
         bg_group_stats: &mut [GroupStats],
     ) {
         let resource_stats = match self.resource_quota_getter.get_current_stats(resource_type) {
@@ -217,17 +245,15 @@ impl<R: ResourceStatsProvider> GroupQuotaAdjustWorker<R> {
             return;
         }
 
+        // Collect statistics for metrics.
         let mut total_ru_quota = 0.0;
         let mut background_consumed_total = 0.0;
-        let mut has_wait = false;
         for g in bg_group_stats.iter_mut() {
             total_ru_quota += g.ru_quota;
             let total_stats = g.limiter.get_limit_statistics(resource_type);
             let last_stats = self.prev_stats_by_group[resource_type as usize]
                 .insert(g.name.clone(), total_stats)
                 .unwrap_or_default();
-            // version changes means this is a brand new limiter, so no need to sub the old
-            // statistics.
             let stats_delta = if total_stats.version == last_stats.version {
                 total_stats - last_stats
             } else {
@@ -241,95 +267,120 @@ impl<R: ResourceStatsProvider> GroupQuotaAdjustWorker<R> {
                     .with_label_values(&[&g.name])
                     .inc_by(stats_delta.total_wait_dur_us);
             }
-
             let stats_per_sec = stats_delta / dur_secs;
             background_consumed_total += stats_per_sec.total_consumed as f64;
-            g.stats_per_sec = stats_per_sec;
-            if stats_per_sec.total_wait_dur_us > 0 {
-                has_wait = true;
-            }
         }
 
         let background_util =
             (background_consumed_total / resource_stats.total_quota * 100.0) as u64;
+        let resource_util = resource_stats.current_used / resource_stats.total_quota * 100.0;
         BACKGROUND_TASK_RESOURCE_UTILIZATION_VEC
             .with_label_values(&[resource_type.as_str()])
             .set(background_util as i64);
 
-        // fast path if process cpu is low
-        let is_low_load = resource_stats.current_used <= (resource_stats.total_quota * 0.1);
-        if is_low_load && !has_wait && self.is_last_time_low_load[resource_type as usize] {
+        if total_ru_quota <= f64::EPSILON {
             return;
         }
-        self.is_last_time_low_load[resource_type as usize] = is_low_load;
 
         let util_limit_percent = (utilization_limit as f64 / 100.0).min(1.0);
-        // the available resource for background tasks is defined as:
-        // (total_resource_quota - foreground_task_used). foreground_task_used
-        // resource is calculated by: (resource_current_total_used -
-        // background_consumed_total). We reserve 20% of the free resources for
-        // foreground tasks in case the fore ground traffics increases.
-        let mut available_resource_rate = ((resource_stats.total_quota
-            - resource_stats.current_used
-            + background_consumed_total)
-            * 0.8)
-            .min(resource_stats.total_quota * util_limit_percent)
-            .max(resource_stats.total_quota * 0.1);
-        let mut total_expected_cost = 0.0;
-        for g in bg_group_stats.iter_mut() {
-            let mut rate_limit = g.limiter.get_limiter(resource_type).get_rate_limit();
-            if rate_limit.is_infinite() {
-                rate_limit = 0.0;
-            }
-            let group_expected_cost = g.stats_per_sec.total_consumed as f64
-                + g.stats_per_sec.total_wait_dur_us as f64 / MICROS_PER_SEC * rate_limit;
-            g.expect_cost_rate = group_expected_cost;
-            total_expected_cost += group_expected_cost;
-        }
-        // sort groups by the expect_cost_rate per ru
-        bg_group_stats.sort_by(|g1, g2| {
-            (g1.expect_cost_rate / g1.ru_quota)
-                .partial_cmp(&(g2.expect_cost_rate / g2.ru_quota))
-                .unwrap()
-        });
+        let target = resource_stats.total_quota * util_limit_percent;
 
-        // quota is enough, group is allowed to got more resource then its share by ru.
-        // e.g. Given a totol resource of 10000, and ("name", ru_quota, expected_rate)
-        // of:  (rg1, 2000, 3000), (rg2, 3000, 1000), (rg3, 5000, 5000)
-        // then after the previous sort, the order is rg2, rg3, rg1 and the handle order
-        // is rg1, rg3, rg2 so the final rate limit assigned is: (rg1, 3000),
-        // (rg3, 5833(7000/6*5)), (rg2, 1166(7000/6*1))
-        if total_expected_cost <= available_resource_rate {
-            for g in bg_group_stats.iter().rev() {
-                let limit = g
-                    .expect_cost_rate
-                    .max(available_resource_rate / total_ru_quota * g.ru_quota);
-                g.limiter.get_limiter(resource_type).set_rate_limit(limit);
-                BACKGROUND_QUOTA_LIMIT_VEC
-                    .with_label_values(&[&g.name, resource_type.as_str()])
-                    .set(limit as i64);
-                available_resource_rate -= limit;
-                total_ru_quota -= g.ru_quota;
-            }
-            return;
+        // Sum current background limits; treat infinity as an equal share of
+        // the target (initial state before first adjustment).
+        let current_total_bg_limit: f64 = bg_group_stats
+            .iter()
+            .map(|g| {
+                let limit = g.limiter.get_limiter(resource_type).get_rate_limit();
+                if limit.is_infinite() {
+                    target / bg_group_stats.len() as f64
+                } else {
+                    limit
+                }
+            })
+            .sum();
+
+        // Minimum: 1 CPU core for CPU, 10% of total for IO.
+        let min_floor = match resource_type {
+            ResourceType::Cpu => MICROS_PER_SEC,
+            ResourceType::Io => resource_stats.total_quota * 0.1,
+        }
+        .min(target);
+
+        let mut new_total_bg_budget = target;
+        if resource_util > bg_resource_threshold {
+            // System is overloaded. Linearly scale budget from target down to
+            // min_floor as utilization goes from threshold (70%) to 100%.
+            // This aggressively throttles background regardless of how much
+            // it's consuming, freeing resources for online traffic.
+            let pressure =
+                (resource_util - bg_resource_threshold) / (100.0 - bg_resource_threshold);
+            new_total_bg_budget = target * (1.0 - pressure) + min_floor * pressure;
+        } else if current_total_bg_limit > target {
+            // Background limit exceeds its allowed share; reset to target.
+            new_total_bg_budget = target;
+        } else if current_total_bg_limit < 0.9 * target
+            && resource_util < 0.9 * bg_resource_threshold
+        {
+            // System is idle; increase limit incrementally from current limit.
+            new_total_bg_budget = current_total_bg_limit + 0.1 * current_total_bg_limit;
         }
 
-        // quota is not enough, assign by share
-        // e.g. Given a totol resource of 10000, and ("name", ru_quota, expected_rate)
-        // of:  (rg1, 2000, 1000), (rg2, 3000, 5000), (rg3, 5000, 7000)
-        // then after the previous sort, the order is rg1, rg3, rg2, and handle order is
-        // rg1, rg3, rg2 so the final rate limit assigned is: (rg1, 1000), (rg3,
-        // 5250(9000/12*7)), (rg2, 3750(9000/12*5))
-        for g in bg_group_stats {
-            let limit = g
-                .expect_cost_rate
-                .min(available_resource_rate / total_ru_quota * g.ru_quota);
+        let new_total_bg_budget = new_total_bg_budget.clamp(min_floor, target);
+
+        // Distribute proportionally by RU quota.
+        for g in bg_group_stats.iter() {
+            let limit = new_total_bg_budget * (g.ru_quota / total_ru_quota);
             g.limiter.get_limiter(resource_type).set_rate_limit(limit);
             BACKGROUND_QUOTA_LIMIT_VEC
                 .with_label_values(&[&g.name, resource_type.as_str()])
                 .set(limit as i64);
-            available_resource_rate -= limit;
-            total_ru_quota -= g.ru_quota;
+        }
+    }
+
+    /// Adjust the write-only IO limiter based on compaction pressure.
+    /// When pressure >= threshold, linearly scale write IO from ceiling to
+    /// floor. Below threshold, write IO is unlimited (infinity).
+    ///
+    /// Ceiling and floor are read from config (bg_write_io_ceiling,
+    /// bg_write_io_floor) in MB/s.
+    fn adjust_write_io_by_compaction_pressure(
+        &self,
+        bg_group_stats: &[GroupStats],
+        _dur_secs: f64,
+    ) {
+        let pressure = self.compaction_pending_bytes_ratio.load(Ordering::Relaxed) as f64;
+        let config = self.resource_ctl.get_config().value().clone();
+        let threshold = config.bg_compaction_pressure_threshold.clamp(1.0, 99.0);
+        let ceiling = config.bg_write_io_ceiling.0 as f64; // bytes/s
+        let floor = config.bg_write_io_floor.0 as f64; // bytes/s
+
+        let total_budget = if pressure < threshold {
+            // Below threshold: ramp up current limit by 10%, capped at ceiling.
+            let current_limit = bg_group_stats
+                .first()
+                .map(|g| g.limiter.get_write_io_limiter().get_rate_limit())
+                .unwrap_or(ceiling);
+            if current_limit.is_infinite() || current_limit >= ceiling {
+                ceiling
+            } else {
+                (current_limit * 1.1).min(ceiling)
+            }
+        } else {
+            // Linear interpolation from ceiling to floor as pressure goes from
+            // threshold to 100%.
+            let pressure_ratio = ((pressure - threshold) / (100.0 - threshold)).clamp(0.0, 1.0);
+            let total_budget = ceiling * (1.0 - pressure_ratio) + floor * pressure_ratio;
+            total_budget.max(floor)
+        };
+
+        // Distribute proportionally by RU quota.
+        let total_ru_quota: f64 = bg_group_stats.iter().map(|g| g.ru_quota).sum();
+        if total_ru_quota <= f64::EPSILON {
+            return;
+        }
+        for g in bg_group_stats {
+            let limit = total_budget * (g.ru_quota / total_ru_quota);
+            g.limiter.get_write_io_limiter().set_rate_limit(limit);
         }
     }
 }
@@ -338,8 +389,6 @@ struct GroupStats {
     name: String,
     limiter: Arc<ResourceLimiter>,
     ru_quota: f64,
-    stats_per_sec: GroupStatistics,
-    expect_cost_rate: f64,
 }
 
 /// PriorityLimiterAdjustWorker automically adjust the quota of each priority
@@ -593,7 +642,7 @@ mod tests {
     use std::time::Duration;
 
     use super::*;
-    use crate::{resource_group::tests::*, resource_limiter::QuotaLimiter};
+    use crate::resource_group::tests::*;
 
     struct TestResourceStatsProvider {
         cpu_total: f64,
@@ -631,6 +680,8 @@ mod tests {
     #[test]
     fn test_adjust_resource_limiter() {
         let resource_ctl = Arc::new(ResourceGroupManager::default());
+
+        // Non-background group should not get a limiter.
         let rg1 = new_resource_group_ru("test".into(), 1000, 14);
         resource_ctl.add_resource_group(rg1);
         assert!(
@@ -639,13 +690,23 @@ mod tests {
                 .is_none()
         );
 
+        // 8 CPU cores, 10000 bytes/s IO bandwidth.
         let test_provider = TestResourceStatsProvider::new(8.0, 10000.0);
-        let mut worker =
-            GroupQuotaAdjustWorker::with_quota_getter(resource_ctl.clone(), test_provider);
+        let compaction_pending_bytes_ratio = Arc::new(AtomicU32::new(0));
+        let mut worker = GroupQuotaAdjustWorker::with_quota_getter(
+            resource_ctl.clone(),
+            test_provider,
+            compaction_pending_bytes_ratio,
+        );
 
-        let default_bg =
-            new_background_resource_group_ru("default".into(), 100000, 8, vec!["br".into()]);
+        // Create default background group with 80% utilization limit.
+        let mut default_bg =
+            new_background_resource_group_ru("default".into(), 2000, 8, vec!["br".into()]);
+        default_bg
+            .mut_background_settings()
+            .set_utilization_limit(80);
         resource_ctl.add_resource_group(default_bg);
+
         assert!(
             resource_ctl
                 .get_background_resource_limiter("default", "lightning")
@@ -666,19 +727,6 @@ mod tests {
                 .get_rate_limit()
                 .is_infinite()
         );
-
-        fn reset_quota_limiter(limiter: &QuotaLimiter) {
-            let limit = limiter.get_rate_limit();
-            if limit.is_finite() {
-                limiter.set_rate_limit(f64::INFINITY);
-                limiter.set_rate_limit(limit);
-            }
-        }
-
-        fn reset_limiter(limiter: &Arc<ResourceLimiter>) {
-            reset_quota_limiter(limiter.get_limiter(ResourceType::Cpu));
-            reset_quota_limiter(limiter.get_limiter(ResourceType::Io));
-        }
 
         let reset_quota = |worker: &mut GroupQuotaAdjustWorker<TestResourceStatsProvider>,
                            cpu: f64,
@@ -701,187 +749,100 @@ mod tests {
         }
 
         #[track_caller]
-        fn check_limiter(limiter: &Arc<ResourceLimiter>, cpu: f64, io: IoBytes) {
+        fn check_limiter_rates(limiter: &Arc<ResourceLimiter>, cpu: f64, io: f64) {
             check(
                 limiter.get_limiter(ResourceType::Cpu).get_rate_limit(),
                 cpu * MICROS_PER_SEC,
             );
-            check(
-                limiter.get_limiter(ResourceType::Io).get_rate_limit(),
-                (io.read + io.write) as f64,
-            );
-            reset_limiter(limiter);
+            check(limiter.get_limiter(ResourceType::Io).get_rate_limit(), io);
         }
 
+        // util_limit configured at 80% but capped to 70%.
+        // CPU target = 8 * 0.7 = 5.6 cores, IO target = 10000 * 0.7 = 7000
+        // CPU min_floor = 1 core, IO min_floor = 1000
+
+        // No load: initial infinity → treated as target → budget = target.
         reset_quota(&mut worker, 0.0, 0.0, Duration::from_secs(1));
         worker.adjust_quota();
-        check_limiter(
-            &limiter,
-            6.4,
-            IoBytes {
-                read: 4000,
-                write: 4000,
-            },
-        );
+        check_limiter_rates(&limiter, 5.6, 7000.0);
 
+        // Short duration (< 1s): adjustment skipped, limits unchanged.
         reset_quota(&mut worker, 4.0, 2000.0, Duration::from_millis(500));
         worker.adjust_quota();
-        check_limiter(
-            &limiter,
-            6.4,
-            IoBytes {
-                read: 4000,
-                write: 4000,
-            },
-        );
+        check_limiter_rates(&limiter, 5.6, 7000.0);
 
+        // Under target (50% CPU): resource_util < 70%, current == target,
+        // so none of the branches fire → budget = target.
         reset_quota(&mut worker, 4.0, 2000.0, Duration::from_secs(1));
         worker.adjust_quota();
-        check_limiter(
-            &limiter,
-            3.2,
-            IoBytes {
-                read: 3200,
-                write: 3200,
-            },
-        );
+        check_limiter_rates(&limiter, 5.6, 7000.0);
 
-        reset_quota(&mut worker, 6.0, 4000.0, Duration::from_secs(1));
-        limiter.consume(
-            Duration::from_secs(2),
-            IoBytes {
-                read: 1000,
-                write: 1000,
-            },
-            true,
-        );
+        // Above 70% (80% CPU, 80% IO): resource_util > 70 branch fires.
+        // Budget linearly interpolates from target to min_floor.
+        // CPU: pressure = (80-70)/(100-70) = 1/3. budget = 5.6*(1-1/3) + 1.0*(1/3) ≈
+        // 4.067 IO: pressure = (80-70)/(100-70) = 1/3. budget = 7000*(2/3) +
+        // 1000*(1/3) ≈ 5000
+        reset_quota(&mut worker, 6.4, 8000.0, Duration::from_secs(1));
         worker.adjust_quota();
-        check_limiter(
-            &limiter,
-            3.2,
-            IoBytes {
-                read: 3200,
-                write: 3200,
-            },
-        );
+        check_limiter_rates(&limiter, 4.067, 5000.0);
 
+        // 100% CPU, 95% IO: heavier pressure.
+        // CPU: pressure = (100-70)/30 = 1.0. budget = 5.6*0 + 1.0*1.0 = 1.0 (min_floor)
+        // IO: pressure = (95-70)/30 = 25/30 = 5/6. budget = 7000*(1/6) + 1000*(5/6) ≈
+        // 2000
         reset_quota(&mut worker, 8.0, 9500.0, Duration::from_secs(1));
         worker.adjust_quota();
-        check_limiter(
-            &limiter,
-            0.8,
-            IoBytes {
-                read: 500,
-                write: 500,
-            },
-        );
+        check_limiter_rates(&limiter, 1.0, 2000.0);
 
-        reset_quota(&mut worker, 7.5, 9500.0, Duration::from_secs(1));
-        limiter.consume(
-            Duration::from_secs(2),
-            IoBytes {
-                read: 1000,
-                write: 1000,
-            },
-            true,
-        );
+        // Still at 100% CPU, 95% IO: same result (deterministic, no decay).
+        reset_quota(&mut worker, 8.0, 9500.0, Duration::from_secs(1));
         worker.adjust_quota();
-        check_limiter(
-            &limiter,
-            2.0,
-            IoBytes {
-                read: 1000,
-                write: 1000,
-            },
-        );
+        check_limiter_rates(&limiter, 1.0, 2000.0);
 
-        reset_quota(&mut worker, 7.5, 9500.0, Duration::from_secs(5));
-        limiter.consume(
-            Duration::from_secs(10),
-            IoBytes {
-                read: 5000,
-                write: 5000,
-            },
-            true,
-        );
+        // 85% CPU, 80% IO: moderate pressure.
+        // CPU: pressure = (85-70)/30 = 0.5. budget = 5.6*0.5 + 1.0*0.5 = 3.3
+        // IO: pressure = (80-70)/30 = 1/3. budget = 7000*(2/3) + 1000*(1/3) = 5000
+        reset_quota(&mut worker, 6.8, 8000.0, Duration::from_secs(1));
         worker.adjust_quota();
-        check_limiter(
-            &limiter,
-            2.0,
-            IoBytes {
-                read: 1000,
-                write: 1000,
-            },
-        );
+        check_limiter_rates(&limiter, 3.3, 5000.0);
 
-        let default =
-            new_background_resource_group_ru("default".into(), 2000, 8, vec!["br".into()]);
-        resource_ctl.add_resource_group(default);
-        let new_limiter = resource_ctl
-            .get_background_resource_limiter("default", "br")
-            .unwrap();
-        assert_eq!(&*new_limiter as *const _, &*limiter as *const _);
+        // Load drops (50% CPU, 20% IO): resource_util < 63%, current < 0.9*target
+        // → incremental increase: budget = current * 1.1
+        // CPU: 3.3 * 1.1 = 3.63
+        // IO: 5000 * 1.1 = 5500
+        reset_quota(&mut worker, 4.0, 2000.0, Duration::from_secs(1));
+        worker.adjust_quota();
+        check_limiter_rates(&limiter, 3.63, 5500.0);
 
+        // --- Multi-group: proportional distribution by RU quota ---
         let bg = new_background_resource_group_ru("background".into(), 1000, 15, vec!["br".into()]);
         resource_ctl.add_resource_group(bg);
         let bg_limiter = resource_ctl
             .get_background_resource_limiter("background", "br")
             .unwrap();
 
-        reset_quota(&mut worker, 5.0, 7000.0, Duration::from_secs(1));
+        // default ru=2000, bg ru=1000 → shares: 2/3, 1/3
+        // No load: default at 3.63M, bg at infinity → target/2 = 2.8M
+        // current_total = 3.63M + 2.8M = 6.43M > target (5.6M) → budget = target = 5.6M
+        // default: 5.6 * 2/3 ≈ 3.733, bg: 5.6/3 ≈ 1.867
+        // IO: current_total = 5500 + 3500 = 9000 > 7000 → budget = 7000
+        // default: 7000 * 2/3 ≈ 4667, bg: 7000/3 ≈ 2333
+        reset_quota(&mut worker, 0.0, 0.0, Duration::from_secs(1));
         worker.adjust_quota();
-        check_limiter(
-            &limiter,
-            1.6,
-            IoBytes {
-                read: 800,
-                write: 800,
-            },
-        );
-        check_limiter(
-            &bg_limiter,
-            0.8,
-            IoBytes {
-                read: 400,
-                write: 400,
-            },
-        );
+        check_limiter_rates(&limiter, 3.733, 4666.7);
+        check_limiter_rates(&bg_limiter, 1.867, 2333.3);
 
-        reset_quota(&mut worker, 6.0, 5000.0, Duration::from_secs(1));
-        limiter.consume(
-            Duration::from_millis(1200),
-            IoBytes {
-                read: 600,
-                write: 600,
-            },
-            true,
-        );
-        bg_limiter.consume(
-            Duration::from_millis(1800),
-            IoBytes {
-                read: 900,
-                write: 900,
-            },
-            true,
-        );
+        // Over 70% (100% CPU, 95% IO): budget scales down from target.
+        // CPU: pressure = 1.0. budget = min_floor = 1.0M
+        //   default: 1.0M * 2/3 ≈ 0.667, bg: 1.0M/3 ≈ 0.333
+        // IO: pressure = 25/30 = 5/6. budget = 7000*(1/6) + 1000*(5/6) = 2000
+        //   default: 2000 * 2/3 ≈ 1333.3, bg: 2000/3 ≈ 666.7
+        reset_quota(&mut worker, 8.0, 9500.0, Duration::from_secs(1));
         worker.adjust_quota();
-        check_limiter(
-            &limiter,
-            1.2,
-            IoBytes {
-                read: 1800,
-                write: 1800,
-            },
-        );
-        check_limiter(
-            &bg_limiter,
-            2.8,
-            IoBytes {
-                read: 1400,
-                write: 1400,
-            },
-        );
+        check_limiter_rates(&limiter, 0.667, 1333.3);
+        check_limiter_rates(&bg_limiter, 0.333, 666.7);
 
+        // --- Limiter version change ---
         let bg = new_resource_group_ru("background".into(), 1000, 15);
         resource_ctl.add_resource_group(bg);
 
@@ -905,59 +866,121 @@ mod tests {
         assert_eq!(io_stats.total_consumed, 0);
         assert_eq!(io_stats.total_wait_dur_us, 0);
 
+        // New bg limiter at infinity → target/2 = 2.8M.
+        // default at 0.667M. current_total = 0.667M + 2.8M = 3.467M
+        // 3.467M < 5.04M → incremental: budget = 3.467 * 1.1 = 3.8137M
+        // default: 3.8137 * 2/3 ≈ 2.542, new_bg: 3.8137/3 ≈ 1.271
+        // IO: default 1333.3, bg inf→3500, total=4833.3 < 6300 → 4833.3*1.1=5316.6
+        // default: 5316.6 * 2/3 ≈ 3544.4, new_bg: 5316.6/3 ≈ 1772.2
         reset_quota(&mut worker, 0.0, 0.0, Duration::from_secs(1));
         worker.adjust_quota();
-        check_limiter(
-            &limiter,
-            4.27,
-            IoBytes {
-                read: 2667,
-                write: 2667,
-            },
-        );
-        check_limiter(
-            &new_bg_limiter,
-            2.13,
-            IoBytes {
-                read: 1334,
-                write: 1334,
-            },
+        check_limiter_rates(&limiter, 2.542, 3544.4);
+        check_limiter_rates(&new_bg_limiter, 1.271, 1772.2);
+    }
+
+    #[test]
+    fn test_bg_limiter_with_infinite_ru_groups() {
+        let resource_ctl = Arc::new(ResourceGroupManager::default());
+
+        // 3 foreground groups with large RU quota (no background limiter).
+        for i in 0..3 {
+            let rg = new_resource_group_ru(format!("fg_{i}"), i32::MAX as u64, 8);
+            resource_ctl.add_resource_group(rg);
+        }
+
+        // 1 background group with no explicit utilization limit.
+        // bg_util_limit defaults to 100, capped to 70 by bg_resource_threshold.
+        let bg = new_background_resource_group_ru("bg_worker".into(), 5000, 8, vec!["br".into()]);
+        resource_ctl.add_resource_group(bg);
+        let limiter = resource_ctl
+            .get_background_resource_limiter("bg_worker", "br")
+            .unwrap();
+
+        // 8 CPU cores, 10000 bytes/s IO.
+        let test_provider = TestResourceStatsProvider::new(8.0, 10000.0);
+        let compaction_pending_bytes_ratio = Arc::new(AtomicU32::new(0));
+        let mut worker = GroupQuotaAdjustWorker::with_quota_getter(
+            resource_ctl.clone(),
+            test_provider,
+            compaction_pending_bytes_ratio,
         );
 
-        reset_quota(&mut worker, 6.0, 5000.0, Duration::from_secs(1));
-        limiter.consume(
-            Duration::from_millis(1200),
-            IoBytes {
-                read: 600,
-                write: 600,
-            },
-            true,
-        );
-        new_bg_limiter.consume(
-            Duration::from_millis(1800),
-            IoBytes {
-                read: 900,
-                write: 900,
-            },
-            true,
-        );
+        let reset_quota = |worker: &mut GroupQuotaAdjustWorker<TestResourceStatsProvider>,
+                           cpu: f64,
+                           io: f64,
+                           dur: Duration| {
+            worker.resource_quota_getter.cpu_used = cpu;
+            worker.resource_quota_getter.io_used = io;
+            let now = Instant::now_coarse();
+            worker.last_adjust_time = now - dur;
+        };
 
+        #[track_caller]
+        fn check(val: f64, expected: f64) {
+            assert!(
+                expected * 0.99 < val && val < expected * 1.01,
+                "actual: {}, expected: {}",
+                val,
+                expected
+            );
+        }
+
+        // CPU target = 8 * 0.7 = 5.6 cores, IO target = 10000 * 0.7 = 7000
+        // Only bg_worker has a limiter; fg groups are not in bg_group_stats.
+
+        // --- Initial: no load → budget = target ---
+        reset_quota(&mut worker, 0.0, 0.0, Duration::from_secs(1));
         worker.adjust_quota();
-        check_limiter(
-            &limiter,
-            2.2,
-            IoBytes {
-                read: 2133,
-                write: 2133,
-            },
+        check(
+            limiter.get_limiter(ResourceType::Cpu).get_rate_limit(),
+            5.6 * MICROS_PER_SEC,
         );
-        check_limiter(
-            &new_bg_limiter,
-            1.8,
-            IoBytes {
-                read: 1066,
-                write: 1066,
-            },
+        check(
+            limiter.get_limiter(ResourceType::Io).get_rate_limit(),
+            7000.0,
+        );
+
+        // --- Saturate CPU (100%, 80% IO) → budget scales down from target ---
+        // CPU: pressure = (100-70)/30 = 1.0. budget = min_floor = 1.0
+        // IO: pressure = (80-70)/30 = 1/3. budget = 7000*(2/3) + 1000*(1/3) = 5000
+        reset_quota(&mut worker, 8.0, 8000.0, Duration::from_secs(1));
+        worker.adjust_quota();
+        check(
+            limiter.get_limiter(ResourceType::Cpu).get_rate_limit(),
+            1.0 * MICROS_PER_SEC,
+        );
+        check(
+            limiter.get_limiter(ResourceType::Io).get_rate_limit(),
+            5000.0,
+        );
+
+        // --- Unsaturate CPU (25%) → budget recovers incrementally ---
+        // CPU: resource_util = 25% < 63, current 1.0M < 5.04M → budget = 1.0 * 1.1 =
+        // 1.1 IO: resource_util = 20% < 63, current 5000 < 6300 → budget = 5000
+        // * 1.1 = 5500
+        reset_quota(&mut worker, 2.0, 2000.0, Duration::from_secs(1));
+        worker.adjust_quota();
+        check(
+            limiter.get_limiter(ResourceType::Cpu).get_rate_limit(),
+            1.1 * MICROS_PER_SEC,
+        );
+        check(
+            limiter.get_limiter(ResourceType::Io).get_rate_limit(),
+            5500.0,
+        );
+
+        // --- 85% CPU, 80% IO: moderate pressure ---
+        // CPU: pressure = (85-70)/30 = 0.5. budget = 5.6*0.5 + 1.0*0.5 = 3.3
+        // IO: pressure = (80-70)/30 = 1/3. budget = 7000*(2/3) + 1000*(1/3) = 5000
+        reset_quota(&mut worker, 6.8, 8000.0, Duration::from_secs(1));
+        worker.adjust_quota();
+        check(
+            limiter.get_limiter(ResourceType::Cpu).get_rate_limit(),
+            3.3 * MICROS_PER_SEC,
+        );
+        check(
+            limiter.get_limiter(ResourceType::Io).get_rate_limit(),
+            5000.0,
         );
     }
 
@@ -1015,7 +1038,7 @@ mod tests {
 
         // only default group, always return infinity.
         reset_quota(&mut worker, 6.4);
-        priority_limiters[1].consume(Duration::from_secs(50), IoBytes::default(), true);
+        priority_limiters[1].consume(Duration::from_secs(50), IoBytes::default(), true, false);
         worker.adjust();
         check_limiter(f64::INFINITY, f64::INFINITY, f64::INFINITY);
 
@@ -1025,46 +1048,96 @@ mod tests {
         resource_ctl.add_resource_group(rg2);
 
         reset_quota(&mut worker, 6.4);
-        priority_limiters[1].consume(Duration::from_secs(64), IoBytes::default(), true);
+        priority_limiters[1].consume(Duration::from_secs(64), IoBytes::default(), true, false);
         worker.adjust();
         check_limiter(f64::INFINITY, f64::INFINITY, f64::INFINITY);
 
         reset_quota(&mut worker, 6.4);
         for _i in 0..100 {
-            priority_limiters[0].consume(Duration::from_millis(240), IoBytes::default(), true);
-            priority_limiters[1].consume(Duration::from_millis(400), IoBytes::default(), true);
+            priority_limiters[0].consume(
+                Duration::from_millis(240),
+                IoBytes::default(),
+                true,
+                false,
+            );
+            priority_limiters[1].consume(
+                Duration::from_millis(400),
+                IoBytes::default(),
+                true,
+                false,
+            );
         }
         worker.adjust();
         check_limiter(f64::INFINITY, 3.2, 0.8);
 
         reset_quota(&mut worker, 6.4);
         for _i in 0..100 {
-            priority_limiters[0].consume(Duration::from_millis(120), IoBytes::default(), true);
-            priority_limiters[1].consume(Duration::from_millis(200), IoBytes::default(), true);
+            priority_limiters[0].consume(
+                Duration::from_millis(120),
+                IoBytes::default(),
+                true,
+                false,
+            );
+            priority_limiters[1].consume(
+                Duration::from_millis(200),
+                IoBytes::default(),
+                true,
+                false,
+            );
         }
         worker.adjust();
         check_limiter(f64::INFINITY, 1.6, 0.8);
 
         reset_quota(&mut worker, 6.4);
         for _i in 0..100 {
-            priority_limiters[2].consume(Duration::from_millis(200), IoBytes::default(), true);
+            priority_limiters[2].consume(
+                Duration::from_millis(200),
+                IoBytes::default(),
+                true,
+                false,
+            );
         }
         worker.adjust();
         check_limiter(f64::INFINITY, f64::INFINITY, f64::INFINITY);
 
         reset_quota(&mut worker, 8.0);
         for _i in 0..100 {
-            priority_limiters[0].consume(Duration::from_millis(240), IoBytes::default(), true);
-            priority_limiters[1].consume(Duration::from_millis(240), IoBytes::default(), true);
-            priority_limiters[2].consume(Duration::from_millis(320), IoBytes::default(), true);
+            priority_limiters[0].consume(
+                Duration::from_millis(240),
+                IoBytes::default(),
+                true,
+                false,
+            );
+            priority_limiters[1].consume(
+                Duration::from_millis(240),
+                IoBytes::default(),
+                true,
+                false,
+            );
+            priority_limiters[2].consume(
+                Duration::from_millis(320),
+                IoBytes::default(),
+                true,
+                false,
+            );
         }
         worker.adjust();
         check_limiter(f64::INFINITY, 3.2, 0.8);
 
         reset_quota(&mut worker, 6.0);
         for _i in 0..100 {
-            priority_limiters[0].consume(Duration::from_millis(240), IoBytes::default(), true);
-            priority_limiters[2].consume(Duration::from_millis(360), IoBytes::default(), true);
+            priority_limiters[0].consume(
+                Duration::from_millis(240),
+                IoBytes::default(),
+                true,
+                false,
+            );
+            priority_limiters[2].consume(
+                Duration::from_millis(360),
+                IoBytes::default(),
+                true,
+                false,
+            );
         }
         worker.adjust();
         check_limiter(f64::INFINITY, 3.2, 3.2);
@@ -1074,5 +1147,155 @@ mod tests {
         worker.last_adjust_time = Instant::now_coarse() - Duration::from_millis(500);
         worker.adjust();
         check_limiter(f64::INFINITY, 3.2, 3.2);
+    }
+
+    #[test]
+    fn test_compaction_pending_bytes_ratio_write_io_throttle() {
+        let resource_ctl = Arc::new(ResourceGroupManager::default());
+
+        // 8 CPU cores, 10000 bytes/s IO bandwidth.
+        let test_provider = TestResourceStatsProvider::new(8.0, 10000.0);
+        let compaction_pending_bytes_ratio = Arc::new(AtomicU32::new(0));
+        let mut worker = GroupQuotaAdjustWorker::with_quota_getter(
+            resource_ctl.clone(),
+            test_provider,
+            compaction_pending_bytes_ratio.clone(),
+        );
+
+        // Create default background group with 80% utilization limit.
+        let mut default_bg =
+            new_background_resource_group_ru("default".into(), 2000, 8, vec!["br".into()]);
+        default_bg
+            .mut_background_settings()
+            .set_utilization_limit(80);
+        resource_ctl.add_resource_group(default_bg);
+
+        let limiter = resource_ctl
+            .get_background_resource_limiter("default", "br")
+            .unwrap();
+
+        let reset_quota = |worker: &mut GroupQuotaAdjustWorker<TestResourceStatsProvider>,
+                           cpu: f64,
+                           io: f64,
+                           dur: Duration| {
+            worker.resource_quota_getter.cpu_used = cpu;
+            worker.resource_quota_getter.io_used = io;
+            let now = Instant::now_coarse();
+            worker.last_adjust_time = now - dur;
+        };
+
+        #[track_caller]
+        fn check(val: f64, expected: f64) {
+            assert!(
+                (val.is_infinite() && expected.is_infinite())
+                    || (expected * 0.99 < val && val < expected * 1.01),
+                "actual: {}, expected: {}",
+                val,
+                expected
+            );
+        }
+
+        // Constants matching config defaults (bg_write_io_ceiling=100GB/s,
+        // bg_write_io_floor=10MB/s).
+        let ceiling = 100.0 * 1024.0 * 1024.0 * 1024.0; // 100 GB/s in bytes/s
+        let floor = 10.0 * 1024.0 * 1024.0; // 10 MB/s in bytes/s
+
+        // First adjustment: establish baseline limits.
+        // util_limit 80% capped to 70%. CPU target = 5.6 cores, IO target = 7000
+        reset_quota(&mut worker, 0.0, 0.0, Duration::from_secs(1));
+        worker.adjust_quota();
+        check(
+            limiter.get_limiter(ResourceType::Cpu).get_rate_limit(),
+            5.6 * MICROS_PER_SEC,
+        );
+        check(
+            limiter.get_limiter(ResourceType::Io).get_rate_limit(),
+            7000.0,
+        );
+
+        // Pressure = 0: below threshold → first call, current is infinite so
+        // set to ceiling.
+        check(limiter.get_write_io_limiter().get_rate_limit(), ceiling);
+
+        // Pressure = 50 (< 70): already at ceiling, stays at ceiling.
+        compaction_pending_bytes_ratio.store(50, Ordering::Relaxed);
+        reset_quota(&mut worker, 0.0, 0.0, Duration::from_secs(1));
+        worker.adjust_quota();
+        check(limiter.get_write_io_limiter().get_rate_limit(), ceiling);
+
+        // CPU and combined IO limits unchanged at target.
+        check(
+            limiter.get_limiter(ResourceType::Cpu).get_rate_limit(),
+            5.6 * MICROS_PER_SEC,
+        );
+        check(
+            limiter.get_limiter(ResourceType::Io).get_rate_limit(),
+            7000.0,
+        );
+
+        // Pressure = 70 (at threshold): pressure_ratio = 0 → budget = ceiling.
+        compaction_pending_bytes_ratio.store(70, Ordering::Relaxed);
+        reset_quota(&mut worker, 0.0, 0.0, Duration::from_secs(1));
+        worker.adjust_quota();
+        check(limiter.get_write_io_limiter().get_rate_limit(), ceiling);
+
+        // CPU and combined IO limits should not be affected by compaction pressure.
+        check(
+            limiter.get_limiter(ResourceType::Cpu).get_rate_limit(),
+            5.6 * MICROS_PER_SEC,
+        );
+
+        // Pressure = 85: pressure_ratio = (85-70)/(100-70) = 0.5
+        // budget = ceiling * 0.5 + floor * 0.5
+        compaction_pending_bytes_ratio.store(85, Ordering::Relaxed);
+        reset_quota(&mut worker, 0.0, 0.0, Duration::from_secs(1));
+        worker.adjust_quota();
+        let expected_85 = ceiling * 0.5 + floor * 0.5;
+        check(limiter.get_write_io_limiter().get_rate_limit(), expected_85);
+
+        // CPU limit unaffected.
+        check(
+            limiter.get_limiter(ResourceType::Cpu).get_rate_limit(),
+            5.6 * MICROS_PER_SEC,
+        );
+
+        // Pressure = 100: pressure_ratio = 1.0 → budget = floor (10 MB/s).
+        compaction_pending_bytes_ratio.store(100, Ordering::Relaxed);
+        reset_quota(&mut worker, 0.0, 0.0, Duration::from_secs(1));
+        worker.adjust_quota();
+        check(limiter.get_write_io_limiter().get_rate_limit(), floor);
+
+        // CPU limit unaffected.
+        check(
+            limiter.get_limiter(ResourceType::Cpu).get_rate_limit(),
+            5.6 * MICROS_PER_SEC,
+        );
+
+        // Pressure drops to 0 (< threshold): ramp up by 10% from floor.
+        // floor * 1.1 = 10 MB/s * 1.1 = 11534336
+        compaction_pending_bytes_ratio.store(0, Ordering::Relaxed);
+        reset_quota(&mut worker, 0.0, 0.0, Duration::from_secs(1));
+        worker.adjust_quota();
+        let ramp1 = floor * 1.1;
+        check(limiter.get_write_io_limiter().get_rate_limit(), ramp1);
+
+        // Pressure stays at 0: another 10% ramp up.
+        reset_quota(&mut worker, 0.0, 0.0, Duration::from_secs(1));
+        worker.adjust_quota();
+        let ramp2 = ramp1 * 1.1;
+        check(limiter.get_write_io_limiter().get_rate_limit(), ramp2);
+
+        // Keep ramping until we hit ceiling.
+        let mut current = ramp2;
+        while current * 1.1 < ceiling {
+            reset_quota(&mut worker, 0.0, 0.0, Duration::from_secs(1));
+            worker.adjust_quota();
+            current = (current * 1.1).min(ceiling);
+            check(limiter.get_write_io_limiter().get_rate_limit(), current);
+        }
+        // One more adjustment should cap at ceiling.
+        reset_quota(&mut worker, 0.0, 0.0, Duration::from_secs(1));
+        worker.adjust_quota();
+        check(limiter.get_write_io_limiter().get_rate_limit(), ceiling);
     }
 }

--- a/components/resource_control/src/worker.rs
+++ b/components/resource_control/src/worker.rs
@@ -2,7 +2,6 @@
 
 use std::{
     array,
-    collections::{HashMap, HashSet},
     io::Result as IoResult,
     sync::{
         Arc,
@@ -95,12 +94,18 @@ impl ResourceStatsProvider for SysQuotaGetter {
 }
 
 pub struct GroupQuotaAdjustWorker<R> {
-    prev_stats_by_group: [HashMap<String, GroupStatistics>; ResourceType::COUNT],
     last_adjust_time: Instant,
     resource_ctl: Arc<ResourceGroupManager>,
     resource_quota_getter: R,
     // Shared compaction pressure (0-100+) written by EnginesResourceInfo::update().
     compaction_pending_bytes_ratio: Arc<AtomicU32>,
+    // Single shared limiter for all background tasks.
+    bg_limiter: Arc<ResourceLimiter>,
+    // Previous statistics snapshot per resource type for delta computation.
+    prev_stats: [GroupStatistics; ResourceType::COUNT],
+    // Whether the previous tick had background groups. Used to detect the
+    // empty->non-empty transition and discard stale accumulated consumption.
+    prev_had_background: bool,
 }
 
 impl GroupQuotaAdjustWorker<SysQuotaGetter> {
@@ -129,13 +134,15 @@ impl<R: ResourceStatsProvider> GroupQuotaAdjustWorker<R> {
         resource_quota_getter: R,
         compaction_pending_bytes_ratio: Arc<AtomicU32>,
     ) -> Self {
-        let prev_stats_by_group = array::from_fn(|_| HashMap::default());
+        let bg_limiter = resource_ctl.get_background_limiter();
         Self {
-            prev_stats_by_group,
             last_adjust_time: Instant::now_coarse(),
             resource_ctl,
             resource_quota_getter,
             compaction_pending_bytes_ratio,
+            bg_limiter,
+            prev_stats: array::from_fn(|_| GroupStatistics::default()),
+            prev_had_background: false,
         }
     }
 
@@ -175,21 +182,22 @@ impl<R: ResourceStatsProvider> GroupQuotaAdjustWorker<R> {
             .with_label_values(&["limit"])
             .set(bg_util_limit as i64);
 
-        let mut background_groups: Vec<_> = self
-            .resource_ctl
-            .resource_groups
-            .iter()
-            .filter_map(|kv| {
-                let g = kv.value();
-                g.limiter.as_ref().map(|limiter| GroupStats {
-                    name: g.group.name.clone(),
-                    ru_quota: g.get_ru_quota() as f64,
-                    limiter: limiter.clone(),
-                })
-            })
-            .collect();
-        if background_groups.is_empty() {
+        if !self.resource_ctl.has_background_groups() {
+            self.prev_had_background = false;
             return;
+        }
+        if !self.prev_had_background {
+            // Flush consumption that accumulated while the limiter ran unlimited
+            // during the empty period, and drain the CPU delta so the first real
+            // tick sees a clean baseline.
+            self.prev_stats = [
+                self.bg_limiter.get_limit_statistics(ResourceType::Cpu),
+                self.bg_limiter.get_limit_statistics(ResourceType::Io),
+            ];
+            let _ = self
+                .resource_quota_getter
+                .get_current_stats(ResourceType::Cpu);
+            self.prev_had_background = true;
         }
 
         self.do_adjust(
@@ -197,27 +205,14 @@ impl<R: ResourceStatsProvider> GroupQuotaAdjustWorker<R> {
             dur_secs,
             bg_util_limit,
             bg_resource_threshold,
-            &mut background_groups,
         );
         self.do_adjust(
             ResourceType::Io,
             dur_secs,
             bg_util_limit,
             bg_resource_threshold,
-            &mut background_groups,
         );
-
-        // Adjust write IO limiter based on compaction pressure.
-        self.adjust_write_io_by_compaction_pressure(&background_groups, dur_secs);
-
-        // clean up deleted group stats
-        if self.prev_stats_by_group[0].len() != background_groups.len() {
-            let name_set: HashSet<_> =
-                HashSet::from_iter(background_groups.iter().map(|g| &g.name));
-            for stat_map in &mut self.prev_stats_by_group {
-                stat_map.retain(|k, _v| !name_set.contains(k));
-            }
-        }
+        self.adjust_write_io_by_compaction_pressure();
     }
 
     fn do_adjust(
@@ -226,7 +221,6 @@ impl<R: ResourceStatsProvider> GroupQuotaAdjustWorker<R> {
         dur_secs: f64,
         utilization_limit: u64,
         bg_resource_threshold: f64,
-        bg_group_stats: &mut [GroupStats],
     ) {
         let resource_stats = match self.resource_quota_getter.get_current_stats(resource_type) {
             Ok(r) => r,
@@ -235,69 +229,41 @@ impl<R: ResourceStatsProvider> GroupQuotaAdjustWorker<R> {
                 return;
             }
         };
-        // if total resource quota is unlimited, set all groups' limit to unlimited.
+        // if total resource quota is unlimited, set background limit to unlimited.
         if resource_stats.total_quota <= f64::EPSILON {
-            for g in bg_group_stats {
-                g.limiter
-                    .get_limiter(resource_type)
-                    .set_rate_limit(f64::INFINITY);
-            }
+            self.bg_limiter
+                .get_limiter(resource_type)
+                .set_rate_limit(f64::INFINITY);
             return;
         }
 
-        // Collect statistics for metrics.
-        let mut total_ru_quota = 0.0;
-        let mut background_consumed_total = 0.0;
-        for g in bg_group_stats.iter_mut() {
-            total_ru_quota += g.ru_quota;
-            let total_stats = g.limiter.get_limit_statistics(resource_type);
-            let last_stats = self.prev_stats_by_group[resource_type as usize]
-                .insert(g.name.clone(), total_stats)
-                .unwrap_or_default();
-            let stats_delta = if total_stats.version == last_stats.version {
-                total_stats - last_stats
-            } else {
-                total_stats
-            };
-            BACKGROUND_RESOURCE_CONSUMPTION
-                .with_label_values(&[&g.name, resource_type.as_str()])
-                .inc_by(stats_delta.total_consumed);
-            if resource_type == ResourceType::Cpu {
-                BACKGROUND_TASKS_WAIT_DURATION
-                    .with_label_values(&[&g.name])
-                    .inc_by(stats_delta.total_wait_dur_us);
-            }
-            let stats_per_sec = stats_delta / dur_secs;
-            background_consumed_total += stats_per_sec.total_consumed as f64;
+        // Collect statistics for metrics from the single global limiter.
+        let total_stats = self.bg_limiter.get_limit_statistics(resource_type);
+        let last_stats =
+            std::mem::replace(&mut self.prev_stats[resource_type as usize], total_stats);
+        let stats_delta = total_stats - last_stats;
+        BACKGROUND_RESOURCE_CONSUMPTION
+            .with_label_values(&[resource_type.as_str()])
+            .inc_by(stats_delta.total_consumed);
+        if resource_type == ResourceType::Cpu {
+            BACKGROUND_TASKS_WAIT_DURATION.inc_by(stats_delta.total_wait_dur_us);
         }
+        let background_consumed = (stats_delta / dur_secs).total_consumed as f64;
 
-        let background_util =
-            (background_consumed_total / resource_stats.total_quota * 100.0) as u64;
+        let background_util = (background_consumed / resource_stats.total_quota * 100.0) as u64;
         let resource_util = resource_stats.current_used / resource_stats.total_quota * 100.0;
         BACKGROUND_TASK_RESOURCE_UTILIZATION_VEC
             .with_label_values(&[resource_type.as_str()])
             .set(background_util as i64);
 
-        if total_ru_quota <= f64::EPSILON {
-            return;
-        }
-
         let util_limit_percent = (utilization_limit as f64 / 100.0).min(1.0);
         let target = resource_stats.total_quota * util_limit_percent;
 
-        // Sum current background limits; treat infinity as an equal share of
-        // the target (initial state before first adjustment).
-        let current_total_bg_limit: f64 = bg_group_stats
-            .iter()
-            .map(|g| {
-                let limit = g.limiter.get_limiter(resource_type).get_rate_limit();
-                if limit.is_infinite() {
-                    target / bg_group_stats.len() as f64
-                } else {
-                    limit
-                }
-            })
-            .sum();
+        // Treat infinity as target (initial state before first adjustment).
+        let current_limit = {
+            let l = self.bg_limiter.get_limiter(resource_type).get_rate_limit();
+            if l.is_infinite() { target } else { l }
+        };
 
         // Minimum: 1 CPU core for CPU, 10% of total for IO.
         let min_floor = match resource_type {
@@ -306,60 +272,44 @@ impl<R: ResourceStatsProvider> GroupQuotaAdjustWorker<R> {
         }
         .min(target);
 
-        let mut new_total_bg_budget = target;
+        let mut new_budget = target;
         if resource_util > bg_resource_threshold {
             // System is overloaded. Linearly scale budget from target down to
             // min_floor as utilization goes from threshold (70%) to 100%.
-            // This aggressively throttles background regardless of how much
-            // it's consuming, freeing resources for online traffic.
             let pressure =
                 (resource_util - bg_resource_threshold) / (100.0 - bg_resource_threshold);
-            new_total_bg_budget = target * (1.0 - pressure) + min_floor * pressure;
-        } else if current_total_bg_limit > target {
+            new_budget = target * (1.0 - pressure) + min_floor * pressure;
+        } else if current_limit > target {
             // Background limit exceeds its allowed share; reset to target.
-            new_total_bg_budget = target;
-        } else if current_total_bg_limit < 0.9 * target
-            && resource_util < 0.9 * bg_resource_threshold
-        {
+            new_budget = target;
+        } else if current_limit < 0.9 * target && resource_util < 0.9 * bg_resource_threshold {
             // System is idle; increase limit incrementally from current limit.
-            new_total_bg_budget = current_total_bg_limit + 0.1 * current_total_bg_limit;
+            new_budget = current_limit * 1.1;
         }
 
-        let new_total_bg_budget = new_total_bg_budget.clamp(min_floor, target);
-
-        // Distribute proportionally by RU quota.
-        for g in bg_group_stats.iter() {
-            let limit = new_total_bg_budget * (g.ru_quota / total_ru_quota);
-            g.limiter.get_limiter(resource_type).set_rate_limit(limit);
-            BACKGROUND_QUOTA_LIMIT_VEC
-                .with_label_values(&[&g.name, resource_type.as_str()])
-                .set(limit as i64);
-        }
+        let new_budget = new_budget.clamp(min_floor, target);
+        self.bg_limiter
+            .get_limiter(resource_type)
+            .set_rate_limit(new_budget);
+        BACKGROUND_QUOTA_LIMIT_VEC
+            .with_label_values(&[resource_type.as_str()])
+            .set(new_budget as i64);
     }
 
     /// Adjust the write-only IO limiter based on compaction pressure.
     /// When pressure >= threshold, linearly scale write IO from ceiling to
-    /// floor. Below threshold, write IO is unlimited (infinity).
-    ///
-    /// Ceiling and floor are read from config (bg_write_io_ceiling,
-    /// bg_write_io_floor) in MB/s.
-    fn adjust_write_io_by_compaction_pressure(
-        &self,
-        bg_group_stats: &[GroupStats],
-        _dur_secs: f64,
-    ) {
+    /// floor. Below threshold, write IO ramps up 10% per tick capped at
+    /// ceiling.
+    fn adjust_write_io_by_compaction_pressure(&self) {
         let pressure = self.compaction_pending_bytes_ratio.load(Ordering::Relaxed) as f64;
         let config = self.resource_ctl.get_config().value().clone();
         let threshold = config.bg_compaction_pressure_threshold.clamp(1.0, 99.0);
         let ceiling = config.bg_write_io_ceiling.0 as f64; // bytes/s
         let floor = config.bg_write_io_floor.0 as f64; // bytes/s
 
-        let total_budget = if pressure < threshold {
+        let new_limit = if pressure < threshold {
             // Below threshold: ramp up current limit by 10%, capped at ceiling.
-            let current_limit = bg_group_stats
-                .first()
-                .map(|g| g.limiter.get_write_io_limiter().get_rate_limit())
-                .unwrap_or(ceiling);
+            let current_limit = self.bg_limiter.get_write_io_limiter().get_rate_limit();
             if current_limit.is_infinite() || current_limit >= ceiling {
                 ceiling
             } else {
@@ -369,26 +319,13 @@ impl<R: ResourceStatsProvider> GroupQuotaAdjustWorker<R> {
             // Linear interpolation from ceiling to floor as pressure goes from
             // threshold to 100%.
             let pressure_ratio = ((pressure - threshold) / (100.0 - threshold)).clamp(0.0, 1.0);
-            let total_budget = ceiling * (1.0 - pressure_ratio) + floor * pressure_ratio;
-            total_budget.max(floor)
+            (ceiling * (1.0 - pressure_ratio) + floor * pressure_ratio).max(floor)
         };
 
-        // Distribute proportionally by RU quota.
-        let total_ru_quota: f64 = bg_group_stats.iter().map(|g| g.ru_quota).sum();
-        if total_ru_quota <= f64::EPSILON {
-            return;
-        }
-        for g in bg_group_stats {
-            let limit = total_budget * (g.ru_quota / total_ru_quota);
-            g.limiter.get_write_io_limiter().set_rate_limit(limit);
-        }
+        self.bg_limiter
+            .get_write_io_limiter()
+            .set_rate_limit(new_limit);
     }
-}
-
-struct GroupStats {
-    name: String,
-    limiter: Arc<ResourceLimiter>,
-    ru_quota: f64,
 }
 
 /// PriorityLimiterAdjustWorker automically adjust the quota of each priority
@@ -814,68 +751,29 @@ mod tests {
         worker.adjust_quota();
         check_limiter_rates(&limiter, 3.63, 5500.0);
 
-        // --- Multi-group: proportional distribution by RU quota ---
+        // Adding a second background group does not change the limiter —
+        // all background groups share the single global bg_limiter.
         let bg = new_background_resource_group_ru("background".into(), 1000, 15, vec!["br".into()]);
         resource_ctl.add_resource_group(bg);
-        let bg_limiter = resource_ctl
+        let bg_limiter2 = resource_ctl
             .get_background_resource_limiter("background", "br")
             .unwrap();
+        // Both groups return the same shared limiter.
+        assert!(Arc::ptr_eq(&limiter, &bg_limiter2));
 
-        // default ru=2000, bg ru=1000 → shares: 2/3, 1/3
-        // No load: default at 3.63M, bg at infinity → target/2 = 2.8M
-        // current_total = 3.63M + 2.8M = 6.43M > target (5.6M) → budget = target = 5.6M
-        // default: 5.6 * 2/3 ≈ 3.733, bg: 5.6/3 ≈ 1.867
-        // IO: current_total = 5500 + 3500 = 9000 > 7000 → budget = 7000
-        // default: 7000 * 2/3 ≈ 4667, bg: 7000/3 ≈ 2333
+        // No load: current at 3.63M < 0.9*target (5.04M) and util < 63% → incremental.
+        // budget = 3.63 * 1.1 = 3.993
+        // IO: 5500 * 1.1 = 6050
         reset_quota(&mut worker, 0.0, 0.0, Duration::from_secs(1));
         worker.adjust_quota();
-        check_limiter_rates(&limiter, 3.733, 4666.7);
-        check_limiter_rates(&bg_limiter, 1.867, 2333.3);
+        check_limiter_rates(&limiter, 3.993, 6050.0);
 
-        // Over 70% (100% CPU, 95% IO): budget scales down from target.
-        // CPU: pressure = 1.0. budget = min_floor = 1.0M
-        //   default: 1.0M * 2/3 ≈ 0.667, bg: 1.0M/3 ≈ 0.333
+        // Over 70% (100% CPU, 95% IO): budget scales down.
+        // CPU: pressure = 1.0. budget = min_floor = 1.0
         // IO: pressure = 25/30 = 5/6. budget = 7000*(1/6) + 1000*(5/6) = 2000
-        //   default: 2000 * 2/3 ≈ 1333.3, bg: 2000/3 ≈ 666.7
         reset_quota(&mut worker, 8.0, 9500.0, Duration::from_secs(1));
         worker.adjust_quota();
-        check_limiter_rates(&limiter, 0.667, 1333.3);
-        check_limiter_rates(&bg_limiter, 0.333, 666.7);
-
-        // --- Limiter version change ---
-        let bg = new_resource_group_ru("background".into(), 1000, 15);
-        resource_ctl.add_resource_group(bg);
-
-        let new_bg =
-            new_background_resource_group_ru("background".into(), 1000, 15, vec!["br".into()]);
-        resource_ctl.add_resource_group(new_bg);
-        let new_bg_limiter = resource_ctl
-            .get_background_resource_limiter("background", "br")
-            .unwrap();
-        assert_ne!(&*bg_limiter as *const _, &*new_bg_limiter as *const _);
-        assert!(
-            new_bg_limiter
-                .get_limit_statistics(ResourceType::Cpu)
-                .version
-                > bg_limiter.get_limit_statistics(ResourceType::Cpu).version
-        );
-        let cpu_stats = new_bg_limiter.get_limit_statistics(ResourceType::Cpu);
-        assert_eq!(cpu_stats.total_consumed, 0);
-        assert_eq!(cpu_stats.total_wait_dur_us, 0);
-        let io_stats = new_bg_limiter.get_limit_statistics(ResourceType::Io);
-        assert_eq!(io_stats.total_consumed, 0);
-        assert_eq!(io_stats.total_wait_dur_us, 0);
-
-        // New bg limiter at infinity → target/2 = 2.8M.
-        // default at 0.667M. current_total = 0.667M + 2.8M = 3.467M
-        // 3.467M < 5.04M → incremental: budget = 3.467 * 1.1 = 3.8137M
-        // default: 3.8137 * 2/3 ≈ 2.542, new_bg: 3.8137/3 ≈ 1.271
-        // IO: default 1333.3, bg inf→3500, total=4833.3 < 6300 → 4833.3*1.1=5316.6
-        // default: 5316.6 * 2/3 ≈ 3544.4, new_bg: 5316.6/3 ≈ 1772.2
-        reset_quota(&mut worker, 0.0, 0.0, Duration::from_secs(1));
-        worker.adjust_quota();
-        check_limiter_rates(&limiter, 2.542, 3544.4);
-        check_limiter_rates(&new_bg_limiter, 1.271, 1772.2);
+        check_limiter_rates(&limiter, 1.0, 2000.0);
     }
 
     #[test]
@@ -926,7 +824,7 @@ mod tests {
         }
 
         // CPU target = 8 * 0.7 = 5.6 cores, IO target = 10000 * 0.7 = 7000
-        // Only bg_worker has a limiter; fg groups are not in bg_group_stats.
+        // fg groups have no background settings; only bg_worker triggers adjustment.
 
         // --- Initial: no load → budget = target ---
         reset_quota(&mut worker, 0.0, 0.0, Duration::from_secs(1));
@@ -1297,5 +1195,99 @@ mod tests {
         reset_quota(&mut worker, 0.0, 0.0, Duration::from_secs(1));
         worker.adjust_quota();
         check(limiter.get_write_io_limiter().get_rate_limit(), ceiling);
+    }
+
+    // Verify that with multiple background groups the budget is set globally on
+    // a single shared limiter, not split proportionally across groups.
+    //
+    // Old behaviour: 2 groups with RU 2000 and 1000 would receive 2/3 and 1/3
+    // of the total budget.
+    // New behaviour: both groups return the same Arc<ResourceLimiter> and the
+    // full budget is applied to it once.
+    #[test]
+    fn test_global_budget_not_split_across_groups() {
+        let resource_ctl = Arc::new(ResourceGroupManager::default());
+
+        // 8 CPU cores, 10000 bytes/s IO bandwidth.
+        let test_provider = TestResourceStatsProvider::new(8.0, 10000.0);
+        let compaction_pending_bytes_ratio = Arc::new(AtomicU32::new(0));
+        let mut worker = GroupQuotaAdjustWorker::with_quota_getter(
+            resource_ctl.clone(),
+            test_provider,
+            compaction_pending_bytes_ratio,
+        );
+
+        // Add two background groups with different RU quotas.
+        let mut grp_a =
+            new_background_resource_group_ru("group_a".into(), 2000, 8, vec!["br".into()]);
+        grp_a.mut_background_settings().set_utilization_limit(80);
+        resource_ctl.add_resource_group(grp_a);
+
+        let grp_b = new_background_resource_group_ru("group_b".into(), 1000, 8, vec!["br".into()]);
+        resource_ctl.add_resource_group(grp_b);
+
+        let limiter_a = resource_ctl
+            .get_background_resource_limiter("group_a", "br")
+            .unwrap();
+        let limiter_b = resource_ctl
+            .get_background_resource_limiter("group_b", "br")
+            .unwrap();
+
+        // Both groups must point to the same global limiter.
+        assert!(Arc::ptr_eq(&limiter_a, &limiter_b));
+
+        // util_limit = 80% capped to 70% by bg_resource_threshold.
+        // CPU target = 8 * 0.7 = 5.6 cores, IO target = 10000 * 0.7 = 7000.
+        // Under no load the full target is applied to the single limiter.
+        worker.resource_quota_getter.cpu_used = 0.0;
+        worker.resource_quota_getter.io_used = 0.0;
+        worker.last_adjust_time = Instant::now_coarse() - Duration::from_secs(1);
+        worker.adjust_quota();
+
+        #[track_caller]
+        fn check(val: f64, expected: f64) {
+            assert!(
+                expected * 0.99 < val && val < expected * 1.01,
+                "actual: {val}, expected: {expected}"
+            );
+        }
+
+        // Full budget, not 2/3 of it.
+        check(
+            limiter_a.get_limiter(ResourceType::Cpu).get_rate_limit(),
+            5.6 * MICROS_PER_SEC,
+        );
+        check(
+            limiter_a.get_limiter(ResourceType::Io).get_rate_limit(),
+            7000.0,
+        );
+
+        // limiter_b is the same Arc so it reflects the same rates.
+        check(
+            limiter_b.get_limiter(ResourceType::Cpu).get_rate_limit(),
+            5.6 * MICROS_PER_SEC,
+        );
+        check(
+            limiter_b.get_limiter(ResourceType::Io).get_rate_limit(),
+            7000.0,
+        );
+
+        // Under heavy load (100% CPU) the budget scales down to min_floor for
+        // the single global limiter — not independently per group.
+        worker.resource_quota_getter.cpu_used = 8.0;
+        worker.resource_quota_getter.io_used = 9500.0;
+        worker.last_adjust_time = Instant::now_coarse() - Duration::from_secs(1);
+        worker.adjust_quota();
+
+        // CPU: pressure = 1.0 → budget = min_floor = 1.0 core.
+        // IO: pressure = (95-70)/30 = 5/6 → budget = 7000/6 + 1000*5/6 ≈ 2000.
+        check(
+            limiter_a.get_limiter(ResourceType::Cpu).get_rate_limit(),
+            1.0 * MICROS_PER_SEC,
+        );
+        check(
+            limiter_a.get_limiter(ResourceType::Io).get_rate_limit(),
+            2000.0,
+        );
     }
 }

--- a/components/resource_control/src/worker.rs
+++ b/components/resource_control/src/worker.rs
@@ -2,9 +2,11 @@
 
 use std::{
     array,
-    collections::{HashMap, HashSet},
     io::Result as IoResult,
-    sync::Arc,
+    sync::{
+        atomic::{AtomicU32, Ordering},
+        Arc,
+    },
     time::Duration,
 };
 
@@ -12,7 +14,6 @@ use file_system::{fetch_io_bytes, IoBytes, IoType};
 use prometheus::Histogram;
 use strum::EnumCount;
 use tikv_util::{
-    debug,
     resource_control::{TaskPriority, DEFAULT_RESOURCE_GROUP_NAME},
     sys::{cpu_time::ProcessStat, SysQuota},
     time::Instant,
@@ -26,7 +27,7 @@ use crate::{
     resource_limiter::{GroupStatistics, ResourceLimiter, ResourceType},
 };
 
-pub const BACKGROUND_LIMIT_ADJUST_DURATION: Duration = Duration::from_secs(10);
+pub const QUOTA_ADJUST_DURATION: Duration = Duration::from_secs(10);
 
 const MICROS_PER_SEC: f64 = 1_000_000.0;
 // the minimal schedule wait duration due to the overhead of queue.
@@ -92,22 +93,37 @@ impl ResourceStatsProvider for SysQuotaGetter {
 }
 
 pub struct GroupQuotaAdjustWorker<R> {
-    prev_stats_by_group: [HashMap<String, GroupStatistics>; ResourceType::COUNT],
     last_adjust_time: Instant,
     resource_ctl: Arc<ResourceGroupManager>,
-    is_last_time_low_load: [bool; ResourceType::COUNT],
     resource_quota_getter: R,
+    // Shared compaction pressure (0-100+) written by EnginesResourceInfo::update().
+    compaction_pending_bytes_ratio: Arc<AtomicU32>,
+    // Single shared limiter for all background tasks.
+    bg_limiter: Arc<ResourceLimiter>,
+    // Previous statistics snapshot per resource type for delta computation.
+    prev_stats: [GroupStatistics; ResourceType::COUNT],
+    // Whether the previous tick had background groups. Used to detect the
+    // empty->non-empty transition and discard stale accumulated consumption.
+    prev_had_background: bool,
 }
 
 impl GroupQuotaAdjustWorker<SysQuotaGetter> {
-    pub fn new(resource_ctl: Arc<ResourceGroupManager>, io_bandwidth: u64) -> Self {
+    pub fn new(
+        resource_ctl: Arc<ResourceGroupManager>,
+        io_bandwidth: u64,
+        compaction_pending_bytes_ratio: Arc<AtomicU32>,
+    ) -> Self {
         let resource_quota_getter = SysQuotaGetter {
             process_stat: ProcessStat::cur_proc_stat().unwrap(),
             prev_io_stats: [IoBytes::default(); IoType::COUNT],
             prev_io_ts: Instant::now_coarse(),
             io_bandwidth: io_bandwidth as f64,
         };
-        Self::with_quota_getter(resource_ctl, resource_quota_getter)
+        Self::with_quota_getter(
+            resource_ctl,
+            resource_quota_getter,
+            compaction_pending_bytes_ratio,
+        )
     }
 }
 
@@ -115,14 +131,17 @@ impl<R: ResourceStatsProvider> GroupQuotaAdjustWorker<R> {
     pub fn with_quota_getter(
         resource_ctl: Arc<ResourceGroupManager>,
         resource_quota_getter: R,
+        compaction_pending_bytes_ratio: Arc<AtomicU32>,
     ) -> Self {
-        let prev_stats_by_group = array::from_fn(|_| HashMap::default());
+        let bg_limiter = resource_ctl.get_background_limiter();
         Self {
-            prev_stats_by_group,
             last_adjust_time: Instant::now_coarse(),
             resource_ctl,
             resource_quota_getter,
-            is_last_time_low_load: array::from_fn(|_| false),
+            compaction_pending_bytes_ratio,
+            bg_limiter,
+            prev_stats: array::from_fn(|_| GroupStatistics::default()),
+            prev_had_background: false,
         }
     }
 
@@ -137,209 +156,226 @@ impl<R: ResourceStatsProvider> GroupQuotaAdjustWorker<R> {
         }
         self.last_adjust_time = now;
 
-        let mut background_util_limit = self
+        // Fetch CPU stats once so background and foreground use a consistent
+        // snapshot and we avoid double-reading /proc/stat.
+        let cpu_stats = match self
+            .resource_quota_getter
+            .get_current_stats(ResourceType::Cpu)
+        {
+            Ok(s) => s,
+            Err(e) => {
+                warn!("get process total cpu failed; skip adjustment."; "err" => ?e);
+                return;
+            }
+        };
+        let cpu_util = if cpu_stats.total_quota > f64::EPSILON {
+            cpu_stats.current_used / cpu_stats.total_quota * 100.0
+        } else {
+            0.0
+        };
+
+        self.background_adjust_quota(dur_secs, &cpu_stats);
+        self.foreground_adjust_quota(cpu_util);
+    }
+
+    fn foreground_adjust_quota(&mut self, cpu_util: f64) {
+        self.resource_ctl.online_adjust_resource_quota(cpu_util);
+    }
+
+    fn background_adjust_quota(&mut self, dur_secs: f64, cpu_stats: &ResourceUsageStats) {
+        let mut bg_util_limit = self
             .resource_ctl
             .get_resource_group(DEFAULT_RESOURCE_GROUP_NAME)
             .map_or(0, |r| {
                 r.group.get_background_settings().get_utilization_limit()
             });
-        if background_util_limit == 0 {
-            background_util_limit = 100;
+        if bg_util_limit == 0 {
+            bg_util_limit = 100;
         }
+        let (bg_scale_start, fg_cpu_throttle_threshold) = {
+            let config = self.resource_ctl.get_config().value();
+            let start = config.bg_cpu_throttle_threshold.clamp(1.0, 99.0);
+            let end = config.fg_cpu_throttle_threshold.clamp(start, 99.0);
+            (start, end)
+        };
+        // Cap utilization limit to fg_cpu_throttle_threshold. Background tasks should
+        // never consume more than this fraction of total resources. Scale-down
+        // begins at bg_scale_start and reaches min_floor at fg_cpu_throttle_threshold.
+        bg_util_limit = bg_util_limit.min(fg_cpu_throttle_threshold as u64);
 
-        BACKGROUND_TASK_RESOURCE_UTILIZATION_VEC
-            .with_label_values(&["limit"])
-            .set(background_util_limit as i64);
-
-        let mut background_groups: Vec<_> = self
-            .resource_ctl
-            .resource_groups
-            .iter()
-            .filter_map(|kv| {
-                let g = kv.value();
-                g.limiter.as_ref().map(|limiter| GroupStats {
-                    name: g.group.name.clone(),
-                    ru_quota: g.get_ru_quota() as f64,
-                    limiter: limiter.clone(),
-                    stats_per_sec: GroupStatistics::default(),
-                    expect_cost_rate: 0.0,
-                })
-            })
-            .collect();
-        if background_groups.is_empty() {
+        if !self.resource_ctl.has_background_groups() {
+            self.resource_ctl.set_bg_cpu_at_floor(true);
+            self.prev_had_background = false;
             return;
         }
+        if !self.prev_had_background {
+            // Flush consumption that accumulated while the limiter ran unlimited
+            // during the empty period, and drain the CPU delta so the first real
+            // tick sees a clean baseline.
+            self.prev_stats = [
+                self.bg_limiter.get_limit_statistics(ResourceType::Cpu),
+                self.bg_limiter.get_limit_statistics(ResourceType::Io),
+            ];
+            let _ = self
+                .resource_quota_getter
+                .get_current_stats(ResourceType::Cpu);
+            self.prev_had_background = true;
+        }
 
-        self.do_adjust(
+        self.background_adjust_resource_quota(
             ResourceType::Cpu,
             dur_secs,
-            background_util_limit,
-            &mut background_groups,
+            bg_util_limit,
+            bg_scale_start,
+            fg_cpu_throttle_threshold,
+            Some(cpu_stats),
         );
-        self.do_adjust(
+        self.background_adjust_resource_quota(
             ResourceType::Io,
             dur_secs,
-            background_util_limit,
-            &mut background_groups,
+            bg_util_limit,
+            bg_scale_start,
+            fg_cpu_throttle_threshold,
+            None,
         );
-
-        // clean up deleted group stats
-        if self.prev_stats_by_group[0].len() != background_groups.len() {
-            let name_set: HashSet<_> =
-                HashSet::from_iter(background_groups.iter().map(|g| &g.name));
-            for stat_map in &mut self.prev_stats_by_group {
-                stat_map.retain(|k, _v| !name_set.contains(k));
-            }
-        }
+        self.adjust_write_io_by_compaction_pressure();
     }
 
-    fn do_adjust(
+    fn background_adjust_resource_quota(
         &mut self,
         resource_type: ResourceType,
         dur_secs: f64,
         utilization_limit: u64,
-        bg_group_stats: &mut [GroupStats],
+        bg_scale_start: f64,
+        fg_cpu_throttle_threshold: f64,
+        // Pre-fetched stats for CPU (avoids a second /proc/stat read); None for
+        // IO, which always fetches fresh bytes-transferred counters.
+        prefetched_stats: Option<&ResourceUsageStats>,
     ) {
-        let resource_stats = match self.resource_quota_getter.get_current_stats(resource_type) {
-            Ok(r) => r,
-            Err(e) => {
-                warn!("get resource statistics info failed, skip adjust"; "type" => ?resource_type, "err" => ?e);
-                return;
-            }
+        let fetched;
+        let resource_stats = if let Some(s) = prefetched_stats {
+            s
+        } else {
+            fetched = match self.resource_quota_getter.get_current_stats(resource_type) {
+                Ok(r) => r,
+                Err(e) => {
+                    warn!("get resource statistics info failed, skip adjust"; "type" => ?resource_type, "err" => ?e);
+                    return;
+                }
+            };
+            &fetched
         };
-        // if total resource quota is unlimited, set all groups' limit to unlimited.
+        // if total resource quota is unlimited, set background limit to unlimited.
         if resource_stats.total_quota <= f64::EPSILON {
-            for g in bg_group_stats {
-                g.limiter
-                    .get_limiter(resource_type)
-                    .set_rate_limit(f64::INFINITY);
-            }
+            self.bg_limiter
+                .get_limiter(resource_type)
+                .set_rate_limit(f64::INFINITY);
             return;
         }
 
-        let mut total_ru_quota = 0.0;
-        let mut background_consumed_total = 0.0;
-        let mut has_wait = false;
-        for g in bg_group_stats.iter_mut() {
-            total_ru_quota += g.ru_quota;
-            let total_stats = g.limiter.get_limit_statistics(resource_type);
-            let last_stats = self.prev_stats_by_group[resource_type as usize]
-                .insert(g.name.clone(), total_stats)
-                .unwrap_or_default();
-            // version changes means this is a brand new limiter, so no need to sub the old
-            // statistics.
-            let stats_delta = if total_stats.version == last_stats.version {
-                total_stats - last_stats
-            } else {
-                total_stats
-            };
-            BACKGROUND_RESOURCE_CONSUMPTION
-                .with_label_values(&[&g.name, resource_type.as_str()])
-                .inc_by(stats_delta.total_consumed);
-            if resource_type == ResourceType::Cpu {
-                BACKGROUND_TASKS_WAIT_DURATION
-                    .with_label_values(&[&g.name])
-                    .inc_by(stats_delta.total_wait_dur_us);
-            }
-
-            let stats_per_sec = stats_delta / dur_secs;
-            background_consumed_total += stats_per_sec.total_consumed as f64;
-            g.stats_per_sec = stats_per_sec;
-            if stats_per_sec.total_wait_dur_us > 0 {
-                has_wait = true;
-            }
+        // Collect statistics for metrics from the single global limiter.
+        let total_stats = self.bg_limiter.get_limit_statistics(resource_type);
+        let last_stats =
+            std::mem::replace(&mut self.prev_stats[resource_type as usize], total_stats);
+        let stats_delta = total_stats - last_stats;
+        BACKGROUND_RESOURCE_CONSUMPTION
+            .with_label_values(&[resource_type.as_str()])
+            .inc_by(stats_delta.total_consumed);
+        if resource_type == ResourceType::Cpu {
+            BACKGROUND_TASKS_WAIT_DURATION.inc_by(stats_delta.total_wait_dur_us);
         }
+        let background_consumed = (stats_delta / dur_secs).total_consumed as f64;
 
-        let background_util =
-            (background_consumed_total / resource_stats.total_quota * 100.0) as u64;
+        let background_util = (background_consumed / resource_stats.total_quota * 100.0) as u64;
+        let resource_util = resource_stats.current_used / resource_stats.total_quota * 100.0;
         BACKGROUND_TASK_RESOURCE_UTILIZATION_VEC
             .with_label_values(&[resource_type.as_str()])
             .set(background_util as i64);
 
-        // fast path if process cpu is low
-        let is_low_load = resource_stats.current_used <= (resource_stats.total_quota * 0.1);
-        if is_low_load && !has_wait && self.is_last_time_low_load[resource_type as usize] {
-            return;
-        }
-        self.is_last_time_low_load[resource_type as usize] = is_low_load;
-
         let util_limit_percent = (utilization_limit as f64 / 100.0).min(1.0);
-        // the available resource for background tasks is defined as:
-        // (total_resource_quota - foreground_task_used). foreground_task_used
-        // resource is calculated by: (resource_current_total_used -
-        // background_consumed_total). We reserve 20% of the free resources for
-        // foreground tasks in case the fore ground traffics increases.
-        let mut available_resource_rate = ((resource_stats.total_quota
-            - resource_stats.current_used
-            + background_consumed_total)
-            * 0.8)
-            .min(resource_stats.total_quota * util_limit_percent)
-            .max(resource_stats.total_quota * 0.1);
-        let mut total_expected_cost = 0.0;
-        for g in bg_group_stats.iter_mut() {
-            let mut rate_limit = g.limiter.get_limiter(resource_type).get_rate_limit();
-            if rate_limit.is_infinite() {
-                rate_limit = 0.0;
-            }
-            let group_expected_cost = g.stats_per_sec.total_consumed as f64
-                + g.stats_per_sec.total_wait_dur_us as f64 / MICROS_PER_SEC * rate_limit;
-            g.expect_cost_rate = group_expected_cost;
-            total_expected_cost += group_expected_cost;
-        }
-        // sort groups by the expect_cost_rate per ru
-        bg_group_stats.sort_by(|g1, g2| {
-            (g1.expect_cost_rate / g1.ru_quota)
-                .partial_cmp(&(g2.expect_cost_rate / g2.ru_quota))
-                .unwrap()
-        });
+        let target = resource_stats.total_quota * util_limit_percent;
 
-        // quota is enough, group is allowed to got more resource then its share by ru.
-        // e.g. Given a totol resource of 10000, and ("name", ru_quota, expected_rate)
-        // of:  (rg1, 2000, 3000), (rg2, 3000, 1000), (rg3, 5000, 5000)
-        // then after the previous sort, the order is rg2, rg3, rg1 and the handle order
-        // is rg1, rg3, rg2 so the final rate limit assigned is: (rg1, 3000),
-        // (rg3, 5833(7000/6*5)), (rg2, 1166(7000/6*1))
-        if total_expected_cost <= available_resource_rate {
-            for g in bg_group_stats.iter().rev() {
-                let limit = g
-                    .expect_cost_rate
-                    .max(available_resource_rate / total_ru_quota * g.ru_quota);
-                g.limiter.get_limiter(resource_type).set_rate_limit(limit);
-                BACKGROUND_QUOTA_LIMIT_VEC
-                    .with_label_values(&[&g.name, resource_type.as_str()])
-                    .set(limit as i64);
-                available_resource_rate -= limit;
-                total_ru_quota -= g.ru_quota;
+        // Treat infinity as target (initial state before first adjustment).
+        let current_limit = {
+            let l = self.bg_limiter.get_limiter(resource_type).get_rate_limit();
+            if l.is_infinite() { target } else { l }
+        };
+
+        // Minimum: 1 CPU core for CPU, 10% of total for IO.
+        let min_floor = match resource_type {
+            ResourceType::Cpu => MICROS_PER_SEC,
+            ResourceType::Io => resource_stats.total_quota * 0.1,
+        }
+        .min(target);
+
+        let mut new_budget = target;
+        if resource_util > bg_scale_start {
+            // Linearly scale budget from target down to min_floor as utilization
+            // goes from bg_scale_start to fg_cpu_throttle_threshold.
+            let range = (fg_cpu_throttle_threshold - bg_scale_start).max(1.0);
+            let pressure = ((resource_util - bg_scale_start) / range).clamp(0.0, 1.0);
+            new_budget = target * (1.0 - pressure) + min_floor * pressure;
+            // Only tighten: never increase the limit in the throttle branch.
+            if new_budget > current_limit {
+                new_budget = current_limit;
             }
-            return;
+        } else if current_limit > target {
+            // Background limit exceeds its allowed share; reset to target.
+            new_budget = target;
+        } else if current_limit < 0.9 * target && resource_util < 0.9 * bg_scale_start {
+            // System is idle; increase limit incrementally from current limit.
+            new_budget = current_limit * 1.1;
         }
 
-        // quota is not enough, assign by share
-        // e.g. Given a totol resource of 10000, and ("name", ru_quota, expected_rate)
-        // of:  (rg1, 2000, 1000), (rg2, 3000, 5000), (rg3, 5000, 7000)
-        // then after the previous sort, the order is rg1, rg3, rg2, and handle order is
-        // rg1, rg3, rg2 so the final rate limit assigned is: (rg1, 1000), (rg3,
-        // 5250(9000/12*7)), (rg2, 3750(9000/12*5))
-        for g in bg_group_stats {
-            let limit = g
-                .expect_cost_rate
-                .min(available_resource_rate / total_ru_quota * g.ru_quota);
-            g.limiter.get_limiter(resource_type).set_rate_limit(limit);
-            BACKGROUND_QUOTA_LIMIT_VEC
-                .with_label_values(&[&g.name, resource_type.as_str()])
-                .set(limit as i64);
-            available_resource_rate -= limit;
-            total_ru_quota -= g.ru_quota;
+        let new_budget = new_budget.clamp(min_floor, target);
+        self.bg_limiter
+            .get_limiter(resource_type)
+            .set_rate_limit(new_budget);
+        BACKGROUND_QUOTA_LIMIT_VEC
+            .with_label_values(&[resource_type.as_str()])
+            .set(new_budget as i64);
+
+        // Update the "background at floor" flag so foreground throttling
+        // only kicks in after background has been fully squeezed.
+        if resource_type == ResourceType::Cpu {
+            let at_floor = new_budget <= min_floor && background_consumed <= new_budget;
+            self.resource_ctl.set_bg_cpu_at_floor(at_floor);
         }
     }
-}
 
-struct GroupStats {
-    name: String,
-    limiter: Arc<ResourceLimiter>,
-    ru_quota: f64,
-    stats_per_sec: GroupStatistics,
-    expect_cost_rate: f64,
+    /// Adjust the write-only IO limiter based on compaction pressure.
+    /// When pressure >= threshold, linearly scale write IO from ceiling to
+    /// floor over a window of 50% of threshold (i.e. threshold to
+    /// threshold * 1.5). Below threshold, write IO ramps up 10% per tick
+    /// capped at ceiling.
+    fn adjust_write_io_by_compaction_pressure(&self) {
+        let pressure = self.compaction_pending_bytes_ratio.load(Ordering::Relaxed) as f64;
+        let config = self.resource_ctl.get_config().value().clone();
+        let threshold = config.bg_compaction_pressure_threshold.clamp(1.0, 99.0);
+        let ceiling = config.bg_write_io_ceiling.0 as f64; // bytes/s
+        let floor = config.bg_write_io_floor.0 as f64; // bytes/s
+
+        let new_limit = if pressure < threshold {
+            // Below threshold: ramp up current limit by 10%, capped at ceiling.
+            let current_limit = self.bg_limiter.get_write_io_limiter().get_rate_limit();
+            if current_limit.is_infinite() || current_limit >= ceiling {
+                ceiling
+            } else {
+                (current_limit * 1.1).min(ceiling)
+            }
+        } else {
+            // Linear interpolation from ceiling to floor over the window
+            // [threshold, threshold * 1.5]. Beyond that window the rate is
+            // clamped to floor.
+            let window = threshold * 0.5;
+            let pressure_ratio = ((pressure - threshold) / window).clamp(0.0, 1.0);
+            (ceiling * (1.0 - pressure_ratio) + floor * pressure_ratio).max(floor)
+        };
+
+        self.bg_limiter
+            .get_write_io_limiter()
+            .set_rate_limit(new_limit);
+    }
 }
 
 /// PriorityLimiterAdjustWorker automically adjust the quota of each priority
@@ -495,10 +531,6 @@ impl<R: ResourceStatsProvider> PriorityLimiterAdjustWorker<R> {
             limits[i - 1] = limit;
             expect_cpu_time_total -= level_expected[i];
         }
-        debug!("adjsut cpu limiter by priority"; "cpu_quota" => process_cpu_stats.total_quota,
-            "process_cpu" => process_cpu_stats.current_used, "expected_cpu" => ?level_expected,
-            "cpu_costs" => ?cpu_duration, "limits" => ?limits,
-            "limit_cpu_total" => expect_pool_cpu_total, "pool_cpu_cost" => real_cpu_total);
     }
 }
 
@@ -593,7 +625,7 @@ mod tests {
     use std::time::Duration;
 
     use super::*;
-    use crate::{resource_group::tests::*, resource_limiter::QuotaLimiter};
+    use crate::resource_group::tests::*;
 
     struct TestResourceStatsProvider {
         cpu_total: f64,
@@ -631,6 +663,8 @@ mod tests {
     #[test]
     fn test_adjust_resource_limiter() {
         let resource_ctl = Arc::new(ResourceGroupManager::default());
+
+        // Non-background group should not get a limiter.
         let rg1 = new_resource_group_ru("test".into(), 1000, 14);
         resource_ctl.add_resource_group(rg1);
         assert!(
@@ -639,13 +673,23 @@ mod tests {
                 .is_none()
         );
 
+        // 8 CPU cores, 10000 bytes/s IO bandwidth.
         let test_provider = TestResourceStatsProvider::new(8.0, 10000.0);
-        let mut worker =
-            GroupQuotaAdjustWorker::with_quota_getter(resource_ctl.clone(), test_provider);
+        let compaction_pending_bytes_ratio = Arc::new(AtomicU32::new(0));
+        let mut worker = GroupQuotaAdjustWorker::with_quota_getter(
+            resource_ctl.clone(),
+            test_provider,
+            compaction_pending_bytes_ratio,
+        );
 
-        let default_bg =
-            new_background_resource_group_ru("default".into(), 100000, 8, vec!["br".into()]);
+        // Create default background group with 80% utilization limit.
+        let mut default_bg =
+            new_background_resource_group_ru("default".into(), 2000, 8, vec!["br".into()]);
+        default_bg
+            .mut_background_settings()
+            .set_utilization_limit(80);
         resource_ctl.add_resource_group(default_bg);
+
         assert!(
             resource_ctl
                 .get_background_resource_limiter("default", "lightning")
@@ -666,19 +710,6 @@ mod tests {
                 .get_rate_limit()
                 .is_infinite()
         );
-
-        fn reset_quota_limiter(limiter: &QuotaLimiter) {
-            let limit = limiter.get_rate_limit();
-            if limit.is_finite() {
-                limiter.set_rate_limit(f64::INFINITY);
-                limiter.set_rate_limit(limit);
-            }
-        }
-
-        fn reset_limiter(limiter: &Arc<ResourceLimiter>) {
-            reset_quota_limiter(limiter.get_limiter(ResourceType::Cpu));
-            reset_quota_limiter(limiter.get_limiter(ResourceType::Io));
-        }
 
         let reset_quota = |worker: &mut GroupQuotaAdjustWorker<TestResourceStatsProvider>,
                            cpu: f64,
@@ -701,263 +732,197 @@ mod tests {
         }
 
         #[track_caller]
-        fn check_limiter(limiter: &Arc<ResourceLimiter>, cpu: f64, io: IoBytes) {
+        fn check_limiter_rates(limiter: &Arc<ResourceLimiter>, cpu: f64, io: f64) {
             check(
                 limiter.get_limiter(ResourceType::Cpu).get_rate_limit(),
                 cpu * MICROS_PER_SEC,
             );
-            check(
-                limiter.get_limiter(ResourceType::Io).get_rate_limit(),
-                (io.read + io.write) as f64,
-            );
-            reset_limiter(limiter);
+            check(limiter.get_limiter(ResourceType::Io).get_rate_limit(), io);
         }
 
+        // util_limit configured at 80% but capped to fg_cpu_throttle_threshold=70%.
+        // CPU target = 8 * 0.7 = 5.6 cores, IO target = 10000 * 0.7 = 7000
+        // CPU min_floor = 1 core, IO min_floor = 1000
+        // bg_scale_start=60%, fg_cpu_throttle_threshold=70% (scale range: 60→70).
+
+        // No load: initial infinity → treated as target → budget = target.
         reset_quota(&mut worker, 0.0, 0.0, Duration::from_secs(1));
         worker.adjust_quota();
-        check_limiter(
-            &limiter,
-            6.4,
-            IoBytes {
-                read: 4000,
-                write: 4000,
-            },
-        );
+        check_limiter_rates(&limiter, 5.6, 7000.0);
 
+        // Short duration (< 1s): adjustment skipped, limits unchanged.
         reset_quota(&mut worker, 4.0, 2000.0, Duration::from_millis(500));
         worker.adjust_quota();
-        check_limiter(
-            &limiter,
-            6.4,
-            IoBytes {
-                read: 4000,
-                write: 4000,
-            },
-        );
+        check_limiter_rates(&limiter, 5.6, 7000.0);
 
+        // Under target (50% CPU): resource_util < 60%, current == target,
+        // so none of the branches fire → budget = target.
         reset_quota(&mut worker, 4.0, 2000.0, Duration::from_secs(1));
         worker.adjust_quota();
-        check_limiter(
-            &limiter,
-            3.2,
-            IoBytes {
-                read: 3200,
-                write: 3200,
-            },
-        );
+        check_limiter_rates(&limiter, 5.6, 7000.0);
 
-        reset_quota(&mut worker, 6.0, 4000.0, Duration::from_secs(1));
-        limiter.consume(
-            Duration::from_secs(2),
-            IoBytes {
-                read: 1000,
-                write: 1000,
-            },
-            true,
-        );
+        // 80% CPU, 80% IO: resource_util > 60% (bg_scale_start).
+        // pressure = (80-60)/(70-60) = 2.0 clamped to 1.0 → min_floor.
+        // CPU: budget = min_floor = 1.0. IO: budget = min_floor = 1000.
+        reset_quota(&mut worker, 6.4, 8000.0, Duration::from_secs(1));
         worker.adjust_quota();
-        check_limiter(
-            &limiter,
-            3.2,
-            IoBytes {
-                read: 3200,
-                write: 3200,
-            },
-        );
+        check_limiter_rates(&limiter, 1.0, 1000.0);
 
+        // 100% CPU, 95% IO: pressure still clamped 1.0 → min_floor.
         reset_quota(&mut worker, 8.0, 9500.0, Duration::from_secs(1));
         worker.adjust_quota();
-        check_limiter(
-            &limiter,
-            0.8,
-            IoBytes {
-                read: 500,
-                write: 500,
-            },
-        );
+        check_limiter_rates(&limiter, 1.0, 1000.0);
 
-        reset_quota(&mut worker, 7.5, 9500.0, Duration::from_secs(1));
-        limiter.consume(
-            Duration::from_secs(2),
-            IoBytes {
-                read: 1000,
-                write: 1000,
-            },
-            true,
-        );
+        // Still at 100% CPU, 95% IO: same result (deterministic, no decay).
+        reset_quota(&mut worker, 8.0, 9500.0, Duration::from_secs(1));
         worker.adjust_quota();
-        check_limiter(
-            &limiter,
-            2.0,
-            IoBytes {
-                read: 1000,
-                write: 1000,
-            },
-        );
+        check_limiter_rates(&limiter, 1.0, 1000.0);
 
-        reset_quota(&mut worker, 7.5, 9500.0, Duration::from_secs(5));
-        limiter.consume(
-            Duration::from_secs(10),
-            IoBytes {
-                read: 5000,
-                write: 5000,
-            },
-            true,
-        );
+        // 65% CPU, 65% IO: in the scale range (60-70%).
+        // CPU: pressure = 0.5, computed = 3.3. But current_limit=1.0 (min_floor)
+        // and 3.3 > 1.0 → only-tighten clamps to 1.0.
+        // IO: same logic → stays 1000.
+        reset_quota(&mut worker, 5.2, 6500.0, Duration::from_secs(1));
         worker.adjust_quota();
-        check_limiter(
-            &limiter,
-            2.0,
-            IoBytes {
-                read: 1000,
-                write: 1000,
-            },
-        );
+        check_limiter_rates(&limiter, 1.0, 1000.0);
 
-        let default =
-            new_background_resource_group_ru("default".into(), 2000, 8, vec!["br".into()]);
-        resource_ctl.add_resource_group(default);
-        let new_limiter = resource_ctl
-            .get_background_resource_limiter("default", "br")
-            .unwrap();
-        assert_eq!(&*new_limiter as *const _, &*limiter as *const _);
+        // Load drops (50% CPU, 20% IO): resource_util < 54% (0.9*60%), current <
+        // 0.9*target → incremental increase: budget = current * 1.1
+        // CPU: 1.0 * 1.1 = 1.1. IO: 1000 * 1.1 = 1100
+        reset_quota(&mut worker, 4.0, 2000.0, Duration::from_secs(1));
+        worker.adjust_quota();
+        check_limiter_rates(&limiter, 1.1, 1100.0);
 
+        // Adding a second background group does not change the limiter —
+        // all background groups share the single global bg_limiter.
         let bg = new_background_resource_group_ru("background".into(), 1000, 15, vec!["br".into()]);
         resource_ctl.add_resource_group(bg);
-        let bg_limiter = resource_ctl
+        let bg_limiter2 = resource_ctl
             .get_background_resource_limiter("background", "br")
             .unwrap();
+        // Both groups return the same shared limiter.
+        assert!(Arc::ptr_eq(&limiter, &bg_limiter2));
 
-        reset_quota(&mut worker, 5.0, 7000.0, Duration::from_secs(1));
-        worker.adjust_quota();
-        check_limiter(
-            &limiter,
-            1.6,
-            IoBytes {
-                read: 800,
-                write: 800,
-            },
-        );
-        check_limiter(
-            &bg_limiter,
-            0.8,
-            IoBytes {
-                read: 400,
-                write: 400,
-            },
-        );
-
-        reset_quota(&mut worker, 6.0, 5000.0, Duration::from_secs(1));
-        limiter.consume(
-            Duration::from_millis(1200),
-            IoBytes {
-                read: 600,
-                write: 600,
-            },
-            true,
-        );
-        bg_limiter.consume(
-            Duration::from_millis(1800),
-            IoBytes {
-                read: 900,
-                write: 900,
-            },
-            true,
-        );
-        worker.adjust_quota();
-        check_limiter(
-            &limiter,
-            1.2,
-            IoBytes {
-                read: 1800,
-                write: 1800,
-            },
-        );
-        check_limiter(
-            &bg_limiter,
-            2.8,
-            IoBytes {
-                read: 1400,
-                write: 1400,
-            },
-        );
-
-        let bg = new_resource_group_ru("background".into(), 1000, 15);
-        resource_ctl.add_resource_group(bg);
-
-        let new_bg =
-            new_background_resource_group_ru("background".into(), 1000, 15, vec!["br".into()]);
-        resource_ctl.add_resource_group(new_bg);
-        let new_bg_limiter = resource_ctl
-            .get_background_resource_limiter("background", "br")
-            .unwrap();
-        assert_ne!(&*bg_limiter as *const _, &*new_bg_limiter as *const _);
-        assert!(
-            new_bg_limiter
-                .get_limit_statistics(ResourceType::Cpu)
-                .version
-                > bg_limiter.get_limit_statistics(ResourceType::Cpu).version
-        );
-        let cpu_stats = new_bg_limiter.get_limit_statistics(ResourceType::Cpu);
-        assert_eq!(cpu_stats.total_consumed, 0);
-        assert_eq!(cpu_stats.total_wait_dur_us, 0);
-        let io_stats = new_bg_limiter.get_limit_statistics(ResourceType::Io);
-        assert_eq!(io_stats.total_consumed, 0);
-        assert_eq!(io_stats.total_wait_dur_us, 0);
-
+        // No load: current at 1.1M < 0.9*target (5.04M) and util < 63% → incremental.
+        // budget = 1.1 * 1.1 = 1.21
+        // IO: 1100 * 1.1 = 1210
         reset_quota(&mut worker, 0.0, 0.0, Duration::from_secs(1));
         worker.adjust_quota();
-        check_limiter(
-            &limiter,
-            4.27,
-            IoBytes {
-                read: 2667,
-                write: 2667,
-            },
-        );
-        check_limiter(
-            &new_bg_limiter,
-            2.13,
-            IoBytes {
-                read: 1334,
-                write: 1334,
-            },
-        );
+        check_limiter_rates(&limiter, 1.21, 1210.0);
 
-        reset_quota(&mut worker, 6.0, 5000.0, Duration::from_secs(1));
-        limiter.consume(
-            Duration::from_millis(1200),
-            IoBytes {
-                read: 600,
-                write: 600,
-            },
-            true,
-        );
-        new_bg_limiter.consume(
-            Duration::from_millis(1800),
-            IoBytes {
-                read: 900,
-                write: 900,
-            },
-            true,
-        );
-
+        // Over 70% (100% CPU, 95% IO): budget scales down to min_floor.
+        // CPU: pressure = 1.0. budget = min_floor = 1.0
+        // IO: pressure = (95-60)/(70-60) = 3.5 clamped 1.0. budget = min_floor = 1000.
+        reset_quota(&mut worker, 8.0, 9500.0, Duration::from_secs(1));
         worker.adjust_quota();
-        check_limiter(
-            &limiter,
-            2.2,
-            IoBytes {
-                read: 2133,
-                write: 2133,
-            },
+        check_limiter_rates(&limiter, 1.0, 1000.0);
+    }
+
+    #[test]
+    fn test_bg_limiter_with_infinite_ru_groups() {
+        let resource_ctl = Arc::new(ResourceGroupManager::default());
+
+        // 3 foreground groups with large RU quota (no background limiter).
+        for i in 0..3 {
+            let rg = new_resource_group_ru(format!("fg_{i}"), i32::MAX as u64, 8);
+            resource_ctl.add_resource_group(rg);
+        }
+
+        // 1 background group with no explicit utilization limit.
+        // bg_util_limit defaults to 100, capped to 70 by fg_cpu_throttle_threshold.
+        // bg_scale_start=60%, fg_cpu_throttle_threshold=70%.
+        let bg = new_background_resource_group_ru("bg_worker".into(), 5000, 8, vec!["br".into()]);
+        resource_ctl.add_resource_group(bg);
+        let limiter = resource_ctl
+            .get_background_resource_limiter("bg_worker", "br")
+            .unwrap();
+
+        // 8 CPU cores, 10000 bytes/s IO.
+        let test_provider = TestResourceStatsProvider::new(8.0, 10000.0);
+        let compaction_pending_bytes_ratio = Arc::new(AtomicU32::new(0));
+        let mut worker = GroupQuotaAdjustWorker::with_quota_getter(
+            resource_ctl.clone(),
+            test_provider,
+            compaction_pending_bytes_ratio,
         );
-        check_limiter(
-            &new_bg_limiter,
-            1.8,
-            IoBytes {
-                read: 1066,
-                write: 1066,
-            },
+
+        let reset_quota = |worker: &mut GroupQuotaAdjustWorker<TestResourceStatsProvider>,
+                           cpu: f64,
+                           io: f64,
+                           dur: Duration| {
+            worker.resource_quota_getter.cpu_used = cpu;
+            worker.resource_quota_getter.io_used = io;
+            let now = Instant::now_coarse();
+            worker.last_adjust_time = now - dur;
+        };
+
+        #[track_caller]
+        fn check(val: f64, expected: f64) {
+            assert!(
+                expected * 0.99 < val && val < expected * 1.01,
+                "actual: {}, expected: {}",
+                val,
+                expected
+            );
+        }
+
+        // CPU target = 8 * 0.7 = 5.6 cores, IO target = 10000 * 0.7 = 7000
+        // fg groups have no background settings; only bg_worker triggers adjustment.
+
+        // --- Initial: no load → budget = target ---
+        reset_quota(&mut worker, 0.0, 0.0, Duration::from_secs(1));
+        worker.adjust_quota();
+        check(
+            limiter.get_limiter(ResourceType::Cpu).get_rate_limit(),
+            5.6 * MICROS_PER_SEC,
+        );
+        check(
+            limiter.get_limiter(ResourceType::Io).get_rate_limit(),
+            7000.0,
+        );
+
+        // --- Saturate CPU (100%, 80% IO) → budget scales to min_floor ---
+        // CPU: pressure = (100-60)/(70-60) = 4.0 clamped 1.0 → min_floor = 1.0
+        // IO: pressure = (80-60)/(70-60) = 2.0 clamped 1.0 → min_floor = 1000
+        reset_quota(&mut worker, 8.0, 8000.0, Duration::from_secs(1));
+        worker.adjust_quota();
+        check(
+            limiter.get_limiter(ResourceType::Cpu).get_rate_limit(),
+            1.0 * MICROS_PER_SEC,
+        );
+        check(
+            limiter.get_limiter(ResourceType::Io).get_rate_limit(),
+            1000.0,
+        );
+
+        // --- Unsaturate CPU (25%) → budget recovers incrementally ---
+        // CPU: resource_util = 25% < 54% (0.9*60%), current 1.0M < 5.04M → 1.0 * 1.1 =
+        // 1.1 IO: resource_util = 20% < 54%, current 1000 < 6300 → 1000 * 1.1 =
+        // 1100
+        reset_quota(&mut worker, 2.0, 2000.0, Duration::from_secs(1));
+        worker.adjust_quota();
+        check(
+            limiter.get_limiter(ResourceType::Cpu).get_rate_limit(),
+            1.1 * MICROS_PER_SEC,
+        );
+        check(
+            limiter.get_limiter(ResourceType::Io).get_rate_limit(),
+            1100.0,
+        );
+
+        // --- 65% CPU, 65% IO: in scale range (60-70%) ---
+        // CPU: pressure = 0.5, computed = 3.3M. current_limit=1.1M < 3.3M → only
+        // tighten → stays 1.1M. IO: computed = 4000, current=1100 < 4000 →
+        // stays 1100.
+        reset_quota(&mut worker, 5.2, 6500.0, Duration::from_secs(1));
+        worker.adjust_quota();
+        check(
+            limiter.get_limiter(ResourceType::Cpu).get_rate_limit(),
+            1.1 * MICROS_PER_SEC,
+        );
+        check(
+            limiter.get_limiter(ResourceType::Io).get_rate_limit(),
+            1100.0,
         );
     }
 
@@ -1015,7 +980,7 @@ mod tests {
 
         // only default group, always return infinity.
         reset_quota(&mut worker, 6.4);
-        priority_limiters[1].consume(Duration::from_secs(50), IoBytes::default(), true);
+        priority_limiters[1].consume(Duration::from_secs(50), IoBytes::default(), true, false);
         worker.adjust();
         check_limiter(f64::INFINITY, f64::INFINITY, f64::INFINITY);
 
@@ -1025,46 +990,96 @@ mod tests {
         resource_ctl.add_resource_group(rg2);
 
         reset_quota(&mut worker, 6.4);
-        priority_limiters[1].consume(Duration::from_secs(64), IoBytes::default(), true);
+        priority_limiters[1].consume(Duration::from_secs(64), IoBytes::default(), true, false);
         worker.adjust();
         check_limiter(f64::INFINITY, f64::INFINITY, f64::INFINITY);
 
         reset_quota(&mut worker, 6.4);
         for _i in 0..100 {
-            priority_limiters[0].consume(Duration::from_millis(240), IoBytes::default(), true);
-            priority_limiters[1].consume(Duration::from_millis(400), IoBytes::default(), true);
+            priority_limiters[0].consume(
+                Duration::from_millis(240),
+                IoBytes::default(),
+                true,
+                false,
+            );
+            priority_limiters[1].consume(
+                Duration::from_millis(400),
+                IoBytes::default(),
+                true,
+                false,
+            );
         }
         worker.adjust();
         check_limiter(f64::INFINITY, 3.2, 0.8);
 
         reset_quota(&mut worker, 6.4);
         for _i in 0..100 {
-            priority_limiters[0].consume(Duration::from_millis(120), IoBytes::default(), true);
-            priority_limiters[1].consume(Duration::from_millis(200), IoBytes::default(), true);
+            priority_limiters[0].consume(
+                Duration::from_millis(120),
+                IoBytes::default(),
+                true,
+                false,
+            );
+            priority_limiters[1].consume(
+                Duration::from_millis(200),
+                IoBytes::default(),
+                true,
+                false,
+            );
         }
         worker.adjust();
         check_limiter(f64::INFINITY, 1.6, 0.8);
 
         reset_quota(&mut worker, 6.4);
         for _i in 0..100 {
-            priority_limiters[2].consume(Duration::from_millis(200), IoBytes::default(), true);
+            priority_limiters[2].consume(
+                Duration::from_millis(200),
+                IoBytes::default(),
+                true,
+                false,
+            );
         }
         worker.adjust();
         check_limiter(f64::INFINITY, f64::INFINITY, f64::INFINITY);
 
         reset_quota(&mut worker, 8.0);
         for _i in 0..100 {
-            priority_limiters[0].consume(Duration::from_millis(240), IoBytes::default(), true);
-            priority_limiters[1].consume(Duration::from_millis(240), IoBytes::default(), true);
-            priority_limiters[2].consume(Duration::from_millis(320), IoBytes::default(), true);
+            priority_limiters[0].consume(
+                Duration::from_millis(240),
+                IoBytes::default(),
+                true,
+                false,
+            );
+            priority_limiters[1].consume(
+                Duration::from_millis(240),
+                IoBytes::default(),
+                true,
+                false,
+            );
+            priority_limiters[2].consume(
+                Duration::from_millis(320),
+                IoBytes::default(),
+                true,
+                false,
+            );
         }
         worker.adjust();
         check_limiter(f64::INFINITY, 3.2, 0.8);
 
         reset_quota(&mut worker, 6.0);
         for _i in 0..100 {
-            priority_limiters[0].consume(Duration::from_millis(240), IoBytes::default(), true);
-            priority_limiters[2].consume(Duration::from_millis(360), IoBytes::default(), true);
+            priority_limiters[0].consume(
+                Duration::from_millis(240),
+                IoBytes::default(),
+                true,
+                false,
+            );
+            priority_limiters[2].consume(
+                Duration::from_millis(360),
+                IoBytes::default(),
+                true,
+                false,
+            );
         }
         worker.adjust();
         check_limiter(f64::INFINITY, 3.2, 3.2);
@@ -1074,5 +1089,349 @@ mod tests {
         worker.last_adjust_time = Instant::now_coarse() - Duration::from_millis(500);
         worker.adjust();
         check_limiter(f64::INFINITY, 3.2, 3.2);
+    }
+
+    /// Verifies background load-shedding:
+    ///
+    /// - 0–60% CPU   : background full
+    /// - 60–70% CPU  : background linearly throttled to min_floor
+    /// - >70% CPU    : background at min_floor
+    #[test]
+    fn test_tiered_load_shedding() {
+        let resource_ctl = Arc::new(ResourceGroupManager::default());
+
+        let bg = new_background_resource_group_ru("bg".into(), 1000, 8, vec!["br".into()]);
+        resource_ctl.add_resource_group(bg);
+        let bg_limiter = resource_ctl
+            .get_background_resource_limiter("bg", "br")
+            .unwrap();
+
+        let compaction_pending_bytes_ratio = Arc::new(AtomicU32::new(0));
+        let mut bg_worker = GroupQuotaAdjustWorker::with_quota_getter(
+            resource_ctl.clone(),
+            TestResourceStatsProvider::new(8.0, 10000.0),
+            compaction_pending_bytes_ratio,
+        );
+
+        const BG_TARGET: f64 = 5.6;
+        const BG_FLOOR: f64 = 1.0;
+
+        #[track_caller]
+        fn approx(val: f64, expected: f64) {
+            assert!(
+                (val.is_infinite() && expected.is_infinite())
+                    || (expected * 0.99 < val && val < expected * 1.01),
+                "actual: {val}, expected: {expected}"
+            );
+        }
+
+        macro_rules! tick {
+            ($cpu:expr) => {{
+                bg_worker.resource_quota_getter.cpu_used = $cpu;
+                bg_worker.last_adjust_time = Instant::now_coarse() - Duration::from_secs(10);
+                bg_worker.adjust_quota();
+            }};
+        }
+
+        // 50% CPU — below bg_scale_start (60%): bg=full.
+        tick!(4.0);
+        approx(
+            bg_limiter.get_limiter(ResourceType::Cpu).get_rate_limit(),
+            BG_TARGET * MICROS_PER_SEC,
+        );
+
+        // 65% CPU — mid bg range: pressure = 0.5.
+        tick!(5.2);
+        approx(
+            bg_limiter.get_limiter(ResourceType::Cpu).get_rate_limit(),
+            3.3 * MICROS_PER_SEC,
+        );
+
+        // 70% CPU — bg fully throttled.
+        tick!(5.6);
+        approx(
+            bg_limiter.get_limiter(ResourceType::Cpu).get_rate_limit(),
+            BG_FLOOR * MICROS_PER_SEC,
+        );
+
+        // 80% CPU — still at min_floor.
+        tick!(6.4);
+        approx(
+            bg_limiter.get_limiter(ResourceType::Cpu).get_rate_limit(),
+            BG_FLOOR * MICROS_PER_SEC,
+        );
+
+        // Recovery: CPU drops to 50%.
+        tick!(4.0);
+        let bg_rate = bg_limiter.get_limiter(ResourceType::Cpu).get_rate_limit();
+        assert!(
+            bg_rate > BG_FLOOR * MICROS_PER_SEC && bg_rate < BG_TARGET * MICROS_PER_SEC,
+            "bg should be recovering, got {bg_rate}"
+        );
+    }
+
+    #[test]
+    fn test_compaction_pending_bytes_ratio_write_io_throttle() {
+        let resource_ctl = Arc::new(ResourceGroupManager::default());
+
+        // 8 CPU cores, 10000 bytes/s IO bandwidth.
+        let test_provider = TestResourceStatsProvider::new(8.0, 10000.0);
+        let compaction_pending_bytes_ratio = Arc::new(AtomicU32::new(0));
+        let mut worker = GroupQuotaAdjustWorker::with_quota_getter(
+            resource_ctl.clone(),
+            test_provider,
+            compaction_pending_bytes_ratio.clone(),
+        );
+
+        // Create default background group with 80% utilization limit.
+        let mut default_bg =
+            new_background_resource_group_ru("default".into(), 2000, 8, vec!["br".into()]);
+        default_bg
+            .mut_background_settings()
+            .set_utilization_limit(80);
+        resource_ctl.add_resource_group(default_bg);
+
+        let limiter = resource_ctl
+            .get_background_resource_limiter("default", "br")
+            .unwrap();
+
+        let reset_quota = |worker: &mut GroupQuotaAdjustWorker<TestResourceStatsProvider>,
+                           cpu: f64,
+                           io: f64,
+                           dur: Duration| {
+            worker.resource_quota_getter.cpu_used = cpu;
+            worker.resource_quota_getter.io_used = io;
+            let now = Instant::now_coarse();
+            worker.last_adjust_time = now - dur;
+        };
+
+        #[track_caller]
+        fn check(val: f64, expected: f64) {
+            assert!(
+                (val.is_infinite() && expected.is_infinite())
+                    || (expected * 0.99 < val && val < expected * 1.01),
+                "actual: {}, expected: {}",
+                val,
+                expected
+            );
+        }
+
+        // Constants matching config defaults (bg_write_io_ceiling=100GB/s,
+        // bg_write_io_floor=10MB/s).
+        let ceiling = 100.0 * 1024.0 * 1024.0 * 1024.0; // 100 GB/s in bytes/s
+        let floor = 10.0 * 1024.0 * 1024.0; // 10 MB/s in bytes/s
+
+        // First adjustment: establish baseline limits.
+        // util_limit 80% capped to 70%. CPU target = 5.6 cores, IO target = 7000
+        reset_quota(&mut worker, 0.0, 0.0, Duration::from_secs(1));
+        worker.adjust_quota();
+        check(
+            limiter.get_limiter(ResourceType::Cpu).get_rate_limit(),
+            5.6 * MICROS_PER_SEC,
+        );
+        check(
+            limiter.get_limiter(ResourceType::Io).get_rate_limit(),
+            7000.0,
+        );
+
+        // Pressure = 0: below threshold → first call, current is infinite so
+        // set to ceiling.
+        check(limiter.get_write_io_limiter().get_rate_limit(), ceiling);
+
+        // Pressure = 50 (< 70): already at ceiling, stays at ceiling.
+        compaction_pending_bytes_ratio.store(50, Ordering::Relaxed);
+        reset_quota(&mut worker, 0.0, 0.0, Duration::from_secs(1));
+        worker.adjust_quota();
+        check(limiter.get_write_io_limiter().get_rate_limit(), ceiling);
+
+        // CPU and combined IO limits unchanged at target.
+        check(
+            limiter.get_limiter(ResourceType::Cpu).get_rate_limit(),
+            5.6 * MICROS_PER_SEC,
+        );
+        check(
+            limiter.get_limiter(ResourceType::Io).get_rate_limit(),
+            7000.0,
+        );
+
+        // Pressure = 70 (at threshold): pressure_ratio = 0 → budget = ceiling.
+        compaction_pending_bytes_ratio.store(70, Ordering::Relaxed);
+        reset_quota(&mut worker, 0.0, 0.0, Duration::from_secs(1));
+        worker.adjust_quota();
+        check(limiter.get_write_io_limiter().get_rate_limit(), ceiling);
+
+        // CPU and combined IO limits should not be affected by compaction pressure.
+        check(
+            limiter.get_limiter(ResourceType::Cpu).get_rate_limit(),
+            5.6 * MICROS_PER_SEC,
+        );
+
+        // Pressure = 85: window = [70, 105], pressure_ratio = (85-70)/35 ≈ 0.429
+        // budget = ceiling * 0.571 + floor * 0.429
+        compaction_pending_bytes_ratio.store(85, Ordering::Relaxed);
+        reset_quota(&mut worker, 0.0, 0.0, Duration::from_secs(1));
+        worker.adjust_quota();
+        let window = 70.0 * 0.5; // threshold * 0.5 = 35
+        let expected_85 = {
+            let r = ((85.0_f64 - 70.0) / window).clamp(0.0, 1.0);
+            ceiling * (1.0 - r) + floor * r
+        };
+        check(limiter.get_write_io_limiter().get_rate_limit(), expected_85);
+
+        // CPU limit unaffected.
+        check(
+            limiter.get_limiter(ResourceType::Cpu).get_rate_limit(),
+            5.6 * MICROS_PER_SEC,
+        );
+
+        // Pressure = 100: pressure_ratio = (100-70)/35 ≈ 0.857 → well below floor
+        // clamp. budget = ceiling * 0.143 + floor * 0.857
+        compaction_pending_bytes_ratio.store(100, Ordering::Relaxed);
+        reset_quota(&mut worker, 0.0, 0.0, Duration::from_secs(1));
+        worker.adjust_quota();
+        let expected_100 = {
+            let r = ((100.0_f64 - 70.0) / window).clamp(0.0, 1.0);
+            ceiling * (1.0 - r) + floor * r
+        };
+        check(
+            limiter.get_write_io_limiter().get_rate_limit(),
+            expected_100,
+        );
+
+        // CPU limit unaffected.
+        check(
+            limiter.get_limiter(ResourceType::Cpu).get_rate_limit(),
+            5.6 * MICROS_PER_SEC,
+        );
+
+        // Pressure = 106 (>= threshold * 1.5 = 105): pressure_ratio clamped to 1.0 →
+        // floor.
+        compaction_pending_bytes_ratio.store(106, Ordering::Relaxed);
+        reset_quota(&mut worker, 0.0, 0.0, Duration::from_secs(1));
+        worker.adjust_quota();
+        check(limiter.get_write_io_limiter().get_rate_limit(), floor);
+
+        // Pressure drops to 0 (< threshold): ramp up by 10% from floor.
+        // floor * 1.1 = 10 MB/s * 1.1 = 11534336
+        compaction_pending_bytes_ratio.store(0, Ordering::Relaxed);
+        reset_quota(&mut worker, 0.0, 0.0, Duration::from_secs(1));
+        worker.adjust_quota();
+        let ramp1 = floor * 1.1;
+        check(limiter.get_write_io_limiter().get_rate_limit(), ramp1);
+
+        // Pressure stays at 0: another 10% ramp up.
+        reset_quota(&mut worker, 0.0, 0.0, Duration::from_secs(1));
+        worker.adjust_quota();
+        let ramp2 = ramp1 * 1.1;
+        check(limiter.get_write_io_limiter().get_rate_limit(), ramp2);
+
+        // Keep ramping until we hit ceiling.
+        let mut current = ramp2;
+        while current * 1.1 < ceiling {
+            reset_quota(&mut worker, 0.0, 0.0, Duration::from_secs(1));
+            worker.adjust_quota();
+            current = (current * 1.1).min(ceiling);
+            check(limiter.get_write_io_limiter().get_rate_limit(), current);
+        }
+        // One more adjustment should cap at ceiling.
+        reset_quota(&mut worker, 0.0, 0.0, Duration::from_secs(1));
+        worker.adjust_quota();
+        check(limiter.get_write_io_limiter().get_rate_limit(), ceiling);
+    }
+
+    // Verify that with multiple background groups the budget is set globally on
+    // a single shared limiter, not split proportionally across groups.
+    //
+    // Old behaviour: 2 groups with RU 2000 and 1000 would receive 2/3 and 1/3
+    // of the total budget.
+    // New behaviour: both groups return the same Arc<ResourceLimiter> and the
+    // full budget is applied to it once.
+    #[test]
+    fn test_global_budget_not_split_across_groups() {
+        let resource_ctl = Arc::new(ResourceGroupManager::default());
+
+        // 8 CPU cores, 10000 bytes/s IO bandwidth.
+        let test_provider = TestResourceStatsProvider::new(8.0, 10000.0);
+        let compaction_pending_bytes_ratio = Arc::new(AtomicU32::new(0));
+        let mut worker = GroupQuotaAdjustWorker::with_quota_getter(
+            resource_ctl.clone(),
+            test_provider,
+            compaction_pending_bytes_ratio,
+        );
+
+        // Add two background groups with different RU quotas.
+        let mut grp_a =
+            new_background_resource_group_ru("group_a".into(), 2000, 8, vec!["br".into()]);
+        grp_a.mut_background_settings().set_utilization_limit(80);
+        resource_ctl.add_resource_group(grp_a);
+
+        let grp_b = new_background_resource_group_ru("group_b".into(), 1000, 8, vec!["br".into()]);
+        resource_ctl.add_resource_group(grp_b);
+
+        let limiter_a = resource_ctl
+            .get_background_resource_limiter("group_a", "br")
+            .unwrap();
+        let limiter_b = resource_ctl
+            .get_background_resource_limiter("group_b", "br")
+            .unwrap();
+
+        // Both groups must point to the same global limiter.
+        assert!(Arc::ptr_eq(&limiter_a, &limiter_b));
+
+        // util_limit = 80% capped to 70% by bg_resource_threshold.
+        // CPU target = 8 * 0.7 = 5.6 cores, IO target = 10000 * 0.7 = 7000.
+        // Under no load the full target is applied to the single limiter.
+        worker.resource_quota_getter.cpu_used = 0.0;
+        worker.resource_quota_getter.io_used = 0.0;
+        worker.last_adjust_time = Instant::now_coarse() - Duration::from_secs(1);
+        worker.adjust_quota();
+
+        #[track_caller]
+        fn check(val: f64, expected: f64) {
+            assert!(
+                expected * 0.99 < val && val < expected * 1.01,
+                "actual: {val}, expected: {expected}"
+            );
+        }
+
+        // Full budget, not 2/3 of it.
+        check(
+            limiter_a.get_limiter(ResourceType::Cpu).get_rate_limit(),
+            5.6 * MICROS_PER_SEC,
+        );
+        check(
+            limiter_a.get_limiter(ResourceType::Io).get_rate_limit(),
+            7000.0,
+        );
+
+        // limiter_b is the same Arc so it reflects the same rates.
+        check(
+            limiter_b.get_limiter(ResourceType::Cpu).get_rate_limit(),
+            5.6 * MICROS_PER_SEC,
+        );
+        check(
+            limiter_b.get_limiter(ResourceType::Io).get_rate_limit(),
+            7000.0,
+        );
+
+        // Under heavy load (100% CPU) the budget scales down to min_floor for
+        // the single global limiter — not independently per group.
+        worker.resource_quota_getter.cpu_used = 8.0;
+        worker.resource_quota_getter.io_used = 9500.0;
+        worker.last_adjust_time = Instant::now_coarse() - Duration::from_secs(1);
+        worker.adjust_quota();
+
+        // CPU: resource_util=100%, bg_scale_start=60%, fg_cpu_throttle_threshold=70%.
+        // pressure = (100-60)/(70-60) = 4.0 clamped to 1.0 → min_floor = 1.0 core.
+        // IO: resource_util=95%, pressure = (95-60)/(70-60) = 3.5 clamped to 1.0 →
+        // min_floor = 1000.
+        check(
+            limiter_a.get_limiter(ResourceType::Cpu).get_rate_limit(),
+            1.0 * MICROS_PER_SEC,
+        );
+        check(
+            limiter_a.get_limiter(ResourceType::Io).get_rate_limit(),
+            1000.0,
+        );
     }
 }

--- a/components/resource_control/src/worker.rs
+++ b/components/resource_control/src/worker.rs
@@ -24,7 +24,7 @@ use tikv_util::{
 
 use crate::{
     metrics::*,
-    resource_group::ResourceGroupManager,
+    resource_group::{ResourceGroupManager, LEEWAY_FACTOR, THROTTLE_INCREASE_FACTOR},
     resource_limiter::{GroupStatistics, ResourceLimiter, ResourceType},
     score::{
         compute_resource_scores, pressure_fraction, ResourceCapacities, ResourceScoreInputs,
@@ -32,22 +32,11 @@ use crate::{
     },
 };
 
-pub const QUOTA_ADJUST_DURATION: Duration = Duration::from_secs(10);
-
 const MICROS_PER_SEC: f64 = 1_000_000.0;
 // the minimal schedule wait duration due to the overhead of queue.
 // We should exclude this cause when calculate the estimated total wait
 // duration.
 const MINIMAL_SCHEDULE_WAIT_SECS: f64 = 0.000_005; //5us
-
-/// Per-tick multiplicative step used to ramp a limit back up once the system is
-/// no longer under pressure: +10% per tick rather than jumping straight to the
-/// ceiling.
-const RAMP_UP_FACTOR: f64 = 1.1;
-/// Fraction of the target below which a limit counts as "not yet recovered",
-/// and fraction of `bg_scale_start` below which the system counts as idle. A
-/// dead zone, so ramp-up doesn't fight the throttle branch tick by tick.
-const IDLE_LEEWAY_RATIO: f64 = 0.9;
 
 /// Bundles the two scale-range thresholds so they can be passed as a single
 /// argument to `background_adjust_resource_quota`.
@@ -471,11 +460,11 @@ impl<R: ResourceStatsProvider> GroupQuotaAdjustWorker<R> {
         } else if current_limit_score > target_score {
             // Background limit exceeds its allowed share; reset to target.
             target_score
-        } else if current_limit_score < IDLE_LEEWAY_RATIO * target_score
-            && resource_score < IDLE_LEEWAY_RATIO * bg_scale_start
+        } else if current_limit_score < LEEWAY_FACTOR * target_score
+            && resource_score < LEEWAY_FACTOR * bg_scale_start
         {
             // System is idle; increase limit incrementally from current limit.
-            current_limit_score * RAMP_UP_FACTOR
+            current_limit_score * THROTTLE_INCREASE_FACTOR
         } else {
             target_score
         }
@@ -504,7 +493,7 @@ impl<R: ResourceStatsProvider> GroupQuotaAdjustWorker<R> {
             if current_limit.is_infinite() || current_limit >= ceiling {
                 ceiling
             } else {
-                (current_limit * RAMP_UP_FACTOR).min(ceiling)
+                (current_limit * THROTTLE_INCREASE_FACTOR).min(ceiling)
             }
         } else {
             // Linear interpolation from ceiling to floor over the window
@@ -1615,25 +1604,26 @@ mod tests {
         worker.adjust_quota();
         check(limiter.get_write_io_limiter().get_rate_limit(), floor);
 
-        // Pressure drops to 0 (< threshold): one RAMP_UP_FACTOR step from floor.
+        // Pressure drops to 0 (< threshold): one THROTTLE_INCREASE_FACTOR step from
+        // floor.
         compaction_pending_bytes_ratio.store(0, Ordering::Relaxed);
         reset_quota(&mut worker, 0.0, 0.0, Duration::from_secs(1));
         worker.adjust_quota();
-        let ramp1 = floor * RAMP_UP_FACTOR;
+        let ramp1 = floor * THROTTLE_INCREASE_FACTOR;
         check(limiter.get_write_io_limiter().get_rate_limit(), ramp1);
 
         // Pressure stays at 0: another ramp-up step.
         reset_quota(&mut worker, 0.0, 0.0, Duration::from_secs(1));
         worker.adjust_quota();
-        let ramp2 = ramp1 * RAMP_UP_FACTOR;
+        let ramp2 = ramp1 * THROTTLE_INCREASE_FACTOR;
         check(limiter.get_write_io_limiter().get_rate_limit(), ramp2);
 
         // Keep ramping until we hit ceiling.
         let mut current = ramp2;
-        while current * RAMP_UP_FACTOR < ceiling {
+        while current * THROTTLE_INCREASE_FACTOR < ceiling {
             reset_quota(&mut worker, 0.0, 0.0, Duration::from_secs(1));
             worker.adjust_quota();
-            current = (current * RAMP_UP_FACTOR).min(ceiling);
+            current = (current * THROTTLE_INCREASE_FACTOR).min(ceiling);
             check(limiter.get_write_io_limiter().get_rate_limit(), current);
         }
         // One more adjustment should cap at ceiling.

--- a/components/resource_control/src/worker.rs
+++ b/components/resource_control/src/worker.rs
@@ -16,6 +16,7 @@ use strum::EnumCount;
 use tikv_util::{
     resource_control::{TaskPriority, DEFAULT_RESOURCE_GROUP_NAME},
     sys::{cpu_time::ProcessStat, SysQuota},
+    thread_name_prefix::GRPC_SERVER_THREAD,
     time::Instant,
     warn,
     yatp_pool::metrics::YATP_POOL_SCHEDULE_WAIT_DURATION_VEC,
@@ -25,6 +26,10 @@ use crate::{
     metrics::*,
     resource_group::ResourceGroupManager,
     resource_limiter::{GroupStatistics, ResourceLimiter, ResourceType},
+    score::{
+        compute_resource_scores, pressure_fraction, ResourceCapacities, ResourceScoreInputs,
+        ResourceScores, ThreadGroupCpuTracker,
+    },
 };
 
 pub const QUOTA_ADJUST_DURATION: Duration = Duration::from_secs(10);
@@ -34,6 +39,23 @@ const MICROS_PER_SEC: f64 = 1_000_000.0;
 // We should exclude this cause when calculate the estimated total wait
 // duration.
 const MINIMAL_SCHEDULE_WAIT_SECS: f64 = 0.000_005; //5us
+
+/// Per-tick multiplicative step used to ramp a limit back up once the system is
+/// no longer under pressure: +10% per tick rather than jumping straight to the
+/// ceiling.
+const RAMP_UP_FACTOR: f64 = 1.1;
+/// Fraction of the target below which a limit counts as "not yet recovered",
+/// and fraction of `bg_scale_start` below which the system counts as idle. A
+/// dead zone, so ramp-up doesn't fight the throttle branch tick by tick.
+const IDLE_LEEWAY_RATIO: f64 = 0.9;
+
+/// Bundles the two scale-range thresholds so they can be passed as a single
+/// argument to `background_adjust_resource_quota`.
+#[derive(Clone, Copy)]
+struct ScaleThresholds {
+    bg_scale_start: f64,
+    fg_cpu_throttle_threshold: f64,
+}
 
 pub struct ResourceUsageStats {
     total_quota: f64,
@@ -105,6 +127,16 @@ pub struct GroupQuotaAdjustWorker<R> {
     // Whether the previous tick had background groups. Used to detect the
     // empty->non-empty transition and discard stale accumulated consumption.
     prev_had_background: bool,
+    // Measures grpc-server thread CPU usage, feeding the common
+    // resource-pressure score alongside whole-process CPU.
+    grpc_cpu_tracker: ThreadGroupCpuTracker,
+    caps: ResourceCapacities,
+    // IO quota (bytes/s) available to `resource_quota_getter` for
+    // ResourceType::Io. 0 means IO rate limiting isn't configured at all, in
+    // which case there's nothing to fetch stats for or throttle.
+    io_bandwidth: f64,
+    // Last measured IO utilization, reused when a fetch fails.
+    prev_io_util: f64,
 }
 
 impl GroupQuotaAdjustWorker<SysQuotaGetter> {
@@ -112,6 +144,7 @@ impl GroupQuotaAdjustWorker<SysQuotaGetter> {
         resource_ctl: Arc<ResourceGroupManager>,
         io_bandwidth: u64,
         compaction_pending_bytes_ratio: Arc<AtomicU32>,
+        grpc_concurrency: usize,
     ) -> Self {
         let resource_quota_getter = SysQuotaGetter {
             process_stat: ProcessStat::cur_proc_stat().unwrap(),
@@ -123,6 +156,8 @@ impl GroupQuotaAdjustWorker<SysQuotaGetter> {
             resource_ctl,
             resource_quota_getter,
             compaction_pending_bytes_ratio,
+            grpc_concurrency,
+            io_bandwidth as f64,
         )
     }
 }
@@ -132,6 +167,8 @@ impl<R: ResourceStatsProvider> GroupQuotaAdjustWorker<R> {
         resource_ctl: Arc<ResourceGroupManager>,
         resource_quota_getter: R,
         compaction_pending_bytes_ratio: Arc<AtomicU32>,
+        grpc_concurrency: usize,
+        io_bandwidth: f64,
     ) -> Self {
         let bg_limiter = resource_ctl.get_background_limiter();
         Self {
@@ -142,6 +179,13 @@ impl<R: ResourceStatsProvider> GroupQuotaAdjustWorker<R> {
             bg_limiter,
             prev_stats: array::from_fn(|_| GroupStatistics::default()),
             prev_had_background: false,
+            grpc_cpu_tracker: ThreadGroupCpuTracker::new(GRPC_SERVER_THREAD),
+            caps: ResourceCapacities {
+                total_cpu_cores: SysQuota::cpu_cores_quota(),
+                grpc_concurrency: grpc_concurrency as f64,
+            },
+            io_bandwidth,
+            prev_io_util: 0.0,
         }
     }
 
@@ -168,21 +212,87 @@ impl<R: ResourceStatsProvider> GroupQuotaAdjustWorker<R> {
                 return;
             }
         };
-        let cpu_util = if cpu_stats.total_quota > f64::EPSILON {
+        let process_cpu_util = if cpu_stats.total_quota > f64::EPSILON {
             cpu_stats.current_used / cpu_stats.total_quota * 100.0
         } else {
             0.0
         };
 
-        self.background_adjust_quota(dur_secs, &cpu_stats);
-        self.foreground_adjust_quota(cpu_util);
+        let io_util = self.fetch_io_util();
+
+        let grpc_cpu_cores = self.grpc_cpu_tracker.measure_cpu_cores();
+
+        let compaction_pending_ratio =
+            self.compaction_pending_bytes_ratio.load(Ordering::Relaxed) as f64;
+
+        let inputs = ResourceScoreInputs {
+            process_cpu_util,
+            grpc_cpu_cores,
+            io_util,
+            compaction_pending_ratio,
+        };
+        let scores = compute_resource_scores(&inputs, &self.caps);
+        RESOURCE_SCORE_VEC
+            .with_label_values(&["cpu"])
+            .set(scores.cpu_score);
+        RESOURCE_SCORE_VEC
+            .with_label_values(&["io"])
+            .set(scores.io_score);
+        RESOURCE_SCORE_VEC
+            .with_label_values(&["compaction"])
+            .set(scores.compaction_score);
+
+        self.background_adjust_quota(
+            dur_secs,
+            cpu_stats.total_quota,
+            &scores,
+            compaction_pending_ratio,
+        );
+        self.foreground_adjust_quota(scores.cpu_score);
     }
 
-    fn foreground_adjust_quota(&mut self, cpu_util: f64) {
-        self.resource_ctl.online_adjust_resource_quota(cpu_util);
+    fn foreground_adjust_quota(&mut self, cpu_score: f64) {
+        self.resource_ctl.online_adjust_resource_quota(cpu_score);
     }
 
-    fn background_adjust_quota(&mut self, dur_secs: f64, cpu_stats: &ResourceUsageStats) {
+    // io_score is only consumed by `background_adjust_quota`, so mirror its
+    // gates here and skip the IO fetch entirely when there's nothing
+    // background to throttle, or when IO rate limiting isn't even configured
+    // (io_bandwidth == 0, so background_adjust_resource_quota would bail out
+    // anyway) — the old code never tracked IO stats unconditionally either.
+    fn fetch_io_util(&mut self) -> f64 {
+        if !self.resource_ctl.has_background_groups() || self.io_bandwidth <= 0.0 {
+            return 0.0;
+        }
+        match self
+            .resource_quota_getter
+            .get_current_stats(ResourceType::Io)
+        {
+            Ok(s) if s.total_quota > f64::EPSILON => {
+                let util = s.current_used / s.total_quota * 100.0;
+                self.prev_io_util = util;
+                util
+            }
+            // Unlimited IO quota: a real zero, not a failure.
+            Ok(_) => 0.0,
+            Err(e) => {
+                warn!(
+                    "get io stats failed; reusing previous io utilization.";
+                    "prev_io_util" => self.prev_io_util,
+                    "err" => ?e,
+                );
+                self.prev_io_util
+            }
+        }
+    }
+
+    fn background_adjust_quota(
+        &mut self,
+        dur_secs: f64,
+        cpu_total_quota: f64,
+        scores: &ResourceScores,
+        compaction_pending_ratio: f64,
+    ) {
         let mut bg_util_limit = self
             .resource_ctl
             .get_resource_group(DEFAULT_RESOURCE_GROUP_NAME)
@@ -194,9 +304,10 @@ impl<R: ResourceStatsProvider> GroupQuotaAdjustWorker<R> {
         }
         let (bg_scale_start, fg_cpu_throttle_threshold) = {
             let config = self.resource_ctl.get_config().value();
-            let start = config.bg_cpu_throttle_threshold.clamp(1.0, 99.0);
-            let end = config.fg_cpu_throttle_threshold.clamp(start, 99.0);
-            (start, end)
+            (
+                config.bg_cpu_throttle_threshold,
+                config.fg_cpu_throttle_threshold,
+            )
         };
         // Cap utilization limit to fg_cpu_throttle_threshold. Background tasks should
         // never consume more than this fraction of total resources. Scale-down
@@ -222,51 +333,43 @@ impl<R: ResourceStatsProvider> GroupQuotaAdjustWorker<R> {
             self.prev_had_background = true;
         }
 
+        let thresholds = ScaleThresholds {
+            bg_scale_start,
+            fg_cpu_throttle_threshold,
+        };
         self.background_adjust_resource_quota(
             ResourceType::Cpu,
             dur_secs,
             bg_util_limit,
-            bg_scale_start,
-            fg_cpu_throttle_threshold,
-            Some(cpu_stats),
+            thresholds,
+            cpu_total_quota,
+            scores.cpu_score,
         );
         self.background_adjust_resource_quota(
             ResourceType::Io,
             dur_secs,
             bg_util_limit,
-            bg_scale_start,
-            fg_cpu_throttle_threshold,
-            None,
+            thresholds,
+            self.io_bandwidth,
+            scores.io_score,
         );
-        self.adjust_write_io_by_compaction_pressure();
+        self.adjust_write_io_by_compaction_pressure(compaction_pending_ratio);
     }
 
     fn background_adjust_resource_quota(
         &mut self,
         resource_type: ResourceType,
         dur_secs: f64,
+        // Configured background share, 0-100 — a score in the same units as
+        // `resource_score`.
         utilization_limit: u64,
-        bg_scale_start: f64,
-        fg_cpu_throttle_threshold: f64,
-        // Pre-fetched stats for CPU (avoids a second /proc/stat read); None for
-        // IO, which always fetches fresh bytes-transferred counters.
-        prefetched_stats: Option<&ResourceUsageStats>,
+        thresholds: ScaleThresholds,
+        total_quota: f64,
+        // Common 0-100 resource-pressure score for this resource type
+        // (cpu_score or io_score from `compute_resource_scores`).
+        resource_score: f64,
     ) {
-        let fetched;
-        let resource_stats = if let Some(s) = prefetched_stats {
-            s
-        } else {
-            fetched = match self.resource_quota_getter.get_current_stats(resource_type) {
-                Ok(r) => r,
-                Err(e) => {
-                    warn!("get resource statistics info failed, skip adjust"; "type" => ?resource_type, "err" => ?e);
-                    return;
-                }
-            };
-            &fetched
-        };
-        // if total resource quota is unlimited, set background limit to unlimited.
-        if resource_stats.total_quota <= f64::EPSILON {
+        if total_quota <= f64::EPSILON {
             self.bg_limiter
                 .get_limiter(resource_type)
                 .set_rate_limit(f64::INFINITY);
@@ -281,59 +384,54 @@ impl<R: ResourceStatsProvider> GroupQuotaAdjustWorker<R> {
         BACKGROUND_RESOURCE_CONSUMPTION
             .with_label_values(&[resource_type.as_str()])
             .inc_by(stats_delta.total_consumed);
-        if resource_type == ResourceType::Cpu {
-            BACKGROUND_TASKS_WAIT_DURATION.inc_by(stats_delta.total_wait_dur_us);
-        }
         let background_consumed = (stats_delta / dur_secs).total_consumed as f64;
 
-        let background_util = (background_consumed / resource_stats.total_quota * 100.0) as u64;
-        let resource_util = resource_stats.current_used / resource_stats.total_quota * 100.0;
+        // Centi-cores (cores * 100) for CPU (background_consumed is core-us/s), bytes/s
+        // for IO.
+        let background_resource = match resource_type {
+            ResourceType::Cpu => background_consumed / MICROS_PER_SEC * 100.0,
+            ResourceType::Io => background_consumed,
+        };
         BACKGROUND_TASK_RESOURCE_UTILIZATION_VEC
             .with_label_values(&[resource_type.as_str()])
-            .set(background_util as i64);
+            .set(background_resource as i64);
 
-        let util_limit_percent = (utilization_limit as f64 / 100.0).min(1.0);
-        let target = resource_stats.total_quota * util_limit_percent;
+        let utilization_limit_score = (utilization_limit as f64).min(100.0);
+        let target = total_quota * utilization_limit_score / 100.0;
 
         // Treat infinity as target (initial state before first adjustment).
         let current_limit = {
             let l = self.bg_limiter.get_limiter(resource_type).get_rate_limit();
             if l.is_infinite() { target } else { l }
         };
+        let current_limit_score = current_limit / total_quota * 100.0;
 
         // Minimum: 1 CPU core for CPU, 10% of total for IO.
         let min_floor = match resource_type {
             ResourceType::Cpu => MICROS_PER_SEC,
-            ResourceType::Io => resource_stats.total_quota * 0.1,
+            ResourceType::Io => total_quota * 0.1,
         }
         .min(target);
+        let min_floor_score = min_floor / total_quota * 100.0;
 
-        let mut new_budget = target;
-        if resource_util > bg_scale_start {
-            // Linearly scale budget from target down to min_floor as utilization
-            // goes from bg_scale_start to fg_cpu_throttle_threshold.
-            let range = (fg_cpu_throttle_threshold - bg_scale_start).max(1.0);
-            let pressure = ((resource_util - bg_scale_start) / range).clamp(0.0, 1.0);
-            new_budget = target * (1.0 - pressure) + min_floor * pressure;
-            // Only tighten: never increase the limit in the throttle branch.
-            if new_budget > current_limit {
-                new_budget = current_limit;
-            }
-        } else if current_limit > target {
-            // Background limit exceeds its allowed share; reset to target.
-            new_budget = target;
-        } else if current_limit < 0.9 * target && resource_util < 0.9 * bg_scale_start {
-            // System is idle; increase limit incrementally from current limit.
-            new_budget = current_limit * 1.1;
-        }
-
-        let new_budget = new_budget.clamp(min_floor, target);
+        let new_budget_score = Self::compute_budget_score(
+            current_limit_score,
+            utilization_limit_score,
+            min_floor_score,
+            resource_score,
+            thresholds,
+        );
+        let new_budget = (new_budget_score / 100.0 * total_quota).clamp(min_floor, target);
         self.bg_limiter
             .get_limiter(resource_type)
             .set_rate_limit(new_budget);
+        let new_budget_resource = match resource_type {
+            ResourceType::Cpu => new_budget / MICROS_PER_SEC * 100.0,
+            ResourceType::Io => new_budget,
+        };
         BACKGROUND_QUOTA_LIMIT_VEC
             .with_label_values(&[resource_type.as_str()])
-            .set(new_budget as i64);
+            .set(new_budget_resource as i64);
 
         // Update the "background at floor" flag so foreground throttling
         // only kicks in after background has been fully squeezed.
@@ -343,15 +441,60 @@ impl<R: ResourceStatsProvider> GroupQuotaAdjustWorker<R> {
         }
     }
 
+    /// Pure budget decision in score space (0-100 throughout, no absolute
+    /// units or per-resource-type knowledge): tightens `current_limit_score`
+    /// toward `min_floor_score` as `resource_score` rises from
+    /// `bg_scale_start` to `fg_cpu_throttle_threshold`, resets to
+    /// `target_score` if the current limit exceeds it, ramps up
+    /// incrementally when idle, or resets to `target_score` otherwise.
+    /// Always clamped to `[min_floor_score, target_score]` by the caller.
+    fn compute_budget_score(
+        current_limit_score: f64,
+        target_score: f64,
+        min_floor_score: f64,
+        resource_score: f64,
+        thresholds: ScaleThresholds,
+    ) -> f64 {
+        let ScaleThresholds {
+            bg_scale_start,
+            fg_cpu_throttle_threshold,
+        } = thresholds;
+        if resource_score > bg_scale_start {
+            // Linearly scale budget from target down to min_floor as the
+            // resource-utilization score goes from bg_scale_start to
+            // fg_cpu_throttle_threshold.
+            let pressure =
+                pressure_fraction(resource_score, bg_scale_start, fg_cpu_throttle_threshold);
+            let new_budget_score = target_score * (1.0 - pressure) + min_floor_score * pressure;
+            // Only tighten: never increase the limit in the throttle branch.
+            new_budget_score.min(current_limit_score)
+        } else if current_limit_score > target_score {
+            // Background limit exceeds its allowed share; reset to target.
+            target_score
+        } else if current_limit_score < IDLE_LEEWAY_RATIO * target_score
+            && resource_score < IDLE_LEEWAY_RATIO * bg_scale_start
+        {
+            // System is idle; increase limit incrementally from current limit.
+            current_limit_score * RAMP_UP_FACTOR
+        } else {
+            target_score
+        }
+    }
+
     /// Adjust the write-only IO limiter based on compaction pressure.
     /// When pressure >= threshold, linearly scale write IO from ceiling to
     /// floor over a window of 50% of threshold (i.e. threshold to
     /// threshold * 1.5). Below threshold, write IO ramps up 10% per tick
     /// capped at ceiling.
-    fn adjust_write_io_by_compaction_pressure(&self) {
-        let pressure = self.compaction_pending_bytes_ratio.load(Ordering::Relaxed) as f64;
+    ///
+    /// `pressure` must be the raw compaction pending-bytes ratio, not the
+    /// already-computed compaction_score: that score is clamped to [0, 100]
+    /// (see score::compute_resource_scores) while this window's upper bound
+    /// (threshold * 1.5) can exceed 100, which would leave the floor
+    /// unreachable.
+    fn adjust_write_io_by_compaction_pressure(&self, pressure: f64) {
         let config = self.resource_ctl.get_config().value().clone();
-        let threshold = config.bg_compaction_pressure_threshold.clamp(1.0, 99.0);
+        let threshold = config.bg_compaction_pressure_threshold;
         let ceiling = config.bg_write_io_ceiling.0 as f64; // bytes/s
         let floor = config.bg_write_io_floor.0 as f64; // bytes/s
 
@@ -361,7 +504,7 @@ impl<R: ResourceStatsProvider> GroupQuotaAdjustWorker<R> {
             if current_limit.is_infinite() || current_limit >= ceiling {
                 ceiling
             } else {
-                (current_limit * 1.1).min(ceiling)
+                (current_limit * RAMP_UP_FACTOR).min(ceiling)
             }
         } else {
             // Linear interpolation from ceiling to floor over the window
@@ -632,6 +775,7 @@ mod tests {
         cpu_used: f64,
         io_total: f64,
         io_used: f64,
+        io_fails: bool,
     }
 
     impl TestResourceStatsProvider {
@@ -641,6 +785,7 @@ mod tests {
                 cpu_used: 0.0,
                 io_total,
                 io_used: 0.0,
+                io_fails: false,
             }
         }
     }
@@ -652,6 +797,7 @@ mod tests {
                     total_quota: self.cpu_total * MICROS_PER_SEC,
                     current_used: self.cpu_used * MICROS_PER_SEC,
                 }),
+                ResourceType::Io if self.io_fails => Err(std::io::Error::other("injected")),
                 ResourceType::Io => Ok(ResourceUsageStats {
                     total_quota: self.io_total,
                     current_used: self.io_used,
@@ -680,6 +826,8 @@ mod tests {
             resource_ctl.clone(),
             test_provider,
             compaction_pending_bytes_ratio,
+            8,
+            10000.0,
         );
 
         // Create default background group with 80% utilization limit.
@@ -755,13 +903,13 @@ mod tests {
         worker.adjust_quota();
         check_limiter_rates(&limiter, 5.6, 7000.0);
 
-        // Under target (50% CPU): resource_util < 60%, current == target,
+        // Under target (50% CPU): resource_score < 60%, current == target,
         // so none of the branches fire → budget = target.
         reset_quota(&mut worker, 4.0, 2000.0, Duration::from_secs(1));
         worker.adjust_quota();
         check_limiter_rates(&limiter, 5.6, 7000.0);
 
-        // 80% CPU, 80% IO: resource_util > 60% (bg_scale_start).
+        // 80% CPU, 80% IO: resource_score > 60% (bg_scale_start).
         // pressure = (80-60)/(70-60) = 2.0 clamped to 1.0 → min_floor.
         // CPU: budget = min_floor = 1.0. IO: budget = min_floor = 1000.
         reset_quota(&mut worker, 6.4, 8000.0, Duration::from_secs(1));
@@ -786,7 +934,7 @@ mod tests {
         worker.adjust_quota();
         check_limiter_rates(&limiter, 1.0, 1000.0);
 
-        // Load drops (50% CPU, 20% IO): resource_util < 54% (0.9*60%), current <
+        // Load drops (50% CPU, 20% IO): resource_score < 54% (0.9*60%), current <
         // 0.9*target → incremental increase: budget = current * 1.1
         // CPU: 1.0 * 1.1 = 1.1. IO: 1000 * 1.1 = 1100
         reset_quota(&mut worker, 4.0, 2000.0, Duration::from_secs(1));
@@ -844,6 +992,8 @@ mod tests {
             resource_ctl.clone(),
             test_provider,
             compaction_pending_bytes_ratio,
+            8,
+            10000.0,
         );
 
         let reset_quota = |worker: &mut GroupQuotaAdjustWorker<TestResourceStatsProvider>,
@@ -896,8 +1046,8 @@ mod tests {
         );
 
         // --- Unsaturate CPU (25%) → budget recovers incrementally ---
-        // CPU: resource_util = 25% < 54% (0.9*60%), current 1.0M < 5.04M → 1.0 * 1.1 =
-        // 1.1 IO: resource_util = 20% < 54%, current 1000 < 6300 → 1000 * 1.1 =
+        // CPU: resource_score = 25% < 54% (0.9*60%), current 1.0M < 5.04M → 1.0 * 1.1 =
+        // 1.1 IO: resource_score = 20% < 54%, current 1000 < 6300 → 1000 * 1.1 =
         // 1100
         reset_quota(&mut worker, 2.0, 2000.0, Duration::from_secs(1));
         worker.adjust_quota();
@@ -923,6 +1073,156 @@ mod tests {
         check(
             limiter.get_limiter(ResourceType::Io).get_rate_limit(),
             1100.0,
+        );
+    }
+
+    #[test]
+    fn test_compute_budget_score() {
+        let thresholds = ScaleThresholds {
+            bg_scale_start: 60.0,
+            fg_cpu_throttle_threshold: 70.0,
+        };
+
+        // Under target, not idle enough to ramp: holds at target.
+        assert_eq!(
+            GroupQuotaAdjustWorker::<SysQuotaGetter>::compute_budget_score(
+                70.0, 70.0, 10.0, 50.0, thresholds,
+            ),
+            70.0,
+        );
+
+        // Over bg_scale_start: tighten toward min_floor proportional to
+        // pressure, never exceeding current_limit_score.
+        let score = GroupQuotaAdjustWorker::<SysQuotaGetter>::compute_budget_score(
+            70.0, 70.0, 10.0, 80.0, thresholds,
+        );
+        // pressure = (80-60)/(70-60) = 2.0 clamped to 1.0 -> min_floor.
+        assert_eq!(score, 10.0);
+
+        // Current limit exceeds its allowed share: reset to target.
+        assert_eq!(
+            GroupQuotaAdjustWorker::<SysQuotaGetter>::compute_budget_score(
+                90.0, 70.0, 10.0, 50.0, thresholds,
+            ),
+            70.0,
+        );
+
+        // Idle (resource_score comfortably below bg_scale_start) and current
+        // limit well under target: ramp up incrementally.
+        assert_eq!(
+            GroupQuotaAdjustWorker::<SysQuotaGetter>::compute_budget_score(
+                10.0, 70.0, 10.0, 20.0, thresholds,
+            ),
+            11.0,
+        );
+    }
+
+    #[test]
+    fn test_background_throttled_by_grpc_driven_cpu_score() {
+        // cpu_score is max(process_cpu_util, grpc_util) — a grpc-driven
+        // spike must throttle background CPU exactly like a process-CPU
+        // spike would, even though the *measured* process CPU here is low
+        // and total_quota is untouched (a healthy, always-positive 8 cores).
+        let resource_ctl = Arc::new(ResourceGroupManager::default());
+        let bg = new_background_resource_group_ru("bg".into(), 1000, 8, vec!["br".into()]);
+        resource_ctl.add_resource_group(bg);
+        let bg_limiter = resource_ctl
+            .get_background_resource_limiter("bg", "br")
+            .unwrap();
+
+        let compaction_pending_bytes_ratio = Arc::new(AtomicU32::new(0));
+        let mut worker = GroupQuotaAdjustWorker::with_quota_getter(
+            resource_ctl.clone(),
+            TestResourceStatsProvider::new(8.0, 10000.0),
+            compaction_pending_bytes_ratio,
+            8,
+            10000.0,
+        );
+
+        // Process CPU is only 20% (comfortably idle on its own), but
+        // grpc_util is pinned to 90% — cpu_score = max(20, 90) = 90.
+        let scores = ResourceScores {
+            cpu_score: 90.0,
+            io_score: 0.0,
+            compaction_score: 0.0,
+        };
+        // 8 cores * MICROS_PER_SEC, matching TestResourceStatsProvider::new(8.0, ..).
+        let cpu_total_quota = 8.0 * MICROS_PER_SEC;
+        worker.background_adjust_quota(1.0, cpu_total_quota, &scores, 0.0);
+
+        // bg_scale_start=60%, fg_cpu_throttle_threshold=70%: pressure =
+        // (90-60)/(70-60) = 3.0 clamped to 1.0 -> min_floor (1 core).
+        let rate = bg_limiter.get_limiter(ResourceType::Cpu).get_rate_limit();
+        assert!(
+            (rate - MICROS_PER_SEC).abs() < MICROS_PER_SEC * 0.01,
+            "grpc-driven cpu_score should throttle background CPU to the floor, got {rate}"
+        );
+    }
+
+    #[test]
+    fn test_fetch_io_util_reuses_previous_on_failure() {
+        let resource_ctl = Arc::new(ResourceGroupManager::default());
+        let bg = new_background_resource_group_ru("bg_worker".into(), 5000, 8, vec!["br".into()]);
+        resource_ctl.add_resource_group(bg);
+
+        let mut worker = GroupQuotaAdjustWorker::with_quota_getter(
+            resource_ctl,
+            TestResourceStatsProvider::new(8.0, 1000.0),
+            Arc::new(AtomicU32::new(0)),
+            8,
+            1000.0,
+        );
+
+        worker.resource_quota_getter.io_used = 600.0;
+        assert_eq!(worker.fetch_io_util(), 60.0);
+
+        // A failed fetch must not read as an idle disk.
+        worker.resource_quota_getter.io_fails = true;
+        assert_eq!(worker.fetch_io_util(), 60.0);
+
+        // Recovers to the fresh value once the fetch works again.
+        worker.resource_quota_getter.io_fails = false;
+        worker.resource_quota_getter.io_used = 300.0;
+        assert_eq!(worker.fetch_io_util(), 30.0);
+    }
+
+    #[test]
+    fn test_zero_io_bandwidth_skips_io_fetch_and_uncaps_io_limiter() {
+        // io_bandwidth == 0 means IO rate limiting isn't configured at all:
+        // adjust_quota should skip fetching IO stats entirely (unobservable
+        // here directly, but exercised so a panic would catch a regression)
+        // and the background IO limiter should stay/become unlimited, same
+        // as background_adjust_resource_quota's own total_quota <= EPSILON
+        // bailout would produce.
+        let resource_ctl = Arc::new(ResourceGroupManager::default());
+
+        let bg = new_background_resource_group_ru("bg_worker".into(), 5000, 8, vec!["br".into()]);
+        resource_ctl.add_resource_group(bg);
+        let limiter = resource_ctl
+            .get_background_resource_limiter("bg_worker", "br")
+            .unwrap();
+
+        // 8 CPU cores, but io_total == 0 (IO rate limiting disabled).
+        let test_provider = TestResourceStatsProvider::new(8.0, 0.0);
+        let compaction_pending_bytes_ratio = Arc::new(AtomicU32::new(0));
+        let mut worker = GroupQuotaAdjustWorker::with_quota_getter(
+            resource_ctl.clone(),
+            test_provider,
+            compaction_pending_bytes_ratio,
+            8,
+            0.0, // io_bandwidth
+        );
+
+        worker.resource_quota_getter.cpu_used = 8.0; // saturate CPU
+        worker.last_adjust_time = Instant::now_coarse() - Duration::from_secs(1);
+        worker.adjust_quota();
+
+        assert!(
+            limiter
+                .get_limiter(ResourceType::Io)
+                .get_rate_limit()
+                .is_infinite(),
+            "IO limiter should stay unlimited when io_bandwidth == 0"
         );
     }
 
@@ -1111,6 +1411,8 @@ mod tests {
             resource_ctl.clone(),
             TestResourceStatsProvider::new(8.0, 10000.0),
             compaction_pending_bytes_ratio,
+            8,
+            10000.0,
         );
 
         const BG_TARGET: f64 = 5.6;
@@ -1181,6 +1483,8 @@ mod tests {
             resource_ctl.clone(),
             test_provider,
             compaction_pending_bytes_ratio.clone(),
+            8,
+            10000.0,
         );
 
         // Create default background group with 80% utilization limit.
@@ -1311,26 +1615,25 @@ mod tests {
         worker.adjust_quota();
         check(limiter.get_write_io_limiter().get_rate_limit(), floor);
 
-        // Pressure drops to 0 (< threshold): ramp up by 10% from floor.
-        // floor * 1.1 = 10 MB/s * 1.1 = 11534336
+        // Pressure drops to 0 (< threshold): one RAMP_UP_FACTOR step from floor.
         compaction_pending_bytes_ratio.store(0, Ordering::Relaxed);
         reset_quota(&mut worker, 0.0, 0.0, Duration::from_secs(1));
         worker.adjust_quota();
-        let ramp1 = floor * 1.1;
+        let ramp1 = floor * RAMP_UP_FACTOR;
         check(limiter.get_write_io_limiter().get_rate_limit(), ramp1);
 
-        // Pressure stays at 0: another 10% ramp up.
+        // Pressure stays at 0: another ramp-up step.
         reset_quota(&mut worker, 0.0, 0.0, Duration::from_secs(1));
         worker.adjust_quota();
-        let ramp2 = ramp1 * 1.1;
+        let ramp2 = ramp1 * RAMP_UP_FACTOR;
         check(limiter.get_write_io_limiter().get_rate_limit(), ramp2);
 
         // Keep ramping until we hit ceiling.
         let mut current = ramp2;
-        while current * 1.1 < ceiling {
+        while current * RAMP_UP_FACTOR < ceiling {
             reset_quota(&mut worker, 0.0, 0.0, Duration::from_secs(1));
             worker.adjust_quota();
-            current = (current * 1.1).min(ceiling);
+            current = (current * RAMP_UP_FACTOR).min(ceiling);
             check(limiter.get_write_io_limiter().get_rate_limit(), current);
         }
         // One more adjustment should cap at ceiling.
@@ -1357,6 +1660,8 @@ mod tests {
             resource_ctl.clone(),
             test_provider,
             compaction_pending_bytes_ratio,
+            8,
+            10000.0,
         );
 
         // Add two background groups with different RU quotas.
@@ -1421,9 +1726,9 @@ mod tests {
         worker.last_adjust_time = Instant::now_coarse() - Duration::from_secs(1);
         worker.adjust_quota();
 
-        // CPU: resource_util=100%, bg_scale_start=60%, fg_cpu_throttle_threshold=70%.
+        // CPU: resource_score=100%, bg_scale_start=60%, fg_cpu_throttle_threshold=70%.
         // pressure = (100-60)/(70-60) = 4.0 clamped to 1.0 → min_floor = 1.0 core.
-        // IO: resource_util=95%, pressure = (95-60)/(70-60) = 3.5 clamped to 1.0 →
+        // IO: resource_score=95%, pressure = (95-60)/(70-60) = 3.5 clamped to 1.0 →
         // min_floor = 1000.
         check(
             limiter_a.get_limiter(ResourceType::Cpu).get_rate_limit(),

--- a/components/resource_control/src/worker.rs
+++ b/components/resource_control/src/worker.rs
@@ -345,8 +345,9 @@ impl<R: ResourceStatsProvider> GroupQuotaAdjustWorker<R> {
 
     /// Adjust the write-only IO limiter based on compaction pressure.
     /// When pressure >= threshold, linearly scale write IO from ceiling to
-    /// floor. Below threshold, write IO ramps up 10% per tick capped at
-    /// ceiling.
+    /// floor over a window of 50% of threshold (i.e. threshold to
+    /// threshold * 1.5). Below threshold, write IO ramps up 10% per tick
+    /// capped at ceiling.
     fn adjust_write_io_by_compaction_pressure(&self) {
         let pressure = self.compaction_pending_bytes_ratio.load(Ordering::Relaxed) as f64;
         let config = self.resource_ctl.get_config().value().clone();
@@ -363,9 +364,11 @@ impl<R: ResourceStatsProvider> GroupQuotaAdjustWorker<R> {
                 (current_limit * 1.1).min(ceiling)
             }
         } else {
-            // Linear interpolation from ceiling to floor as pressure goes from
-            // threshold to 100%.
-            let pressure_ratio = ((pressure - threshold) / (100.0 - threshold)).clamp(0.0, 1.0);
+            // Linear interpolation from ceiling to floor over the window
+            // [threshold, threshold * 1.5]. Beyond that window the rate is
+            // clamped to floor.
+            let window = threshold * 0.5;
+            let pressure_ratio = ((pressure - threshold) / window).clamp(0.0, 1.0);
             (ceiling * (1.0 - pressure_ratio) + floor * pressure_ratio).max(floor)
         };
 
@@ -1263,12 +1266,16 @@ mod tests {
             5.6 * MICROS_PER_SEC,
         );
 
-        // Pressure = 85: pressure_ratio = (85-70)/(100-70) = 0.5
-        // budget = ceiling * 0.5 + floor * 0.5
+        // Pressure = 85: window = [70, 105], pressure_ratio = (85-70)/35 ≈ 0.429
+        // budget = ceiling * 0.571 + floor * 0.429
         compaction_pending_bytes_ratio.store(85, Ordering::Relaxed);
         reset_quota(&mut worker, 0.0, 0.0, Duration::from_secs(1));
         worker.adjust_quota();
-        let expected_85 = ceiling * 0.5 + floor * 0.5;
+        let window = 70.0 * 0.5; // threshold * 0.5 = 35
+        let expected_85 = {
+            let r = ((85.0_f64 - 70.0) / window).clamp(0.0, 1.0);
+            ceiling * (1.0 - r) + floor * r
+        };
         check(limiter.get_write_io_limiter().get_rate_limit(), expected_85);
 
         // CPU limit unaffected.
@@ -1277,17 +1284,32 @@ mod tests {
             5.6 * MICROS_PER_SEC,
         );
 
-        // Pressure = 100: pressure_ratio = 1.0 → budget = floor (10 MB/s).
+        // Pressure = 100: pressure_ratio = (100-70)/35 ≈ 0.857 → well below floor
+        // clamp. budget = ceiling * 0.143 + floor * 0.857
         compaction_pending_bytes_ratio.store(100, Ordering::Relaxed);
         reset_quota(&mut worker, 0.0, 0.0, Duration::from_secs(1));
         worker.adjust_quota();
-        check(limiter.get_write_io_limiter().get_rate_limit(), floor);
+        let expected_100 = {
+            let r = ((100.0_f64 - 70.0) / window).clamp(0.0, 1.0);
+            ceiling * (1.0 - r) + floor * r
+        };
+        check(
+            limiter.get_write_io_limiter().get_rate_limit(),
+            expected_100,
+        );
 
         // CPU limit unaffected.
         check(
             limiter.get_limiter(ResourceType::Cpu).get_rate_limit(),
             5.6 * MICROS_PER_SEC,
         );
+
+        // Pressure = 106 (>= threshold * 1.5 = 105): pressure_ratio clamped to 1.0 →
+        // floor.
+        compaction_pending_bytes_ratio.store(106, Ordering::Relaxed);
+        reset_quota(&mut worker, 0.0, 0.0, Duration::from_secs(1));
+        worker.adjust_quota();
+        check(limiter.get_write_io_limiter().get_rate_limit(), floor);
 
         // Pressure drops to 0 (< threshold): ramp up by 10% from floor.
         // floor * 1.1 = 10 MB/s * 1.1 = 11534336

--- a/components/resource_control/src/worker.rs
+++ b/components/resource_control/src/worker.rs
@@ -4,8 +4,8 @@ use std::{
     array,
     io::Result as IoResult,
     sync::{
-        Arc,
         atomic::{AtomicU32, Ordering},
+        Arc,
     },
     time::Duration,
 };
@@ -14,7 +14,6 @@ use file_system::{fetch_io_bytes, IoBytes, IoType};
 use prometheus::Histogram;
 use strum::EnumCount;
 use tikv_util::{
-    debug,
     resource_control::{TaskPriority, DEFAULT_RESOURCE_GROUP_NAME},
     sys::{cpu_time::ProcessStat, SysQuota},
     time::Instant,
@@ -28,7 +27,7 @@ use crate::{
     resource_limiter::{GroupStatistics, ResourceLimiter, ResourceType},
 };
 
-pub const BACKGROUND_LIMIT_ADJUST_DURATION: Duration = Duration::from_secs(10);
+pub const QUOTA_ADJUST_DURATION: Duration = Duration::from_secs(10);
 
 const MICROS_PER_SEC: f64 = 1_000_000.0;
 // the minimal schedule wait duration due to the overhead of queue.
@@ -157,6 +156,33 @@ impl<R: ResourceStatsProvider> GroupQuotaAdjustWorker<R> {
         }
         self.last_adjust_time = now;
 
+        // Fetch CPU stats once so background and foreground use a consistent
+        // snapshot and we avoid double-reading /proc/stat.
+        let cpu_stats = match self
+            .resource_quota_getter
+            .get_current_stats(ResourceType::Cpu)
+        {
+            Ok(s) => s,
+            Err(e) => {
+                warn!("get process total cpu failed; skip adjustment."; "err" => ?e);
+                return;
+            }
+        };
+        let cpu_util = if cpu_stats.total_quota > f64::EPSILON {
+            cpu_stats.current_used / cpu_stats.total_quota * 100.0
+        } else {
+            0.0
+        };
+
+        self.background_adjust_quota(dur_secs, &cpu_stats);
+        self.foreground_adjust_quota(cpu_util);
+    }
+
+    fn foreground_adjust_quota(&mut self, cpu_util: f64) {
+        self.resource_ctl.online_adjust_resource_quota(cpu_util);
+    }
+
+    fn background_adjust_quota(&mut self, dur_secs: f64, cpu_stats: &ResourceUsageStats) {
         let mut bg_util_limit = self
             .resource_ctl
             .get_resource_group(DEFAULT_RESOURCE_GROUP_NAME)
@@ -166,23 +192,19 @@ impl<R: ResourceStatsProvider> GroupQuotaAdjustWorker<R> {
         if bg_util_limit == 0 {
             bg_util_limit = 100;
         }
-        let bg_resource_threshold = self
-            .resource_ctl
-            .get_config()
-            .value()
-            .bg_resource_threshold
-            .clamp(1.0, 99.0);
-        // Cap utilization limit to bg_resource_threshold. Background
-        // tasks should never consume more than this fraction of total resources.
-        // When CPU utilization exceeds the threshold, the headroom goes negative
-        // and the background rate limit is reduced.
-        bg_util_limit = bg_util_limit.min(bg_resource_threshold as u64);
-
-        BACKGROUND_TASK_RESOURCE_UTILIZATION_VEC
-            .with_label_values(&["limit"])
-            .set(bg_util_limit as i64);
+        let (bg_scale_start, fg_cpu_throttle_threshold) = {
+            let config = self.resource_ctl.get_config().value();
+            let start = config.bg_cpu_throttle_threshold.clamp(1.0, 99.0);
+            let end = config.fg_cpu_throttle_threshold.clamp(start, 99.0);
+            (start, end)
+        };
+        // Cap utilization limit to fg_cpu_throttle_threshold. Background tasks should
+        // never consume more than this fraction of total resources. Scale-down
+        // begins at bg_scale_start and reaches min_floor at fg_cpu_throttle_threshold.
+        bg_util_limit = bg_util_limit.min(fg_cpu_throttle_threshold as u64);
 
         if !self.resource_ctl.has_background_groups() {
+            self.resource_ctl.set_bg_cpu_at_floor(true);
             self.prev_had_background = false;
             return;
         }
@@ -200,34 +222,48 @@ impl<R: ResourceStatsProvider> GroupQuotaAdjustWorker<R> {
             self.prev_had_background = true;
         }
 
-        self.do_adjust(
+        self.background_adjust_resource_quota(
             ResourceType::Cpu,
             dur_secs,
             bg_util_limit,
-            bg_resource_threshold,
+            bg_scale_start,
+            fg_cpu_throttle_threshold,
+            Some(cpu_stats),
         );
-        self.do_adjust(
+        self.background_adjust_resource_quota(
             ResourceType::Io,
             dur_secs,
             bg_util_limit,
-            bg_resource_threshold,
+            bg_scale_start,
+            fg_cpu_throttle_threshold,
+            None,
         );
         self.adjust_write_io_by_compaction_pressure();
     }
 
-    fn do_adjust(
+    fn background_adjust_resource_quota(
         &mut self,
         resource_type: ResourceType,
         dur_secs: f64,
         utilization_limit: u64,
-        bg_resource_threshold: f64,
+        bg_scale_start: f64,
+        fg_cpu_throttle_threshold: f64,
+        // Pre-fetched stats for CPU (avoids a second /proc/stat read); None for
+        // IO, which always fetches fresh bytes-transferred counters.
+        prefetched_stats: Option<&ResourceUsageStats>,
     ) {
-        let resource_stats = match self.resource_quota_getter.get_current_stats(resource_type) {
-            Ok(r) => r,
-            Err(e) => {
-                warn!("get resource statistics info failed, skip adjust"; "type" => ?resource_type, "err" => ?e);
-                return;
-            }
+        let fetched;
+        let resource_stats = if let Some(s) = prefetched_stats {
+            s
+        } else {
+            fetched = match self.resource_quota_getter.get_current_stats(resource_type) {
+                Ok(r) => r,
+                Err(e) => {
+                    warn!("get resource statistics info failed, skip adjust"; "type" => ?resource_type, "err" => ?e);
+                    return;
+                }
+            };
+            &fetched
         };
         // if total resource quota is unlimited, set background limit to unlimited.
         if resource_stats.total_quota <= f64::EPSILON {
@@ -273,16 +309,20 @@ impl<R: ResourceStatsProvider> GroupQuotaAdjustWorker<R> {
         .min(target);
 
         let mut new_budget = target;
-        if resource_util > bg_resource_threshold {
-            // System is overloaded. Linearly scale budget from target down to
-            // min_floor as utilization goes from threshold (70%) to 100%.
-            let pressure =
-                (resource_util - bg_resource_threshold) / (100.0 - bg_resource_threshold);
+        if resource_util > bg_scale_start {
+            // Linearly scale budget from target down to min_floor as utilization
+            // goes from bg_scale_start to fg_cpu_throttle_threshold.
+            let range = (fg_cpu_throttle_threshold - bg_scale_start).max(1.0);
+            let pressure = ((resource_util - bg_scale_start) / range).clamp(0.0, 1.0);
             new_budget = target * (1.0 - pressure) + min_floor * pressure;
+            // Only tighten: never increase the limit in the throttle branch.
+            if new_budget > current_limit {
+                new_budget = current_limit;
+            }
         } else if current_limit > target {
             // Background limit exceeds its allowed share; reset to target.
             new_budget = target;
-        } else if current_limit < 0.9 * target && resource_util < 0.9 * bg_resource_threshold {
+        } else if current_limit < 0.9 * target && resource_util < 0.9 * bg_scale_start {
             // System is idle; increase limit incrementally from current limit.
             new_budget = current_limit * 1.1;
         }
@@ -294,6 +334,13 @@ impl<R: ResourceStatsProvider> GroupQuotaAdjustWorker<R> {
         BACKGROUND_QUOTA_LIMIT_VEC
             .with_label_values(&[resource_type.as_str()])
             .set(new_budget as i64);
+
+        // Update the "background at floor" flag so foreground throttling
+        // only kicks in after background has been fully squeezed.
+        if resource_type == ResourceType::Cpu {
+            let at_floor = new_budget <= min_floor && background_consumed <= new_budget;
+            self.resource_ctl.set_bg_cpu_at_floor(at_floor);
+        }
     }
 
     /// Adjust the write-only IO limiter based on compaction pressure.
@@ -481,10 +528,6 @@ impl<R: ResourceStatsProvider> PriorityLimiterAdjustWorker<R> {
             limits[i - 1] = limit;
             expect_cpu_time_total -= level_expected[i];
         }
-        debug!("adjsut cpu limiter by priority"; "cpu_quota" => process_cpu_stats.total_quota,
-            "process_cpu" => process_cpu_stats.current_used, "expected_cpu" => ?level_expected,
-            "cpu_costs" => ?cpu_duration, "limits" => ?limits,
-            "limit_cpu_total" => expect_pool_cpu_total, "pool_cpu_cost" => real_cpu_total);
     }
 }
 
@@ -694,9 +737,10 @@ mod tests {
             check(limiter.get_limiter(ResourceType::Io).get_rate_limit(), io);
         }
 
-        // util_limit configured at 80% but capped to 70%.
+        // util_limit configured at 80% but capped to fg_cpu_throttle_threshold=70%.
         // CPU target = 8 * 0.7 = 5.6 cores, IO target = 10000 * 0.7 = 7000
         // CPU min_floor = 1 core, IO min_floor = 1000
+        // bg_scale_start=60%, fg_cpu_throttle_threshold=70% (scale range: 60→70).
 
         // No load: initial infinity → treated as target → budget = target.
         reset_quota(&mut worker, 0.0, 0.0, Duration::from_secs(1));
@@ -708,48 +752,43 @@ mod tests {
         worker.adjust_quota();
         check_limiter_rates(&limiter, 5.6, 7000.0);
 
-        // Under target (50% CPU): resource_util < 70%, current == target,
+        // Under target (50% CPU): resource_util < 60%, current == target,
         // so none of the branches fire → budget = target.
         reset_quota(&mut worker, 4.0, 2000.0, Duration::from_secs(1));
         worker.adjust_quota();
         check_limiter_rates(&limiter, 5.6, 7000.0);
 
-        // Above 70% (80% CPU, 80% IO): resource_util > 70 branch fires.
-        // Budget linearly interpolates from target to min_floor.
-        // CPU: pressure = (80-70)/(100-70) = 1/3. budget = 5.6*(1-1/3) + 1.0*(1/3) ≈
-        // 4.067 IO: pressure = (80-70)/(100-70) = 1/3. budget = 7000*(2/3) +
-        // 1000*(1/3) ≈ 5000
+        // 80% CPU, 80% IO: resource_util > 60% (bg_scale_start).
+        // pressure = (80-60)/(70-60) = 2.0 clamped to 1.0 → min_floor.
+        // CPU: budget = min_floor = 1.0. IO: budget = min_floor = 1000.
         reset_quota(&mut worker, 6.4, 8000.0, Duration::from_secs(1));
         worker.adjust_quota();
-        check_limiter_rates(&limiter, 4.067, 5000.0);
+        check_limiter_rates(&limiter, 1.0, 1000.0);
 
-        // 100% CPU, 95% IO: heavier pressure.
-        // CPU: pressure = (100-70)/30 = 1.0. budget = 5.6*0 + 1.0*1.0 = 1.0 (min_floor)
-        // IO: pressure = (95-70)/30 = 25/30 = 5/6. budget = 7000*(1/6) + 1000*(5/6) ≈
-        // 2000
+        // 100% CPU, 95% IO: pressure still clamped 1.0 → min_floor.
         reset_quota(&mut worker, 8.0, 9500.0, Duration::from_secs(1));
         worker.adjust_quota();
-        check_limiter_rates(&limiter, 1.0, 2000.0);
+        check_limiter_rates(&limiter, 1.0, 1000.0);
 
         // Still at 100% CPU, 95% IO: same result (deterministic, no decay).
         reset_quota(&mut worker, 8.0, 9500.0, Duration::from_secs(1));
         worker.adjust_quota();
-        check_limiter_rates(&limiter, 1.0, 2000.0);
+        check_limiter_rates(&limiter, 1.0, 1000.0);
 
-        // 85% CPU, 80% IO: moderate pressure.
-        // CPU: pressure = (85-70)/30 = 0.5. budget = 5.6*0.5 + 1.0*0.5 = 3.3
-        // IO: pressure = (80-70)/30 = 1/3. budget = 7000*(2/3) + 1000*(1/3) = 5000
-        reset_quota(&mut worker, 6.8, 8000.0, Duration::from_secs(1));
+        // 65% CPU, 65% IO: in the scale range (60-70%).
+        // CPU: pressure = 0.5, computed = 3.3. But current_limit=1.0 (min_floor)
+        // and 3.3 > 1.0 → only-tighten clamps to 1.0.
+        // IO: same logic → stays 1000.
+        reset_quota(&mut worker, 5.2, 6500.0, Duration::from_secs(1));
         worker.adjust_quota();
-        check_limiter_rates(&limiter, 3.3, 5000.0);
+        check_limiter_rates(&limiter, 1.0, 1000.0);
 
-        // Load drops (50% CPU, 20% IO): resource_util < 63%, current < 0.9*target
-        // → incremental increase: budget = current * 1.1
-        // CPU: 3.3 * 1.1 = 3.63
-        // IO: 5000 * 1.1 = 5500
+        // Load drops (50% CPU, 20% IO): resource_util < 54% (0.9*60%), current <
+        // 0.9*target → incremental increase: budget = current * 1.1
+        // CPU: 1.0 * 1.1 = 1.1. IO: 1000 * 1.1 = 1100
         reset_quota(&mut worker, 4.0, 2000.0, Duration::from_secs(1));
         worker.adjust_quota();
-        check_limiter_rates(&limiter, 3.63, 5500.0);
+        check_limiter_rates(&limiter, 1.1, 1100.0);
 
         // Adding a second background group does not change the limiter —
         // all background groups share the single global bg_limiter.
@@ -761,19 +800,19 @@ mod tests {
         // Both groups return the same shared limiter.
         assert!(Arc::ptr_eq(&limiter, &bg_limiter2));
 
-        // No load: current at 3.63M < 0.9*target (5.04M) and util < 63% → incremental.
-        // budget = 3.63 * 1.1 = 3.993
-        // IO: 5500 * 1.1 = 6050
+        // No load: current at 1.1M < 0.9*target (5.04M) and util < 63% → incremental.
+        // budget = 1.1 * 1.1 = 1.21
+        // IO: 1100 * 1.1 = 1210
         reset_quota(&mut worker, 0.0, 0.0, Duration::from_secs(1));
         worker.adjust_quota();
-        check_limiter_rates(&limiter, 3.993, 6050.0);
+        check_limiter_rates(&limiter, 1.21, 1210.0);
 
-        // Over 70% (100% CPU, 95% IO): budget scales down.
+        // Over 70% (100% CPU, 95% IO): budget scales down to min_floor.
         // CPU: pressure = 1.0. budget = min_floor = 1.0
-        // IO: pressure = 25/30 = 5/6. budget = 7000*(1/6) + 1000*(5/6) = 2000
+        // IO: pressure = (95-60)/(70-60) = 3.5 clamped 1.0. budget = min_floor = 1000.
         reset_quota(&mut worker, 8.0, 9500.0, Duration::from_secs(1));
         worker.adjust_quota();
-        check_limiter_rates(&limiter, 1.0, 2000.0);
+        check_limiter_rates(&limiter, 1.0, 1000.0);
     }
 
     #[test]
@@ -787,7 +826,8 @@ mod tests {
         }
 
         // 1 background group with no explicit utilization limit.
-        // bg_util_limit defaults to 100, capped to 70 by bg_resource_threshold.
+        // bg_util_limit defaults to 100, capped to 70 by fg_cpu_throttle_threshold.
+        // bg_scale_start=60%, fg_cpu_throttle_threshold=70%.
         let bg = new_background_resource_group_ru("bg_worker".into(), 5000, 8, vec!["br".into()]);
         resource_ctl.add_resource_group(bg);
         let limiter = resource_ctl
@@ -838,9 +878,9 @@ mod tests {
             7000.0,
         );
 
-        // --- Saturate CPU (100%, 80% IO) → budget scales down from target ---
-        // CPU: pressure = (100-70)/30 = 1.0. budget = min_floor = 1.0
-        // IO: pressure = (80-70)/30 = 1/3. budget = 7000*(2/3) + 1000*(1/3) = 5000
+        // --- Saturate CPU (100%, 80% IO) → budget scales to min_floor ---
+        // CPU: pressure = (100-60)/(70-60) = 4.0 clamped 1.0 → min_floor = 1.0
+        // IO: pressure = (80-60)/(70-60) = 2.0 clamped 1.0 → min_floor = 1000
         reset_quota(&mut worker, 8.0, 8000.0, Duration::from_secs(1));
         worker.adjust_quota();
         check(
@@ -849,13 +889,13 @@ mod tests {
         );
         check(
             limiter.get_limiter(ResourceType::Io).get_rate_limit(),
-            5000.0,
+            1000.0,
         );
 
         // --- Unsaturate CPU (25%) → budget recovers incrementally ---
-        // CPU: resource_util = 25% < 63, current 1.0M < 5.04M → budget = 1.0 * 1.1 =
-        // 1.1 IO: resource_util = 20% < 63, current 5000 < 6300 → budget = 5000
-        // * 1.1 = 5500
+        // CPU: resource_util = 25% < 54% (0.9*60%), current 1.0M < 5.04M → 1.0 * 1.1 =
+        // 1.1 IO: resource_util = 20% < 54%, current 1000 < 6300 → 1000 * 1.1 =
+        // 1100
         reset_quota(&mut worker, 2.0, 2000.0, Duration::from_secs(1));
         worker.adjust_quota();
         check(
@@ -864,21 +904,22 @@ mod tests {
         );
         check(
             limiter.get_limiter(ResourceType::Io).get_rate_limit(),
-            5500.0,
+            1100.0,
         );
 
-        // --- 85% CPU, 80% IO: moderate pressure ---
-        // CPU: pressure = (85-70)/30 = 0.5. budget = 5.6*0.5 + 1.0*0.5 = 3.3
-        // IO: pressure = (80-70)/30 = 1/3. budget = 7000*(2/3) + 1000*(1/3) = 5000
-        reset_quota(&mut worker, 6.8, 8000.0, Duration::from_secs(1));
+        // --- 65% CPU, 65% IO: in scale range (60-70%) ---
+        // CPU: pressure = 0.5, computed = 3.3M. current_limit=1.1M < 3.3M → only
+        // tighten → stays 1.1M. IO: computed = 4000, current=1100 < 4000 →
+        // stays 1100.
+        reset_quota(&mut worker, 5.2, 6500.0, Duration::from_secs(1));
         worker.adjust_quota();
         check(
             limiter.get_limiter(ResourceType::Cpu).get_rate_limit(),
-            3.3 * MICROS_PER_SEC,
+            1.1 * MICROS_PER_SEC,
         );
         check(
             limiter.get_limiter(ResourceType::Io).get_rate_limit(),
-            5000.0,
+            1100.0,
         );
     }
 
@@ -1045,6 +1086,85 @@ mod tests {
         worker.last_adjust_time = Instant::now_coarse() - Duration::from_millis(500);
         worker.adjust();
         check_limiter(f64::INFINITY, 3.2, 3.2);
+    }
+
+    /// Verifies background load-shedding:
+    ///
+    /// - 0–60% CPU   : background full
+    /// - 60–70% CPU  : background linearly throttled to min_floor
+    /// - >70% CPU    : background at min_floor
+    #[test]
+    fn test_tiered_load_shedding() {
+        let resource_ctl = Arc::new(ResourceGroupManager::default());
+
+        let bg = new_background_resource_group_ru("bg".into(), 1000, 8, vec!["br".into()]);
+        resource_ctl.add_resource_group(bg);
+        let bg_limiter = resource_ctl
+            .get_background_resource_limiter("bg", "br")
+            .unwrap();
+
+        let compaction_pending_bytes_ratio = Arc::new(AtomicU32::new(0));
+        let mut bg_worker = GroupQuotaAdjustWorker::with_quota_getter(
+            resource_ctl.clone(),
+            TestResourceStatsProvider::new(8.0, 10000.0),
+            compaction_pending_bytes_ratio,
+        );
+
+        const BG_TARGET: f64 = 5.6;
+        const BG_FLOOR: f64 = 1.0;
+
+        #[track_caller]
+        fn approx(val: f64, expected: f64) {
+            assert!(
+                (val.is_infinite() && expected.is_infinite())
+                    || (expected * 0.99 < val && val < expected * 1.01),
+                "actual: {val}, expected: {expected}"
+            );
+        }
+
+        macro_rules! tick {
+            ($cpu:expr) => {{
+                bg_worker.resource_quota_getter.cpu_used = $cpu;
+                bg_worker.last_adjust_time = Instant::now_coarse() - Duration::from_secs(10);
+                bg_worker.adjust_quota();
+            }};
+        }
+
+        // 50% CPU — below bg_scale_start (60%): bg=full.
+        tick!(4.0);
+        approx(
+            bg_limiter.get_limiter(ResourceType::Cpu).get_rate_limit(),
+            BG_TARGET * MICROS_PER_SEC,
+        );
+
+        // 65% CPU — mid bg range: pressure = 0.5.
+        tick!(5.2);
+        approx(
+            bg_limiter.get_limiter(ResourceType::Cpu).get_rate_limit(),
+            3.3 * MICROS_PER_SEC,
+        );
+
+        // 70% CPU — bg fully throttled.
+        tick!(5.6);
+        approx(
+            bg_limiter.get_limiter(ResourceType::Cpu).get_rate_limit(),
+            BG_FLOOR * MICROS_PER_SEC,
+        );
+
+        // 80% CPU — still at min_floor.
+        tick!(6.4);
+        approx(
+            bg_limiter.get_limiter(ResourceType::Cpu).get_rate_limit(),
+            BG_FLOOR * MICROS_PER_SEC,
+        );
+
+        // Recovery: CPU drops to 50%.
+        tick!(4.0);
+        let bg_rate = bg_limiter.get_limiter(ResourceType::Cpu).get_rate_limit();
+        assert!(
+            bg_rate > BG_FLOOR * MICROS_PER_SEC && bg_rate < BG_TARGET * MICROS_PER_SEC,
+            "bg should be recovering, got {bg_rate}"
+        );
     }
 
     #[test]
@@ -1279,15 +1399,17 @@ mod tests {
         worker.last_adjust_time = Instant::now_coarse() - Duration::from_secs(1);
         worker.adjust_quota();
 
-        // CPU: pressure = 1.0 → budget = min_floor = 1.0 core.
-        // IO: pressure = (95-70)/30 = 5/6 → budget = 7000/6 + 1000*5/6 ≈ 2000.
+        // CPU: resource_util=100%, bg_scale_start=60%, fg_cpu_throttle_threshold=70%.
+        // pressure = (100-60)/(70-60) = 4.0 clamped to 1.0 → min_floor = 1.0 core.
+        // IO: resource_util=95%, pressure = (95-60)/(70-60) = 3.5 clamped to 1.0 →
+        // min_floor = 1000.
         check(
             limiter_a.get_limiter(ResourceType::Cpu).get_rate_limit(),
             1.0 * MICROS_PER_SEC,
         );
         check(
             limiter_a.get_limiter(ResourceType::Io).get_rate_limit(),
-            2000.0,
+            1000.0,
         );
     }
 }

--- a/components/resource_metering/src/model.rs
+++ b/components/resource_metering/src/model.rs
@@ -198,10 +198,51 @@ pub fn handle_records_impl<'a, K, T>(
     }
 }
 
+/// Identifies which thread pool a CPU sample was taken from.
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq, Hash)]
+#[repr(u8)]
+pub enum ThreadPoolType {
+    /// Thread pool type is unknown or not classified.
+    #[default]
+    Unknown = 0,
+    /// Unified read pool threads (prefix "unified-read").
+    UnifiedRead = 1,
+    /// Scheduler worker threads (prefix "sched").
+    Scheduler = 2,
+}
+
+/// Per-region CPU time accumulator with per-thread-pool breakdown.
+///
+/// Used by the PD heartbeat path to track how much CPU each region consumed
+/// on different thread pools between heartbeats.
+#[derive(Debug, Default, Copy, Clone)]
+pub struct RegionCpuRecord {
+    /// Total CPU time in milliseconds (sum of all pools + unknown).
+    pub cpu_time_ms: u32,
+    /// CPU time on unified-read-pool threads (ms).
+    pub unified_read_cpu_time_ms: u32,
+    /// CPU time on scheduler-pool threads (ms).
+    pub scheduler_cpu_time_ms: u32,
+}
+
+impl RegionCpuRecord {
+    /// Accumulate a [`RawRecord`]'s CPU fields into this record.
+    #[inline]
+    pub fn merge_raw_record(&mut self, raw: &RawRecord) {
+        self.cpu_time_ms += raw.cpu_time;
+        self.unified_read_cpu_time_ms += raw.unified_read_cpu_time;
+        self.scheduler_cpu_time_ms += raw.scheduler_cpu_time;
+    }
+}
+
 /// Raw resource statistics record.
 #[derive(Debug, Default, Copy, Clone, PartialEq)]
 pub struct RawRecord {
     pub cpu_time: u32, // ms
+    /// CPU time consumed on unified-read-pool threads (ms).
+    pub unified_read_cpu_time: u32,
+    /// CPU time consumed on scheduler-pool threads (ms).
+    pub scheduler_cpu_time: u32,
     pub read_keys: u32,
     pub write_keys: u32,
     pub logical_read_bytes: u64,
@@ -211,8 +252,24 @@ pub struct RawRecord {
 }
 
 impl RawRecord {
+    /// Add CPU time delta and attribute it to the given thread pool type.
+    pub fn add_cpu_time(&mut self, delta_ms: u32, pool_type: ThreadPoolType) {
+        self.cpu_time += delta_ms;
+        match pool_type {
+            ThreadPoolType::UnifiedRead => {
+                self.unified_read_cpu_time += delta_ms;
+            }
+            ThreadPoolType::Scheduler => {
+                self.scheduler_cpu_time += delta_ms;
+            }
+            ThreadPoolType::Unknown => {}
+        }
+    }
+
     pub fn merge(&mut self, other: &Self) {
         self.cpu_time += other.cpu_time;
+        self.unified_read_cpu_time += other.unified_read_cpu_time;
+        self.scheduler_cpu_time += other.scheduler_cpu_time;
         self.read_keys += other.read_keys;
         self.write_keys += other.write_keys;
         self.logical_read_bytes += other.logical_read_bytes;
@@ -411,6 +468,7 @@ impl From<Records> for Vec<ResourceUsageRecord> {
                     logical_write_bytes,
                     network_in_bytes,
                     network_out_bytes,
+                    ..
                 },
             ) in records.others
             {
@@ -578,6 +636,7 @@ impl From<RegionRecords> for Vec<ResourceUsageRecord> {
                     logical_write_bytes,
                     network_in_bytes,
                     network_out_bytes,
+                    ..
                 },
             ) in records.others
             {
@@ -834,6 +893,7 @@ mod tests {
                 network_out_bytes: 2222,
                 logical_read_bytes: 3333,
                 logical_write_bytes: 4444,
+                ..Default::default()
             },
         );
         raw_map.insert(
@@ -846,6 +906,7 @@ mod tests {
                 network_out_bytes: 5555,
                 logical_read_bytes: 6666,
                 logical_write_bytes: 7777,
+                ..Default::default()
             },
         );
         raw_map.insert(
@@ -858,6 +919,7 @@ mod tests {
                 network_out_bytes: 8888,
                 logical_read_bytes: 9999,
                 logical_write_bytes: 11110,
+                ..Default::default()
             },
         );
         let raw = RawRecords {
@@ -905,6 +967,7 @@ mod tests {
                 network_out_bytes: 2222,
                 logical_read_bytes: 3333,
                 logical_write_bytes: 4444,
+                ..Default::default()
             },
         );
         records.insert(
@@ -917,6 +980,7 @@ mod tests {
                 network_out_bytes: 5555,
                 logical_read_bytes: 6666,
                 logical_write_bytes: 7777,
+                ..Default::default()
             },
         );
         records.insert(
@@ -929,6 +993,7 @@ mod tests {
                 network_out_bytes: 8888,
                 logical_read_bytes: 9999,
                 logical_write_bytes: 11110,
+                ..Default::default()
             },
         );
         let rs = RawRecords {
@@ -1015,6 +1080,7 @@ mod tests {
                 network_out_bytes: 111,
                 logical_read_bytes: 111,
                 logical_write_bytes: 111,
+                ..Default::default()
             },
         );
         raw_records.records.insert(
@@ -1027,6 +1093,7 @@ mod tests {
                 network_out_bytes: 111,
                 logical_read_bytes: 111,
                 logical_write_bytes: 111,
+                ..Default::default()
             },
         );
         raw_records.records.insert(
@@ -1039,6 +1106,7 @@ mod tests {
                 network_out_bytes: 111,
                 logical_read_bytes: 111,
                 logical_write_bytes: 111,
+                ..Default::default()
             },
         );
 
@@ -1118,6 +1186,7 @@ mod tests {
                 network_out_bytes: 2222,
                 logical_read_bytes: 3333,
                 logical_write_bytes: 4444,
+                ..Default::default()
             },
         );
         records.insert(
@@ -1130,6 +1199,7 @@ mod tests {
                 network_out_bytes: 5555,
                 logical_read_bytes: 6666,
                 logical_write_bytes: 7777,
+                ..Default::default()
             },
         );
         records.insert(
@@ -1142,6 +1212,7 @@ mod tests {
                 network_out_bytes: 8888,
                 logical_read_bytes: 9999,
                 logical_write_bytes: 11110,
+                ..Default::default()
             },
         );
         records.insert(
@@ -1154,6 +1225,7 @@ mod tests {
                 network_out_bytes: 22220,
                 logical_read_bytes: 33330,
                 logical_write_bytes: 44440,
+                ..Default::default()
             },
         );
         records.insert(
@@ -1166,6 +1238,7 @@ mod tests {
                 network_out_bytes: 55550,
                 logical_read_bytes: 66660,
                 logical_write_bytes: 77770,
+                ..Default::default()
             },
         );
         records.insert(
@@ -1178,6 +1251,7 @@ mod tests {
                 network_out_bytes: 88880,
                 logical_read_bytes: 99990,
                 logical_write_bytes: 111110,
+                ..Default::default()
             },
         );
         let rs = RawRecords {
@@ -1293,6 +1367,7 @@ mod tests {
                 network_out_bytes: 2222,
                 logical_read_bytes: 3333,
                 logical_write_bytes: 4444,
+                ..Default::default()
             },
         );
         records.insert(
@@ -1305,6 +1380,7 @@ mod tests {
                 network_out_bytes: 5555,
                 logical_read_bytes: 6666,
                 logical_write_bytes: 7777,
+                ..Default::default()
             },
         );
         records.insert(
@@ -1317,6 +1393,7 @@ mod tests {
                 network_out_bytes: 8888,
                 logical_read_bytes: 9999,
                 logical_write_bytes: 11110,
+                ..Default::default()
             },
         );
         records.insert(
@@ -1329,6 +1406,7 @@ mod tests {
                 network_out_bytes: 22220,
                 logical_read_bytes: 33330,
                 logical_write_bytes: 44440,
+                ..Default::default()
             },
         );
         records.insert(
@@ -1341,6 +1419,7 @@ mod tests {
                 network_out_bytes: 55550,
                 logical_read_bytes: 66660,
                 logical_write_bytes: 77770,
+                ..Default::default()
             },
         );
         records.insert(
@@ -1353,6 +1432,7 @@ mod tests {
                 network_out_bytes: 88880,
                 logical_read_bytes: 99990,
                 logical_write_bytes: 111110,
+                ..Default::default()
             },
         );
         let rs = RawRecords {
@@ -1430,6 +1510,7 @@ mod tests {
                 network_out_bytes: 8888,
                 logical_read_bytes: 7777,
                 logical_write_bytes: 6666,
+                ..Default::default()
             },
         );
         // tag2 largest logical io
@@ -1443,6 +1524,7 @@ mod tests {
                 network_out_bytes: 6666,
                 logical_read_bytes: 9999,
                 logical_write_bytes: 9999,
+                ..Default::default()
             },
         );
         // tag3 largest cpu
@@ -1456,6 +1538,7 @@ mod tests {
                 network_out_bytes: 2222,
                 logical_read_bytes: 3333,
                 logical_write_bytes: 4444,
+                ..Default::default()
             },
         );
         let rs = RawRecords {
@@ -1504,6 +1587,7 @@ mod tests {
                 network_out_bytes: 222,
                 logical_read_bytes: 333,
                 logical_write_bytes: 444,
+                ..Default::default()
             },
         );
         // tag5 won't be picked
@@ -1517,6 +1601,7 @@ mod tests {
                 network_out_bytes: 22,
                 logical_read_bytes: 33,
                 logical_write_bytes: 44,
+                ..Default::default()
             },
         );
         let rs = RawRecords {

--- a/components/resource_metering/src/recorder/sub_recorder/cpu.rs
+++ b/components/resource_metering/src/recorder/sub_recorder/cpu.rs
@@ -1,7 +1,7 @@
 // Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
 
 use collections::HashMap;
-use tikv_util::sys::thread::{self, Pid};
+use tikv_util::sys::thread::{self, matches_thread_name_prefix, Pid, THREAD_NAME_HASHMAP};
 
 use crate::{
     metrics::STAT_TASK_COUNT,
@@ -9,7 +9,7 @@ use crate::{
         localstorage::{LocalStorage, SharedTagInfos},
         SubRecorder,
     },
-    RawRecords,
+    RawRecords, ThreadPoolType,
 };
 
 /// An implementation of [SubRecorder] for collecting cpu statistics.
@@ -22,6 +22,34 @@ use crate::{
 #[derive(Default)]
 pub struct CpuRecorder {
     thread_stats: HashMap<Pid, ThreadStat>,
+}
+
+const UNIFIED_READ_POOL_THREAD: &str = "unified-read";
+// Keep scheduler matching broad for CPU attribution. It matches release-8.5's
+// `sched-worker-*` and master's `sched-*`.
+const SCHEDULER_THREAD_PREFIX: &str = "sched";
+
+#[inline]
+fn matches_scheduler_thread_name(thread_name: &str) -> bool {
+    matches_thread_name_prefix(thread_name, SCHEDULER_THREAD_PREFIX)
+}
+
+/// Detect the thread pool type from the thread name stored in
+/// [`THREAD_NAME_HASHMAP`].
+fn detect_thread_pool_type(tid: Pid) -> ThreadPoolType {
+    let map = THREAD_NAME_HASHMAP.lock().unwrap();
+    match map.get(&tid) {
+        Some(name) => {
+            if matches_thread_name_prefix(name, UNIFIED_READ_POOL_THREAD) {
+                ThreadPoolType::UnifiedRead
+            } else if matches_scheduler_thread_name(name) {
+                ThreadPoolType::Scheduler
+            } else {
+                ThreadPoolType::Unknown
+            }
+        }
+        None => ThreadPoolType::Unknown,
+    }
 }
 
 impl SubRecorder for CpuRecorder {
@@ -38,7 +66,7 @@ impl SubRecorder for CpuRecorder {
                         let delta_ms =
                             (cur_stat.total_cpu_time() - last_stat.total_cpu_time()) * 1_000.;
                         let record = records.entry(cur_tag).or_default();
-                        record.cpu_time += delta_ms as u32;
+                        record.add_cpu_time(delta_ms as u32, thread_stat.pool_type);
                     }
                     thread_stat.stat = cur_stat;
                 }
@@ -75,11 +103,13 @@ impl SubRecorder for CpuRecorder {
     }
 
     fn thread_created(&mut self, id: Pid, store: &LocalStorage) {
+        let pool_type = detect_thread_pool_type(id);
         self.thread_stats.insert(
             id,
             ThreadStat {
                 attached_tag: store.attached_tag.clone(),
                 stat: Default::default(),
+                pool_type,
             },
         );
     }
@@ -88,6 +118,7 @@ impl SubRecorder for CpuRecorder {
 struct ThreadStat {
     attached_tag: SharedTagInfos,
     stat: thread::ThreadStat,
+    pool_type: ThreadPoolType,
 }
 
 #[cfg(test)]

--- a/components/resource_metering/src/reporter/mod.rs
+++ b/components/resource_metering/src/reporter/mod.rs
@@ -320,6 +320,7 @@ mod tests {
                 network_out_bytes: 5,
                 logical_read_bytes: 6,
                 logical_write_bytes: 7,
+                ..Default::default()
             },
         );
         r.run(Task::Records(Arc::new(RawRecords {
@@ -370,6 +371,7 @@ mod tests {
                 network_out_bytes: 5,
                 logical_read_bytes: 6,
                 logical_write_bytes: 7,
+                ..Default::default()
             },
         );
 
@@ -438,6 +440,7 @@ mod tests {
                 network_out_bytes: 5,
                 logical_read_bytes: 6,
                 logical_write_bytes: 7,
+                ..Default::default()
             },
         );
         r.run(Task::Records(Arc::new(RawRecords {

--- a/components/server/src/common.rs
+++ b/components/server/src/common.rs
@@ -483,6 +483,8 @@ pub struct EnginesResourceInfo {
     raft_engine: Option<RocksEngine>,
     latest_normalized_pending_bytes: AtomicU32,
     normalized_pending_bytes_collector: MovingAvgU32,
+    // Shared compaction pressure (0-100+) read by GroupQuotaAdjustWorker.
+    compaction_pending_bytes_ratio: Arc<AtomicU32>,
 }
 
 impl EnginesResourceInfo {
@@ -493,6 +495,7 @@ impl EnginesResourceInfo {
         tablet_registry: TabletRegistry<RocksEngine>,
         raft_engine: Option<RocksEngine>,
         max_samples_to_preserve: usize,
+        compaction_pending_bytes_ratio: Arc<AtomicU32>,
     ) -> Self {
         // Match DATA_CFS.
         let base_max_compactions = [
@@ -506,6 +509,7 @@ impl EnginesResourceInfo {
             raft_engine,
             latest_normalized_pending_bytes: AtomicU32::new(0),
             normalized_pending_bytes_collector: MovingAvgU32::new(max_samples_to_preserve),
+            compaction_pending_bytes_ratio,
         }
     }
 
@@ -640,10 +644,11 @@ impl EnginesResourceInfo {
         let (_, avg) = self
             .normalized_pending_bytes_collector
             .add(normalized_pending_bytes);
-        self.latest_normalized_pending_bytes.store(
-            std::cmp::max(normalized_pending_bytes, avg),
-            Ordering::Relaxed,
-        );
+        let effective_pressure = std::cmp::max(normalized_pending_bytes, avg);
+        self.latest_normalized_pending_bytes
+            .store(effective_pressure, Ordering::Relaxed);
+        self.compaction_pending_bytes_ratio
+            .store(effective_pressure, Ordering::Relaxed);
     }
 
     #[cfg(any(test, feature = "testexport"))]

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -16,7 +16,10 @@ use std::{
     convert::TryFrom,
     path::{Path, PathBuf},
     str::FromStr,
-    sync::{atomic::AtomicU64, mpsc, Arc, Mutex},
+    sync::{
+        atomic::{AtomicU32, AtomicU64},
+        mpsc, Arc, Mutex,
+    },
     time::Duration,
     u64,
 };
@@ -289,6 +292,7 @@ where
     sst_worker: Option<Box<LazyWorker<String>>>,
     quota_limiter: Arc<QuotaLimiter>,
     resource_manager: Option<Arc<ResourceGroupManager>>,
+    compaction_pending_bytes_ratio: Arc<AtomicU32>,
     causal_ts_provider: Option<Arc<CausalTsProviderImpl>>, // used for rawkv apiv2
     tablet_registry: Option<TabletRegistry<RocksEngine>>,
     br_snap_recovery_mode: bool, // use for br snapshot recovery
@@ -396,6 +400,7 @@ where
             .thread_count(thread_count)
             .create();
 
+        let compaction_pending_bytes_ratio = Arc::new(AtomicU32::new(0));
         let resource_manager = if config.resource_control.enabled {
             let mgr = Arc::new(ResourceGroupManager::new(config.resource_control.clone()));
             let io_bandwidth = config.storage.io_rate_limit.max_bytes_per_sec.0;
@@ -404,6 +409,7 @@ where
                 pd_client.clone(),
                 &background_worker,
                 io_bandwidth,
+                compaction_pending_bytes_ratio.clone(),
             );
             Some(mgr)
         } else {
@@ -491,6 +497,7 @@ where
             sst_worker: None,
             quota_limiter,
             resource_manager,
+            compaction_pending_bytes_ratio,
             causal_ts_provider,
             tablet_registry: None,
             br_snap_recovery_mode: is_recovering_marked,
@@ -619,6 +626,7 @@ where
                 pd_sender.clone(),
                 engines.engine.clone(),
                 resource_ctl,
+                self.resource_manager.clone(),
                 CleanupMethod::Remote(self.core.background_worker.remote()),
                 true,
             ))
@@ -1882,6 +1890,7 @@ where
             reg,
             engines.raft.as_rocks_engine().cloned(),
             180, // max_samples_to_preserve
+            self.compaction_pending_bytes_ratio.clone(),
         ));
 
         (engines, engines_info, ime_engine)
@@ -1919,7 +1928,10 @@ fn pre_start() {
 
 #[cfg(test)]
 mod test {
-    use std::{collections::HashMap, sync::Arc};
+    use std::{
+        collections::HashMap,
+        sync::{atomic::AtomicU32, Arc},
+    };
 
     use engine_rocks::raw::Env;
     use engine_traits::{
@@ -1984,7 +1996,13 @@ mod test {
 
         assert!(old_pending_compaction_bytes > new_pending_compaction_bytes);
 
-        let engines_info = Arc::new(EnginesResourceInfo::new(&config, reg, None, 10));
+        let engines_info = Arc::new(EnginesResourceInfo::new(
+            &config,
+            reg,
+            None,
+            10,
+            Arc::new(AtomicU32::new(0)),
+        ));
 
         let mut cached_latest_tablets = HashMap::default();
         engines_info.update(Instant::now(), &mut cached_latest_tablets);

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -410,6 +410,7 @@ where
                 &background_worker,
                 io_bandwidth,
                 compaction_pending_bytes_ratio.clone(),
+                config.server.grpc_concurrency,
             );
             Some(mgr)
         } else {

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -17,9 +17,8 @@ use std::{
     path::{Path, PathBuf},
     str::FromStr,
     sync::{
-        Arc, Mutex,
         atomic::{AtomicU32, AtomicU64},
-        mpsc,
+        mpsc, Arc, Mutex,
     },
     time::Duration,
     u64,
@@ -627,6 +626,7 @@ where
                 pd_sender.clone(),
                 engines.engine.clone(),
                 resource_ctl,
+                self.resource_manager.clone(),
                 CleanupMethod::Remote(self.core.background_worker.remote()),
                 true,
             ))
@@ -1930,7 +1930,7 @@ fn pre_start() {
 mod test {
     use std::{
         collections::HashMap,
-        sync::{Arc, atomic::AtomicU32},
+        sync::{atomic::AtomicU32, Arc},
     };
 
     use engine_rocks::raw::Env;

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -16,7 +16,11 @@ use std::{
     convert::TryFrom,
     path::{Path, PathBuf},
     str::FromStr,
-    sync::{atomic::AtomicU64, mpsc, Arc, Mutex},
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicU32, AtomicU64},
+        mpsc,
+    },
     time::Duration,
     u64,
 };
@@ -289,6 +293,7 @@ where
     sst_worker: Option<Box<LazyWorker<String>>>,
     quota_limiter: Arc<QuotaLimiter>,
     resource_manager: Option<Arc<ResourceGroupManager>>,
+    compaction_pending_bytes_ratio: Arc<AtomicU32>,
     causal_ts_provider: Option<Arc<CausalTsProviderImpl>>, // used for rawkv apiv2
     tablet_registry: Option<TabletRegistry<RocksEngine>>,
     br_snap_recovery_mode: bool, // use for br snapshot recovery
@@ -396,6 +401,7 @@ where
             .thread_count(thread_count)
             .create();
 
+        let compaction_pending_bytes_ratio = Arc::new(AtomicU32::new(0));
         let resource_manager = if config.resource_control.enabled {
             let mgr = Arc::new(ResourceGroupManager::new(config.resource_control.clone()));
             let io_bandwidth = config.storage.io_rate_limit.max_bytes_per_sec.0;
@@ -404,6 +410,7 @@ where
                 pd_client.clone(),
                 &background_worker,
                 io_bandwidth,
+                compaction_pending_bytes_ratio.clone(),
             );
             Some(mgr)
         } else {
@@ -491,6 +498,7 @@ where
             sst_worker: None,
             quota_limiter,
             resource_manager,
+            compaction_pending_bytes_ratio,
             causal_ts_provider,
             tablet_registry: None,
             br_snap_recovery_mode: is_recovering_marked,
@@ -1882,6 +1890,7 @@ where
             reg,
             engines.raft.as_rocks_engine().cloned(),
             180, // max_samples_to_preserve
+            self.compaction_pending_bytes_ratio.clone(),
         ));
 
         (engines, engines_info, ime_engine)
@@ -1919,7 +1928,10 @@ fn pre_start() {
 
 #[cfg(test)]
 mod test {
-    use std::{collections::HashMap, sync::Arc};
+    use std::{
+        collections::HashMap,
+        sync::{Arc, atomic::AtomicU32},
+    };
 
     use engine_rocks::raw::Env;
     use engine_traits::{
@@ -1984,7 +1996,13 @@ mod test {
 
         assert!(old_pending_compaction_bytes > new_pending_compaction_bytes);
 
-        let engines_info = Arc::new(EnginesResourceInfo::new(&config, reg, None, 10));
+        let engines_info = Arc::new(EnginesResourceInfo::new(
+            &config,
+            reg,
+            None,
+            10,
+            Arc::new(AtomicU32::new(0)),
+        ));
 
         let mut cached_latest_tablets = HashMap::default();
         engines_info.update(Instant::now(), &mut cached_latest_tablets);

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -699,7 +699,7 @@ where
         if let Some(resource_ctl) = &self.resource_manager {
             cfg_controller.register(
                 tikv::config::Module::ResourceControl,
-                Box::new(ResourceContrlCfgMgr::new(resource_ctl.get_config().clone())),
+                Box::new(ResourceContrlCfgMgr::new(resource_ctl.clone())),
             );
         }
 

--- a/components/server/src/server2.rs
+++ b/components/server/src/server2.rs
@@ -17,7 +17,7 @@ use std::{
     path::{Path, PathBuf},
     str::FromStr,
     sync::{
-        atomic::AtomicU64,
+        atomic::{AtomicU32, AtomicU64},
         mpsc::{self, sync_channel},
         Arc,
     },
@@ -266,6 +266,7 @@ struct TikvServer<ER: RaftEngine> {
     sst_worker: Option<Box<LazyWorker<String>>>,
     quota_limiter: Arc<QuotaLimiter>,
     resource_manager: Option<Arc<ResourceGroupManager>>,
+    compaction_pending_bytes_ratio: Arc<AtomicU32>,
     causal_ts_provider: Option<Arc<CausalTsProviderImpl>>, // used for rawkv apiv2
     tablet_registry: Option<TabletRegistry<RocksEngine>>,
     resolved_ts_scheduler: Option<Scheduler<Task>>,
@@ -358,6 +359,7 @@ where
             config.quota.enable_auto_tune,
         ));
 
+        let compaction_pending_bytes_ratio = Arc::new(AtomicU32::new(0));
         let resource_manager = if config.resource_control.enabled {
             let mgr = Arc::new(ResourceGroupManager::new(config.resource_control.clone()));
             let io_bandwidth = config.storage.io_rate_limit.max_bytes_per_sec.0;
@@ -366,6 +368,7 @@ where
                 pd_client.clone(),
                 &background_worker,
                 io_bandwidth,
+                compaction_pending_bytes_ratio.clone(),
             );
             Some(mgr)
         } else {
@@ -422,6 +425,7 @@ where
             sst_worker: None,
             quota_limiter,
             resource_manager,
+            compaction_pending_bytes_ratio,
             causal_ts_provider,
             tablet_registry: None,
             resolved_ts_scheduler: None,
@@ -495,6 +499,7 @@ where
                 pd_sender.clone(),
                 engines.engine.clone(),
                 resource_ctl,
+                self.resource_manager.clone(),
                 CleanupMethod::Remote(self.core.background_worker.remote()),
                 true,
             ))
@@ -1651,6 +1656,7 @@ impl<CER: ConfiguredRaftEngine> TikvServer<CER> {
             registry,
             raft_engine.as_rocks_engine().cloned(),
             180, // max_samples_to_preserve
+            self.compaction_pending_bytes_ratio.clone(),
         ));
 
         let router = RaftRouter::new(node.id(), router);
@@ -1726,7 +1732,10 @@ fn pre_start() {
 
 #[cfg(test)]
 mod test {
-    use std::{collections::HashMap, sync::Arc};
+    use std::{
+        collections::HashMap,
+        sync::{atomic::AtomicU32, Arc},
+    };
 
     use engine_rocks::raw::Env;
     use engine_traits::{
@@ -1790,7 +1799,13 @@ mod test {
 
         assert!(old_pending_compaction_bytes > new_pending_compaction_bytes);
 
-        let engines_info = Arc::new(EnginesResourceInfo::new(&config, reg, None, 10));
+        let engines_info = Arc::new(EnginesResourceInfo::new(
+            &config,
+            reg,
+            None,
+            10,
+            Arc::new(AtomicU32::new(0)),
+        ));
 
         let mut cached_latest_tablets = HashMap::default();
         engines_info.update(Instant::now(), &mut cached_latest_tablets);

--- a/components/server/src/server2.rs
+++ b/components/server/src/server2.rs
@@ -369,6 +369,7 @@ where
                 &background_worker,
                 io_bandwidth,
                 compaction_pending_bytes_ratio.clone(),
+                config.server.grpc_concurrency,
             );
             Some(mgr)
         } else {

--- a/components/server/src/server2.rs
+++ b/components/server/src/server2.rs
@@ -570,7 +570,7 @@ where
         if let Some(resource_ctl) = &self.resource_manager {
             cfg_controller.register(
                 tikv::config::Module::ResourceControl,
-                Box::new(ResourceContrlCfgMgr::new(resource_ctl.get_config().clone())),
+                Box::new(ResourceContrlCfgMgr::new(resource_ctl.clone())),
             );
         }
 

--- a/components/server/src/server2.rs
+++ b/components/server/src/server2.rs
@@ -17,9 +17,9 @@ use std::{
     path::{Path, PathBuf},
     str::FromStr,
     sync::{
-        atomic::AtomicU64,
-        mpsc::{self, sync_channel},
         Arc,
+        atomic::{AtomicU32, AtomicU64},
+        mpsc::{self, sync_channel},
     },
     time::Duration,
     u64,
@@ -266,6 +266,7 @@ struct TikvServer<ER: RaftEngine> {
     sst_worker: Option<Box<LazyWorker<String>>>,
     quota_limiter: Arc<QuotaLimiter>,
     resource_manager: Option<Arc<ResourceGroupManager>>,
+    compaction_pending_bytes_ratio: Arc<AtomicU32>,
     causal_ts_provider: Option<Arc<CausalTsProviderImpl>>, // used for rawkv apiv2
     tablet_registry: Option<TabletRegistry<RocksEngine>>,
     resolved_ts_scheduler: Option<Scheduler<Task>>,
@@ -358,6 +359,7 @@ where
             config.quota.enable_auto_tune,
         ));
 
+        let compaction_pending_bytes_ratio = Arc::new(AtomicU32::new(0));
         let resource_manager = if config.resource_control.enabled {
             let mgr = Arc::new(ResourceGroupManager::new(config.resource_control.clone()));
             let io_bandwidth = config.storage.io_rate_limit.max_bytes_per_sec.0;
@@ -366,6 +368,7 @@ where
                 pd_client.clone(),
                 &background_worker,
                 io_bandwidth,
+                compaction_pending_bytes_ratio.clone(),
             );
             Some(mgr)
         } else {
@@ -422,6 +425,7 @@ where
             sst_worker: None,
             quota_limiter,
             resource_manager,
+            compaction_pending_bytes_ratio,
             causal_ts_provider,
             tablet_registry: None,
             resolved_ts_scheduler: None,
@@ -1651,6 +1655,7 @@ impl<CER: ConfiguredRaftEngine> TikvServer<CER> {
             registry,
             raft_engine.as_rocks_engine().cloned(),
             180, // max_samples_to_preserve
+            self.compaction_pending_bytes_ratio.clone(),
         ));
 
         let router = RaftRouter::new(node.id(), router);
@@ -1726,7 +1731,10 @@ fn pre_start() {
 
 #[cfg(test)]
 mod test {
-    use std::{collections::HashMap, sync::Arc};
+    use std::{
+        collections::HashMap,
+        sync::{Arc, atomic::AtomicU32},
+    };
 
     use engine_rocks::raw::Env;
     use engine_traits::{
@@ -1790,7 +1798,13 @@ mod test {
 
         assert!(old_pending_compaction_bytes > new_pending_compaction_bytes);
 
-        let engines_info = Arc::new(EnginesResourceInfo::new(&config, reg, None, 10));
+        let engines_info = Arc::new(EnginesResourceInfo::new(
+            &config,
+            reg,
+            None,
+            10,
+            Arc::new(AtomicU32::new(0)),
+        ));
 
         let mut cached_latest_tablets = HashMap::default();
         engines_info.update(Instant::now(), &mut cached_latest_tablets);

--- a/components/server/src/server2.rs
+++ b/components/server/src/server2.rs
@@ -17,9 +17,9 @@ use std::{
     path::{Path, PathBuf},
     str::FromStr,
     sync::{
-        Arc,
         atomic::{AtomicU32, AtomicU64},
         mpsc::{self, sync_channel},
+        Arc,
     },
     time::Duration,
     u64,
@@ -499,6 +499,7 @@ where
                 pd_sender.clone(),
                 engines.engine.clone(),
                 resource_ctl,
+                self.resource_manager.clone(),
                 CleanupMethod::Remote(self.core.background_worker.remote()),
                 true,
             ))
@@ -1733,7 +1734,7 @@ fn pre_start() {
 mod test {
     use std::{
         collections::HashMap,
-        sync::{Arc, atomic::AtomicU32},
+        sync::{atomic::AtomicU32, Arc},
     };
 
     use engine_rocks::raw::Env;

--- a/components/sst_importer/src/lib.rs
+++ b/components/sst_importer/src/lib.rs
@@ -5,8 +5,6 @@
 #![feature(error_reporter)]
 
 #[macro_use]
-extern crate lazy_static;
-#[macro_use]
 extern crate serde_derive;
 #[macro_use]
 extern crate tikv_util;

--- a/components/test_raftstore/src/lib.rs
+++ b/components/test_raftstore/src/lib.rs
@@ -4,8 +4,6 @@
 #![feature(trait_alias)]
 
 #[macro_use]
-extern crate lazy_static;
-#[macro_use]
 extern crate tikv_util;
 
 mod cluster;

--- a/components/tikv_alloc/Cargo.toml
+++ b/components/tikv_alloc/Cargo.toml
@@ -36,15 +36,16 @@ optional = true
 features = ["bundled"]
 
 [dependencies.tikv-jemalloc-ctl]
-version = "0.5.0"
+version = "0.6.1"
 optional = true
+features = ["stats"]
 
 [dependencies.tikv-jemalloc-sys]
-version = "0.5.0"
+version = "0.6.1"
 optional = true
 features = ["stats"]
 
 [dependencies.tikv-jemallocator]
-version = "0.5.0"
+version = "0.6.1"
 optional = true
 features = ["unprefixed_malloc_on_supported_platforms", "stats"]

--- a/components/tikv_util/src/lib.rs
+++ b/components/tikv_util/src/lib.rs
@@ -29,10 +29,12 @@ use std::{
     time::Duration,
 };
 
+use lazy_static::lazy_static;
 use nix::{
     sys::wait::{wait, WaitStatus},
     unistd::{fork, ForkResult},
 };
+use serde::Serialize;
 
 use crate::sys::thread::StdThreadBuildWrapper;
 
@@ -580,6 +582,48 @@ pub fn set_vec_capacity<T>(v: &mut Vec<T>, cap: usize) {
         cmp::Ordering::Less => v.shrink_to(cap),
         cmp::Ordering::Greater => v.reserve_exact(cap - v.len()),
         cmp::Ordering::Equal => {}
+    }
+}
+
+// Global server readiness state.
+//
+// This is used to track whether TiKV is fully ready to serve requests after
+// startup. It is queried by the `/ready` API of the status server.
+lazy_static! {
+    pub static ref GLOBAL_SERVER_READINESS: Arc<ServerReadiness> =
+        Arc::new(ServerReadiness::default());
+}
+
+/// Represents the readiness state of the server.
+///
+/// Each field is a flag indicating a condition that must be met for the server
+/// to be considered fully ready to serve.
+#[derive(Serialize, Default)]
+pub struct ServerReadiness {
+    /// Indicates whether the server has connected to PD.
+    pub connected_to_pd: AtomicBool,
+    /// Indicates whether a sufficient number of Raft peers have caught up
+    /// applying logs.
+    pub raft_peers_caught_up: AtomicBool,
+}
+
+impl ServerReadiness {
+    /// Checks if the server is ready.
+    ///
+    /// All conditions must be met for the server to be considered ready.
+    pub fn is_ready(&self) -> bool {
+        self.raft_peers_caught_up.load(Ordering::SeqCst)
+            && self.connected_to_pd.load(Ordering::SeqCst)
+    }
+
+    pub fn to_json(&self) -> String {
+        let json_result = serde_json::to_string_pretty(&self);
+        match json_result {
+            Ok(json) => json,
+            Err(e) => {
+                format!("failed to serialize ServerReadiness: {}", e)
+            }
+        }
     }
 }
 

--- a/components/tikv_util/src/lib.rs
+++ b/components/tikv_util/src/lib.rs
@@ -64,6 +64,7 @@ pub mod store;
 pub mod stream;
 pub mod sys;
 pub mod thread_group;
+pub mod thread_name_prefix;
 pub mod time;
 pub mod timer;
 pub mod topn;

--- a/components/tikv_util/src/logger/mod.rs
+++ b/components/tikv_util/src/logger/mod.rs
@@ -9,9 +9,11 @@ use std::{
     path::{Path, PathBuf},
     sync::{
         atomic::{AtomicUsize, Ordering},
+        mpsc::channel,
         Mutex,
     },
     thread,
+    time::Duration,
 };
 
 use log::{self, SetLoggerError};
@@ -21,7 +23,10 @@ use slog_async::{Async, AsyncGuard, OverflowStrategy};
 use slog_term::{Decorator, PlainDecorator, RecordDecorator};
 
 use self::file_log::{RotateBySize, RotatingFileLogger, RotatingFileLoggerBuilder};
-use crate::config::{ReadableDuration, ReadableSize};
+use crate::{
+    config::{ReadableDuration, ReadableSize},
+    sys::thread::StdThreadBuildWrapper,
+};
 
 // Default is 128.
 // Extended since blocking is set, and we don't want to block very often.
@@ -144,6 +149,26 @@ pub fn exit_process_gracefully(code: i32) -> ! {
     // force async logger to flush by dropping its guard.
     *ASYNC_LOGGER_GUARD.lock().unwrap() = None;
     std::process::exit(code);
+}
+
+/// Best-effort flushes the async logger, but never waits forever.
+///
+/// This is intended for crash paths such as fail-fast. It gives the async
+/// logger a brief window to drain outstanding messages, then panics so the
+/// normal panic hook can emit a fatal log before the process crashes.
+pub fn panic_after_best_effort_flush(timeout: Duration, message: &str) -> ! {
+    let guard = ASYNC_LOGGER_GUARD.lock().unwrap().take();
+    if let Some(guard) = guard {
+        let (done_tx, done_rx) = channel();
+        let _ = thread::Builder::new()
+            .name("async-log-flush".to_owned())
+            .spawn_wrapper(move || {
+                drop(guard);
+                let _ = done_tx.send(());
+            });
+        let _ = done_rx.recv_timeout(timeout);
+    }
+    panic!("{}", message);
 }
 
 /// Constructs a new file writer which outputs log to a file at the specified

--- a/components/tikv_util/src/range_latch.rs
+++ b/components/tikv_util/src/range_latch.rs
@@ -3,6 +3,7 @@ use std::{
         BTreeMap,
         Bound::{Excluded, Unbounded},
     },
+    mem::ManuallyDrop,
     sync::{Arc, Mutex},
 };
 
@@ -101,14 +102,21 @@ impl RangeLatch {
 
                 // Now acquire the latch after releasing the write guard
                 let mutex_guard = mutex.lock().unwrap();
-                // Safety: `_mutex_guard` is declared before `handle` in `KeyHandleGuard`.
-                // So the mutex guard will be released earlier than the `Arc<KeyHandle>`.
-                // Then we can make sure the mutex guard doesn't point to released memory.
+                // Safety: `transmute` just change the lifetime, do not change
+                // the type.
+                // `_mutex_guard` points to the `Mutex<()>`
+                // We need to make sure it will be dropped before the
+                // `Arc<Mutex<()>>` and the `RangeLatch` while `drop`.
+                // Then we can make sure the mutex guard doesn't point to
+                // released memory.
+                // We use `ManuallyDrop` to promise it.
+
+                #[allow(clippy::missing_transmute_annotations)]
                 let mutex_guard = unsafe { std::mem::transmute(mutex_guard) };
 
                 return RangeLatchGuard {
                     start_key,
-                    _mutex_guard: mutex_guard,
+                    _mutex_guard: ManuallyDrop::new(mutex_guard),
                     handle: self,
                 };
             }
@@ -128,9 +136,10 @@ pub struct RangeLatchGuard<'a> {
     start_key: Vec<u8>,
     /// Hold the mutex guard to prevent concurrent access to the same range.
     ///
-    /// This field must be declared before `handle` so it will be dropped before
-    /// `handle`.
-    _mutex_guard: std::sync::MutexGuard<'a, ()>,
+    /// Use `ManuallyDrop` to promise:
+    /// `_mutex_guard` will be dropped before the `Arc<Mutex<()>>` and the
+    /// `RangeLatch` while `drop`.
+    _mutex_guard: ManuallyDrop<std::sync::MutexGuard<'a, ()>>,
     /// Holds a reference to RangeLatch to release the latch when the guard is
     /// dropped.
     handle: &'a RangeLatch,
@@ -138,7 +147,15 @@ pub struct RangeLatchGuard<'a> {
 
 impl<'a> Drop for RangeLatchGuard<'a> {
     fn drop(&mut self) {
+        // Safety: we call `ManuallyDrop::drop` to drop the mutex guard
+        // once and only once.
+        // So `_mutex_guard` will be released earlier than the
+        // `Arc<Mutex<()>>`. We drop `_mutex_guard` by hand, so dropping order
+        // depends on declaration order no longer matters.
+        unsafe { ManuallyDrop::drop(&mut self._mutex_guard) };
         let mut range_latches = self.handle.range_latches.lock().unwrap();
+        // `range_latches.remove(&self.start_key);` will cause
+        // `Arc<Mutex()>>` dropped.
         range_latches.remove(&self.start_key);
     }
 }
@@ -172,6 +189,7 @@ mod tests {
         drop(guard1);
         drop(guard2);
         drop(guard3);
+        drop(latch);
     }
 
     #[test]

--- a/components/tikv_util/src/sys/thread.rs
+++ b/components/tikv_util/src/sys/thread.rs
@@ -420,6 +420,26 @@ pub(crate) fn remove_thread_name_from_map() {
     THREAD_NAME_HASHMAP.lock().unwrap().remove(&tid);
 }
 
+const LINUX_THREAD_NAME_MAX_LEN: usize = 15;
+
+/// Returns whether `thread_name` belongs to a thread family whose prefix is
+/// `prefix`.
+///
+/// Linux `/proc` thread names are truncated to 15 visible bytes, so callers can
+/// pass either a stable family prefix or the full thread prefix and still match
+/// truncated names such as `unified-read-po`.
+#[inline]
+pub fn matches_thread_name_prefix(thread_name: &str, prefix: &str) -> bool {
+    if thread_name.starts_with(prefix) {
+        return true;
+    }
+    if prefix.len() <= LINUX_THREAD_NAME_MAX_LEN {
+        return false;
+    }
+    // TiKV thread-name prefixes are ASCII constants; byte slicing is safe.
+    thread_name.starts_with(&prefix[..LINUX_THREAD_NAME_MAX_LEN])
+}
+
 impl StdThreadBuildWrapper for std::thread::Builder {
     fn spawn_wrapper<F, T>(self, f: F) -> Result<std::thread::JoinHandle<T>>
     where
@@ -516,6 +536,24 @@ mod tests {
         })
         .join()
         .unwrap();
+    }
+
+    #[test]
+    fn test_matches_thread_name_prefix() {
+        assert!(matches_thread_name_prefix(
+            "unified-read-pool-1",
+            "unified-read"
+        ));
+        assert!(matches_thread_name_prefix(
+            "unified-read-po",
+            "unified-read-pool"
+        ));
+        assert!(matches_thread_name_prefix("sched-worker-pool-1", "sched"));
+        assert!(matches_thread_name_prefix("sched-pool-1", "sched"));
+        assert!(!matches_thread_name_prefix(
+            "foo-unified-read",
+            "unified-read"
+        ));
     }
 
     #[test]

--- a/components/tikv_util/src/thread_name_prefix.rs
+++ b/components/tikv_util/src/thread_name_prefix.rs
@@ -1,0 +1,61 @@
+// Copyright 2025 TiKV Project Authors. Licensed under Apache-2.0.
+
+//! Thread name prefixes needed by `resource_control`'s pressure-scoring
+//! thread scans.
+//!
+//! Upstream master has a much larger, centralized version of this module
+//! covering every TiKV-spawned thread; this branch predates that refactor,
+//! so only the constants/helper actually consumed here are ported.
+
+pub const GRPC_SERVER_THREAD: &str = "grpc-server";
+
+pub const UNIFIED_READ_POOL_THREAD: &str = "unified-read-pool";
+
+const LINUX_THREAD_NAME_MAX_LEN: usize = 15;
+
+/// Returns whether `thread_name` belongs to a thread name family whose prefix
+/// is `prefix`.
+///
+/// On Linux, thread names observed via `/proc` come from the `comm` field,
+/// which is truncated to at most 15 visible characters. For long TiKV prefixes
+/// (for example, `"unified-read-pool"`), the observed thread name may only
+/// contain the first 15 bytes of the prefix. We therefore match both:
+/// 1. the full prefix (normal case), and
+/// 2. the 15-byte truncated prefix (Linux truncation case).
+#[inline]
+pub fn matches_thread_name_prefix(thread_name: &str, prefix: &str) -> bool {
+    if thread_name.starts_with(prefix) {
+        return true;
+    }
+    if prefix.len() <= LINUX_THREAD_NAME_MAX_LEN {
+        return false;
+    }
+    // Thread name prefixes are ASCII constants in TiKV; byte slicing is safe.
+    thread_name.starts_with(&prefix[..LINUX_THREAD_NAME_MAX_LEN])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{matches_thread_name_prefix, LINUX_THREAD_NAME_MAX_LEN};
+
+    #[test]
+    fn test_matches_thread_name_prefix_basic() {
+        assert!(matches_thread_name_prefix("unified-read-1", "unified-read"));
+        assert!(!matches_thread_name_prefix(
+            "foo-unified-read",
+            "unified-read"
+        ));
+    }
+
+    #[test]
+    fn test_matches_thread_name_prefix_truncated() {
+        let long_prefix = "unified-read-pool";
+        let truncated = &long_prefix[..LINUX_THREAD_NAME_MAX_LEN];
+        let thread_name = format!("{truncated}-1");
+        assert!(matches_thread_name_prefix(&thread_name, long_prefix));
+        assert!(!matches_thread_name_prefix(
+            &format!("x{thread_name}"),
+            long_prefix
+        ));
+    }
+}

--- a/deny.toml
+++ b/deny.toml
@@ -110,6 +110,36 @@ ignore = [
     # rand::rng() / thread_rng() during logging, which TiKV does not do.
     # TODO: Upgrade rand to >=0.9.3 or >=0.10.1 when possible.
     "RUSTSEC-2026-0097",
+    # Ignore RUSTSEC-2026-0174 (http-types ASCII invariant violation in
+    # Authorization/WwwAuthenticate headers). http-types is pulled in via
+    # azure_core and is unmaintained with no fix available. TiKV does not
+    # construct Authorization or WwwAuthenticate headers with non-ASCII input.
+    "RUSTSEC-2026-0174",
+    # Ignore RUSTSEC-2026-0186 (unsound issue in memmap2: unchecked pointer
+    # offset in Mmap::advise_range). memmap2 is a transitive dependency with no
+    # fix available on the release branch.
+    "RUSTSEC-2026-0186",
+    # Ignore RUSTSEC-2022-0104 because structopt is only used by tikv-ctl and
+    # does not affect the server runtime. This is safe to ignore.
+    "RUSTSEC-2022-0104",
+    # Ignore RUSTSEC-2026-0190 (unsound `Error::downcast_mut()` in anyhow). The
+    # UB only triggers when context is added via `Error::context` and later
+    # `downcast_mut` is called on the returned error; TiKV does not use that
+    # pattern. No fix available on the release branch's pinned anyhow.
+    "RUSTSEC-2026-0190",
+    # Ignore RUSTSEC-2026-0204 (invalid pointer dereference in the `fmt::Pointer`
+    # impl for crossbeam-epoch's `Atomic`/`Shared`). Only reachable by formatting
+    # a null/invalid `Atomic`/`Shared` via `fmt::Display`, which TiKV does not do.
+    "RUSTSEC-2026-0204",
+    # Ignore RUSTSEC-2026-0194 (quadratic runtime checking a start tag for
+    # duplicate attribute names in quick-xml). quick-xml is pulled in transitively
+    # via the azure SDK and only parses trusted responses; no fix available on the
+    # release branch.
+    "RUSTSEC-2026-0194",
+    # Ignore RUSTSEC-2026-0195 (unbounded namespace-declaration allocation in
+    # quick-xml's `NsReader`, memory-exhaustion DoS). Same transitive azure SDK
+    # dependency parsing trusted responses; no fix available on the release branch.
+    "RUSTSEC-2026-0195",
 ]
 
 # TiKV is licensed under Apache 2.0, according to ASF 3RD PARTY LICENSE POLICY,

--- a/deny.toml
+++ b/deny.toml
@@ -105,6 +105,11 @@ ignore = [
     # in master branch. Because the modification is too large,
     # we decided on the release branch to ignore it.
     "RUSTSEC-2026-0009",
+    # Ignore RUSTSEC-2026-0097 (unsound issue in rand with a custom logger using
+    # rand::rng()). The vulnerability requires a custom logger that calls
+    # rand::rng() / thread_rng() during logging, which TiKV does not do.
+    # TODO: Upgrade rand to >=0.9.3 or >=0.10.1 when possible.
+    "RUSTSEC-2026-0097",
 ]
 
 # TiKV is licensed under Apache 2.0, according to ASF 3RD PARTY LICENSE POLICY,

--- a/deny.toml
+++ b/deny.toml
@@ -110,6 +110,11 @@ ignore = [
     # rand::rng() / thread_rng() during logging, which TiKV does not do.
     # TODO: Upgrade rand to >=0.9.3 or >=0.10.1 when possible.
     "RUSTSEC-2026-0097",
+    # Ignore RUSTSEC-2026-0174 (http-types ASCII invariant violation in
+    # Authorization/WwwAuthenticate headers). http-types is pulled in via
+    # azure_core and is unmaintained with no fix available. TiKV does not
+    # construct Authorization or WwwAuthenticate headers with non-ASCII input.
+    "RUSTSEC-2026-0174",
 ]
 
 # TiKV is licensed under Apache 2.0, according to ASF 3RD PARTY LICENSE POLICY,

--- a/deny.toml
+++ b/deny.toml
@@ -154,6 +154,11 @@ ignore = [
     #
     # See: https://rustsec.org/advisories/RUSTSEC-2026-0253
     "RUSTSEC-2026-0253",
+    # Ignore RUSTSEC-2026-0258 (h2 accepts and queues empty DATA frames without
+    # limit, low severity). Only reachable through the hyper 0.14 client used by
+    # the AWS SDK for outbound requests, not the gRPC service path (grpcio). The
+    # fix only exists in h2 0.4.16, which requires a hyper 0.14 -> 1.x migration.
+    "RUSTSEC-2026-0258",
 ]
 
 # TiKV is licensed under Apache 2.0, according to ASF 3RD PARTY LICENSE POLICY,

--- a/deny.toml
+++ b/deny.toml
@@ -159,6 +159,11 @@ ignore = [
     # the AWS SDK for outbound requests, not the gRPC service path (grpcio). The
     # fix only exists in h2 0.4.16, which requires a hyper 0.14 -> 1.x migration.
     "RUSTSEC-2026-0258",
+    # Ignore RUSTSEC-2026-0275 because we do not run on azure.
+    # See:
+    #   
+    #   https://rustsec.org/advisories/RUSTSEC-2026-0275.html
+    "RUSTSEC-2026-0275",
 ]
 
 # TiKV is licensed under Apache 2.0, according to ASF 3RD PARTY LICENSE POLICY,

--- a/deny.toml
+++ b/deny.toml
@@ -115,6 +115,13 @@ ignore = [
     # azure_core and is unmaintained with no fix available. TiKV does not
     # construct Authorization or WwwAuthenticate headers with non-ASCII input.
     "RUSTSEC-2026-0174",
+    # Ignore RUSTSEC-2026-0186 (unsound issue in memmap2: unchecked pointer
+    # offset in Mmap::advise_range). memmap2 is a transitive dependency with no
+    # fix available on the release branch.
+    "RUSTSEC-2026-0186",
+    # Ignore RUSTSEC-2022-0104 because structopt is only used by tikv-ctl and
+    # does not affect the server runtime. This is safe to ignore.
+    "RUSTSEC-2022-0104",
 ]
 
 # TiKV is licensed under Apache 2.0, according to ASF 3RD PARTY LICENSE POLICY,

--- a/deny.toml
+++ b/deny.toml
@@ -122,6 +122,24 @@ ignore = [
     # Ignore RUSTSEC-2022-0104 because structopt is only used by tikv-ctl and
     # does not affect the server runtime. This is safe to ignore.
     "RUSTSEC-2022-0104",
+    # Ignore RUSTSEC-2026-0190 (unsound `Error::downcast_mut()` in anyhow). The
+    # UB only triggers when context is added via `Error::context` and later
+    # `downcast_mut` is called on the returned error; TiKV does not use that
+    # pattern. No fix available on the release branch's pinned anyhow.
+    "RUSTSEC-2026-0190",
+    # Ignore RUSTSEC-2026-0204 (invalid pointer dereference in the `fmt::Pointer`
+    # impl for crossbeam-epoch's `Atomic`/`Shared`). Only reachable by formatting
+    # a null/invalid `Atomic`/`Shared` via `fmt::Display`, which TiKV does not do.
+    "RUSTSEC-2026-0204",
+    # Ignore RUSTSEC-2026-0194 (quadratic runtime checking a start tag for
+    # duplicate attribute names in quick-xml). quick-xml is pulled in transitively
+    # via the azure SDK and only parses trusted responses; no fix available on the
+    # release branch.
+    "RUSTSEC-2026-0194",
+    # Ignore RUSTSEC-2026-0195 (unbounded namespace-declaration allocation in
+    # quick-xml's `NsReader`, memory-exhaustion DoS). Same transitive azure SDK
+    # dependency parsing trusted responses; no fix available on the release branch.
+    "RUSTSEC-2026-0195",
 ]
 
 # TiKV is licensed under Apache 2.0, according to ASF 3RD PARTY LICENSE POLICY,

--- a/deny.toml
+++ b/deny.toml
@@ -147,6 +147,13 @@ ignore = [
     # types, so the unsound path is not reachable. No fix available on the
     # release branch's pinned version yet.
     "RUSTSEC-2026-0221",
+    # Ignore RUSTSEC-2026-0253 for now: Cargo.lock shows `lru` 0.12.5 is pulled
+    # in only via `aws-sdk-s3`. The advisory is only relevant when unwinding
+    # panics are enabled and `std::panic::catch_unwind` is used with key types
+    # that may panic in `Drop`.
+    #
+    # See: https://rustsec.org/advisories/RUSTSEC-2026-0253
+    "RUSTSEC-2026-0253",
 ]
 
 # TiKV is licensed under Apache 2.0, according to ASF 3RD PARTY LICENSE POLICY,

--- a/deny.toml
+++ b/deny.toml
@@ -140,6 +140,13 @@ ignore = [
     # quick-xml's `NsReader`, memory-exhaustion DoS). Same transitive azure SDK
     # dependency parsing trusted responses; no fix available on the release branch.
     "RUSTSEC-2026-0195",
+    # Ignore RUSTSEC-2026-0221 (unsound `Send`/`Sync` impl for `StackSlot<'_, T>`
+    # in event-listener 5.x, affects >=5.1.0 <5.4.2). Pulled in transitively via
+    # async-channel/async-lock (event-listener-strategy), which only use plain
+    # `Event::listen()` and do not use `Event::with_tag` with non-`Send` tag
+    # types, so the unsound path is not reachable. No fix available on the
+    # release branch's pinned version yet.
+    "RUSTSEC-2026-0221",
 ]
 
 # TiKV is licensed under Apache 2.0, according to ASF 3RD PARTY LICENSE POLICY,

--- a/doc/maintenance-guides/components/resource_control.md
+++ b/doc/maintenance-guides/components/resource_control.md
@@ -1,0 +1,311 @@
+# `components/resource_control` Maintenance Guide
+
+## Purpose And Scope
+
+`resource_control` owns request-level fairness and resource-isolation logic for
+resource groups. It watches PD metadata, maintains group state, wraps futures
+and channels with accounting, and adjusts limiters over time.
+
+## Architectural Views
+
+### Policy view
+
+- resource-group definition and runtime state
+- limiter implementation
+- fairness and admission control policy
+- PD watch/report control plane
+
+### Runtime view
+
+- hot-path wrappers on futures/channels
+- periodic background adjustment workers
+- asynchronous PD metadata synchronization
+
+## Process Lifecycle And Startup Sequencing
+
+- The owning process starts this subsystem from server bootstrap.
+- Periodic tasks are started by `start_periodic_tasks`:
+  min-virtual-time advancement, PD watch loop, quota adjustment, RU reporting.
+- Shutdown safety depends on the owning worker/runtime lifecycle, so long-lived
+  tasks here should remain cancellation-safe and retry-safe.
+
+Concrete runtime anchors:
+
+- periodic-task setup:
+  `lib.rs::start_periodic_tasks`
+- PD watch and reload loop:
+  `service.rs`
+- quota adjustment:
+  `worker.rs`
+
+## Data Model And Metadata Contracts
+
+- Resource-group definitions come from PD meta storage.
+- Runtime metadata includes:
+  group mode, quotas, virtual-time state, baseline usage, limiter statistics,
+  admission decisions.
+- Background usage reports back to PD as request-unit accounting.
+
+Hot contracts to review carefully:
+
+- group-name identity and default/background-group semantics
+- baseline-window and fairness-phase encoding
+- RU accounting inputs and report-unit interpretation
+
+## Start Here
+
+- `components/resource_control/src/lib.rs`
+- `components/resource_control/src/resource_group.rs`
+- `components/resource_control/src/resource_limiter.rs`
+- `components/resource_control/src/service.rs`
+- `components/resource_control/src/config.rs`
+- `components/resource_control/src/worker.rs`
+- `components/resource_control/src/score.rs`
+- `components/resource_control/src/future.rs`
+- `components/resource_control/src/channel.rs`
+- `src/read_pool.rs` (external caller coupled to the read-pool contract below)
+
+## Must-Read File Order
+
+1. `components/resource_control/src/lib.rs`
+2. `components/resource_control/src/config.rs`
+3. `components/resource_control/src/resource_group.rs`
+4. `components/resource_control/src/resource_limiter.rs`
+5. `components/resource_control/src/service.rs`
+6. `components/resource_control/src/worker.rs`
+7. `components/resource_control/src/score.rs`
+8. `components/resource_control/src/future.rs`
+9. `components/resource_control/src/channel.rs`
+
+## Main Responsibilities
+
+- maintain `ResourceGroupManager`
+- track per-group quotas and consumption
+- wrap execution with `ControlledFuture` / `with_resource_limiter`
+- watch resource-group definitions from PD meta storage
+- report background RU usage back to PD
+- adjust quotas and throttling behavior periodically
+- expose fair scheduling and admission-control decisions to callers
+- compute common CPU/IO/compaction pressure scores (`score.rs`) shared by
+  background quota adjustment and foreground/read-pool throttling
+- expose a read-pool CPU-pressure/target-CPU contract that `src/read_pool.rs`
+  consumes to drive unified-read-pool scale in/out
+
+## Important Design Points
+
+- `service.rs` is the PD-facing control plane. It reloads resource groups,
+  watches config paths, and retries on compaction or transient failures.
+- `resource_group.rs` is the policy core. It contains:
+  - resource group state
+  - virtual-time and baseline logic
+  - admission decisions
+  - fairness/two-phase scheduling helpers
+- `resource_limiter.rs` is the actual limiter and statistics store.
+- `worker.rs` adjusts background quota and related runtime state periodically.
+  Each tick it measures CPU/IO/compaction inputs, calls
+  `score::compute_resource_scores` to get `cpu_score`/`io_score`/
+  `compaction_score`, uses `cpu_score`/`io_score` for its own background-quota
+  adjustment, and passes `cpu_score` to
+  `ResourceGroupManager::online_adjust_resource_quota` so the same signal
+  drives foreground throttling and read-pool scheduling in `resource_group.rs`.
+- `score.rs` is the shared pressure-scoring module. `compute_resource_scores`
+  turns raw CPU/IO/compaction measurements into three independent 0-100
+  scores; `pressure_fraction` maps a score onto a `[0, 1]` pressure fraction
+  against caller-supplied thresholds; `ThreadGroupCpuTracker` measures CPU
+  cores consumed by threads matching a name prefix (e.g.
+  `UNIFIED_READ_POOL_THREAD`, `GRPC_SERVER_THREAD`) via `/proc` thread stats.
+  This is the one shared code path behind both background quota adjustment
+  (`worker.rs`) and foreground/read-pool throttling (`resource_group.rs`) — a
+  bug here silently skews both.
+- `config.rs` defines dynamic policy knobs such as fair scheduling and
+  admission-control thresholds.
+
+## Cross-Component Contract: Unified Read Pool Coupling
+
+`ResourceGroupManager` exposes a small API that `src/read_pool.rs` depends on
+to scale the unified read pool's thread count under foreground CPU pressure.
+This is a real cross-crate contract, not an internal implementation detail —
+changes to either side must keep the other consistent:
+
+> **`enable-fair-scheduling` requires `readpool.unified.auto-adjust-pool-size`.**
+> A group is deprioritised while the pool is scaled in and released once the
+> pool recovers to `core_thread_count`, so pool movement *is* the release
+> signal. `adjust_pool_size` returns early when auto-adjustment is off, which
+> means the pool never moves and no group is ever deprioritised. Since
+> `auto-adjust-pool-size` defaults to false, enabling fair scheduling on its
+> own silently does nothing. This is deliberately not rejected at config load,
+> to stay backward compatible with configs that already set only one of them.
+
+
+- `online_adjust_resource_quota(cpu_score)` — called once per tick from
+  `worker.rs` with the shared `cpu_score` from `score::compute_resource_scores`.
+  Internally refreshes `read_pool_cpu_pressure` (a `[0, 1]` fraction, `0` when
+  foreground is not under pressure) and `read_pool_scale_up_allowed` (whether
+  CPU is comfortably idle enough to let the read pool grow back toward its
+  max).
+- `compute_read_pool_target_cpu(read_pool_cpu, interval_secs)` — the read
+  pool's actual scale-down input. Records `read_pool_cpu` into a historical
+  tracker and returns either `f64::INFINITY` (no ceiling — caller's own
+  ceiling wins) or a target below `read_pool_cpu` that slides toward the
+  historical-CPU floor as pressure increases. This only ever scales down; the
+  read pool itself converts the target into a thread count and owns scale-up.
+- `read_pool_scale_up_allowed()` — read pool consults this before growing its
+  thread count back up.
+- `read_pool_cpu_floor(read_pool_cpu, interval_secs)` — lower-level primitive
+  behind `compute_read_pool_target_cpu`; records usage into the historical
+  tracker and returns the floor CPU on its own.
+
+Invariant: `compute_read_pool_target_cpu` must never return a target above
+`read_pool_cpu` when pressure is engaged; a caller `min()`-ing this into its
+own ceiling relies on `INFINITY` (not the current usage) as the "no pressure"
+value. If you change the pressure/threshold math in `resource_group.rs`,
+re-check the read-pool scaling tests in `src/read_pool.rs` (search for
+`online_adjust_resource_quota`, `read_pool_cpu_pressure`,
+`read_pool_scale_up_allowed`).
+
+## Critical Invariants
+
+- Group configuration must converge safely when PD watch streams restart or the
+  watch revision is compacted.
+- Accounting paths must remain cheap because they can sit on hot request paths.
+- Admission control and fair scheduling must degrade specific traffic classes,
+  not accidentally all traffic.
+- Dynamic config updates must alter runtime behavior, not only the stored config
+  value.
+- Background-group reporting must not silently double-count or regress versioned
+  limiter statistics.
+
+## Observability And Operational Signals
+
+- limiter and scheduling metrics in `metrics.rs`
+- logs on PD watch/reload failures, compaction restarts, and config loads
+- RU reporting cadence and background-group behavior
+
+Start triage with:
+
+- `metrics.rs`
+- `service.rs` watch/reload logs
+- `worker.rs` quota-adjustment logic
+
+## Change Management Guidance
+
+- If policy knobs, admission behavior, or PD metadata contracts change, update
+  this guide in the same patch.
+- If callers in storage/server/batch-system start depending on new semantics,
+  update both ends of the contract.
+- Fairness or admission changes should come with before/after reasoning about
+  who gets delayed, who gets rejected, and under which pressure signal.
+
+## Change-Impact Matrix
+
+- PD watch or config reload changes:
+  inspect `service.rs`, PD client interactions, and caller assumptions about
+  convergence
+- Fairness or baseline changes:
+  inspect `resource_group.rs`, `resource_limiter.rs`, and hot-path consumers in
+  storage/server
+- Request admission or delay/reject changes:
+  inspect `future.rs`, `channel.rs`, `src/server/service/kv.rs`, and
+  `src/storage`
+- Background RU reporting changes:
+  inspect `worker.rs`, limiter statistics, and PD-facing reporting contracts
+- Config knob changes:
+  inspect `config.rs`, runtime update sites, metrics, and reviewer-facing docs
+- Pressure-scoring changes (`score.rs`):
+  inspect both consumers — background quota adjustment in `worker.rs` and
+  foreground/read-pool throttling in `resource_group.rs` — since they share
+  the same `cpu_score`/`io_score`/`compaction_score` computation
+- Read-pool coupling changes (`online_adjust_resource_quota`,
+  `compute_read_pool_target_cpu`, `read_pool_scale_up_allowed`,
+  `read_pool_cpu_floor`):
+  inspect both `resource_group.rs` and `src/read_pool.rs`; update this guide's
+  "Cross-Component Contract" section in the same change
+
+## Review Checklist
+
+- Does the change affect `watch_resource_groups`, reload, or retry behavior?
+- Does it alter fairness phase encoding, priority ordering, or baseline logic?
+- Does it change request rejection versus delay behavior?
+- Does it change accounting units or resource-cost interpretation?
+- Does it create lock contention in the hot path?
+- Does it update metrics and tests for new scheduling outcomes?
+- Does it touch `score.rs`? If so, does it affect both the background
+  (`worker.rs`) and foreground/read-pool (`resource_group.rs`) consumers as
+  intended?
+- Does it touch the read-pool coupling API (`online_adjust_resource_quota`,
+  `compute_read_pool_target_cpu`, `read_pool_scale_up_allowed`,
+  `read_pool_cpu_floor`)? If so, is `src/read_pool.rs` updated and are its
+  scaling tests still valid?
+
+## Observability And Tests
+
+- Metrics live under `metrics.rs` and within the group/limiter code.
+- Many unit tests are inline in:
+  `future.rs`, `service.rs`, `worker.rs`, `channel.rs`, `resource_limiter.rs`,
+  and `score.rs`.
+- Changes should usually be validated together with the call sites in
+  `src/server`, `src/storage`, `components/batch-system`, and (for
+  pressure-scoring / read-pool coupling changes) `src/read_pool.rs`.
+
+## Common Failure Modes
+
+- watcher stalls after compaction or transient PD errors
+- starvation due to incorrect priority or baseline math
+- too-aggressive shedding that impacts non-target traffic
+- silently stale background-limiter reporting
+- dynamic-config changes that fail to take effect operationally
+- transient `/proc` read failures in `ThreadGroupCpuTracker` corrupting the
+  next tick's CPU delta baseline (see `score.rs`)
+- read-pool scale-down target computed from stale or unrecorded
+  `read_pool_cpu` history, causing the read pool to over- or under-shrink
+
+## Reading Map And Companion Docs
+
+Suggested reading order:
+
+1. `lib.rs`
+2. `config.rs`
+3. `resource_group.rs`
+4. `resource_limiter.rs`
+5. `service.rs`
+6. `worker.rs`
+7. `score.rs`
+8. `future.rs`
+
+Companion docs:
+
+- `repo-overview.md`
+- `src/server.md`
+- `src/storage.md`
+- `src/read_pool.rs` — no dedicated guide yet; see "Cross-Component Contract:
+  Unified Read Pool Coupling" above for the API surface it depends on here
+
+## Glossary
+
+- RU:
+  request unit used for resource accounting
+- Baseline:
+  historical usage reference for fairness and admission control
+- Admission control:
+  delay or reject logic under pressure
+- Virtual time:
+  scheduling progress notion used to compare group fairness state
+- Resource score (`cpu_score`/`io_score`/`compaction_score`):
+  0-100 utilization percentages from `score::compute_resource_scores`, shared
+  by background quota adjustment and foreground/read-pool throttling
+- Pressure fraction:
+  a score mapped to `[0, 1]` via `score::pressure_fraction` against a
+  caller-supplied `(start, end)` threshold range; drives both background
+  throttling and read-pool target-CPU scaling
+- Read-pool target CPU:
+  the scale-down ceiling `resource_group.rs::compute_read_pool_target_cpu`
+  hands to `src/read_pool.rs`; `INFINITY` means no pressure-driven ceiling
+
+## Related Components
+
+- `src/server/service/kv.rs` consumes resource-group context at the RPC edge.
+- `src/storage` uses resource-control metadata and limiters during scheduling.
+- `src/read_pool.rs` consumes `ResourceGroupManager`'s pressure/target-CPU API
+  (see "Cross-Component Contract: Unified Read Pool Coupling" above) to scale
+  the unified read pool's thread count under foreground CPU pressure.
+- `components/batch-system` integrates with priority-aware execution.

--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -616,9 +616,12 @@
 ## When storage.engine is "partitioned-raft-kv", default value is 0.
 # stats-dump-period = "10m"
 
-## Refer to: https://github.com/facebook/rocksdb/wiki/RocksDB-FAQ
-## If you want to use RocksDB on multi disks or spinning disks, you should set value at least 2MB.
-# compaction-readahead-size = 0
+## RocksDB 8.x compaction no longer relies on the old setup-time file hint path,
+## so TiKV keeps compaction readahead enabled by default instead of forcing it
+## to 0. Refer to: https://github.com/facebook/rocksdb/wiki/RocksDB-FAQ
+## If you want to use RocksDB on multi disks or spinning disks, you should set
+## value at least 2MB.
+# compaction-readahead-size = "2MB"
 
 ## Max buffer size that is used by WritableFileWrite.
 # writable-file-max-buffer-size = "1MB"
@@ -1088,7 +1091,9 @@
 ## Do not set this config the same as `rocksdb.wal-dir`.
 # wal-dir = ""
 
-# compaction-readahead-size = 0
+## Keep compaction readahead enabled by default for the same reason as
+## `rocksdb.compaction-readahead-size`.
+# compaction-readahead-size = "2MB"
 # writable-file-max-buffer-size = "1MB"
 # use-direct-io-for-flush-and-compaction = false
 # enable-pipelined-write = true

--- a/metrics/grafana/common.py
+++ b/metrics/grafana/common.py
@@ -492,7 +492,7 @@ def expr_count_rate(
 
     count(rate(
         tikv_thread_cpu_seconds_total
-        {k8s_cluster="$k8s_cluster",tidb_cluster="$tidb_cluster",instance=~"$instance",name=~"sst_.*"}
+        {k8s_cluster="$k8s_cluster",tidb_cluster="$tidb_cluster",instance=~"$instance",name=~"(sst_|impwkr).*"}
         [$__rate_interval]
     )) by (instance)
     """

--- a/metrics/grafana/tikv_details.dashboard.py
+++ b/metrics/grafana/tikv_details.dashboard.py
@@ -10284,7 +10284,7 @@ def ResourceControl() -> RowPanel:
                     target(
                         expr=expr_sum_rate(
                             "tikv_resource_control_background_task_wait_duration",
-                            by_labels=["instance", "resource_group"],
+                            by_labels=["instance"],
                         ),
                     ),
                 ],
@@ -10298,6 +10298,271 @@ def ResourceControl() -> RowPanel:
                         expr=expr_sum(
                             "tikv_resource_control_priority_quota_limit",
                             by_labels=["instance", "priority"],
+                        ),
+                    ),
+                ],
+            ),
+        ]
+    )
+    layout.row(
+        [
+            graph_panel(
+                title="Analyze read ops per second (total vs block read)",
+                yaxes=yaxes(left_format=UNITS.OPS_PER_SEC),
+                targets=[
+                    target(
+                        expr=expr_sum_rate(
+                            "tikv_analyze_metrics_total",
+                            label_selectors=['metric="read_total_op_count"'],
+                            by_labels=["instance"],
+                        ),
+                        legend_format="total-op/{{instance}}",
+                    ),
+                    target(
+                        expr=expr_sum_rate(
+                            "tikv_analyze_metrics_total",
+                            label_selectors=['metric="read_iops"'],
+                            by_labels=["instance"],
+                        ),
+                        legend_format="block-read/{{instance}}",
+                    ),
+                    target(
+                        expr=expr_sum_rate(
+                            "tikv_coprocessor_rocksdb_perf",
+                            label_selectors=[
+                                'req="analyze_full_sampling"',
+                                'metric="block_read_count"',
+                            ],
+                            by_labels=["instance"],
+                        ),
+                        legend_format="copr-block-read/{{instance}}",
+                    ),
+                ],
+            ),
+            graph_panel(
+                title="Analyze next batch count per second",
+                yaxes=yaxes(left_format=UNITS.OPS_PER_SEC),
+                targets=[
+                    target(
+                        expr=expr_sum_rate(
+                            "tikv_analyze_metrics_total",
+                            label_selectors=['metric="next_batch_count"'],
+                            by_labels=["instance"],
+                        ),
+                        legend_format="{{instance}}",
+                    ),
+                ],
+            ),
+        ]
+    )
+    return layout.row_panel
+
+
+def LoadShedding() -> RowPanel:
+    layout = Layout(title="Load Shedding")
+    # Row 1: RU rates per group
+    layout.row(
+        [
+            graph_panel(
+                title="CPU Utilization % per Resource Group",
+                description="Historical baseline and current CPU utilization % per resource group (100% = 1 core).",
+                yaxes=yaxes(left_format=UNITS.PERCENT_FORMAT),
+                targets=[
+                    target(
+                        expr=expr_sum(
+                            "tikv_resource_control_group_ru_historical_rate",
+                            by_labels=["resource_group"],
+                        ).extra(" > 0"),
+                        legend_format="historical-{{resource_group}}",
+                    ),
+                    target(
+                        expr=expr_sum(
+                            "tikv_resource_control_group_ru_current_rate",
+                            by_labels=["resource_group"],
+                        ).extra(" > 0"),
+                        legend_format="current-{{resource_group}}",
+                    ),
+                ],
+            ),
+            graph_panel(
+                title="Background Resource Utilization",
+                description="Total resource utilization percentage of background tasks.",
+                yaxes=yaxes(left_format=UNITS.PERCENT_FORMAT),
+                targets=[
+                    target(
+                        expr=expr_sum(
+                            "tikv_resource_control_bg_resource_utilization",
+                            by_labels=["type"],
+                        ).extra(" > 0"),
+                    ),
+                ],
+            ),
+        ]
+    )
+    # Row 2: Quota limits
+    layout.row(
+        [
+            graph_panel(
+                title="Resource Group Quota Limit",
+                description="Current rate limit per resource group (0 = unlimited, hidden).",
+                targets=[
+                    target(
+                        expr=expr_sum(
+                            "tikv_resource_control_group_quota_limit",
+                            by_labels=["resource_group", "type"],
+                        ).extra(" > 0"),
+                    ),
+                ],
+            ),
+            graph_panel(
+                title="Background Quota Limit",
+                description="Current quota limit for background resource groups.",
+                targets=[
+                    target(
+                        expr=expr_sum(
+                            "tikv_resource_control_background_quota_limiter",
+                            by_labels=["resource_group", "type"],
+                        ).extra(" > 0"),
+                    ),
+                ],
+            ),
+        ]
+    )
+    # Row 3: Deprioritized/delayed/rejected + currently delayed
+    layout.row(
+        [
+            graph_panel(
+                title="Deprioritized / Delayed / Rejected Requests",
+                description="Rate of deprioritized (phase 1), delayed, and rejected requests.",
+                yaxes=yaxes(left_format=UNITS.OPS_PER_SEC),
+                targets=[
+                    target(
+                        expr=expr_sum_rate(
+                            "tikv_resource_control_two_phase_throttled_requests_total",
+                            by_labels=["resource_group"],
+                        ).extra(" > 0"),
+                        legend_format="deprioritized-{{resource_group}}",
+                    ),
+                    target(
+                        expr=expr_sum_rate(
+                            "tikv_resource_control_admission_delayed_requests_total",
+                            by_labels=["resource_group", "is_background"],
+                        ).extra(" > 0"),
+                        legend_format="delayed-{{resource_group}}-{{is_background}}",
+                    ),
+                    target(
+                        expr=expr_sum_rate(
+                            "tikv_resource_control_admission_rejected_requests_total",
+                            by_labels=["resource_group", "is_background"],
+                        ).extra(" > 0"),
+                        legend_format="rejected-{{resource_group}}-{{is_background}}",
+                    ),
+                ],
+            ),
+            graph_panel(
+                title="Currently Delayed Requests",
+                description="Number of requests currently sitting in admission control delay.",
+                targets=[
+                    target(
+                        expr=expr_sum(
+                            "tikv_resource_control_admission_currently_delayed",
+                        ).extra(" > 0"),
+                    ),
+                ],
+            ),
+        ]
+    )
+    # Row 4: Delay duration + background wait duration
+    layout.row(
+        [
+            graph_panel_histogram_quantiles(
+                title="Admission Delay Duration",
+                description="Delay duration imposed by foreground admission control.",
+                yaxes=yaxes(left_format=UNITS.SECONDS),
+                metric="tikv_resource_control_admission_delay_duration_seconds",
+                label_selectors=['is_background="false"'],
+                by_labels=["resource_group"],
+            ),
+            graph_panel(
+                title="Background Task Wait Duration",
+                description="Total wait duration of background tasks per resource group.",
+                yaxes=yaxes(left_format=UNITS.MICRO_SECONDS),
+                targets=[
+                    target(
+                        expr=expr_sum_rate(
+                            "tikv_resource_control_background_task_wait_duration",
+                            by_labels=["resource_group"],
+                        ).extra(" > 0"),
+                    ),
+                ],
+            ),
+        ]
+    )
+    return layout.row_panel
+
+
+def TikvConfig() -> RowPanel:
+    layout = Layout(title="Config")
+    # RocksDB DB Configuration Table
+    layout.row(
+        [
+            table_panel(
+                title="RocksDB DB Config",
+                description="TiKV RocksDB DB Configuration",
+                targets=[
+                    target(
+                        expr=expr_simple(
+                            "tikv_config_rocksdb_db",
+                        ),
+                    ),
+                ],
+            ),
+        ]
+    )
+    # RocksDB CF Configuration Table
+    layout.row(
+        [
+            table_panel(
+                title="RocksDB CF Config",
+                description="TiKV RocksDB CF Configuration",
+                targets=[
+                    target(
+                        expr=expr_simple(
+                            "tikv_config_rocksdb_cf",
+                        ).extra(
+                            " or (tikv_config_rocksdb unless tikv_config_rocksdb_cf)"
+                        ),
+                    ),
+                ],
+            ),
+        ]
+    )
+    # Flow Control Configuration Table
+    layout.row(
+        [
+            table_panel(
+                title="Flow Control Config",
+                description="TiKV Flow Control Configuration",
+                targets=[
+                    target(
+                        expr=expr_simple(
+                            "tikv_config_flow_control",
+                        ),
+                    ),
+                ],
+            ),
+        ]
+    )
+    # Raftstore Configuration Table
+    layout.row(
+        [
+            table_panel(
+                title="Raftstore Config",
+                description="TiKV Raftstore Configuration",
+                targets=[
+                    target(
+                        expr=expr_simple(
+                            "tikv_config_raftstore",
                         ),
                     ),
                 ],
@@ -10371,6 +10636,7 @@ dashboard = Dashboard(
         Memory(),
         # Infrequently Used
         ResourceControl(),
+        LoadShedding(),
         StatusServer(),
         Encryption(),
         TTL(),

--- a/metrics/grafana/tikv_details.dashboard.py
+++ b/metrics/grafana/tikv_details.dashboard.py
@@ -1383,7 +1383,7 @@ def ThreadCPU() -> RowPanel:
                     target(
                         expr=expr_sum_rate(
                             "tikv_thread_cpu_seconds_total",
-                            label_selectors=['name=~"sst_.*"'],
+                            label_selectors=['name=~"(sst_|impwkr_).*"'],
                         ),
                     ),
                 ],

--- a/metrics/grafana/tikv_details.dashboard.py
+++ b/metrics/grafana/tikv_details.dashboard.py
@@ -10368,7 +10368,7 @@ def LoadShedding() -> RowPanel:
         [
             graph_panel(
                 title="CPU Utilization % per Resource Group",
-                description="Historical baseline and current CPU utilization % per resource group (100% = 1 core).",
+                description="Historical (live sliding average), baseline (frozen while the group is selected as noisy) and current CPU utilization % per resource group (100% = 1 core).",
                 yaxes=yaxes(left_format=UNITS.PERCENT_FORMAT),
                 targets=[
                     target(
@@ -10377,6 +10377,13 @@ def LoadShedding() -> RowPanel:
                             by_labels=["resource_group"],
                         ).extra(" > 0"),
                         legend_format="historical-{{resource_group}}",
+                    ),
+                    target(
+                        expr=expr_sum(
+                            "tikv_resource_control_group_ru_baseline",
+                            by_labels=["resource_group"],
+                        ).extra(" > 0"),
+                        legend_format="baseline-{{resource_group}}",
                     ),
                     target(
                         expr=expr_sum(
@@ -10402,7 +10409,7 @@ def LoadShedding() -> RowPanel:
             ),
             graph_panel(
                 title="Unified Read Pool CPU",
-                description="Historical (floor), current (measured), and target (foreground-pressure-driven ceiling) CPU usage of the unified read pool, as a percentage of one core (100 = 1 core).",
+                description="Historical (live sliding average), baseline (floor frozen at overload onset), current (measured), and target (foreground-pressure-driven ceiling) CPU usage of the unified read pool, as a percentage of one core (100 = 1 core).",
                 yaxes=yaxes(left_format=UNITS.PERCENT_FORMAT),
                 targets=[
                     target(
@@ -10536,6 +10543,27 @@ def LoadShedding() -> RowPanel:
                         ),
                         legend_format="avg-{{resource_group}}",
                         additional_groupby=True,
+                    ),
+                ],
+            ),
+            graph_panel(
+                title="Read Pool Rejections",
+                description="Requests rejected before they enter the unified read pool, per resource group. `busy-threshold` is the client's own gate, sent as `busy_threshold_ms` from TiDB's `tidb_load_based_replica_read_threshold`: TiKV answers ServerIsBusy with its estimated wait and the client retries the read on an idle follower, so a high rate here is a redirect signal, not an error rate. `pool-full` is the queue capacity gate and has no such fallback -- the client sees a retry against the same leader.",
+                yaxes=yaxes(left_format=UNITS.OPS_PER_SEC),
+                targets=[
+                    target(
+                        expr=expr_sum_rate(
+                            "tikv_unified_read_pool_busy_threshold_rejected_total",
+                            by_labels=["resource_group"],
+                        ).extra(" > 0"),
+                        legend_format="busy-threshold-{{resource_group}}",
+                    ),
+                    target(
+                        expr=expr_sum_rate(
+                            "tikv_unified_read_pool_full_rejected_total",
+                            by_labels=["resource_group"],
+                        ).extra(" > 0"),
+                        legend_format="pool-full-{{resource_group}}",
                     ),
                 ],
             ),

--- a/metrics/grafana/tikv_details.dashboard.py
+++ b/metrics/grafana/tikv_details.dashboard.py
@@ -10293,18 +10293,6 @@ def ResourceControl() -> RowPanel:
     layout.row(
         [
             graph_panel(
-                title="Background Task Total Wait Duration",
-                yaxes=yaxes(left_format=UNITS.MICRO_SECONDS),
-                targets=[
-                    target(
-                        expr=expr_sum_rate(
-                            "tikv_resource_control_background_task_wait_duration",
-                            by_labels=["instance"],
-                        ),
-                    ),
-                ],
-            ),
-            graph_panel(
                 title="Priority Quota Limit",
                 description="The memory usage of the resource control module.",
                 yaxes=yaxes(left_format=UNITS.MICRO_SECONDS),
@@ -10401,14 +10389,42 @@ def LoadShedding() -> RowPanel:
             ),
             graph_panel(
                 title="Background Resource Utilization",
-                description="Total resource utilization percentage of background tasks.",
-                yaxes=yaxes(left_format=UNITS.PERCENT_FORMAT),
+                description="Total resource consumed by background tasks, in centi-cores (cores * 100) for CPU or bytes/s for IO.",
+                yaxes=yaxes(left_format=UNITS.SHORT),
                 targets=[
                     target(
                         expr=expr_sum(
                             "tikv_resource_control_bg_resource_utilization",
                             by_labels=["type"],
                         ).extra(" > 0"),
+                    ),
+                ],
+            ),
+            graph_panel(
+                title="Unified Read Pool CPU",
+                description="Historical (floor), current (measured), and target (foreground-pressure-driven ceiling) CPU usage of the unified read pool, as a percentage of one core (100 = 1 core).",
+                yaxes=yaxes(left_format=UNITS.PERCENT_FORMAT),
+                targets=[
+                    target(
+                        expr=expr_sum(
+                            "tikv_resource_control_read_pool_cpu_percent",
+                            by_labels=["instance", "type"],
+                        ),
+                        legend_format="{{type}}-{{instance}}",
+                    ),
+                ],
+            ),
+            graph_panel(
+                title="Resource Pressure Scores",
+                description="Common 0-100 resource-pressure score per resource type (cpu, io, compaction) used to drive background/foreground throttling.",
+                yaxes=yaxes(left_format=UNITS.SHORT),
+                targets=[
+                    target(
+                        expr=expr_sum(
+                            "tikv_resource_control_resource_score",
+                            by_labels=["instance", "type"],
+                        ),
+                        legend_format="{{type}}-{{instance}}",
                     ),
                 ],
             ),
@@ -10431,7 +10447,7 @@ def LoadShedding() -> RowPanel:
             ),
             graph_panel(
                 title="Background Quota Limit",
-                description="Current quota limit for background resource groups.",
+                description="Current quota limit for background resource groups, in centi-cores (cores * 100) for CPU or bytes/s for IO.",
                 targets=[
                     target(
                         expr=expr_sum(
@@ -10461,16 +10477,16 @@ def LoadShedding() -> RowPanel:
                     target(
                         expr=expr_sum_rate(
                             "tikv_resource_control_admission_delayed_requests_total",
-                            by_labels=["resource_group", "is_background"],
+                            by_labels=["resource_group"],
                         ).extra(" > 0"),
-                        legend_format="delayed-{{resource_group}}-{{is_background}}",
+                        legend_format="delayed-{{resource_group}}",
                     ),
                     target(
                         expr=expr_sum_rate(
                             "tikv_resource_control_admission_rejected_requests_total",
-                            by_labels=["resource_group", "is_background"],
+                            by_labels=["resource_group"],
                         ).extra(" > 0"),
-                        legend_format="rejected-{{resource_group}}-{{is_background}}",
+                        legend_format="rejected-{{resource_group}}",
                     ),
                 ],
             ),
@@ -10487,27 +10503,39 @@ def LoadShedding() -> RowPanel:
             ),
         ]
     )
-    # Row 4: Delay duration + background wait duration
+    # Row 4: Delay duration
     layout.row(
         [
-            graph_panel_histogram_quantiles(
+            graph_panel(
                 title="Admission Delay Duration",
                 description="Delay duration imposed by foreground admission control.",
                 yaxes=yaxes(left_format=UNITS.SECONDS),
-                metric="tikv_resource_control_admission_delay_duration_seconds",
-                label_selectors=['is_background="false"'],
-                by_labels=["resource_group"],
-            ),
-            graph_panel(
-                title="Background Task Wait Duration",
-                description="Total wait duration of background tasks per resource group.",
-                yaxes=yaxes(left_format=UNITS.MICRO_SECONDS),
                 targets=[
                     target(
-                        expr=expr_sum_rate(
-                            "tikv_resource_control_background_task_wait_duration",
+                        expr=expr_histogram_quantile(
+                            0.9999,
+                            "tikv_resource_control_admission_delay_duration_seconds",
                             by_labels=["resource_group"],
-                        ).extra(" > 0"),
+                        ),
+                        legend_format="99.99%-{{resource_group}}",
+                        additional_groupby=True,
+                    ),
+                    target(
+                        expr=expr_histogram_quantile(
+                            0.99,
+                            "tikv_resource_control_admission_delay_duration_seconds",
+                            by_labels=["resource_group"],
+                        ),
+                        legend_format="99%-{{resource_group}}",
+                        additional_groupby=True,
+                    ),
+                    target(
+                        expr=expr_histogram_avg(
+                            "tikv_resource_control_admission_delay_duration_seconds",
+                            by_labels=["resource_group"],
+                        ),
+                        legend_format="avg-{{resource_group}}",
+                        additional_groupby=True,
                     ),
                 ],
             ),

--- a/metrics/grafana/tikv_details.dashboard.py
+++ b/metrics/grafana/tikv_details.dashboard.py
@@ -10284,7 +10284,7 @@ def ResourceControl() -> RowPanel:
                     target(
                         expr=expr_sum_rate(
                             "tikv_resource_control_background_task_wait_duration",
-                            by_labels=["instance", "resource_group"],
+                            by_labels=["instance"],
                         ),
                     ),
                 ],

--- a/metrics/grafana/tikv_details.dashboard.py
+++ b/metrics/grafana/tikv_details.dashboard.py
@@ -10304,6 +10304,271 @@ def ResourceControl() -> RowPanel:
             ),
         ]
     )
+    layout.row(
+        [
+            graph_panel(
+                title="Analyze read ops per second (total vs block read)",
+                yaxes=yaxes(left_format=UNITS.OPS_PER_SEC),
+                targets=[
+                    target(
+                        expr=expr_sum_rate(
+                            "tikv_analyze_metrics_total",
+                            label_selectors=['metric="read_total_op_count"'],
+                            by_labels=["instance"],
+                        ),
+                        legend_format="total-op/{{instance}}",
+                    ),
+                    target(
+                        expr=expr_sum_rate(
+                            "tikv_analyze_metrics_total",
+                            label_selectors=['metric="read_iops"'],
+                            by_labels=["instance"],
+                        ),
+                        legend_format="block-read/{{instance}}",
+                    ),
+                    target(
+                        expr=expr_sum_rate(
+                            "tikv_coprocessor_rocksdb_perf",
+                            label_selectors=[
+                                'req="analyze_full_sampling"',
+                                'metric="block_read_count"',
+                            ],
+                            by_labels=["instance"],
+                        ),
+                        legend_format="copr-block-read/{{instance}}",
+                    ),
+                ],
+            ),
+            graph_panel(
+                title="Analyze next batch count per second",
+                yaxes=yaxes(left_format=UNITS.OPS_PER_SEC),
+                targets=[
+                    target(
+                        expr=expr_sum_rate(
+                            "tikv_analyze_metrics_total",
+                            label_selectors=['metric="next_batch_count"'],
+                            by_labels=["instance"],
+                        ),
+                        legend_format="{{instance}}",
+                    ),
+                ],
+            ),
+        ]
+    )
+    return layout.row_panel
+
+
+def LoadShedding() -> RowPanel:
+    layout = Layout(title="Load Shedding")
+    # Row 1: RU rates per group
+    layout.row(
+        [
+            graph_panel(
+                title="CPU Utilization % per Resource Group",
+                description="Historical baseline and current CPU utilization % per resource group (100% = 1 core).",
+                yaxes=yaxes(left_format=UNITS.PERCENT_FORMAT),
+                targets=[
+                    target(
+                        expr=expr_sum(
+                            "tikv_resource_control_group_ru_historical_rate",
+                            by_labels=["resource_group"],
+                        ).extra(" > 0"),
+                        legend_format="historical-{{resource_group}}",
+                    ),
+                    target(
+                        expr=expr_sum(
+                            "tikv_resource_control_group_ru_current_rate",
+                            by_labels=["resource_group"],
+                        ).extra(" > 0"),
+                        legend_format="current-{{resource_group}}",
+                    ),
+                ],
+            ),
+            graph_panel(
+                title="Background Resource Utilization",
+                description="Total resource utilization percentage of background tasks.",
+                yaxes=yaxes(left_format=UNITS.PERCENT_FORMAT),
+                targets=[
+                    target(
+                        expr=expr_sum(
+                            "tikv_resource_control_bg_resource_utilization",
+                            by_labels=["type"],
+                        ).extra(" > 0"),
+                    ),
+                ],
+            ),
+        ]
+    )
+    # Row 2: Quota limits
+    layout.row(
+        [
+            graph_panel(
+                title="Resource Group Quota Limit",
+                description="Current rate limit per resource group (0 = unlimited, hidden).",
+                targets=[
+                    target(
+                        expr=expr_sum(
+                            "tikv_resource_control_group_quota_limit",
+                            by_labels=["resource_group", "type"],
+                        ).extra(" > 0"),
+                    ),
+                ],
+            ),
+            graph_panel(
+                title="Background Quota Limit",
+                description="Current quota limit for background resource groups.",
+                targets=[
+                    target(
+                        expr=expr_sum(
+                            "tikv_resource_control_background_quota_limiter",
+                            by_labels=["resource_group", "type"],
+                        ).extra(" > 0"),
+                    ),
+                ],
+            ),
+        ]
+    )
+    # Row 3: Deprioritized/delayed/rejected + currently delayed
+    layout.row(
+        [
+            graph_panel(
+                title="Deprioritized / Delayed / Rejected Requests",
+                description="Rate of deprioritized (phase 1), delayed, and rejected requests.",
+                yaxes=yaxes(left_format=UNITS.OPS_PER_SEC),
+                targets=[
+                    target(
+                        expr=expr_sum_rate(
+                            "tikv_resource_control_two_phase_throttled_requests_total",
+                            by_labels=["resource_group"],
+                        ).extra(" > 0"),
+                        legend_format="deprioritized-{{resource_group}}",
+                    ),
+                    target(
+                        expr=expr_sum_rate(
+                            "tikv_resource_control_admission_delayed_requests_total",
+                            by_labels=["resource_group", "is_background"],
+                        ).extra(" > 0"),
+                        legend_format="delayed-{{resource_group}}-{{is_background}}",
+                    ),
+                    target(
+                        expr=expr_sum_rate(
+                            "tikv_resource_control_admission_rejected_requests_total",
+                            by_labels=["resource_group", "is_background"],
+                        ).extra(" > 0"),
+                        legend_format="rejected-{{resource_group}}-{{is_background}}",
+                    ),
+                ],
+            ),
+            graph_panel(
+                title="Currently Delayed Requests",
+                description="Number of requests currently sitting in admission control delay.",
+                targets=[
+                    target(
+                        expr=expr_sum(
+                            "tikv_resource_control_admission_currently_delayed",
+                        ).extra(" > 0"),
+                    ),
+                ],
+            ),
+        ]
+    )
+    # Row 4: Delay duration + background wait duration
+    layout.row(
+        [
+            graph_panel_histogram_quantiles(
+                title="Admission Delay Duration",
+                description="Delay duration imposed by foreground admission control.",
+                yaxes=yaxes(left_format=UNITS.SECONDS),
+                metric="tikv_resource_control_admission_delay_duration_seconds",
+                label_selectors=['is_background="false"'],
+                by_labels=["resource_group"],
+            ),
+            graph_panel(
+                title="Background Task Wait Duration",
+                description="Total wait duration of background tasks per resource group.",
+                yaxes=yaxes(left_format=UNITS.MICRO_SECONDS),
+                targets=[
+                    target(
+                        expr=expr_sum_rate(
+                            "tikv_resource_control_background_task_wait_duration",
+                            by_labels=["resource_group"],
+                        ).extra(" > 0"),
+                    ),
+                ],
+            ),
+        ]
+    )
+    return layout.row_panel
+
+
+def TikvConfig() -> RowPanel:
+    layout = Layout(title="Config")
+    # RocksDB DB Configuration Table
+    layout.row(
+        [
+            table_panel(
+                title="RocksDB DB Config",
+                description="TiKV RocksDB DB Configuration",
+                targets=[
+                    target(
+                        expr=expr_simple(
+                            "tikv_config_rocksdb_db",
+                        ),
+                    ),
+                ],
+            ),
+        ]
+    )
+    # RocksDB CF Configuration Table
+    layout.row(
+        [
+            table_panel(
+                title="RocksDB CF Config",
+                description="TiKV RocksDB CF Configuration",
+                targets=[
+                    target(
+                        expr=expr_simple(
+                            "tikv_config_rocksdb_cf",
+                        ).extra(
+                            " or (tikv_config_rocksdb unless tikv_config_rocksdb_cf)"
+                        ),
+                    ),
+                ],
+            ),
+        ]
+    )
+    # Flow Control Configuration Table
+    layout.row(
+        [
+            table_panel(
+                title="Flow Control Config",
+                description="TiKV Flow Control Configuration",
+                targets=[
+                    target(
+                        expr=expr_simple(
+                            "tikv_config_flow_control",
+                        ),
+                    ),
+                ],
+            ),
+        ]
+    )
+    # Raftstore Configuration Table
+    layout.row(
+        [
+            table_panel(
+                title="Raftstore Config",
+                description="TiKV Raftstore Configuration",
+                targets=[
+                    target(
+                        expr=expr_simple(
+                            "tikv_config_raftstore",
+                        ),
+                    ),
+                ],
+            ),
+        ]
+    )
     return layout.row_panel
 
 
@@ -10371,6 +10636,7 @@ dashboard = Dashboard(
         Memory(),
         # Infrequently Used
         ResourceControl(),
+        LoadShedding(),
         StatusServer(),
         Encryption(),
         TTL(),

--- a/metrics/grafana/tikv_details.dashboard.py
+++ b/metrics/grafana/tikv_details.dashboard.py
@@ -10163,6 +10163,21 @@ def SlowTrendStatistics() -> RowPanel:
                     ),
                 ],
             ),
+            graph_panel(
+                title="Disk Probe Duration",
+                description="The fail-fast disk probe duration by disk and outcome.",
+                yaxes=yaxes(left_format=UNITS.SECONDS),
+                targets=[
+                    target(
+                        expr=expr_histogram_quantile(
+                            0.99,
+                            "tikv_raftstore_disk_probe_duration_seconds",
+                            by_labels=["instance", "disk", "outcome"],
+                        ),
+                        legend_format="{{instance}}-{{disk}}-{{outcome}}-0.99",
+                    ),
+                ],
+            ),
         ]
     )
     layout.row(

--- a/metrics/grafana/tikv_details.json
+++ b/metrics/grafana/tikv_details.json
@@ -81157,15 +81157,15 @@
           "targets": [
             {
               "datasource": "${DS_TEST-CLUSTER}",
-              "expr": "sum(rate(\n    tikv_resource_control_background_task_wait_duration\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (instance, resource_group) ",
+              "expr": "sum(rate(\n    tikv_resource_control_background_task_wait_duration\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (instance) ",
               "format": "time_series",
               "hide": false,
               "instant": false,
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "{{instance}}-{{resource_group}}",
+              "legendFormat": "{{instance}}",
               "metric": "",
-              "query": "sum(rate(\n    tikv_resource_control_background_task_wait_duration\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (instance, resource_group) ",
+              "query": "sum(rate(\n    tikv_resource_control_background_task_wait_duration\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (instance) ",
               "refId": "",
               "step": 10,
               "target": ""
@@ -81347,6 +81347,302 @@
             "align": false,
             "alignLevel": 0
           }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "cacheTimeout": null,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": null,
+          "editable": true,
+          "error": false,
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              }
+            }
+          },
+          "fill": 1,
+          "fillGradient": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 7
+          },
+          "height": null,
+          "hideTimeOverride": false,
+          "id": 595,
+          "interval": null,
+          "isNew": true,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": null,
+            "sort": "max",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "maxDataPoints": null,
+          "maxPerRow": null,
+          "minSpan": null,
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true,
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "repeatDirection": null,
+          "seriesOverrides": [],
+          "span": null,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "sum(rate(\n    tikv_analyze_metrics_total\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",metric=\"read_total_op_count\"}\n    [$__rate_interval]\n)) by (instance) ",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "total-op/{{instance}}",
+              "metric": "",
+              "query": "sum(rate(\n    tikv_analyze_metrics_total\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",metric=\"read_total_op_count\"}\n    [$__rate_interval]\n)) by (instance) ",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            },
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "sum(rate(\n    tikv_analyze_metrics_total\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",metric=\"read_iops\"}\n    [$__rate_interval]\n)) by (instance) ",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "block-read/{{instance}}",
+              "metric": "",
+              "query": "sum(rate(\n    tikv_analyze_metrics_total\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",metric=\"read_iops\"}\n    [$__rate_interval]\n)) by (instance) ",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            },
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "sum(rate(\n    tikv_coprocessor_rocksdb_perf\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",req=\"analyze_full_sampling\",metric=\"block_read_count\"}\n    [$__rate_interval]\n)) by (instance) ",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "copr-block-read/{{instance}}",
+              "metric": "",
+              "query": "sum(rate(\n    tikv_coprocessor_rocksdb_perf\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",req=\"analyze_full_sampling\",metric=\"block_read_count\"}\n    [$__rate_interval]\n)) by (instance) ",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Analyze read ops per second (total vs block read)",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "transformations": [],
+          "transparent": false,
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "ops",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": 0
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "cacheTimeout": null,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": null,
+          "editable": true,
+          "error": false,
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              }
+            }
+          },
+          "fill": 1,
+          "fillGradient": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 7
+          },
+          "height": null,
+          "hideTimeOverride": false,
+          "id": 596,
+          "interval": null,
+          "isNew": true,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": null,
+            "sort": "max",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "maxDataPoints": null,
+          "maxPerRow": null,
+          "minSpan": null,
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true,
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "repeatDirection": null,
+          "seriesOverrides": [],
+          "span": null,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "sum(rate(\n    tikv_analyze_metrics_total\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",metric=\"next_batch_count\"}\n    [$__rate_interval]\n)) by (instance) ",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{instance}}",
+              "metric": "",
+              "query": "sum(rate(\n    tikv_analyze_metrics_total\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",metric=\"next_batch_count\"}\n    [$__rate_interval]\n)) by (instance) ",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Analyze next batch count per second",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "transformations": [],
+          "transparent": false,
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "ops",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": 0
+          }
         }
       ],
       "repeat": null,
@@ -81383,7 +81679,1226 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 595,
+      "id": 597,
+      "interval": null,
+      "links": [],
+      "maxDataPoints": 100,
+      "maxPerRow": null,
+      "minSpan": null,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "cacheTimeout": null,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "Historical baseline and current CPU utilization % per resource group (100% = 1 core).",
+          "editable": true,
+          "error": false,
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              }
+            }
+          },
+          "fill": 1,
+          "fillGradient": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 0
+          },
+          "height": null,
+          "hideTimeOverride": false,
+          "id": 598,
+          "interval": null,
+          "isNew": true,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": null,
+            "sort": "max",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "maxDataPoints": null,
+          "maxPerRow": null,
+          "minSpan": null,
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true,
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "repeatDirection": null,
+          "seriesOverrides": [],
+          "span": null,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "sum((\n    tikv_resource_control_group_ru_historical_rate\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    \n)) by (resource_group)  > 0",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "historical-{{resource_group}}",
+              "metric": "",
+              "query": "sum((\n    tikv_resource_control_group_ru_historical_rate\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    \n)) by (resource_group)  > 0",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            },
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "sum((\n    tikv_resource_control_group_ru_current_rate\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    \n)) by (resource_group)  > 0",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "current-{{resource_group}}",
+              "metric": "",
+              "query": "sum((\n    tikv_resource_control_group_ru_current_rate\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    \n)) by (resource_group)  > 0",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "CPU Utilization % per Resource Group",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "transformations": [],
+          "transparent": false,
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "percent",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": 0
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "cacheTimeout": null,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "Total resource utilization percentage of background tasks.",
+          "editable": true,
+          "error": false,
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              }
+            }
+          },
+          "fill": 1,
+          "fillGradient": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 0
+          },
+          "height": null,
+          "hideTimeOverride": false,
+          "id": 599,
+          "interval": null,
+          "isNew": true,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": null,
+            "sort": "max",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "maxDataPoints": null,
+          "maxPerRow": null,
+          "minSpan": null,
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true,
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "repeatDirection": null,
+          "seriesOverrides": [],
+          "span": null,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "sum((\n    tikv_resource_control_bg_resource_utilization\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    \n)) by (type)  > 0",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{type}}",
+              "metric": "",
+              "query": "sum((\n    tikv_resource_control_bg_resource_utilization\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    \n)) by (type)  > 0",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Background Resource Utilization",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "transformations": [],
+          "transparent": false,
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "percent",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": 0
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "cacheTimeout": null,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "Current rate limit per resource group (0 = unlimited, hidden).",
+          "editable": true,
+          "error": false,
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              }
+            }
+          },
+          "fill": 1,
+          "fillGradient": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 7
+          },
+          "height": null,
+          "hideTimeOverride": false,
+          "id": 600,
+          "interval": null,
+          "isNew": true,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": null,
+            "sort": "max",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "maxDataPoints": null,
+          "maxPerRow": null,
+          "minSpan": null,
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true,
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "repeatDirection": null,
+          "seriesOverrides": [],
+          "span": null,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "sum((\n    tikv_resource_control_group_quota_limit\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    \n)) by (resource_group, type)  > 0",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{resource_group}}-{{type}}",
+              "metric": "",
+              "query": "sum((\n    tikv_resource_control_group_quota_limit\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    \n)) by (resource_group, type)  > 0",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Resource Group Quota Limit",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "transformations": [],
+          "transparent": false,
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "none",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": 0
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "cacheTimeout": null,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "Current quota limit for background resource groups.",
+          "editable": true,
+          "error": false,
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              }
+            }
+          },
+          "fill": 1,
+          "fillGradient": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 7
+          },
+          "height": null,
+          "hideTimeOverride": false,
+          "id": 601,
+          "interval": null,
+          "isNew": true,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": null,
+            "sort": "max",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "maxDataPoints": null,
+          "maxPerRow": null,
+          "minSpan": null,
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true,
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "repeatDirection": null,
+          "seriesOverrides": [],
+          "span": null,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "sum((\n    tikv_resource_control_background_quota_limiter\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    \n)) by (resource_group, type)  > 0",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{resource_group}}-{{type}}",
+              "metric": "",
+              "query": "sum((\n    tikv_resource_control_background_quota_limiter\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    \n)) by (resource_group, type)  > 0",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Background Quota Limit",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "transformations": [],
+          "transparent": false,
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "none",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": 0
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "cacheTimeout": null,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "Rate of deprioritized (phase 1), delayed, and rejected requests.",
+          "editable": true,
+          "error": false,
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              }
+            }
+          },
+          "fill": 1,
+          "fillGradient": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 14
+          },
+          "height": null,
+          "hideTimeOverride": false,
+          "id": 602,
+          "interval": null,
+          "isNew": true,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": null,
+            "sort": "max",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "maxDataPoints": null,
+          "maxPerRow": null,
+          "minSpan": null,
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true,
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "repeatDirection": null,
+          "seriesOverrides": [],
+          "span": null,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "sum(rate(\n    tikv_resource_control_two_phase_throttled_requests_total\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (resource_group)  > 0",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "deprioritized-{{resource_group}}",
+              "metric": "",
+              "query": "sum(rate(\n    tikv_resource_control_two_phase_throttled_requests_total\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (resource_group)  > 0",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            },
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "sum(rate(\n    tikv_resource_control_admission_delayed_requests_total\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (resource_group, is_background)  > 0",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "delayed-{{resource_group}}-{{is_background}}",
+              "metric": "",
+              "query": "sum(rate(\n    tikv_resource_control_admission_delayed_requests_total\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (resource_group, is_background)  > 0",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            },
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "sum(rate(\n    tikv_resource_control_admission_rejected_requests_total\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (resource_group, is_background)  > 0",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "rejected-{{resource_group}}-{{is_background}}",
+              "metric": "",
+              "query": "sum(rate(\n    tikv_resource_control_admission_rejected_requests_total\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (resource_group, is_background)  > 0",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Deprioritized / Delayed / Rejected Requests",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "transformations": [],
+          "transparent": false,
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "ops",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": 0
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "cacheTimeout": null,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "Number of requests currently sitting in admission control delay.",
+          "editable": true,
+          "error": false,
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              }
+            }
+          },
+          "fill": 1,
+          "fillGradient": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 14
+          },
+          "height": null,
+          "hideTimeOverride": false,
+          "id": 603,
+          "interval": null,
+          "isNew": true,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": null,
+            "sort": "max",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "maxDataPoints": null,
+          "maxPerRow": null,
+          "minSpan": null,
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true,
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "repeatDirection": null,
+          "seriesOverrides": [],
+          "span": null,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "sum((\n    tikv_resource_control_admission_currently_delayed\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    \n)) by (instance)  > 0",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{instance}}",
+              "metric": "",
+              "query": "sum((\n    tikv_resource_control_admission_currently_delayed\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    \n)) by (instance)  > 0",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Currently Delayed Requests",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "transformations": [],
+          "transparent": false,
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "none",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": 0
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "cacheTimeout": null,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "Delay duration imposed by foreground admission control.",
+          "editable": true,
+          "error": false,
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              }
+            }
+          },
+          "fill": 1,
+          "fillGradient": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 21
+          },
+          "height": null,
+          "hideTimeOverride": false,
+          "id": 604,
+          "interval": null,
+          "isNew": true,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": null,
+            "sort": "max",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "maxDataPoints": null,
+          "maxPerRow": null,
+          "minSpan": null,
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true,
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "repeatDirection": null,
+          "seriesOverrides": [
+            {
+              "alias": "/^count/",
+              "bars": false,
+              "dashLength": 1,
+              "dashes": true,
+              "fill": 2,
+              "fillBelowTo": null,
+              "lines": true,
+              "spaceLength": 1,
+              "transform": "negative-Y",
+              "yaxis": 2,
+              "zindex": -3
+            },
+            {
+              "alias": "/^avg/",
+              "bars": false,
+              "fill": 7,
+              "fillBelowTo": null,
+              "lines": true,
+              "yaxis": 1,
+              "zindex": 0
+            }
+          ],
+          "span": null,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "histogram_quantile(0.9999,(\n    sum(rate(\n    tikv_resource_control_admission_delay_duration_seconds_bucket\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",is_background=\"false\"}\n    [$__rate_interval]\n)) by (resource_group, le, $additional_groupby) \n    \n    \n))  ",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "99.99%-{{resource_group}} {{$additional_groupby}}",
+              "metric": "",
+              "query": "histogram_quantile(0.9999,(\n    sum(rate(\n    tikv_resource_control_admission_delay_duration_seconds_bucket\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",is_background=\"false\"}\n    [$__rate_interval]\n)) by (resource_group, le, $additional_groupby) \n    \n    \n))  ",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            },
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "histogram_quantile(0.99,(\n    sum(rate(\n    tikv_resource_control_admission_delay_duration_seconds_bucket\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",is_background=\"false\"}\n    [$__rate_interval]\n)) by (resource_group, le, $additional_groupby) \n    \n    \n))  ",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "99%-{{resource_group}} {{$additional_groupby}}",
+              "metric": "",
+              "query": "histogram_quantile(0.99,(\n    sum(rate(\n    tikv_resource_control_admission_delay_duration_seconds_bucket\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",is_background=\"false\"}\n    [$__rate_interval]\n)) by (resource_group, le, $additional_groupby) \n    \n    \n))  ",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            },
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "(sum(rate(\n    tikv_resource_control_admission_delay_duration_seconds_sum\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",is_background=\"false\"}\n    [$__rate_interval]\n)) by (resource_group, $additional_groupby)  / sum(rate(\n    tikv_resource_control_admission_delay_duration_seconds_count\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",is_background=\"false\"}\n    [$__rate_interval]\n)) by (resource_group, $additional_groupby) )",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "avg-{{resource_group}} {{$additional_groupby}}",
+              "metric": "",
+              "query": "(sum(rate(\n    tikv_resource_control_admission_delay_duration_seconds_sum\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",is_background=\"false\"}\n    [$__rate_interval]\n)) by (resource_group, $additional_groupby)  / sum(rate(\n    tikv_resource_control_admission_delay_duration_seconds_count\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",is_background=\"false\"}\n    [$__rate_interval]\n)) by (resource_group, $additional_groupby) )",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            },
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "sum(rate(\n    tikv_resource_control_admission_delay_duration_seconds_count\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",is_background=\"false\"}\n    [$__rate_interval]\n)) by (resource_group, $additional_groupby) ",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "count-{{resource_group}} {{$additional_groupby}}",
+              "metric": "",
+              "query": "sum(rate(\n    tikv_resource_control_admission_delay_duration_seconds_count\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",is_background=\"false\"}\n    [$__rate_interval]\n)) by (resource_group, $additional_groupby) ",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Admission Delay Duration",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "transformations": [],
+          "transparent": false,
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "s",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": 0
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "cacheTimeout": null,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "Total wait duration of background tasks per resource group.",
+          "editable": true,
+          "error": false,
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              }
+            }
+          },
+          "fill": 1,
+          "fillGradient": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 21
+          },
+          "height": null,
+          "hideTimeOverride": false,
+          "id": 605,
+          "interval": null,
+          "isNew": true,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": null,
+            "sort": "max",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "maxDataPoints": null,
+          "maxPerRow": null,
+          "minSpan": null,
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true,
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "repeatDirection": null,
+          "seriesOverrides": [],
+          "span": null,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "sum(rate(\n    tikv_resource_control_background_task_wait_duration\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (resource_group)  > 0",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{resource_group}}",
+              "metric": "",
+              "query": "sum(rate(\n    tikv_resource_control_background_task_wait_duration\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (resource_group)  > 0",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Background Task Wait Duration",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "transformations": [],
+          "transparent": false,
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "\u00b5s",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": 0
+          }
+        }
+      ],
+      "repeat": null,
+      "repeatDirection": null,
+      "span": null,
+      "targets": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Load Shedding",
+      "transformations": [],
+      "transparent": false,
+      "type": "row"
+    },
+    {
+      "cacheTimeout": null,
+      "collapsed": true,
+      "datasource": null,
+      "description": null,
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          }
+        }
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "height": null,
+      "hideTimeOverride": false,
+      "id": 606,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -81422,7 +82937,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 596,
+          "id": 607,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -81623,7 +83138,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 597,
+          "id": 608,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -81759,7 +83274,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 598,
+      "id": 609,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -81798,7 +83313,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 599,
+          "id": 610,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -81931,7 +83446,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 600,
+          "id": 611,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -82064,7 +83579,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 601,
+          "id": 612,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -82197,7 +83712,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 602,
+          "id": 613,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -82330,7 +83845,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 603,
+          "id": 614,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -82478,7 +83993,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 604,
+          "id": 615,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -82682,7 +84197,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 605,
+      "id": 616,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -82721,7 +84236,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 606,
+          "id": 617,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -82854,7 +84369,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 607,
+          "id": 618,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -82987,7 +84502,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 608,
+          "id": 619,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -83120,7 +84635,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 609,
+          "id": 620,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -83253,7 +84768,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 610,
+          "id": 621,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -83450,7 +84965,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 611,
+          "id": 622,
           "interval": null,
           "links": [],
           "maxDataPoints": 100,

--- a/metrics/grafana/tikv_details.json
+++ b/metrics/grafana/tikv_details.json
@@ -12752,7 +12752,7 @@
           "targets": [
             {
               "datasource": "${DS_TEST-CLUSTER}",
-              "expr": "sum(rate(\n    tikv_thread_cpu_seconds_total\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",name=~\"sst_.*\"}\n    [$__rate_interval]\n)) by (instance) ",
+              "expr": "sum(rate(\n    tikv_thread_cpu_seconds_total\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",name=~\"(sst_|impwkr_).*\"}\n    [$__rate_interval]\n)) by (instance) ",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -12760,7 +12760,7 @@
               "intervalFactor": 1,
               "legendFormat": "{{instance}}",
               "metric": "",
-              "query": "sum(rate(\n    tikv_thread_cpu_seconds_total\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",name=~\"sst_.*\"}\n    [$__rate_interval]\n)) by (instance) ",
+              "query": "sum(rate(\n    tikv_thread_cpu_seconds_total\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",name=~\"(sst_|impwkr_).*\"}\n    [$__rate_interval]\n)) by (instance) ",
               "refId": "",
               "step": 10,
               "target": ""

--- a/metrics/grafana/tikv_details.json
+++ b/metrics/grafana/tikv_details.json
@@ -81157,15 +81157,15 @@
           "targets": [
             {
               "datasource": "${DS_TEST-CLUSTER}",
-              "expr": "sum(rate(\n    tikv_resource_control_background_task_wait_duration\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (instance, resource_group) ",
+              "expr": "sum(rate(\n    tikv_resource_control_background_task_wait_duration\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (instance) ",
               "format": "time_series",
               "hide": false,
               "instant": false,
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "{{instance}}-{{resource_group}}",
+              "legendFormat": "{{instance}}",
               "metric": "",
-              "query": "sum(rate(\n    tikv_resource_control_background_task_wait_duration\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (instance, resource_group) ",
+              "query": "sum(rate(\n    tikv_resource_control_background_task_wait_duration\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (instance) ",
               "refId": "",
               "step": 10,
               "target": ""

--- a/metrics/grafana/tikv_details.json
+++ b/metrics/grafana/tikv_details.json
@@ -63846,7 +63846,7 @@
           },
           "gridPos": {
             "h": 7,
-            "w": 12,
+            "w": 8,
             "x": 0,
             "y": 0
           },
@@ -63979,8 +63979,8 @@
           },
           "gridPos": {
             "h": 7,
-            "w": 12,
-            "x": 12,
+            "w": 8,
+            "x": 8,
             "y": 0
           },
           "height": null,
@@ -64091,6 +64091,139 @@
           "bars": false,
           "cacheTimeout": null,
           "datasource": "${DS_TEST-CLUSTER}",
+          "description": "The fail-fast disk probe duration by disk and outcome.",
+          "editable": true,
+          "error": false,
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              }
+            }
+          },
+          "fill": 1,
+          "fillGradient": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 16,
+            "y": 0
+          },
+          "height": null,
+          "hideTimeOverride": false,
+          "id": 454,
+          "interval": null,
+          "isNew": true,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": null,
+            "sort": "max",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "maxDataPoints": null,
+          "maxPerRow": null,
+          "minSpan": null,
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true,
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "repeatDirection": null,
+          "seriesOverrides": [],
+          "span": null,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "histogram_quantile(0.99,(\n    sum(rate(\n    tikv_raftstore_disk_probe_duration_seconds_bucket\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (instance, disk, outcome, le) \n    \n    \n))  ",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{instance}}-{{disk}}-{{outcome}}-0.99",
+              "metric": "",
+              "query": "histogram_quantile(0.99,(\n    sum(rate(\n    tikv_raftstore_disk_probe_duration_seconds_bucket\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (instance, disk, outcome, le) \n    \n    \n))  ",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Disk Probe Duration",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "transformations": [],
+          "transparent": false,
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "s",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": 0
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "cacheTimeout": null,
+          "datasource": "${DS_TEST-CLUSTER}",
           "description": "The changing trend of the slowness on I/O operations. 'value > 0' means the related store might have a slow trend.",
           "editable": true,
           "error": false,
@@ -64118,7 +64251,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 454,
+          "id": 455,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -64251,7 +64384,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 455,
+          "id": 456,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -64384,7 +64517,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 456,
+          "id": 457,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -64517,7 +64650,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 457,
+          "id": 458,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -64650,7 +64783,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 458,
+          "id": 459,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -64786,7 +64919,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 459,
+      "id": 460,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -64825,7 +64958,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 460,
+          "id": 461,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -64958,7 +65091,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 461,
+          "id": 462,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -65091,7 +65224,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 462,
+          "id": 463,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -65239,7 +65372,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 463,
+          "id": 464,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -65402,7 +65535,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 464,
+          "id": 465,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -65535,7 +65668,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 465,
+          "id": 466,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -65668,7 +65801,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 466,
+          "id": 467,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -65831,7 +65964,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 467,
+          "id": 468,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -65979,7 +66112,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 468,
+          "id": 469,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -66115,7 +66248,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 469,
+      "id": 470,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -66154,7 +66287,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 470,
+          "id": 471,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -66287,7 +66420,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 471,
+          "id": 472,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -66420,7 +66553,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 472,
+          "id": 473,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -66553,7 +66686,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 473,
+          "id": 474,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -66686,7 +66819,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 474,
+          "id": 475,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -66819,7 +66952,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 475,
+          "id": 476,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -66952,7 +67085,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 476,
+          "id": 477,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -67085,7 +67218,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 477,
+          "id": 478,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -67218,7 +67351,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 478,
+          "id": 479,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -67358,7 +67491,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 479,
+          "id": 480,
           "interval": null,
           "legend": {
             "show": false
@@ -67456,7 +67589,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 480,
+          "id": 481,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -67589,7 +67722,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 481,
+          "id": 482,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -67737,7 +67870,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 482,
+          "id": 483,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -67885,7 +68018,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 483,
+          "id": 484,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -68025,7 +68158,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 484,
+          "id": 485,
           "interval": null,
           "legend": {
             "show": false
@@ -68123,7 +68256,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 485,
+          "id": 486,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -68256,7 +68389,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 486,
+          "id": 487,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -68392,7 +68525,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 487,
+      "id": 488,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -68431,7 +68564,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 488,
+          "id": 489,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -68564,7 +68697,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 489,
+          "id": 490,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -68727,7 +68860,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 490,
+          "id": 491,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -68875,7 +69008,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 491,
+          "id": 492,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -69008,7 +69141,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 492,
+          "id": 493,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -69148,7 +69281,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 493,
+          "id": 494,
           "interval": null,
           "legend": {
             "show": false
@@ -69253,7 +69386,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 494,
+          "id": 495,
           "interval": null,
           "legend": {
             "show": false
@@ -69358,7 +69491,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 495,
+          "id": 496,
           "interval": null,
           "legend": {
             "show": false
@@ -69456,7 +69589,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 496,
+          "id": 497,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -69596,7 +69729,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 497,
+          "id": 498,
           "interval": null,
           "legend": {
             "show": false
@@ -69701,7 +69834,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 498,
+          "id": 499,
           "interval": null,
           "legend": {
             "show": false
@@ -69806,7 +69939,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 499,
+          "id": 500,
           "interval": null,
           "legend": {
             "show": false
@@ -69904,7 +70037,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 500,
+          "id": 501,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -70037,7 +70170,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 501,
+          "id": 502,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -70170,7 +70303,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 502,
+          "id": 503,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -70310,7 +70443,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 503,
+          "id": 504,
           "interval": null,
           "legend": {
             "show": false
@@ -70408,7 +70541,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 504,
+          "id": 505,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -70544,7 +70677,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 505,
+      "id": 506,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -70583,7 +70716,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 506,
+          "id": 507,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -70746,7 +70879,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 507,
+          "id": 508,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -70879,7 +71012,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 508,
+          "id": 509,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -71019,7 +71152,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 509,
+          "id": 510,
           "interval": null,
           "legend": {
             "show": false
@@ -71124,7 +71257,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 510,
+          "id": 511,
           "interval": null,
           "legend": {
             "show": false
@@ -71222,7 +71355,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 511,
+          "id": 512,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -71377,7 +71510,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 512,
+          "id": 513,
           "interval": null,
           "legend": {
             "show": false
@@ -71482,7 +71615,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 513,
+          "id": 514,
           "interval": null,
           "legend": {
             "show": false
@@ -71587,7 +71720,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 514,
+          "id": 515,
           "interval": null,
           "legend": {
             "show": false
@@ -71685,7 +71818,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 515,
+          "id": 516,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -71855,7 +71988,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 516,
+          "id": 517,
           "interval": null,
           "legend": {
             "show": false
@@ -71953,7 +72086,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 517,
+          "id": 518,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -72154,7 +72287,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 518,
+          "id": 519,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -72355,7 +72488,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 519,
+          "id": 520,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -72488,7 +72621,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 520,
+          "id": 521,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -72651,7 +72784,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 521,
+          "id": 522,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -72784,7 +72917,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 522,
+          "id": 523,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -72917,7 +73050,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 523,
+          "id": 524,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -73118,7 +73251,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 524,
+          "id": 525,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -73251,7 +73384,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 525,
+          "id": 526,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -73391,7 +73524,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 526,
+          "id": 527,
           "interval": null,
           "legend": {
             "show": false
@@ -73496,7 +73629,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 527,
+          "id": 528,
           "interval": null,
           "legend": {
             "show": false
@@ -73601,7 +73734,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 528,
+          "id": 529,
           "interval": null,
           "legend": {
             "show": false
@@ -73706,7 +73839,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 529,
+          "id": 530,
           "interval": null,
           "legend": {
             "show": false
@@ -73811,7 +73944,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 530,
+          "id": 531,
           "interval": null,
           "legend": {
             "show": false
@@ -73916,7 +74049,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 531,
+          "id": 532,
           "interval": null,
           "legend": {
             "show": false
@@ -74021,7 +74154,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 532,
+          "id": 533,
           "interval": null,
           "legend": {
             "show": false
@@ -74119,7 +74252,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 533,
+          "id": 534,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -74267,7 +74400,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 534,
+          "id": 535,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -74400,7 +74533,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 535,
+          "id": 536,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -74533,7 +74666,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 536,
+          "id": 537,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -74681,7 +74814,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 537,
+          "id": 538,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -74817,7 +74950,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 538,
+      "id": 539,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -74868,7 +75001,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 539,
+          "id": 540,
           "interval": null,
           "links": [],
           "maxDataPoints": 100,
@@ -74964,7 +75097,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 540,
+          "id": 541,
           "interval": null,
           "links": [],
           "maxDataPoints": 100,
@@ -75039,7 +75172,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 541,
+          "id": 542,
           "interval": null,
           "links": [],
           "maxDataPoints": 100,
@@ -75114,7 +75247,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 542,
+          "id": 543,
           "interval": null,
           "links": [],
           "maxDataPoints": 100,
@@ -75189,7 +75322,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 543,
+          "id": 544,
           "interval": null,
           "links": [],
           "maxDataPoints": 100,
@@ -75264,7 +75397,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 544,
+          "id": 545,
           "interval": null,
           "links": [],
           "maxDataPoints": 100,
@@ -75339,7 +75472,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 545,
+          "id": 546,
           "interval": null,
           "links": [],
           "maxDataPoints": 100,
@@ -75414,7 +75547,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 546,
+          "id": 547,
           "interval": null,
           "links": [],
           "maxDataPoints": 100,
@@ -75493,7 +75626,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 547,
+          "id": 548,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -75626,7 +75759,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 548,
+          "id": 549,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -75759,7 +75892,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 549,
+          "id": 550,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -75892,7 +76025,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 550,
+          "id": 551,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -76025,7 +76158,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 551,
+          "id": 552,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -76158,7 +76291,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 552,
+          "id": 553,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -76306,7 +76439,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 553,
+          "id": 554,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -76439,7 +76572,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 554,
+          "id": 555,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -76572,7 +76705,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 555,
+          "id": 556,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -76738,7 +76871,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 556,
+          "id": 557,
           "interval": null,
           "legend": {
             "show": false
@@ -76843,7 +76976,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 557,
+          "id": 558,
           "interval": null,
           "legend": {
             "show": false
@@ -76948,7 +77081,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 558,
+          "id": 559,
           "interval": null,
           "legend": {
             "show": false
@@ -77053,7 +77186,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 559,
+          "id": 560,
           "interval": null,
           "legend": {
             "show": false
@@ -77158,7 +77291,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 560,
+          "id": 561,
           "interval": null,
           "legend": {
             "show": false
@@ -77263,7 +77396,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 561,
+          "id": 562,
           "interval": null,
           "legend": {
             "show": false
@@ -77368,7 +77501,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 562,
+          "id": 563,
           "interval": null,
           "legend": {
             "show": false
@@ -77473,7 +77606,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 563,
+          "id": 564,
           "interval": null,
           "legend": {
             "show": false
@@ -77571,7 +77704,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 564,
+          "id": 565,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -77704,7 +77837,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 565,
+          "id": 566,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -77837,7 +77970,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 566,
+          "id": 567,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -77970,7 +78103,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 567,
+          "id": 568,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -78103,7 +78236,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 568,
+          "id": 569,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -78236,7 +78369,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 569,
+          "id": 570,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -78369,7 +78502,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 570,
+          "id": 571,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -78502,7 +78635,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 571,
+          "id": 572,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -78642,7 +78775,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 572,
+          "id": 573,
           "interval": null,
           "legend": {
             "show": false
@@ -78747,7 +78880,7 @@
           "hideTimeOverride": false,
           "hideZeroBuckets": true,
           "highlightCards": true,
-          "id": 573,
+          "id": 574,
           "interval": null,
           "legend": {
             "show": false
@@ -78845,7 +78978,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 574,
+          "id": 575,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -78978,7 +79111,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 575,
+          "id": 576,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -79111,7 +79244,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 576,
+          "id": 577,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -79244,7 +79377,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 577,
+          "id": 578,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -79377,7 +79510,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 578,
+          "id": 579,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -79510,7 +79643,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 579,
+          "id": 580,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -79646,7 +79779,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 580,
+      "id": 581,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -79685,7 +79818,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 581,
+          "id": 582,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -79833,7 +79966,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 582,
+          "id": 583,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -79966,7 +80099,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 583,
+          "id": 584,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -80099,7 +80232,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 584,
+          "id": 585,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -80235,7 +80368,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 585,
+      "id": 586,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -80274,7 +80407,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 586,
+          "id": 587,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -80407,7 +80540,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 587,
+          "id": 588,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -80540,7 +80673,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 588,
+          "id": 589,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -80673,7 +80806,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 589,
+          "id": 590,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -80806,7 +80939,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 590,
+          "id": 591,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -80939,7 +81072,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 591,
+          "id": 592,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -81075,7 +81208,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 592,
+      "id": 593,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -81114,7 +81247,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 593,
+          "id": 594,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -81247,7 +81380,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 594,
+          "id": 595,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -81380,7 +81513,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 595,
+          "id": 596,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -81543,7 +81676,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 596,
+          "id": 597,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -81679,7 +81812,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 597,
+      "id": 598,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -81718,7 +81851,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 598,
+          "id": 599,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -81866,7 +81999,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 599,
+          "id": 600,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -81999,7 +82132,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 600,
+          "id": 601,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -82132,7 +82265,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 601,
+          "id": 602,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -82265,7 +82398,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 602,
+          "id": 603,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -82428,7 +82561,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 603,
+          "id": 604,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -82561,7 +82694,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 604,
+          "id": 605,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -82762,7 +82895,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 605,
+          "id": 606,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -82898,7 +83031,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 606,
+      "id": 607,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -82937,7 +83070,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 607,
+          "id": 608,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -83138,7 +83271,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 608,
+          "id": 609,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -83274,7 +83407,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 609,
+      "id": 610,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -83313,7 +83446,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 610,
+          "id": 611,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -83446,7 +83579,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 611,
+          "id": 612,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -83579,7 +83712,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 612,
+          "id": 613,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -83712,7 +83845,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 613,
+          "id": 614,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -83845,7 +83978,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 614,
+          "id": 615,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -83993,7 +84126,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 615,
+          "id": 616,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -84197,7 +84330,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 616,
+      "id": 617,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -84236,7 +84369,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 617,
+          "id": 618,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -84369,7 +84502,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 618,
+          "id": 619,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -84502,7 +84635,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 619,
+          "id": 620,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -84635,7 +84768,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 620,
+          "id": 621,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -84768,7 +84901,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 621,
+          "id": 622,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -84965,7 +85098,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 622,
+          "id": 623,
           "interval": null,
           "links": [],
           "maxDataPoints": 100,

--- a/metrics/grafana/tikv_details.json
+++ b/metrics/grafana/tikv_details.json
@@ -81347,6 +81347,302 @@
             "align": false,
             "alignLevel": 0
           }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "cacheTimeout": null,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": null,
+          "editable": true,
+          "error": false,
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              }
+            }
+          },
+          "fill": 1,
+          "fillGradient": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 7
+          },
+          "height": null,
+          "hideTimeOverride": false,
+          "id": 595,
+          "interval": null,
+          "isNew": true,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": null,
+            "sort": "max",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "maxDataPoints": null,
+          "maxPerRow": null,
+          "minSpan": null,
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true,
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "repeatDirection": null,
+          "seriesOverrides": [],
+          "span": null,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "sum(rate(\n    tikv_analyze_metrics_total\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",metric=\"read_total_op_count\"}\n    [$__rate_interval]\n)) by (instance) ",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "total-op/{{instance}}",
+              "metric": "",
+              "query": "sum(rate(\n    tikv_analyze_metrics_total\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",metric=\"read_total_op_count\"}\n    [$__rate_interval]\n)) by (instance) ",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            },
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "sum(rate(\n    tikv_analyze_metrics_total\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",metric=\"read_iops\"}\n    [$__rate_interval]\n)) by (instance) ",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "block-read/{{instance}}",
+              "metric": "",
+              "query": "sum(rate(\n    tikv_analyze_metrics_total\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",metric=\"read_iops\"}\n    [$__rate_interval]\n)) by (instance) ",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            },
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "sum(rate(\n    tikv_coprocessor_rocksdb_perf\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",req=\"analyze_full_sampling\",metric=\"block_read_count\"}\n    [$__rate_interval]\n)) by (instance) ",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "copr-block-read/{{instance}}",
+              "metric": "",
+              "query": "sum(rate(\n    tikv_coprocessor_rocksdb_perf\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",req=\"analyze_full_sampling\",metric=\"block_read_count\"}\n    [$__rate_interval]\n)) by (instance) ",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Analyze read ops per second (total vs block read)",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "transformations": [],
+          "transparent": false,
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "ops",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": 0
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "cacheTimeout": null,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": null,
+          "editable": true,
+          "error": false,
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              }
+            }
+          },
+          "fill": 1,
+          "fillGradient": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 7
+          },
+          "height": null,
+          "hideTimeOverride": false,
+          "id": 596,
+          "interval": null,
+          "isNew": true,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": null,
+            "sort": "max",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "maxDataPoints": null,
+          "maxPerRow": null,
+          "minSpan": null,
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true,
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "repeatDirection": null,
+          "seriesOverrides": [],
+          "span": null,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "sum(rate(\n    tikv_analyze_metrics_total\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",metric=\"next_batch_count\"}\n    [$__rate_interval]\n)) by (instance) ",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{instance}}",
+              "metric": "",
+              "query": "sum(rate(\n    tikv_analyze_metrics_total\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",metric=\"next_batch_count\"}\n    [$__rate_interval]\n)) by (instance) ",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Analyze next batch count per second",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "transformations": [],
+          "transparent": false,
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "ops",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": 0
+          }
         }
       ],
       "repeat": null,
@@ -81383,7 +81679,1226 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 595,
+      "id": 597,
+      "interval": null,
+      "links": [],
+      "maxDataPoints": 100,
+      "maxPerRow": null,
+      "minSpan": null,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "cacheTimeout": null,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "Historical baseline and current CPU utilization % per resource group (100% = 1 core).",
+          "editable": true,
+          "error": false,
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              }
+            }
+          },
+          "fill": 1,
+          "fillGradient": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 0
+          },
+          "height": null,
+          "hideTimeOverride": false,
+          "id": 598,
+          "interval": null,
+          "isNew": true,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": null,
+            "sort": "max",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "maxDataPoints": null,
+          "maxPerRow": null,
+          "minSpan": null,
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true,
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "repeatDirection": null,
+          "seriesOverrides": [],
+          "span": null,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "sum((\n    tikv_resource_control_group_ru_historical_rate\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    \n)) by (resource_group)  > 0",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "historical-{{resource_group}}",
+              "metric": "",
+              "query": "sum((\n    tikv_resource_control_group_ru_historical_rate\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    \n)) by (resource_group)  > 0",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            },
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "sum((\n    tikv_resource_control_group_ru_current_rate\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    \n)) by (resource_group)  > 0",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "current-{{resource_group}}",
+              "metric": "",
+              "query": "sum((\n    tikv_resource_control_group_ru_current_rate\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    \n)) by (resource_group)  > 0",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "CPU Utilization % per Resource Group",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "transformations": [],
+          "transparent": false,
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "percent",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": 0
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "cacheTimeout": null,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "Total resource utilization percentage of background tasks.",
+          "editable": true,
+          "error": false,
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              }
+            }
+          },
+          "fill": 1,
+          "fillGradient": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 0
+          },
+          "height": null,
+          "hideTimeOverride": false,
+          "id": 599,
+          "interval": null,
+          "isNew": true,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": null,
+            "sort": "max",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "maxDataPoints": null,
+          "maxPerRow": null,
+          "minSpan": null,
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true,
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "repeatDirection": null,
+          "seriesOverrides": [],
+          "span": null,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "sum((\n    tikv_resource_control_bg_resource_utilization\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    \n)) by (type)  > 0",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{type}}",
+              "metric": "",
+              "query": "sum((\n    tikv_resource_control_bg_resource_utilization\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    \n)) by (type)  > 0",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Background Resource Utilization",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "transformations": [],
+          "transparent": false,
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "percent",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": 0
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "cacheTimeout": null,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "Current rate limit per resource group (0 = unlimited, hidden).",
+          "editable": true,
+          "error": false,
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              }
+            }
+          },
+          "fill": 1,
+          "fillGradient": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 7
+          },
+          "height": null,
+          "hideTimeOverride": false,
+          "id": 600,
+          "interval": null,
+          "isNew": true,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": null,
+            "sort": "max",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "maxDataPoints": null,
+          "maxPerRow": null,
+          "minSpan": null,
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true,
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "repeatDirection": null,
+          "seriesOverrides": [],
+          "span": null,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "sum((\n    tikv_resource_control_group_quota_limit\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    \n)) by (resource_group, type)  > 0",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{resource_group}}-{{type}}",
+              "metric": "",
+              "query": "sum((\n    tikv_resource_control_group_quota_limit\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    \n)) by (resource_group, type)  > 0",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Resource Group Quota Limit",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "transformations": [],
+          "transparent": false,
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "none",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": 0
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "cacheTimeout": null,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "Current quota limit for background resource groups.",
+          "editable": true,
+          "error": false,
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              }
+            }
+          },
+          "fill": 1,
+          "fillGradient": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 7
+          },
+          "height": null,
+          "hideTimeOverride": false,
+          "id": 601,
+          "interval": null,
+          "isNew": true,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": null,
+            "sort": "max",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "maxDataPoints": null,
+          "maxPerRow": null,
+          "minSpan": null,
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true,
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "repeatDirection": null,
+          "seriesOverrides": [],
+          "span": null,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "sum((\n    tikv_resource_control_background_quota_limiter\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    \n)) by (resource_group, type)  > 0",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{resource_group}}-{{type}}",
+              "metric": "",
+              "query": "sum((\n    tikv_resource_control_background_quota_limiter\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    \n)) by (resource_group, type)  > 0",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Background Quota Limit",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "transformations": [],
+          "transparent": false,
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "none",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": 0
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "cacheTimeout": null,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "Rate of deprioritized (phase 1), delayed, and rejected requests.",
+          "editable": true,
+          "error": false,
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              }
+            }
+          },
+          "fill": 1,
+          "fillGradient": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 14
+          },
+          "height": null,
+          "hideTimeOverride": false,
+          "id": 602,
+          "interval": null,
+          "isNew": true,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": null,
+            "sort": "max",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "maxDataPoints": null,
+          "maxPerRow": null,
+          "minSpan": null,
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true,
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "repeatDirection": null,
+          "seriesOverrides": [],
+          "span": null,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "sum(rate(\n    tikv_resource_control_two_phase_throttled_requests_total\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (resource_group)  > 0",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "deprioritized-{{resource_group}}",
+              "metric": "",
+              "query": "sum(rate(\n    tikv_resource_control_two_phase_throttled_requests_total\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (resource_group)  > 0",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            },
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "sum(rate(\n    tikv_resource_control_admission_delayed_requests_total\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (resource_group, is_background)  > 0",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "delayed-{{resource_group}}-{{is_background}}",
+              "metric": "",
+              "query": "sum(rate(\n    tikv_resource_control_admission_delayed_requests_total\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (resource_group, is_background)  > 0",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            },
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "sum(rate(\n    tikv_resource_control_admission_rejected_requests_total\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (resource_group, is_background)  > 0",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "rejected-{{resource_group}}-{{is_background}}",
+              "metric": "",
+              "query": "sum(rate(\n    tikv_resource_control_admission_rejected_requests_total\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (resource_group, is_background)  > 0",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Deprioritized / Delayed / Rejected Requests",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "transformations": [],
+          "transparent": false,
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "ops",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": 0
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "cacheTimeout": null,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "Number of requests currently sitting in admission control delay.",
+          "editable": true,
+          "error": false,
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              }
+            }
+          },
+          "fill": 1,
+          "fillGradient": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 14
+          },
+          "height": null,
+          "hideTimeOverride": false,
+          "id": 603,
+          "interval": null,
+          "isNew": true,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": null,
+            "sort": "max",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "maxDataPoints": null,
+          "maxPerRow": null,
+          "minSpan": null,
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true,
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "repeatDirection": null,
+          "seriesOverrides": [],
+          "span": null,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "sum((\n    tikv_resource_control_admission_currently_delayed\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    \n)) by (instance)  > 0",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{instance}}",
+              "metric": "",
+              "query": "sum((\n    tikv_resource_control_admission_currently_delayed\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    \n)) by (instance)  > 0",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Currently Delayed Requests",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "transformations": [],
+          "transparent": false,
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "none",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": 0
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "cacheTimeout": null,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "Delay duration imposed by foreground admission control.",
+          "editable": true,
+          "error": false,
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              }
+            }
+          },
+          "fill": 1,
+          "fillGradient": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 21
+          },
+          "height": null,
+          "hideTimeOverride": false,
+          "id": 604,
+          "interval": null,
+          "isNew": true,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": null,
+            "sort": "max",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "maxDataPoints": null,
+          "maxPerRow": null,
+          "minSpan": null,
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true,
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "repeatDirection": null,
+          "seriesOverrides": [
+            {
+              "alias": "/^count/",
+              "bars": false,
+              "dashLength": 1,
+              "dashes": true,
+              "fill": 2,
+              "fillBelowTo": null,
+              "lines": true,
+              "spaceLength": 1,
+              "transform": "negative-Y",
+              "yaxis": 2,
+              "zindex": -3
+            },
+            {
+              "alias": "/^avg/",
+              "bars": false,
+              "fill": 7,
+              "fillBelowTo": null,
+              "lines": true,
+              "yaxis": 1,
+              "zindex": 0
+            }
+          ],
+          "span": null,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "histogram_quantile(0.9999,(\n    sum(rate(\n    tikv_resource_control_admission_delay_duration_seconds_bucket\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",is_background=\"false\"}\n    [$__rate_interval]\n)) by (resource_group, le, $additional_groupby) \n    \n    \n))  ",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "99.99%-{{resource_group}} {{$additional_groupby}}",
+              "metric": "",
+              "query": "histogram_quantile(0.9999,(\n    sum(rate(\n    tikv_resource_control_admission_delay_duration_seconds_bucket\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",is_background=\"false\"}\n    [$__rate_interval]\n)) by (resource_group, le, $additional_groupby) \n    \n    \n))  ",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            },
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "histogram_quantile(0.99,(\n    sum(rate(\n    tikv_resource_control_admission_delay_duration_seconds_bucket\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",is_background=\"false\"}\n    [$__rate_interval]\n)) by (resource_group, le, $additional_groupby) \n    \n    \n))  ",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "99%-{{resource_group}} {{$additional_groupby}}",
+              "metric": "",
+              "query": "histogram_quantile(0.99,(\n    sum(rate(\n    tikv_resource_control_admission_delay_duration_seconds_bucket\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",is_background=\"false\"}\n    [$__rate_interval]\n)) by (resource_group, le, $additional_groupby) \n    \n    \n))  ",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            },
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "(sum(rate(\n    tikv_resource_control_admission_delay_duration_seconds_sum\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",is_background=\"false\"}\n    [$__rate_interval]\n)) by (resource_group, $additional_groupby)  / sum(rate(\n    tikv_resource_control_admission_delay_duration_seconds_count\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",is_background=\"false\"}\n    [$__rate_interval]\n)) by (resource_group, $additional_groupby) )",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "avg-{{resource_group}} {{$additional_groupby}}",
+              "metric": "",
+              "query": "(sum(rate(\n    tikv_resource_control_admission_delay_duration_seconds_sum\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",is_background=\"false\"}\n    [$__rate_interval]\n)) by (resource_group, $additional_groupby)  / sum(rate(\n    tikv_resource_control_admission_delay_duration_seconds_count\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",is_background=\"false\"}\n    [$__rate_interval]\n)) by (resource_group, $additional_groupby) )",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            },
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "sum(rate(\n    tikv_resource_control_admission_delay_duration_seconds_count\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",is_background=\"false\"}\n    [$__rate_interval]\n)) by (resource_group, $additional_groupby) ",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "count-{{resource_group}} {{$additional_groupby}}",
+              "metric": "",
+              "query": "sum(rate(\n    tikv_resource_control_admission_delay_duration_seconds_count\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",is_background=\"false\"}\n    [$__rate_interval]\n)) by (resource_group, $additional_groupby) ",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Admission Delay Duration",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "transformations": [],
+          "transparent": false,
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "s",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": 0
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "cacheTimeout": null,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "Total wait duration of background tasks per resource group.",
+          "editable": true,
+          "error": false,
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              }
+            }
+          },
+          "fill": 1,
+          "fillGradient": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 21
+          },
+          "height": null,
+          "hideTimeOverride": false,
+          "id": 605,
+          "interval": null,
+          "isNew": true,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": null,
+            "sort": "max",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "maxDataPoints": null,
+          "maxPerRow": null,
+          "minSpan": null,
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true,
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "repeatDirection": null,
+          "seriesOverrides": [],
+          "span": null,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "sum(rate(\n    tikv_resource_control_background_task_wait_duration\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (resource_group)  > 0",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{resource_group}}",
+              "metric": "",
+              "query": "sum(rate(\n    tikv_resource_control_background_task_wait_duration\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (resource_group)  > 0",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Background Task Wait Duration",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "transformations": [],
+          "transparent": false,
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "\u00b5s",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": 0
+          }
+        }
+      ],
+      "repeat": null,
+      "repeatDirection": null,
+      "span": null,
+      "targets": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Load Shedding",
+      "transformations": [],
+      "transparent": false,
+      "type": "row"
+    },
+    {
+      "cacheTimeout": null,
+      "collapsed": true,
+      "datasource": null,
+      "description": null,
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          }
+        }
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "height": null,
+      "hideTimeOverride": false,
+      "id": 606,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -81422,7 +82937,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 596,
+          "id": 607,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -81623,7 +83138,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 597,
+          "id": 608,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -81759,7 +83274,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 598,
+      "id": 609,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -81798,7 +83313,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 599,
+          "id": 610,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -81931,7 +83446,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 600,
+          "id": 611,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -82064,7 +83579,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 601,
+          "id": 612,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -82197,7 +83712,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 602,
+          "id": 613,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -82330,7 +83845,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 603,
+          "id": 614,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -82478,7 +83993,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 604,
+          "id": 615,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -82682,7 +84197,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 605,
+      "id": 616,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -82721,7 +84236,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 606,
+          "id": 617,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -82854,7 +84369,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 607,
+          "id": 618,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -82987,7 +84502,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 608,
+          "id": 619,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -83120,7 +84635,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 609,
+          "id": 620,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -83253,7 +84768,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 610,
+          "id": 621,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -83450,7 +84965,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 611,
+          "id": 622,
           "interval": null,
           "links": [],
           "maxDataPoints": 100,

--- a/metrics/grafana/tikv_details.json
+++ b/metrics/grafana/tikv_details.json
@@ -81691,7 +81691,7 @@
           "bars": false,
           "cacheTimeout": null,
           "datasource": "${DS_TEST-CLUSTER}",
-          "description": "Historical baseline and current CPU utilization % per resource group (100% = 1 core).",
+          "description": "Historical (live sliding average), baseline (frozen while the group is selected as noisy) and current CPU utilization % per resource group (100% = 1 core).",
           "editable": true,
           "error": false,
           "fieldConfig": {
@@ -81770,6 +81770,21 @@
               "legendFormat": "historical-{{resource_group}}",
               "metric": "",
               "query": "sum((\n    tikv_resource_control_group_ru_historical_rate\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    \n)) by (resource_group)  > 0",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            },
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "sum((\n    tikv_resource_control_group_ru_baseline\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    \n)) by (resource_group)  > 0",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "baseline-{{resource_group}}",
+              "metric": "",
+              "query": "sum((\n    tikv_resource_control_group_ru_baseline\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    \n)) by (resource_group)  > 0",
               "refId": "",
               "step": 10,
               "target": ""
@@ -81972,7 +81987,7 @@
           "bars": false,
           "cacheTimeout": null,
           "datasource": "${DS_TEST-CLUSTER}",
-          "description": "Historical (floor), current (measured), and target (foreground-pressure-driven ceiling) CPU usage of the unified read pool, as a percentage of one core (100 = 1 core).",
+          "description": "Historical (live sliding average), baseline (floor frozen at overload onset), current (measured), and target (foreground-pressure-driven ceiling) CPU usage of the unified read pool, as a percentage of one core (100 = 1 core).",
           "editable": true,
           "error": false,
           "fieldConfig": {
@@ -82821,7 +82836,7 @@
           },
           "gridPos": {
             "h": 7,
-            "w": 24,
+            "w": 12,
             "x": 0,
             "y": 21
           },
@@ -82957,6 +82972,154 @@
             "align": false,
             "alignLevel": 0
           }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "cacheTimeout": null,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "Requests rejected before they enter the unified read pool, per resource group. `busy-threshold` is the client's own gate, sent as `busy_threshold_ms` from TiDB's `tidb_load_based_replica_read_threshold`: TiKV answers ServerIsBusy with its estimated wait and the client retries the read on an idle follower, so a high rate here is a redirect signal, not an error rate. `pool-full` is the queue capacity gate and has no such fallback -- the client sees a retry against the same leader.",
+          "editable": true,
+          "error": false,
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              }
+            }
+          },
+          "fill": 1,
+          "fillGradient": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 21
+          },
+          "height": null,
+          "hideTimeOverride": false,
+          "id": 607,
+          "interval": null,
+          "isNew": true,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": null,
+            "sort": "max",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "maxDataPoints": null,
+          "maxPerRow": null,
+          "minSpan": null,
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true,
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "repeatDirection": null,
+          "seriesOverrides": [],
+          "span": null,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "sum(rate(\n    tikv_unified_read_pool_busy_threshold_rejected_total\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (resource_group)  > 0",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "busy-threshold-{{resource_group}}",
+              "metric": "",
+              "query": "sum(rate(\n    tikv_unified_read_pool_busy_threshold_rejected_total\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (resource_group)  > 0",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            },
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "sum(rate(\n    tikv_unified_read_pool_full_rejected_total\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (resource_group)  > 0",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "pool-full-{{resource_group}}",
+              "metric": "",
+              "query": "sum(rate(\n    tikv_unified_read_pool_full_rejected_total\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (resource_group)  > 0",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Read Pool Rejections",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "transformations": [],
+          "transparent": false,
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "ops",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": 0
+          }
         }
       ],
       "repeat": null,
@@ -82993,7 +83156,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 607,
+      "id": 608,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -83032,7 +83195,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 608,
+          "id": 609,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -83233,7 +83396,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 609,
+          "id": 610,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -83369,7 +83532,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 610,
+      "id": 611,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -83408,7 +83571,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 611,
+          "id": 612,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -83541,7 +83704,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 612,
+          "id": 613,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -83674,7 +83837,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 613,
+          "id": 614,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -83807,7 +83970,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 614,
+          "id": 615,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -83940,7 +84103,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 615,
+          "id": 616,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -84088,7 +84251,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 616,
+          "id": 617,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -84292,7 +84455,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 617,
+      "id": 618,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -84331,7 +84494,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 618,
+          "id": 619,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -84464,7 +84627,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 619,
+          "id": 620,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -84597,7 +84760,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 620,
+          "id": 621,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -84730,7 +84893,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 621,
+          "id": 622,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -84863,7 +85026,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 622,
+          "id": 623,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -85060,7 +85223,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 623,
+          "id": 624,
           "interval": null,
           "links": [],
           "maxDataPoints": 100,

--- a/metrics/grafana/tikv_details.json
+++ b/metrics/grafana/tikv_details.json
@@ -81220,139 +81220,6 @@
           "bars": false,
           "cacheTimeout": null,
           "datasource": "${DS_TEST-CLUSTER}",
-          "description": null,
-          "editable": true,
-          "error": false,
-          "fieldConfig": {
-            "defaults": {
-              "thresholds": {
-                "mode": "absolute",
-                "steps": []
-              }
-            }
-          },
-          "fill": 1,
-          "fillGradient": 1,
-          "grid": {
-            "threshold1": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2": null,
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "gridPos": {
-            "h": 7,
-            "w": 12,
-            "x": 0,
-            "y": 0
-          },
-          "height": null,
-          "hideTimeOverride": false,
-          "id": 594,
-          "interval": null,
-          "isNew": true,
-          "legend": {
-            "alignAsTable": true,
-            "avg": false,
-            "current": true,
-            "hideEmpty": true,
-            "hideZero": true,
-            "max": true,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "sideWidth": null,
-            "sort": "max",
-            "sortDesc": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "maxDataPoints": null,
-          "maxPerRow": null,
-          "minSpan": null,
-          "nullPointMode": "null as zero",
-          "options": {
-            "alertThreshold": true,
-            "dataLinks": []
-          },
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "repeat": null,
-          "repeatDirection": null,
-          "seriesOverrides": [],
-          "span": null,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "datasource": "${DS_TEST-CLUSTER}",
-              "expr": "sum(rate(\n    tikv_resource_control_background_task_wait_duration\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (instance) ",
-              "format": "time_series",
-              "hide": false,
-              "instant": false,
-              "interval": "",
-              "intervalFactor": 1,
-              "legendFormat": "{{instance}}",
-              "metric": "",
-              "query": "sum(rate(\n    tikv_resource_control_background_task_wait_duration\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (instance) ",
-              "refId": "",
-              "step": 10,
-              "target": ""
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Background Task Total Wait Duration",
-          "tooltip": {
-            "msResolution": true,
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "transformations": [],
-          "transparent": false,
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "decimals": null,
-              "format": "\u00b5s",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "decimals": null,
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": 0
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "cacheTimeout": null,
-          "datasource": "${DS_TEST-CLUSTER}",
           "description": "The memory usage of the resource control module.",
           "editable": true,
           "error": false,
@@ -81374,13 +81241,13 @@
           },
           "gridPos": {
             "h": 7,
-            "w": 12,
-            "x": 12,
+            "w": 24,
+            "x": 0,
             "y": 0
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 595,
+          "id": 594,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -81513,7 +81380,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 596,
+          "id": 595,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -81676,7 +81543,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 597,
+          "id": 596,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -81812,7 +81679,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 598,
+      "id": 597,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -81845,13 +81712,13 @@
           },
           "gridPos": {
             "h": 7,
-            "w": 12,
+            "w": 6,
             "x": 0,
             "y": 0
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 599,
+          "id": 598,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -81972,7 +81839,7 @@
           "bars": false,
           "cacheTimeout": null,
           "datasource": "${DS_TEST-CLUSTER}",
-          "description": "Total resource utilization percentage of background tasks.",
+          "description": "Total resource consumed by background tasks, in centi-cores (cores * 100) for CPU or bytes/s for IO.",
           "editable": true,
           "error": false,
           "fieldConfig": {
@@ -81993,13 +81860,13 @@
           },
           "gridPos": {
             "h": 7,
-            "w": 12,
-            "x": 12,
+            "w": 6,
+            "x": 6,
             "y": 0
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 600,
+          "id": 599,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -82078,7 +81945,273 @@
           "yaxes": [
             {
               "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": 0
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "cacheTimeout": null,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "Historical (floor), current (measured), and target (foreground-pressure-driven ceiling) CPU usage of the unified read pool, as a percentage of one core (100 = 1 core).",
+          "editable": true,
+          "error": false,
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              }
+            }
+          },
+          "fill": 1,
+          "fillGradient": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 6,
+            "x": 12,
+            "y": 0
+          },
+          "height": null,
+          "hideTimeOverride": false,
+          "id": 600,
+          "interval": null,
+          "isNew": true,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": null,
+            "sort": "max",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "maxDataPoints": null,
+          "maxPerRow": null,
+          "minSpan": null,
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true,
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "repeatDirection": null,
+          "seriesOverrides": [],
+          "span": null,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "sum((\n    tikv_resource_control_read_pool_cpu_percent\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    \n)) by (instance, type) ",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{type}}-{{instance}}",
+              "metric": "",
+              "query": "sum((\n    tikv_resource_control_read_pool_cpu_percent\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    \n)) by (instance, type) ",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Unified Read Pool CPU",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "transformations": [],
+          "transparent": false,
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
               "format": "percent",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": 0
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "cacheTimeout": null,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "Common 0-100 resource-pressure score per resource type (cpu, io, compaction) used to drive background/foreground throttling.",
+          "editable": true,
+          "error": false,
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              }
+            }
+          },
+          "fill": 1,
+          "fillGradient": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 6,
+            "x": 18,
+            "y": 0
+          },
+          "height": null,
+          "hideTimeOverride": false,
+          "id": 601,
+          "interval": null,
+          "isNew": true,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": null,
+            "sort": "max",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "maxDataPoints": null,
+          "maxPerRow": null,
+          "minSpan": null,
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true,
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "repeatDirection": null,
+          "seriesOverrides": [],
+          "span": null,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "sum((\n    tikv_resource_control_resource_score\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    \n)) by (instance, type) ",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{type}}-{{instance}}",
+              "metric": "",
+              "query": "sum((\n    tikv_resource_control_resource_score\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    \n)) by (instance, type) ",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Resource Pressure Scores",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "transformations": [],
+          "transparent": false,
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "short",
               "label": null,
               "logBase": 1,
               "max": null,
@@ -82132,7 +82265,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 601,
+          "id": 602,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -82238,7 +82371,7 @@
           "bars": false,
           "cacheTimeout": null,
           "datasource": "${DS_TEST-CLUSTER}",
-          "description": "Current quota limit for background resource groups.",
+          "description": "Current quota limit for background resource groups, in centi-cores (cores * 100) for CPU or bytes/s for IO.",
           "editable": true,
           "error": false,
           "fieldConfig": {
@@ -82265,7 +82398,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 602,
+          "id": 603,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -82398,7 +82531,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 603,
+          "id": 604,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -82456,30 +82589,30 @@
             },
             {
               "datasource": "${DS_TEST-CLUSTER}",
-              "expr": "sum(rate(\n    tikv_resource_control_admission_delayed_requests_total\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (resource_group, is_background)  > 0",
+              "expr": "sum(rate(\n    tikv_resource_control_admission_delayed_requests_total\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (resource_group)  > 0",
               "format": "time_series",
               "hide": false,
               "instant": false,
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "delayed-{{resource_group}}-{{is_background}}",
+              "legendFormat": "delayed-{{resource_group}}",
               "metric": "",
-              "query": "sum(rate(\n    tikv_resource_control_admission_delayed_requests_total\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (resource_group, is_background)  > 0",
+              "query": "sum(rate(\n    tikv_resource_control_admission_delayed_requests_total\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (resource_group)  > 0",
               "refId": "",
               "step": 10,
               "target": ""
             },
             {
               "datasource": "${DS_TEST-CLUSTER}",
-              "expr": "sum(rate(\n    tikv_resource_control_admission_rejected_requests_total\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (resource_group, is_background)  > 0",
+              "expr": "sum(rate(\n    tikv_resource_control_admission_rejected_requests_total\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (resource_group)  > 0",
               "format": "time_series",
               "hide": false,
               "instant": false,
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "rejected-{{resource_group}}-{{is_background}}",
+              "legendFormat": "rejected-{{resource_group}}",
               "metric": "",
-              "query": "sum(rate(\n    tikv_resource_control_admission_rejected_requests_total\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (resource_group, is_background)  > 0",
+              "query": "sum(rate(\n    tikv_resource_control_admission_rejected_requests_total\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (resource_group)  > 0",
               "refId": "",
               "step": 10,
               "target": ""
@@ -82561,7 +82694,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 604,
+          "id": 605,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -82688,209 +82821,8 @@
           },
           "gridPos": {
             "h": 7,
-            "w": 12,
+            "w": 24,
             "x": 0,
-            "y": 21
-          },
-          "height": null,
-          "hideTimeOverride": false,
-          "id": 605,
-          "interval": null,
-          "isNew": true,
-          "legend": {
-            "alignAsTable": true,
-            "avg": false,
-            "current": true,
-            "hideEmpty": true,
-            "hideZero": true,
-            "max": true,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "sideWidth": null,
-            "sort": "max",
-            "sortDesc": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "maxDataPoints": null,
-          "maxPerRow": null,
-          "minSpan": null,
-          "nullPointMode": "null as zero",
-          "options": {
-            "alertThreshold": true,
-            "dataLinks": []
-          },
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "repeat": null,
-          "repeatDirection": null,
-          "seriesOverrides": [
-            {
-              "alias": "/^count/",
-              "bars": false,
-              "dashLength": 1,
-              "dashes": true,
-              "fill": 2,
-              "fillBelowTo": null,
-              "lines": true,
-              "spaceLength": 1,
-              "transform": "negative-Y",
-              "yaxis": 2,
-              "zindex": -3
-            },
-            {
-              "alias": "/^avg/",
-              "bars": false,
-              "fill": 7,
-              "fillBelowTo": null,
-              "lines": true,
-              "yaxis": 1,
-              "zindex": 0
-            }
-          ],
-          "span": null,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "datasource": "${DS_TEST-CLUSTER}",
-              "expr": "histogram_quantile(0.9999,(\n    sum(rate(\n    tikv_resource_control_admission_delay_duration_seconds_bucket\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",is_background=\"false\"}\n    [$__rate_interval]\n)) by (resource_group, le, $additional_groupby) \n    \n    \n))  ",
-              "format": "time_series",
-              "hide": false,
-              "instant": false,
-              "interval": "",
-              "intervalFactor": 1,
-              "legendFormat": "99.99%-{{resource_group}} {{$additional_groupby}}",
-              "metric": "",
-              "query": "histogram_quantile(0.9999,(\n    sum(rate(\n    tikv_resource_control_admission_delay_duration_seconds_bucket\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",is_background=\"false\"}\n    [$__rate_interval]\n)) by (resource_group, le, $additional_groupby) \n    \n    \n))  ",
-              "refId": "",
-              "step": 10,
-              "target": ""
-            },
-            {
-              "datasource": "${DS_TEST-CLUSTER}",
-              "expr": "histogram_quantile(0.99,(\n    sum(rate(\n    tikv_resource_control_admission_delay_duration_seconds_bucket\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",is_background=\"false\"}\n    [$__rate_interval]\n)) by (resource_group, le, $additional_groupby) \n    \n    \n))  ",
-              "format": "time_series",
-              "hide": false,
-              "instant": false,
-              "interval": "",
-              "intervalFactor": 1,
-              "legendFormat": "99%-{{resource_group}} {{$additional_groupby}}",
-              "metric": "",
-              "query": "histogram_quantile(0.99,(\n    sum(rate(\n    tikv_resource_control_admission_delay_duration_seconds_bucket\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",is_background=\"false\"}\n    [$__rate_interval]\n)) by (resource_group, le, $additional_groupby) \n    \n    \n))  ",
-              "refId": "",
-              "step": 10,
-              "target": ""
-            },
-            {
-              "datasource": "${DS_TEST-CLUSTER}",
-              "expr": "(sum(rate(\n    tikv_resource_control_admission_delay_duration_seconds_sum\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",is_background=\"false\"}\n    [$__rate_interval]\n)) by (resource_group, $additional_groupby)  / sum(rate(\n    tikv_resource_control_admission_delay_duration_seconds_count\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",is_background=\"false\"}\n    [$__rate_interval]\n)) by (resource_group, $additional_groupby) )",
-              "format": "time_series",
-              "hide": false,
-              "instant": false,
-              "interval": "",
-              "intervalFactor": 1,
-              "legendFormat": "avg-{{resource_group}} {{$additional_groupby}}",
-              "metric": "",
-              "query": "(sum(rate(\n    tikv_resource_control_admission_delay_duration_seconds_sum\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",is_background=\"false\"}\n    [$__rate_interval]\n)) by (resource_group, $additional_groupby)  / sum(rate(\n    tikv_resource_control_admission_delay_duration_seconds_count\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",is_background=\"false\"}\n    [$__rate_interval]\n)) by (resource_group, $additional_groupby) )",
-              "refId": "",
-              "step": 10,
-              "target": ""
-            },
-            {
-              "datasource": "${DS_TEST-CLUSTER}",
-              "expr": "sum(rate(\n    tikv_resource_control_admission_delay_duration_seconds_count\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",is_background=\"false\"}\n    [$__rate_interval]\n)) by (resource_group, $additional_groupby) ",
-              "format": "time_series",
-              "hide": false,
-              "instant": false,
-              "interval": "",
-              "intervalFactor": 1,
-              "legendFormat": "count-{{resource_group}} {{$additional_groupby}}",
-              "metric": "",
-              "query": "sum(rate(\n    tikv_resource_control_admission_delay_duration_seconds_count\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",is_background=\"false\"}\n    [$__rate_interval]\n)) by (resource_group, $additional_groupby) ",
-              "refId": "",
-              "step": 10,
-              "target": ""
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Admission Delay Duration",
-          "tooltip": {
-            "msResolution": true,
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "transformations": [],
-          "transparent": false,
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "decimals": null,
-              "format": "s",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "decimals": null,
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": 0
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "cacheTimeout": null,
-          "datasource": "${DS_TEST-CLUSTER}",
-          "description": "Total wait duration of background tasks per resource group.",
-          "editable": true,
-          "error": false,
-          "fieldConfig": {
-            "defaults": {
-              "thresholds": {
-                "mode": "absolute",
-                "steps": []
-              }
-            }
-          },
-          "fill": 1,
-          "fillGradient": 1,
-          "grid": {
-            "threshold1": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2": null,
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "gridPos": {
-            "h": 7,
-            "w": 12,
-            "x": 12,
             "y": 21
           },
           "height": null,
@@ -82938,15 +82870,45 @@
           "targets": [
             {
               "datasource": "${DS_TEST-CLUSTER}",
-              "expr": "sum(rate(\n    tikv_resource_control_background_task_wait_duration\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (resource_group)  > 0",
+              "expr": "histogram_quantile(0.9999,(\n    sum(rate(\n    tikv_resource_control_admission_delay_duration_seconds_bucket\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (resource_group, le, $additional_groupby) \n    \n    \n))  ",
               "format": "time_series",
               "hide": false,
               "instant": false,
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "{{resource_group}}",
+              "legendFormat": "99.99%-{{resource_group}} {{$additional_groupby}}",
               "metric": "",
-              "query": "sum(rate(\n    tikv_resource_control_background_task_wait_duration\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (resource_group)  > 0",
+              "query": "histogram_quantile(0.9999,(\n    sum(rate(\n    tikv_resource_control_admission_delay_duration_seconds_bucket\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (resource_group, le, $additional_groupby) \n    \n    \n))  ",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            },
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "histogram_quantile(0.99,(\n    sum(rate(\n    tikv_resource_control_admission_delay_duration_seconds_bucket\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (resource_group, le, $additional_groupby) \n    \n    \n))  ",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "99%-{{resource_group}} {{$additional_groupby}}",
+              "metric": "",
+              "query": "histogram_quantile(0.99,(\n    sum(rate(\n    tikv_resource_control_admission_delay_duration_seconds_bucket\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (resource_group, le, $additional_groupby) \n    \n    \n))  ",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            },
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "(sum(rate(\n    tikv_resource_control_admission_delay_duration_seconds_sum\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (resource_group, $additional_groupby)  / sum(rate(\n    tikv_resource_control_admission_delay_duration_seconds_count\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (resource_group, $additional_groupby) )",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "avg-{{resource_group}} {{$additional_groupby}}",
+              "metric": "",
+              "query": "(sum(rate(\n    tikv_resource_control_admission_delay_duration_seconds_sum\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (resource_group, $additional_groupby)  / sum(rate(\n    tikv_resource_control_admission_delay_duration_seconds_count\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (resource_group, $additional_groupby) )",
               "refId": "",
               "step": 10,
               "target": ""
@@ -82955,7 +82917,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Background Task Wait Duration",
+          "title": "Admission Delay Duration",
           "tooltip": {
             "msResolution": true,
             "shared": true,
@@ -82974,7 +82936,7 @@
           "yaxes": [
             {
               "decimals": null,
-              "format": "\u00b5s",
+              "format": "s",
               "label": null,
               "logBase": 1,
               "max": null,

--- a/metrics/grafana/tikv_details.json.sha256
+++ b/metrics/grafana/tikv_details.json.sha256
@@ -1,1 +1,1 @@
-6eec0ec9db2211fe1c0ef6b2826174572615da78e70f894aa9b417db274d9089  ./metrics/grafana/tikv_details.json
+69af5cde43ce8752864fbb079b122ad4fc0674e0e531e77c1cb9af3b25aeda5c  ./metrics/grafana/tikv_details.json

--- a/metrics/grafana/tikv_details.json.sha256
+++ b/metrics/grafana/tikv_details.json.sha256
@@ -1,1 +1,1 @@
-255d36bd582b388385c70c68790c90257d2f1e92d9d550ab159ea3a6d1a3234c  ./metrics/grafana/tikv_details.json
+6eec0ec9db2211fe1c0ef6b2826174572615da78e70f894aa9b417db274d9089  ./metrics/grafana/tikv_details.json

--- a/metrics/grafana/tikv_details.json.sha256
+++ b/metrics/grafana/tikv_details.json.sha256
@@ -1,1 +1,1 @@
-afbc8f2762bfb6e9addf1ba2f7904c044ded43e58852e46c375568b0e40fba48  ./metrics/grafana/tikv_details.json
+69af5cde43ce8752864fbb079b122ad4fc0674e0e531e77c1cb9af3b25aeda5c  ./metrics/grafana/tikv_details.json

--- a/metrics/grafana/tikv_details.json.sha256
+++ b/metrics/grafana/tikv_details.json.sha256
@@ -1,1 +1,1 @@
-69af5cde43ce8752864fbb079b122ad4fc0674e0e531e77c1cb9af3b25aeda5c  ./metrics/grafana/tikv_details.json
+b99d19c09df2e79c6bec523087224c39f5d375715eeab6e1e5552169d4dd02fe  ./metrics/grafana/tikv_details.json

--- a/metrics/grafana/tikv_details.json.sha256
+++ b/metrics/grafana/tikv_details.json.sha256
@@ -1,1 +1,1 @@
-a591c218bfe62afe71c1ba3827f0eb3aa63e1bacf52d2d1eb21dc7085338dd32  ./metrics/grafana/tikv_details.json
+35255abf7b60b9b85457dda073754742f9721ad309a8f0bc90cdb40749eda37e  ./metrics/grafana/tikv_details.json

--- a/metrics/grafana/tikv_details.json.sha256
+++ b/metrics/grafana/tikv_details.json.sha256
@@ -1,1 +1,1 @@
-6eec0ec9db2211fe1c0ef6b2826174572615da78e70f894aa9b417db274d9089  ./metrics/grafana/tikv_details.json
+afbc8f2762bfb6e9addf1ba2f7904c044ded43e58852e46c375568b0e40fba48  ./metrics/grafana/tikv_details.json

--- a/metrics/grafana/tikv_details.json.sha256
+++ b/metrics/grafana/tikv_details.json.sha256
@@ -1,1 +1,1 @@
-b99d19c09df2e79c6bec523087224c39f5d375715eeab6e1e5552169d4dd02fe  ./metrics/grafana/tikv_details.json
+a591c218bfe62afe71c1ba3827f0eb3aa63e1bacf52d2d1eb21dc7085338dd32  ./metrics/grafana/tikv_details.json

--- a/scripts/test
+++ b/scripts/test
@@ -22,6 +22,14 @@ CUSTOM_TEST_COMMAND=${CUSTOM_TEST_COMMAND:-"test"}
 # EXTRA_CARGO_ARGS is unecessary now: this can just be given as arguments to ./scripts/test-all or ./scripts/test
 EXTRA_CARGO_ARGS=${EXTRA_CARGO_ARGS:-""}
 
+if [ -f /.dockerenv ]; then
+  if [ -z "$TIKV_ENABLE_FEATURES" ]; then
+    TIKV_ENABLE_FEATURES="docker_test"
+  else
+    TIKV_ENABLE_FEATURES="$TIKV_ENABLE_FEATURES docker_test"
+  fi
+fi
+
 # When SIP is enabled, DYLD_LIBRARY_PATH will not work in subshell, so we have to set it
 # again here. LOCAL_DIR is defined in .travis.yml.
 export DYLD_LIBRARY_PATH="${DYLD_LIBRARY_PATH}:${LOCAL_DIR}/lib"

--- a/scripts/test-all
+++ b/scripts/test-all
@@ -21,5 +21,5 @@ fi
 
 if [[ "$(uname)" = "Linux" ]]; then
     CUSTOM_TEST_COMMAND="" EXTRA_CARGO_ARGS="" ./scripts/test --message-format=json-render-diagnostics -q --no-run |
-        python scripts/check-bins.py --features "${TIKV_ENABLE_FEATURES}" --check-tests
+        python3 scripts/check-bins.py --features "${TIKV_ENABLE_FEATURES}" --check-tests
 fi

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2946,6 +2946,7 @@ pub struct BackupStreamConfig {
     #[online_config(skip)]
     pub initial_scan_rate_limit: ReadableSize,
     pub initial_scan_concurrency: usize,
+    pub s3_multi_part_size: ReadableSize,
 }
 
 impl BackupStreamConfig {
@@ -2979,6 +2980,14 @@ impl BackupStreamConfig {
         if self.initial_scan_rate_limit.0 < 1024 {
             return Err("the `initial_scan_rate_limit` should be at least 1024 bytes".into());
         }
+        if self.s3_multi_part_size.0 > ReadableSize::gb(5).0 {
+            warn!(
+                "backup.s3_multi_part_size cannot larger than 5GB, change it to {:?}",
+                default_cfg.s3_multi_part_size
+            );
+            self.s3_multi_part_size = default_cfg.s3_multi_part_size;
+        }
+
         Ok(())
     }
 }
@@ -3008,6 +3017,7 @@ impl Default for BackupStreamConfig {
             initial_scan_rate_limit: ReadableSize::mb(60),
             initial_scan_concurrency: 6,
             temp_file_memory_quota: cache_size,
+            s3_multi_part_size: ReadableSize::mb(5),
         }
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -6029,8 +6029,9 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "#ifdef MALLOC_CONF"]
     #[cfg(feature = "mem-profiling")]
-    fn test_change_memory_config() {
+    fn test_change_memory_config_ifdef_malloc_conf() {
         let (cfg, _dir) = TikvConfig::with_tmp().unwrap();
         let cfg_controller = ConfigController::new(cfg);
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1260,6 +1260,9 @@ pub struct DbConfig {
     pub enable_statistics: bool,
     #[online_config(skip)]
     pub stats_dump_period: Option<ReadableDuration>,
+    // RocksDB 8.x compaction no longer relies on the old setup-time file hint
+    // path, so keep compaction readahead enabled by default instead of forcing
+    // it to 0 from TiKV config.
     pub compaction_readahead_size: ReadableSize,
     #[doc(hidden)]
     #[serde(skip_serializing)]
@@ -1356,7 +1359,7 @@ impl Default for DbConfig {
             max_open_files: 40960,
             enable_statistics: true,
             stats_dump_period: None,
-            compaction_readahead_size: ReadableSize::kb(0),
+            compaction_readahead_size: ReadableSize::mb(2),
             info_log_max_size: ReadableSize::gb(1),
             info_log_roll_time: ReadableDuration::secs(0),
             info_log_keep_log_file_num: 10,
@@ -1829,6 +1832,9 @@ pub struct RaftDbConfig {
     pub enable_statistics: bool,
     #[online_config(skip)]
     pub stats_dump_period: ReadableDuration,
+    // RocksDB 8.x compaction no longer relies on the old setup-time file hint
+    // path, so keep compaction readahead enabled by default instead of forcing
+    // it to 0 from TiKV config.
     pub compaction_readahead_size: ReadableSize,
     #[doc(hidden)]
     #[serde(skip_serializing)]
@@ -1894,7 +1900,7 @@ impl Default for RaftDbConfig {
             max_open_files: 40960,
             enable_statistics: true,
             stats_dump_period: ReadableDuration::minutes(10),
-            compaction_readahead_size: ReadableSize::kb(0),
+            compaction_readahead_size: ReadableSize::mb(2),
             info_log_max_size: ReadableSize::gb(1),
             info_log_roll_time: ReadableDuration::secs(0),
             info_log_keep_log_file_num: 10,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3997,6 +3997,7 @@ impl TikvConfig {
         self.resource_metering.validate()?;
         self.quota.validate()?;
         self.causal_ts.validate()?;
+        self.resource_control.validate()?;
 
         // Disable in memory engine if api version is V1ttl or V2.
         if (self.storage.api_version() == ApiVersion::V2 || self.storage.enable_ttl)

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -15,7 +15,7 @@ use concurrency_manager::ConcurrencyManager;
 use engine_traits::PerfLevel;
 use futures::{
     channel::{mpsc, oneshot},
-    future::Either,
+    future::{BoxFuture, Either},
     prelude::*,
 };
 use kvproto::{coprocessor as coppb, errorpb, kvrpcpb, kvrpcpb::CommandPri, metapb};
@@ -597,7 +597,7 @@ impl<E: Engine> Endpoint<E> {
                 .map(move |res| {
                     let _ = tx.send(res);
                 });
-        let res = self.read_pool_spawn_with_memory_quota_check(
+        let spawn_fut_result = self.read_pool_spawn_with_memory_quota_check(
             allocated_bytes,
             future,
             priority,
@@ -606,7 +606,7 @@ impl<E: Engine> Endpoint<E> {
             resource_limiter,
         );
         async move {
-            res?;
+            spawn_fut_result?.await?;
             rx.map_err(|_| Error::MaxPendingTasksExceeded).await?
         }
     }
@@ -879,7 +879,7 @@ impl<E: Engine> Endpoint<E> {
                     warn!("coprocessor stream send error"; "error" => %e);
                 });
 
-        self.read_pool_spawn_with_memory_quota_check(
+        let spawn_fut = self.read_pool_spawn_with_memory_quota_check(
             allocated_bytes,
             future,
             priority,
@@ -887,7 +887,18 @@ impl<E: Engine> Endpoint<E> {
             metadata,
             resource_limiter,
         )?;
-        Ok(rx)
+        // Transparent to caller: embed admission delay into the stream itself.
+        // On first poll, drives spawn_fut (sleep if delayed, then submit to
+        // yatp). On error yields one error item. Then chains with rx items.
+        let stream = futures::stream::once(Box::pin(async move {
+            spawn_fut
+                .await
+                .err()
+                .map(|_| Err(Error::MaxPendingTasksExceeded))
+        }))
+        .filter_map(futures::future::ready)
+        .chain(rx);
+        Ok(stream)
     }
 
     /// Parses and handles a stream request. Returns a stream that produce each
@@ -927,7 +938,7 @@ impl<E: Engine> Endpoint<E> {
         task_id: u64,
         metadata: TaskMetadata<'_>,
         resource_limiter: Option<Arc<ResourceLimiter>>,
-    ) -> Result<()>
+    ) -> Result<BoxFuture<'static, Result<()>>>
     where
         F: Future<Output = ()> + Send + 'static,
     {
@@ -938,9 +949,11 @@ impl<E: Engine> Endpoint<E> {
             // Release quota after handle completed.
             drop(owned_quota);
         });
-        self.read_pool
+        Ok(self
+            .read_pool
             .spawn(fut, priority, task_id, metadata, resource_limiter)
-            .map_err(|_| Error::MaxPendingTasksExceeded)
+            .map(|r| r.map_err(|_| Error::MaxPendingTasksExceeded))
+            .boxed())
     }
 }
 

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -623,9 +623,13 @@ impl<E: Engine> Endpoint<E> {
         let now = Instant::now();
         // Check the load of the read pool. If it's too busy, generate and return
         // error in the gRPC thread to avoid waiting in the queue of the read pool.
-        if let Err(busy_err) = self.read_pool.check_busy_threshold(Duration::from_millis(
-            req.get_context().get_busy_threshold_ms() as u64,
-        )) {
+        if let Err(busy_err) = self.read_pool.check_busy_threshold(
+            Duration::from_millis(req.get_context().get_busy_threshold_ms() as u64),
+            req.get_context()
+                .get_resource_control_context()
+                .get_resource_group_name()
+                .as_bytes(),
+        ) {
             let mut pb_error = errorpb::Error::new();
             pb_error.set_server_is_busy(busy_err);
             let resp = make_error_response(Error::Region(pb_error));

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -710,7 +710,7 @@ macro_rules! impl_write {
                                     writer.write(batch)?;
                                     Ok(writer)
                                 };
-                                with_resource_limiter(f, limiter.clone())
+                                with_resource_limiter(f, limiter.clone(), true, false, None, 0)
                                     .await
                                     .map(|w| (w, limiter))
                             },
@@ -727,7 +727,9 @@ macro_rules! impl_write {
                         Ok(metas)
                     };
 
-                    let metas: Result<_> = with_resource_limiter(finish_fn, resource_limiter).await;
+                    let metas: Result<_> =
+                        with_resource_limiter(finish_fn, resource_limiter, true, false, None, 0)
+                            .await;
                     let metas = match metas {
                         Ok(r) => r,
                         Err(e) => return (Err(e), None),
@@ -1050,6 +1052,10 @@ impl<E: Engine> ImportSst for ImportSstService<E> {
                         .req_type(req.get_request_type()),
                 ),
                 resource_limiter,
+                true,
+                false,
+                None,
+                0,
             )
             .await;
             let mut resp = DownloadResponse::default();
@@ -1175,6 +1181,10 @@ impl<E: Engine> ImportSst for ImportSstService<E> {
                         .req_type(req.get_request_type()),
                 ),
                 resource_limiter,
+                true,
+                false,
+                None,
+                0,
             )
             .await;
 

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -710,7 +710,7 @@ macro_rules! impl_write {
                                     writer.write(batch)?;
                                     Ok(writer)
                                 };
-                                with_resource_limiter(f, limiter.clone())
+                                with_resource_limiter(f, limiter.clone(), true)
                                     .await
                                     .map(|w| (w, limiter))
                             },
@@ -727,7 +727,8 @@ macro_rules! impl_write {
                         Ok(metas)
                     };
 
-                    let metas: Result<_> = with_resource_limiter(finish_fn, resource_limiter).await;
+                    let metas: Result<_> =
+                        with_resource_limiter(finish_fn, resource_limiter, true).await;
                     let metas = match metas {
                         Ok(r) => r,
                         Err(e) => return (Err(e), None),
@@ -1050,6 +1051,7 @@ impl<E: Engine> ImportSst for ImportSstService<E> {
                         .req_type(req.get_request_type()),
                 ),
                 resource_limiter,
+                true,
             )
             .await;
             let mut resp = DownloadResponse::default();
@@ -1175,6 +1177,7 @@ impl<E: Engine> ImportSst for ImportSstService<E> {
                         .req_type(req.get_request_type()),
                 ),
                 resource_limiter,
+                true,
             )
             .await;
 

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -710,7 +710,7 @@ macro_rules! impl_write {
                                     writer.write(batch)?;
                                     Ok(writer)
                                 };
-                                with_resource_limiter(f, limiter.clone(), true)
+                                with_resource_limiter(f, limiter.clone(), true, false, None, 0)
                                     .await
                                     .map(|w| (w, limiter))
                             },
@@ -728,7 +728,8 @@ macro_rules! impl_write {
                     };
 
                     let metas: Result<_> =
-                        with_resource_limiter(finish_fn, resource_limiter, true).await;
+                        with_resource_limiter(finish_fn, resource_limiter, true, false, None, 0)
+                            .await;
                     let metas = match metas {
                         Ok(r) => r,
                         Err(e) => return (Err(e), None),
@@ -1052,6 +1053,9 @@ impl<E: Engine> ImportSst for ImportSstService<E> {
                 ),
                 resource_limiter,
                 true,
+                false,
+                None,
+                0,
             )
             .await;
             let mut resp = DownloadResponse::default();
@@ -1178,6 +1182,9 @@ impl<E: Engine> ImportSst for ImportSstService<E> {
                 ),
                 resource_limiter,
                 true,
+                false,
+                None,
+                0,
             )
             .await;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,8 +37,6 @@
 #[macro_use(fail_point)]
 extern crate fail;
 #[macro_use]
-extern crate lazy_static;
-#[macro_use]
 extern crate serde_derive;
 #[macro_use]
 extern crate more_asserts;

--- a/src/read_pool.rs
+++ b/src/read_pool.rs
@@ -14,17 +14,18 @@ use std::{
 use file_system::{set_io_type, IoType};
 use futures::{
     channel::oneshot,
-    future::{FutureExt, TryFutureExt},
+    future::{BoxFuture, FutureExt, TryFutureExt},
 };
 use kvproto::{errorpb, kvrpcpb::CommandPri};
 use online_config::{ConfigChange, ConfigManager, ConfigValue, Result as CfgResult};
 use prometheus::{core::Metric, Histogram, IntCounter, IntGauge};
 use resource_control::{
-    with_resource_limiter, ControlledFuture, ResourceController, ResourceLimiter, TaskPriority,
+    with_resource_limiter, AdmissionDecision, ControlledFuture, ResourceController,
+    ResourceGroupManager, ResourceLimiter, TaskPriority,
 };
 use thiserror::Error;
 use tikv_util::{
-    resource_control::TaskMetadata,
+    resource_control::{priority_from_task_meta, TaskMetadata},
     sys::{cpu_time::ProcessStat, SysQuota},
     time::Instant,
     worker::{Runnable, RunnableWithTimer, Scheduler, Worker},
@@ -32,7 +33,10 @@ use tikv_util::{
 };
 use tracker::TrackedFuture;
 use yatp::{
-    metrics::MULTILEVEL_LEVEL_ELAPSED, pool::Remote, queue::Extras, task::future::TaskCell,
+    metrics::MULTILEVEL_LEVEL_ELAPSED,
+    pool::Remote,
+    queue::{Extras, TaskCell as TaskCellTrait},
+    task::future::TaskCell,
 };
 
 use self::metrics::*;
@@ -65,6 +69,7 @@ pub enum ReadPool {
         max_tasks: usize,
         pool_size: usize,
         resource_ctl: Option<Arc<ResourceController>>,
+        resource_manager: Option<Arc<ResourceGroupManager>>,
         time_slice_inspector: Arc<TimeSliceInspector>,
     },
 }
@@ -88,6 +93,7 @@ impl ReadPool {
                 max_tasks,
                 pool_size,
                 resource_ctl,
+                resource_manager,
                 time_slice_inspector,
             } => ReadPoolHandle::Yatp {
                 remote: pool.remote().clone(),
@@ -96,6 +102,7 @@ impl ReadPool {
                 max_tasks: *max_tasks,
                 pool_size: *pool_size,
                 resource_ctl: resource_ctl.clone(),
+                resource_manager: resource_manager.clone(),
                 time_slice_inspector: time_slice_inspector.clone(),
             },
         }
@@ -116,8 +123,68 @@ pub enum ReadPoolHandle {
         max_tasks: usize,
         pool_size: usize,
         resource_ctl: Option<Arc<ResourceController>>,
+        resource_manager: Option<Arc<ResourceGroupManager>>,
         time_slice_inspector: Arc<TimeSliceInspector>,
     },
+}
+
+/// Runs admission control then, if the task is allowed through, enqueues it.
+/// Admission is checked before the capacity/eviction check so that a rejected
+/// or timed-out delayed task never causes an already-queued task to be dropped.
+async fn admission_and_enqueue(
+    resource_manager: Option<Arc<ResourceGroupManager>>,
+    resource_limiter: Option<Arc<ResourceLimiter>>,
+    task_priority: TaskPriority,
+    gauge: IntGauge,
+    max_tasks: usize,
+    remote: Remote<TaskCell>,
+    task_cell: TaskCell,
+    running_tasks: Vec<IntGauge>,
+    resource_ctl: Option<Arc<ResourceController>>,
+    estimated_priority: u64,
+) -> Result<(), ReadPoolError> {
+    // Admission control runs before any eviction so that a rejected or
+    // timed-out delayed task never causes an already-queued task to be dropped.
+    let delay = match (resource_manager.as_deref(), resource_limiter.as_deref()) {
+        (Some(rm), Some(limiter)) => match rm.admission_decision(true, limiter) {
+            AdmissionDecision::Reject => return Err(ReadPoolError::Rejected),
+            AdmissionDecision::Delay(d) => {
+                if task_priority == TaskPriority::High {
+                    warn!("admission delay on high-priority read task";
+                          "group" => limiter.name(),
+                          "delay" => ?d);
+                }
+                Some((d, resource_manager))
+            }
+            AdmissionDecision::Allow => None,
+        },
+        _ => None,
+    };
+    if let Some((d, slot)) = delay {
+        let mut _guard = slot.as_ref().map(|rm| rm.delay_slot_guard());
+        futures_timer::Delay::new(d).await;
+        if let Some(guard) = _guard.as_mut() {
+            guard.release();
+        }
+    }
+    // After admission (and any sleep), check pool capacity and evict if needed.
+    if gauge.get() as usize >= max_tasks {
+        if let Some(ref _resource_ctl) = resource_ctl {
+            if let Some(mut evicted) = remote.try_evict_lowest(estimated_priority) {
+                let evicted_prio = priority_from_task_meta(evicted.mut_extras().metadata());
+                running_tasks[evicted_prio as usize].dec();
+                UNIFIED_READ_POOL_EVICTED_TASKS.inc();
+                drop(evicted);
+            } else {
+                return Err(ReadPoolError::UnifiedReadPoolFull);
+            }
+        } else {
+            return Err(ReadPoolError::UnifiedReadPoolFull);
+        }
+    }
+    gauge.inc();
+    remote.spawn(task_cell);
+    Ok(())
 }
 
 impl ReadPoolHandle {
@@ -128,7 +195,7 @@ impl ReadPoolHandle {
         task_id: u64,
         metadata: TaskMetadata<'_>,
         resource_limiter: Option<Arc<ResourceLimiter>>,
-    ) -> Result<(), ReadPoolError>
+    ) -> BoxFuture<'static, Result<(), ReadPoolError>>
     where
         F: Future<Output = ()> + Send + 'static,
     {
@@ -143,60 +210,82 @@ impl ReadPoolHandle {
                     CommandPri::Normal => read_pool_normal,
                     CommandPri::Low => read_pool_low,
                 };
-
-                pool.spawn(f)?;
+                let res = pool.spawn(f).map_err(ReadPoolError::from);
+                futures::future::ready(res).boxed()
             }
             ReadPoolHandle::Yatp {
                 remote,
                 running_tasks,
                 max_tasks,
                 resource_ctl,
+                resource_manager,
                 ..
             } => {
                 let task_priority = TaskPriority::from(metadata.override_priority());
-                let running_tasks = running_tasks[task_priority as usize].clone();
-                // Note that the running task number limit is not strict.
-                // If several tasks are spawned at the same time while the running task number
-                // is close to the limit, they may all pass this check and the number of running
-                // tasks may exceed the limit.
-                if running_tasks.get() as usize >= *max_tasks {
-                    return Err(ReadPoolError::UnifiedReadPoolFull);
-                }
-                running_tasks.inc();
-                let fixed_level = match priority {
-                    CommandPri::High => Some(0),
-                    CommandPri::Normal => None,
-                    CommandPri::Low => Some(2),
+                let running_task_gauge = running_tasks[task_priority as usize].clone();
+
+                let is_background = resource_limiter.as_ref().is_some_and(|l| l.is_background());
+                let fixed_level = if is_background {
+                    // Background tasks always run at low priority in the pool.
+                    Some(2)
+                } else {
+                    match priority {
+                        CommandPri::High => Some(0),
+                        CommandPri::Normal => None,
+                        CommandPri::Low => Some(2),
+                    }
                 };
                 let group_name = metadata.group_name().to_owned();
+                let estimated_priority = resource_ctl
+                    .as_ref()
+                    .map_or(u64::MAX, |ctl| ctl.peek_priority_of(&metadata, priority));
                 let mut extras = Extras::new_multilevel(task_id, fixed_level);
                 extras.set_metadata(metadata.to_vec());
+                // Clone gauge: one for inc (after admission), one inside the
+                // future for dec (when the task completes).
+                let gauge_for_spawn = running_task_gauge.clone();
                 let task_cell = if let Some(resource_ctl) = resource_ctl {
+                    let inner = ControlledFuture::new(
+                        f.map(move |_| {
+                            running_task_gauge.dec();
+                        }),
+                        resource_ctl.clone(),
+                        group_name.clone(),
+                    );
                     TaskCell::new(
                         TrackedFuture::new(with_resource_limiter(
-                            ControlledFuture::new(
-                                f.map(move |_| {
-                                    running_tasks.dec();
-                                }),
-                                resource_ctl.clone(),
-                                group_name,
-                            ),
-                            resource_limiter,
+                            inner,
+                            resource_limiter.clone(),
+                            true, // skip compaction pressure for foreground jobs
+                            true, // measure-only: build debt, never sleep inside pool
+                            resource_manager.clone(),
+                            0, // read path: no write bytes
                         )),
                         extras,
                     )
                 } else {
                     TaskCell::new(
                         TrackedFuture::new(f.map(move |_| {
-                            running_tasks.dec();
+                            running_task_gauge.dec();
                         })),
                         extras,
                     )
                 };
-                remote.spawn(task_cell);
+                admission_and_enqueue(
+                    resource_manager.clone(),
+                    resource_limiter,
+                    task_priority,
+                    gauge_for_spawn,
+                    *max_tasks,
+                    remote.clone(),
+                    task_cell,
+                    running_tasks.to_vec(),
+                    resource_ctl.clone(),
+                    estimated_priority,
+                )
+                .boxed()
             }
         }
-        Ok(())
     }
 
     pub fn spawn_handle<F, T>(
@@ -212,7 +301,7 @@ impl ReadPoolHandle {
         T: Send + 'static,
     {
         let (tx, rx) = oneshot::channel::<T>();
-        let res = self.spawn(
+        let spawn_fut = self.spawn(
             f.map(move |res| {
                 let _ = tx.send(res);
             }),
@@ -222,7 +311,7 @@ impl ReadPoolHandle {
             resource_limiter,
         );
         async move {
-            res?;
+            spawn_fut.await?;
             rx.map_err(ReadPoolError::from).await
         }
     }
@@ -448,6 +537,7 @@ pub fn build_yatp_read_pool<E: Engine, R: FlowStatsReporter>(
     reporter: R,
     engine: E,
     resource_ctl: Option<Arc<ResourceController>>,
+    resource_manager: Option<Arc<ResourceGroupManager>>,
     cleanup_method: CleanupMethod,
     enable_task_wait_metrics: bool,
 ) -> ReadPool {
@@ -457,6 +547,7 @@ pub fn build_yatp_read_pool<E: Engine, R: FlowStatsReporter>(
         reporter,
         engine,
         resource_ctl,
+        resource_manager,
         cleanup_method,
         unified_read_pool_name,
         enable_task_wait_metrics,
@@ -468,6 +559,7 @@ pub fn build_yatp_read_pool_with_name<E: Engine, R: FlowStatsReporter>(
     reporter: R,
     engine: E,
     resource_ctl: Option<Arc<ResourceController>>,
+    resource_manager: Option<Arc<ResourceGroupManager>>,
     cleanup_method: CleanupMethod,
     unified_read_pool_name: String,
     enable_task_wait_metrics: bool,
@@ -521,6 +613,7 @@ pub fn build_yatp_read_pool_with_name<E: Engine, R: FlowStatsReporter>(
             .saturating_mul(config.max_thread_count),
         pool_size: config.max_thread_count,
         resource_ctl,
+        resource_manager,
         time_slice_inspector,
     }
 }
@@ -881,6 +974,9 @@ pub enum ReadPoolError {
     #[error("Unified read pool is full")]
     UnifiedReadPoolFull,
 
+    #[error("Request rejected by admission control")]
+    Rejected,
+
     #[error("{0}")]
     Canceled(#[from] oneshot::Canceled),
 }
@@ -899,6 +995,11 @@ mod metrics {
             "tikv_unified_read_pool_thread_count",
             "The number of running threads in the unified read pool",
             &["name"]
+        )
+        .unwrap();
+        pub static ref UNIFIED_READ_POOL_EVICTED_TASKS: IntCounter = register_int_counter!(
+            "tikv_unified_read_pool_evicted_tasks",
+            "Number of tasks evicted from the unified read pool by higher-priority tasks"
         )
         .unwrap();
     }
@@ -942,6 +1043,7 @@ mod tests {
             DummyReporter,
             engine,
             None,
+            None,
             CleanupMethod::InPlace,
             name.to_owned(),
             false,
@@ -961,23 +1063,20 @@ mod tests {
         let (task3, _tx3) = gen_task();
         let (task4, _tx4) = gen_task();
 
-        handle
-            .spawn(task1, CommandPri::Normal, 1, TaskMetadata::default(), None)
+        block_on(handle.spawn(task1, CommandPri::Normal, 1, TaskMetadata::default(), None))
             .unwrap();
-        handle
-            .spawn(task2, CommandPri::Normal, 2, TaskMetadata::default(), None)
+        block_on(handle.spawn(task2, CommandPri::Normal, 2, TaskMetadata::default(), None))
             .unwrap();
 
         thread::sleep(Duration::from_millis(300));
-        match handle.spawn(task3, CommandPri::Normal, 3, TaskMetadata::default(), None) {
+        match block_on(handle.spawn(task3, CommandPri::Normal, 3, TaskMetadata::default(), None)) {
             Err(ReadPoolError::UnifiedReadPoolFull) => {}
             _ => panic!("should return full error"),
         }
         tx1.send(()).unwrap();
 
         thread::sleep(Duration::from_millis(300));
-        handle
-            .spawn(task4, CommandPri::Normal, 4, TaskMetadata::default(), None)
+        block_on(handle.spawn(task4, CommandPri::Normal, 4, TaskMetadata::default(), None))
             .unwrap();
         assert_eq!(
             UNIFIED_READ_POOL_RUNNING_TASKS
@@ -1003,6 +1102,7 @@ mod tests {
             DummyReporter,
             engine,
             None,
+            None,
             CleanupMethod::InPlace,
             false,
         );
@@ -1022,15 +1122,13 @@ mod tests {
         let (task4, _tx4) = gen_task();
         let (task5, _tx5) = gen_task();
 
-        handle
-            .spawn(task1, CommandPri::Normal, 1, TaskMetadata::default(), None)
+        block_on(handle.spawn(task1, CommandPri::Normal, 1, TaskMetadata::default(), None))
             .unwrap();
-        handle
-            .spawn(task2, CommandPri::Normal, 2, TaskMetadata::default(), None)
+        block_on(handle.spawn(task2, CommandPri::Normal, 2, TaskMetadata::default(), None))
             .unwrap();
 
         thread::sleep(Duration::from_millis(300));
-        match handle.spawn(task3, CommandPri::Normal, 3, TaskMetadata::default(), None) {
+        match block_on(handle.spawn(task3, CommandPri::Normal, 3, TaskMetadata::default(), None)) {
             Err(ReadPoolError::UnifiedReadPoolFull) => {}
             _ => panic!("should return full error"),
         }
@@ -1038,12 +1136,11 @@ mod tests {
         handle.scale_pool_size(3);
         assert_eq!(handle.get_normal_pool_size(), 3);
 
-        handle
-            .spawn(task4, CommandPri::Normal, 4, TaskMetadata::default(), None)
+        block_on(handle.spawn(task4, CommandPri::Normal, 4, TaskMetadata::default(), None))
             .unwrap();
 
         thread::sleep(Duration::from_millis(300));
-        match handle.spawn(task5, CommandPri::Normal, 5, TaskMetadata::default(), None) {
+        match block_on(handle.spawn(task5, CommandPri::Normal, 5, TaskMetadata::default(), None)) {
             Err(ReadPoolError::UnifiedReadPoolFull) => {}
             _ => panic!("should return full error"),
         }
@@ -1065,6 +1162,7 @@ mod tests {
             DummyReporter,
             engine,
             None,
+            None,
             CleanupMethod::InPlace,
             false,
         );
@@ -1084,15 +1182,13 @@ mod tests {
         let (task4, _tx4) = gen_task();
         let (task5, _tx5) = gen_task();
 
-        handle
-            .spawn(task1, CommandPri::Normal, 1, TaskMetadata::default(), None)
+        block_on(handle.spawn(task1, CommandPri::Normal, 1, TaskMetadata::default(), None))
             .unwrap();
-        handle
-            .spawn(task2, CommandPri::Normal, 2, TaskMetadata::default(), None)
+        block_on(handle.spawn(task2, CommandPri::Normal, 2, TaskMetadata::default(), None))
             .unwrap();
 
         thread::sleep(Duration::from_millis(300));
-        match handle.spawn(task3, CommandPri::Normal, 3, TaskMetadata::default(), None) {
+        match block_on(handle.spawn(task3, CommandPri::Normal, 3, TaskMetadata::default(), None)) {
             Err(ReadPoolError::UnifiedReadPoolFull) => {}
             _ => panic!("should return full error"),
         }
@@ -1113,12 +1209,11 @@ mod tests {
         handle.scale_pool_size(1);
         assert_eq!(handle.get_normal_pool_size(), 1);
 
-        handle
-            .spawn(task4, CommandPri::Normal, 4, TaskMetadata::default(), None)
+        block_on(handle.spawn(task4, CommandPri::Normal, 4, TaskMetadata::default(), None))
             .unwrap();
 
         thread::sleep(Duration::from_millis(300));
-        match handle.spawn(task5, CommandPri::Normal, 5, TaskMetadata::default(), None) {
+        match block_on(handle.spawn(task5, CommandPri::Normal, 5, TaskMetadata::default(), None)) {
             Err(ReadPoolError::UnifiedReadPoolFull) => {}
             _ => panic!("should return full error"),
         }
@@ -1209,6 +1304,7 @@ mod tests {
             DummyReporter,
             engine,
             None,
+            None,
             CleanupMethod::InPlace,
             false,
         );
@@ -1281,12 +1377,12 @@ mod tests {
 
         for control in [false, true] {
             let name = format!("test_yatp_task_poll_duration_metric_{}", control);
-            let resource_manager = if control {
-                let resource_manager = ResourceGroupManager::default();
-                let resource_ctl = resource_manager.derive_controller(name.clone(), true);
-                Some(resource_ctl)
+            let (resource_ctl, resource_manager) = if control {
+                let rm = Arc::new(ResourceGroupManager::default());
+                let ctl = rm.derive_controller(name.clone(), true);
+                (Some(ctl), Some(rm))
             } else {
-                None
+                (None, None)
             };
             let config = UnifiedReadPoolConfig {
                 min_thread_count: 1,
@@ -1301,6 +1397,7 @@ mod tests {
                 &config,
                 DummyReporter,
                 engine,
+                resource_ctl,
                 resource_manager,
                 CleanupMethod::InPlace,
                 name.clone(),
@@ -1321,11 +1418,9 @@ mod tests {
             let (task1, tx1) = gen_task();
             let (task2, tx2) = gen_task();
 
-            handle
-                .spawn(task1, CommandPri::Normal, 1, TaskMetadata::default(), None)
+            block_on(handle.spawn(task1, CommandPri::Normal, 1, TaskMetadata::default(), None))
                 .unwrap();
-            handle
-                .spawn(task2, CommandPri::Normal, 2, TaskMetadata::default(), None)
+            block_on(handle.spawn(task2, CommandPri::Normal, 2, TaskMetadata::default(), None))
                 .unwrap();
 
             tx1.send(()).unwrap();
@@ -1335,5 +1430,184 @@ mod tests {
             assert_eq!(count_metric(&name), 2);
             drop(pool);
         }
+    }
+
+    // Duplicated from resource_control::resource_group::tests which is
+    // #[cfg(test)] pub(crate) and not accessible from this crate.
+    fn new_resource_group_ru(
+        name: String,
+        ru: u64,
+        group_priority: u32,
+    ) -> kvproto::resource_manager::ResourceGroup {
+        use kvproto::resource_manager::{GroupMode, GroupRequestUnitSettings, ResourceGroup};
+        let mut group = ResourceGroup::new();
+        group.set_name(name);
+        group.set_mode(GroupMode::RuMode);
+        group.set_priority(group_priority);
+        let mut ru_setting = GroupRequestUnitSettings::new();
+        ru_setting.mut_r_u().mut_settings().set_fill_rate(ru);
+        group.set_r_u_settings(ru_setting);
+        group
+    }
+
+    #[test]
+    fn test_yatp_eviction() {
+        // Test that when the read pool is full, a higher-priority incoming task
+        // can evict the lowest-priority queued task.
+        //
+        // Strategy: Use 1 worker thread and max_tasks_per_worker=4 (total=4).
+        // Spawn 1 blocking task to occupy the only worker thread, then spawn
+        // 3 low-priority tasks that will sit in the queue. The pool is now
+        // "full" (4 running_tasks). A high-priority task should evict one of
+        // the queued low-priority tasks.
+        //
+        // Note on the two priority systems:
+        // - `override_priority` (in ResourceControlContext) determines the TaskPriority
+        //   bucket (High/Medium/Low) used for running_tasks counters. Both groups use 0
+        //   here, so all tasks are "medium".
+        // - Resource group priority (1 vs 16) is what peek_priority_of uses for the
+        //   eviction comparison. "high_group" (priority=16) produces a numerically
+        //   smaller value than "low_group" (priority=1), meaning it is scheduled first
+        //   and can evict low_group tasks.
+        let resource_manager = Arc::new(ResourceGroupManager::default());
+        let low_group = new_resource_group_ru("low_group".into(), 5000, 1);
+        resource_manager.add_resource_group(low_group);
+        let high_group = new_resource_group_ru("high_group".into(), 5000, 16);
+        resource_manager.add_resource_group(high_group);
+
+        let name = "test-yatp-eviction";
+        let resource_ctl = resource_manager.derive_controller(name.into(), true);
+
+        let config = UnifiedReadPoolConfig {
+            min_thread_count: 1,
+            max_thread_count: 1,
+            max_tasks_per_worker: 4,
+            ..Default::default()
+        };
+
+        let engine = TestEngineBuilder::new().build().unwrap();
+        let pool = build_yatp_read_pool_with_name(
+            &config,
+            DummyReporter,
+            engine,
+            Some(resource_ctl),
+            Some(resource_manager),
+            CleanupMethod::InPlace,
+            name.to_owned(),
+            false,
+        );
+
+        let gen_task = || {
+            let (tx, rx) = oneshot::channel::<()>();
+            let task = async move {
+                let _ = rx.await;
+            };
+            (task, tx)
+        };
+
+        let handle = pool.handle();
+
+        let low_ctx = ResourceControlContext {
+            resource_group_name: "low_group".to_string(),
+            override_priority: 0,
+            ..Default::default()
+        };
+
+        // Task 1: synchronously blocks the only worker thread so that it
+        // cannot pop any further tasks from the global priority queue. An
+        // async-only future (oneshot::channel::await) would return Pending
+        // immediately, letting the worker loop back and drain tasks 2-4 from
+        // the queue before the eviction attempt — causing a race.
+        let (block_tx, block_rx) = std::sync::mpsc::channel::<()>();
+        let task1 = async move {
+            let _ = block_rx.recv();
+        };
+        block_on(handle.spawn(
+            task1,
+            CommandPri::Normal,
+            1,
+            TaskMetadata::from_ctx(&low_ctx),
+            None,
+        ))
+        .unwrap();
+
+        // Wait for task1 to be picked up and block the worker.
+        thread::sleep(Duration::from_millis(300));
+
+        // Tasks 2-4: these will sit in the global queue since the worker is
+        // blocked by task1.
+        let (task2, _tx2) = gen_task();
+        let (task3, _tx3) = gen_task();
+        let (task4, _tx4) = gen_task();
+
+        block_on(handle.spawn(
+            task2,
+            CommandPri::Normal,
+            2,
+            TaskMetadata::from_ctx(&low_ctx),
+            None,
+        ))
+        .unwrap();
+        block_on(handle.spawn(
+            task3,
+            CommandPri::Normal,
+            3,
+            TaskMetadata::from_ctx(&low_ctx),
+            None,
+        ))
+        .unwrap();
+        block_on(handle.spawn(
+            task4,
+            CommandPri::Normal,
+            4,
+            TaskMetadata::from_ctx(&low_ctx),
+            None,
+        ))
+        .unwrap();
+
+        // Verify pool is full: spawning another low-priority task should fail.
+        let (task_low5, _tx_low5) = gen_task();
+        match block_on(handle.spawn(
+            task_low5,
+            CommandPri::Normal,
+            5,
+            TaskMetadata::from_ctx(&low_ctx),
+            None,
+        )) {
+            Err(ReadPoolError::UnifiedReadPoolFull) => {}
+            other => panic!(
+                "expected UnifiedReadPoolFull for low-priority task, got {:?}",
+                other.err()
+            ),
+        }
+
+        // Now spawn a high-priority task — should succeed via eviction of a
+        // queued low-priority task.
+        let (task_high, _tx_high) = gen_task();
+        let high_ctx = ResourceControlContext {
+            resource_group_name: "high_group".to_string(),
+            override_priority: 0,
+            ..Default::default()
+        };
+
+        block_on(handle.spawn(
+            task_high,
+            CommandPri::High,
+            6,
+            TaskMetadata::from_ctx(&high_ctx),
+            None,
+        ))
+        .expect("high-priority task should succeed via eviction");
+
+        // The eviction metric should have been incremented.
+        assert!(
+            UNIFIED_READ_POOL_EVICTED_TASKS.get() >= 1,
+            "eviction counter should be incremented"
+        );
+
+        // Unblock task1 so the worker thread can resume and the pool can
+        // shut down cleanly.
+        let _ = block_tx.send(());
+        thread::sleep(Duration::from_millis(300));
     }
 }

--- a/src/read_pool.rs
+++ b/src/read_pool.rs
@@ -24,15 +24,18 @@ use resource_control::{
 };
 use thiserror::Error;
 use tikv_util::{
-    resource_control::TaskMetadata,
-    sys::{cpu_time::ProcessStat, SysQuota},
+    resource_control::{TaskMetadata, priority_from_task_meta},
+    sys::{SysQuota, cpu_time::ProcessStat, thread::matches_thread_name_prefix},
     time::Instant,
     worker::{Runnable, RunnableWithTimer, Scheduler, Worker},
     yatp_pool::{self, CleanupMethod, FuturePool, PoolTicker, YatpPoolBuilder},
 };
 use tracker::TrackedFuture;
 use yatp::{
-    metrics::MULTILEVEL_LEVEL_ELAPSED, pool::Remote, queue::Extras, task::future::TaskCell,
+    metrics::MULTILEVEL_LEVEL_ELAPSED,
+    pool::Remote,
+    queue::{Extras, TaskCell as TaskCellTrait},
+    task::future::TaskCell,
 };
 
 use self::metrics::*;
@@ -154,15 +157,45 @@ impl ReadPoolHandle {
                 ..
             } => {
                 let task_priority = TaskPriority::from(metadata.override_priority());
-                let running_tasks = running_tasks[task_priority as usize].clone();
+                let running_task_gauge = running_tasks[task_priority as usize].clone();
                 // Note that the running task number limit is not strict.
                 // If several tasks are spawned at the same time while the running task number
                 // is close to the limit, they may all pass this check and the number of running
                 // tasks may exceed the limit.
-                if running_tasks.get() as usize >= *max_tasks {
-                    return Err(ReadPoolError::UnifiedReadPoolFull);
+                if running_task_gauge.get() as usize >= *max_tasks {
+                    // When resource control is enabled, attempt to evict the
+                    // lowest-priority queued task if the incoming task has
+                    // strictly higher priority. This implements queue fairness:
+                    // important tasks can preempt less important queued tasks
+                    // when the pool is full.
+                    if let Some(ref ctl) = resource_ctl {
+                        let estimated_priority = ctl.peek_priority_of(&metadata, priority);
+                        if let Some(mut evicted) = remote.try_evict_lowest(estimated_priority) {
+                            // Decrement the running_tasks counter for the
+                            // evicted task's priority level. The evicted task's
+                            // future (which contains the running_tasks.dec()
+                            // closure) will be dropped without executing.
+                            let evicted_prio =
+                                priority_from_task_meta(evicted.mut_extras().metadata());
+                            running_tasks[evicted_prio as usize].dec();
+                            UNIFIED_READ_POOL_EVICTED_TASKS.inc();
+                            // Dropping the evicted TaskCell destroys the future
+                            // inside it. That future holds the oneshot::Sender
+                            // used by spawn_handle (or by coprocessor's manual
+                            // channel). When the sender is dropped the
+                            // corresponding receiver gets a Canceled error,
+                            // which callers surface as SchedTooBusy /
+                            // ServerIsBusy back to the client.
+                            drop(evicted);
+                            // Fall through to enqueue the new task below.
+                        } else {
+                            return Err(ReadPoolError::UnifiedReadPoolFull);
+                        }
+                    } else {
+                        return Err(ReadPoolError::UnifiedReadPoolFull);
+                    }
                 }
-                running_tasks.inc();
+                running_task_gauge.inc();
                 let fixed_level = match priority {
                     CommandPri::High => Some(0),
                     CommandPri::Normal => None,
@@ -176,7 +209,7 @@ impl ReadPoolHandle {
                         TrackedFuture::new(with_resource_limiter(
                             ControlledFuture::new(
                                 f.map(move |_| {
-                                    running_tasks.dec();
+                                    running_task_gauge.dec();
                                 }),
                                 resource_ctl.clone(),
                                 group_name,
@@ -188,7 +221,7 @@ impl ReadPoolHandle {
                 } else {
                     TaskCell::new(
                         TrackedFuture::new(f.map(move |_| {
-                            running_tasks.dec();
+                            running_task_gauge.dec();
                         })),
                         extras,
                     )
@@ -901,6 +934,11 @@ mod metrics {
             &["name"]
         )
         .unwrap();
+        pub static ref UNIFIED_READ_POOL_EVICTED_TASKS: IntCounter = register_int_counter!(
+            "tikv_unified_read_pool_evicted_tasks",
+            "Number of tasks evicted from the unified read pool by higher-priority tasks"
+        )
+        .unwrap();
     }
 }
 
@@ -1335,5 +1373,188 @@ mod tests {
             assert_eq!(count_metric(&name), 2);
             drop(pool);
         }
+    }
+
+    // Duplicated from resource_control::resource_group::tests which is
+    // #[cfg(test)] pub(crate) and not accessible from this crate.
+    fn new_resource_group_ru(
+        name: String,
+        ru: u64,
+        group_priority: u32,
+    ) -> kvproto::resource_manager::ResourceGroup {
+        use kvproto::resource_manager::{GroupMode, GroupRequestUnitSettings, ResourceGroup};
+        let mut group = ResourceGroup::new();
+        group.set_name(name);
+        group.set_mode(GroupMode::RuMode);
+        group.set_priority(group_priority);
+        let mut ru_setting = GroupRequestUnitSettings::new();
+        ru_setting.mut_r_u().mut_settings().set_fill_rate(ru);
+        group.set_r_u_settings(ru_setting);
+        group
+    }
+
+    #[test]
+    fn test_yatp_eviction() {
+        // Test that when the read pool is full, a higher-priority incoming task
+        // can evict the lowest-priority queued task.
+        //
+        // Strategy: Use 1 worker thread and max_tasks_per_worker=4 (total=4).
+        // Spawn 1 blocking task to occupy the only worker thread, then spawn
+        // 3 low-priority tasks that will sit in the queue. The pool is now
+        // "full" (4 running_tasks). A high-priority task should evict one of
+        // the queued low-priority tasks.
+        //
+        // Note on the two priority systems:
+        // - `override_priority` (in ResourceControlContext) determines the TaskPriority
+        //   bucket (High/Medium/Low) used for running_tasks counters. Both groups use 0
+        //   here, so all tasks are "medium".
+        // - Resource group priority (1 vs 16) is what peek_priority_of uses for the
+        //   eviction comparison. "high_group" (priority=16) produces a numerically
+        //   smaller value than "low_group" (priority=1), meaning it is scheduled first
+        //   and can evict low_group tasks.
+        let resource_manager = ResourceGroupManager::default();
+        let low_group = new_resource_group_ru("low_group".into(), 5000, 1);
+        resource_manager.add_resource_group(low_group);
+        let high_group = new_resource_group_ru("high_group".into(), 5000, 16);
+        resource_manager.add_resource_group(high_group);
+
+        let name = "test-yatp-eviction";
+        let resource_ctl = resource_manager.derive_controller(name.into(), true);
+
+        let config = UnifiedReadPoolConfig {
+            min_thread_count: 1,
+            max_thread_count: 1,
+            max_tasks_per_worker: 4,
+            ..Default::default()
+        };
+
+        let engine = TestEngineBuilder::new().build().unwrap();
+        let pool = build_yatp_read_pool_with_name(
+            &config,
+            DummyReporter,
+            engine,
+            Some(resource_ctl),
+            CleanupMethod::InPlace,
+            name.to_owned(),
+            false,
+        );
+
+        let gen_task = || {
+            let (tx, rx) = oneshot::channel::<()>();
+            let task = async move {
+                let _ = rx.await;
+            };
+            (task, tx)
+        };
+
+        let handle = pool.handle();
+
+        let low_ctx = ResourceControlContext {
+            resource_group_name: "low_group".to_string(),
+            override_priority: 0,
+            ..Default::default()
+        };
+
+        // Task 1: synchronously blocks the only worker thread so that it
+        // cannot pop any further tasks from the global priority queue. An
+        // async-only future (oneshot::channel::await) would return Pending
+        // immediately, letting the worker loop back and drain tasks 2-4 from
+        // the queue before the eviction attempt — causing a race.
+        let (block_tx, block_rx) = std::sync::mpsc::channel::<()>();
+        let task1 = async move {
+            let _ = block_rx.recv();
+        };
+        handle
+            .spawn(
+                task1,
+                CommandPri::Normal,
+                1,
+                TaskMetadata::from_ctx(&low_ctx),
+                None,
+            )
+            .unwrap();
+
+        // Wait for task1 to be picked up and block the worker.
+        thread::sleep(Duration::from_millis(300));
+
+        // Tasks 2-4: these will sit in the global queue since the worker is
+        // blocked by task1.
+        let (task2, _tx2) = gen_task();
+        let (task3, _tx3) = gen_task();
+        let (task4, _tx4) = gen_task();
+
+        handle
+            .spawn(
+                task2,
+                CommandPri::Normal,
+                2,
+                TaskMetadata::from_ctx(&low_ctx),
+                None,
+            )
+            .unwrap();
+        handle
+            .spawn(
+                task3,
+                CommandPri::Normal,
+                3,
+                TaskMetadata::from_ctx(&low_ctx),
+                None,
+            )
+            .unwrap();
+        handle
+            .spawn(
+                task4,
+                CommandPri::Normal,
+                4,
+                TaskMetadata::from_ctx(&low_ctx),
+                None,
+            )
+            .unwrap();
+
+        // Verify pool is full: spawning another low-priority task should fail.
+        let (task_low5, _tx_low5) = gen_task();
+        match handle.spawn(
+            task_low5,
+            CommandPri::Normal,
+            5,
+            TaskMetadata::from_ctx(&low_ctx),
+            None,
+        ) {
+            Err(ReadPoolError::UnifiedReadPoolFull) => {}
+            other => panic!(
+                "expected UnifiedReadPoolFull for low-priority task, got {:?}",
+                other.err()
+            ),
+        }
+
+        // Now spawn a high-priority task — should succeed via eviction of a
+        // queued low-priority task.
+        let (task_high, _tx_high) = gen_task();
+        let high_ctx = ResourceControlContext {
+            resource_group_name: "high_group".to_string(),
+            override_priority: 0,
+            ..Default::default()
+        };
+
+        handle
+            .spawn(
+                task_high,
+                CommandPri::High,
+                6,
+                TaskMetadata::from_ctx(&high_ctx),
+                None,
+            )
+            .expect("high-priority task should succeed via eviction");
+
+        // The eviction metric should have been incremented.
+        assert!(
+            UNIFIED_READ_POOL_EVICTED_TASKS.get() >= 1,
+            "eviction counter should be incremented"
+        );
+
+        // Unblock task1 so the worker thread can resume and the pool can
+        // shut down cleanly.
+        let _ = block_tx.send(());
+        thread::sleep(Duration::from_millis(300));
     }
 }

--- a/src/read_pool.rs
+++ b/src/read_pool.rs
@@ -26,7 +26,7 @@ use resource_control::{
 use thiserror::Error;
 use tikv_util::{
     resource_control::{priority_from_task_meta, TaskMetadata},
-    sys::{cpu_time::ProcessStat, SysQuota},
+    sys::{cpu_time::ProcessStat, thread::matches_thread_name_prefix, SysQuota},
     time::Instant,
     worker::{Runnable, RunnableWithTimer, Scheduler, Worker},
     yatp_pool::{self, CleanupMethod, FuturePool, PoolTicker, YatpPoolBuilder},
@@ -55,6 +55,7 @@ const READ_POOL_THREAD_HIGH_THRESHOLD: f64 = 0.8;
 const READ_POOL_THREAD_LOW_THRESHOLD: f64 = 0.7;
 // avg running tasks per-thread that indicates read-pool is busy
 const RUNNING_TASKS_PER_THREAD_THRESHOLD: i64 = 3;
+const UNIFIED_READ_POOL_THREAD: &str = "unified-read";
 
 pub enum ReadPool {
     FuturePools {
@@ -690,7 +691,7 @@ impl ReadPoolCpuTimeTracker {
         for &tid in &tids {
             if let Ok(stat) = full_thread_stat(pid, tid) {
                 // Look for unified read pool thread name pattern
-                if stat.command.contains("unified-read-po") {
+                if matches_thread_name_prefix(&stat.command, UNIFIED_READ_POOL_THREAD) {
                     // Sum utime + stime (user + system time)
                     current_total_cpu_time += stat.utime + stat.stime;
                 }

--- a/src/read_pool.rs
+++ b/src/read_pool.rs
@@ -21,11 +21,12 @@ use online_config::{ConfigChange, ConfigManager, ConfigValue, Result as CfgResul
 use prometheus::{core::Metric, Histogram, IntCounter, IntGauge};
 use resource_control::{
     with_resource_limiter, AdmissionDecision, ControlledFuture, ResourceController,
-    ResourceGroupManager, ResourceLimiter, TaskPriority, READ_POOL_CPU_VEC,
+    ResourceGroupManager, ResourceLimiter, TaskPriority, CONTROL_TICK, LEEWAY_FACTOR,
+    LEEWAY_FRACTION, READ_POOL_CPU_VEC,
 };
 use thiserror::Error;
 use tikv_util::{
-    resource_control::{priority_from_task_meta, TaskMetadata},
+    resource_control::{priority_from_task_meta, TaskMetadata, DEFAULT_RESOURCE_GROUP_NAME},
     sys::{cpu_time::ProcessStat, thread::matches_thread_name_prefix, SysQuota},
     time::Instant,
     worker::{Runnable, RunnableWithTimer, Scheduler, Worker},
@@ -45,8 +46,6 @@ use crate::{
     storage::kv::{destroy_tls_engine, set_tls_engine, Engine, FlowStatsReporter},
 };
 
-// the duration to check auto-scale unified-thread-pool's thread
-const READ_POOL_THREAD_CHECK_DURATION: Duration = Duration::from_secs(10);
 // consider scale out read pool size if the average thread cpu usage is higher
 // than this threshold.
 const READ_POOL_THREAD_HIGH_THRESHOLD: f64 = 0.8;
@@ -139,7 +138,7 @@ async fn admission_and_enqueue(
     gauge: IntGauge,
     max_tasks: usize,
     remote: Remote<TaskCell>,
-    task_cell: TaskCell,
+    mut task_cell: TaskCell,
     running_tasks: Vec<IntGauge>,
     resource_ctl: Option<Arc<ResourceController>>,
     estimated_priority: u64,
@@ -155,14 +154,14 @@ async fn admission_and_enqueue(
                           "group" => limiter.name(),
                           "delay" => ?d);
                 }
-                Some((d, resource_manager))
+                Some(d)
             }
             AdmissionDecision::Allow => None,
         },
         _ => None,
     };
-    if let Some((d, slot)) = delay {
-        let mut _guard = slot.as_ref().map(|rm| rm.delay_slot_guard());
+    if let Some(d) = delay {
+        let mut _guard = resource_manager.as_ref().map(|rm| rm.delay_slot_guard());
         futures_timer::Delay::new(d).await;
         if let Some(guard) = _guard.as_mut() {
             guard.release();
@@ -170,17 +169,41 @@ async fn admission_and_enqueue(
     }
     // After admission (and any sleep), check pool capacity and evict if needed.
     if gauge.get() as usize >= max_tasks {
-        if let Some(ref _resource_ctl) = resource_ctl {
-            if let Some(mut evicted) = remote.try_evict_lowest(estimated_priority) {
+        // Eviction is only available with a resource controller, and normally
+        // succeeds -- so nothing about the rejection is computed until the
+        // request is actually being rejected.
+        let evicted = if resource_ctl.is_some() {
+            remote.try_evict_lowest(estimated_priority)
+        } else {
+            None
+        };
+        match evicted {
+            Some(mut evicted) => {
                 let evicted_prio = priority_from_task_meta(evicted.mut_extras().metadata());
                 running_tasks[evicted_prio as usize].dec();
                 UNIFIED_READ_POOL_EVICTED_TASKS.inc();
                 drop(evicted);
-            } else {
+            }
+            None => {
+                let meta = TaskMetadata::from(task_cell.mut_extras().metadata());
+                // The name reaches us from the client, so bound it to the
+                // configured groups before it becomes a metric label -- see
+                // `ResourceGroupManager::bounded_group_name`. Invalid UTF-8
+                // cannot name a configured group either, so it collapses the
+                // same way. `group_name()` already reports "default" for the
+                // default group, which is the label `check_busy_threshold`
+                // uses for it, so the two pre-pool counters agree there with
+                // no special case.
+                let name = std::str::from_utf8(meta.group_name()).unwrap_or_default();
+                let label = match resource_manager.as_deref() {
+                    Some(rm) => rm.bounded_group_name(name),
+                    None => DEFAULT_RESOURCE_GROUP_NAME,
+                };
+                UNIFIED_READ_POOL_FULL_REJECTED
+                    .with_label_values(&[label])
+                    .inc();
                 return Err(ReadPoolError::UnifiedReadPoolFull);
             }
-        } else {
-            return Err(ReadPoolError::UnifiedReadPoolFull);
         }
     }
     gauge.inc();
@@ -393,6 +416,13 @@ impl ReadPoolHandle {
         } = self
         {
             time_slice_inspector.update();
+            UNIFIED_READ_POOL_EWMA_TIME_SLICE_US
+                .set(time_slice_inspector.get_ewma_time_slice().as_micros() as i64);
+        }
+        // The input to `check_busy_threshold`. Sampled here rather than at the
+        // gate so it is reported even when no client sends a busy threshold.
+        if let Some(wait) = self.get_estimated_wait_duration() {
+            UNIFIED_READ_POOL_ESTIMATED_WAIT_US.set(wait.as_micros() as i64);
         }
     }
 
@@ -401,9 +431,28 @@ impl ReadPoolHandle {
             .map(|s| s * (self.get_queue_size_per_worker() as u32))
     }
 
+    /// Bound a wire-supplied resource group name for use as a metric label.
+    /// With no resource manager there are no configured groups to validate
+    /// against, so everything collapses to the default rather than letting an
+    /// unvalidated name reach the label.
+    fn bounded_group_label<'a>(&self, resource_group: &'a str) -> &'a str {
+        match self {
+            ReadPoolHandle::Yatp {
+                resource_manager: Some(rm),
+                ..
+            } => rm.bounded_group_name(resource_group),
+            _ => DEFAULT_RESOURCE_GROUP_NAME,
+        }
+    }
+
+    /// `resource_group` is bytes rather than `&str` because most requests
+    /// return at one of the two gates below without ever needing the name:
+    /// a client that does not set `busy_threshold` never gets past the first.
+    /// Validating UTF-8 in the caller spent that work on every request.
     pub fn check_busy_threshold(
         &self,
         busy_threshold: Duration,
+        resource_group: &[u8],
     ) -> Result<(), errorpb::ServerIsBusy> {
         if busy_threshold.is_zero() {
             return Ok(());
@@ -418,6 +467,10 @@ impl ReadPoolHandle {
         let mut busy_err = errorpb::ServerIsBusy::default();
         busy_err.set_reason("estimated wait time exceeds threshold".to_owned());
         busy_err.estimated_wait_ms = u32::try_from(estimated_wait.as_millis()).unwrap_or(u32::MAX);
+        let group = std::str::from_utf8(resource_group).unwrap_or_default();
+        UNIFIED_READ_POOL_BUSY_THRESHOLD_REJECTED
+            .with_label_values(&[self.bounded_group_label(group)])
+            .inc();
         warn!("Already many pending tasks in the read queue, task is rejected";
             "busy_threshold" => ?&busy_threshold,
             "busy_err" => ?&busy_err,
@@ -884,9 +937,8 @@ impl ReadPoolConfigRunner {
             && thread_usage < (self.cur_thread_count - 1) as f64 * READ_POOL_THREAD_LOW_THRESHOLD
             && running_tasks < self.cur_thread_count as i64 * RUNNING_TASKS_PER_THREAD_THRESHOLD;
 
-        let leeway = 0.1;
-        let busy_cpu_scale_in = read_pool_cpu > (leeway + 1.0) * target_cpu_cores;
-        let busy_cpu_scale_out = read_pool_cpu < (1.0 - leeway) * target_cpu_cores
+        let busy_cpu_scale_in = read_pool_cpu > (1.0 + LEEWAY_FRACTION) * target_cpu_cores;
+        let busy_cpu_scale_out = read_pool_cpu < LEEWAY_FACTOR * target_cpu_cores
             && self.cur_thread_count < self.core_thread_count
             && scale_out_allowed;
 
@@ -912,14 +964,13 @@ impl ReadPoolConfigRunner {
 
         self.set_thread_count(new_thread_count);
 
-        // While we haven't scaled back up to core_thread_count, keep noisy
-        // resource groups deprioritized. Once recovered, release everyone —
-        // which also clears any flags left over from when fair scheduling was
-        // last enabled, since deprioritizing is a no-op while it is off.
+        // Only CPU pressure justifies penalizing a tenant — the thread ladder
+        // also scales in when the pool is merely oversized. Release at full
+        // recovery also clears flags left from when fair scheduling was off.
         if let Some(rm) = resource_manager.as_ref() {
-            if self.cur_thread_count < self.core_thread_count {
+            if busy_cpu_scale_in {
                 rm.deprioritize_over_quota_groups();
-            } else {
+            } else if self.cur_thread_count == self.core_thread_count {
                 rm.reset_group_priorities();
             }
         }
@@ -981,7 +1032,7 @@ impl ReadPoolConfigManager {
         cpu_threshold: f64,
     ) -> Self {
         let runner = ReadPoolConfigRunner {
-            interval: READ_POOL_THREAD_CHECK_DURATION,
+            interval: CONTROL_TICK,
             sender,
             handle,
             cpu_time_tracker: ReadPoolCpuTimeTracker::new(&get_unified_read_pool_name()),
@@ -1067,6 +1118,34 @@ mod metrics {
             "Number of tasks evicted from the unified read pool by higher-priority tasks"
         )
         .unwrap();
+        // Splits the two sources of `ServerIsBusy`: the estimated-wait gate in
+        // `check_busy_threshold` and the capacity gate in the spawn path. Both
+        // return the same error to the client, so without these the share of
+        // each is not recoverable from metrics.
+        pub static ref UNIFIED_READ_POOL_BUSY_THRESHOLD_REJECTED: IntCounterVec =
+            register_int_counter_vec!(
+                "tikv_unified_read_pool_busy_threshold_rejected_total",
+                "Requests rejected because the estimated read pool wait exceeded the client's busy threshold",
+                &["resource_group"]
+            )
+            .unwrap();
+        pub static ref UNIFIED_READ_POOL_FULL_REJECTED: IntCounterVec =
+            register_int_counter_vec!(
+                "tikv_unified_read_pool_full_rejected_total",
+                "Requests rejected because the unified read pool queue was at capacity",
+                &["resource_group"]
+            )
+            .unwrap();
+        pub static ref UNIFIED_READ_POOL_ESTIMATED_WAIT_US: IntGauge = register_int_gauge!(
+            "tikv_unified_read_pool_estimated_wait_us",
+            "Estimated queueing wait for a new unified read pool task, in microseconds"
+        )
+        .unwrap();
+        pub static ref UNIFIED_READ_POOL_EWMA_TIME_SLICE_US: IntGauge = register_int_gauge!(
+            "tikv_unified_read_pool_ewma_time_slice_us",
+            "EWMA of a single task poll duration in the unified read pool, in microseconds"
+        )
+        .unwrap();
     }
 }
 
@@ -1133,11 +1212,33 @@ mod tests {
         block_on(handle.spawn(task2, CommandPri::Normal, 2, TaskMetadata::default(), None))
             .unwrap();
 
+        let full_rejected = || {
+            UNIFIED_READ_POOL_FULL_REJECTED
+                .with_label_values(&[DEFAULT_RESOURCE_GROUP_NAME])
+                .get()
+        };
+        let before = full_rejected();
+
         thread::sleep(Duration::from_millis(300));
         match block_on(handle.spawn(task3, CommandPri::Normal, 3, TaskMetadata::default(), None)) {
             Err(ReadPoolError::UnifiedReadPoolFull) => {}
             _ => panic!("should return full error"),
         }
+        // The metadata above carries no resource group. Its rejection has to be
+        // attributed to "default", the label `check_busy_threshold` uses for the
+        // same group, so the two pre-pool counters stay comparable.
+        assert!(
+            full_rejected() > before,
+            "the default group's full-pool rejection must be counted under \
+             {DEFAULT_RESOURCE_GROUP_NAME}"
+        );
+        assert_eq!(
+            UNIFIED_READ_POOL_FULL_REJECTED
+                .with_label_values(&[""])
+                .get(),
+            0,
+            "an empty group name must never reach the label"
+        );
         tx1.send(()).unwrap();
 
         thread::sleep(Duration::from_millis(300));
@@ -1497,7 +1598,7 @@ mod tests {
 
         // Repeated ticks keep reducing cur_thread_count relative to itself
         // each time (via the read pool's own cur_thread_count * ratio math),
-        // until it stabilizes at floor(0.9 * 4.0) = 3 — the target ceiling's
+        // until it stabilizes at floor(0.85 * 4.0) = 3 — the target ceiling's
         // own floor, since the fixed test reading never drops further to
         // push the ceiling down any more.
         for _ in 0..20 {
@@ -1597,8 +1698,6 @@ mod tests {
         auto_adjust: bool,
         resource_manager: Option<Arc<ResourceGroupManager>>,
     ) -> (ReadPoolConfigRunner, tikv_util::worker::Worker) {
-        use tikv_util::worker::Worker;
-
         let config = UnifiedReadPoolConfig {
             min_thread_count: 1,
             max_thread_count: 8,
@@ -2102,6 +2201,97 @@ mod tests {
     }
 
     #[test]
+    fn test_busy_threshold_rejection_is_counted() {
+        let config = UnifiedReadPoolConfig {
+            min_thread_count: 1,
+            max_thread_count: 1,
+            max_tasks_per_worker: 100,
+            ..Default::default()
+        };
+        let resource_manager = Arc::new(ResourceGroupManager::default());
+        resource_manager.add_resource_group(new_resource_group_ru("noisy".into(), 5000, 1));
+        let engine = TestEngineBuilder::new().build().unwrap();
+        let pool = build_yatp_read_pool_with_name(
+            &config,
+            DummyReporter,
+            engine,
+            None,
+            Some(resource_manager.clone()),
+            CleanupMethod::InPlace,
+            "test-busy-threshold".to_owned(),
+            false,
+        );
+        let handle = pool.handle();
+
+        // The estimate is one poll's duration times the queued tasks per
+        // worker, so both have to be non-zero before the gate can fire at all.
+        let (inspector, running_tasks) = match &handle {
+            ReadPoolHandle::Yatp {
+                time_slice_inspector,
+                running_tasks,
+                ..
+            } => (time_slice_inspector, running_tasks),
+            _ => panic!("expected a yatp pool"),
+        };
+        inspector.atomic_ewma_nanos.store(
+            Duration::from_millis(1).as_nanos() as u64,
+            std::sync::atomic::Ordering::Release,
+        );
+        running_tasks[0].add(500);
+        assert_eq!(
+            handle.get_estimated_wait_duration(),
+            Some(Duration::from_millis(500)),
+            "500 queued tasks on one worker at 1ms per poll"
+        );
+
+        let counter = |g: &str| {
+            UNIFIED_READ_POOL_BUSY_THRESHOLD_REJECTED
+                .with_label_values(&[g])
+                .get()
+        };
+        let before = counter("noisy");
+        // Zero means the client asked for no gate; 1s is above the estimate.
+        // Neither is a rejection.
+        handle
+            .check_busy_threshold(Duration::ZERO, b"noisy")
+            .expect("a zero threshold disables the gate");
+        handle
+            .check_busy_threshold(Duration::from_secs(1), b"noisy")
+            .expect("1s is above the 500ms estimate");
+        assert_eq!(counter("noisy"), before);
+
+        let err = handle
+            .check_busy_threshold(Duration::from_millis(100), b"noisy")
+            .expect_err("the estimate is over the threshold");
+        assert_eq!(err.estimated_wait_ms, 500);
+        assert_eq!(counter("noisy"), before + 1, "rejection must be counted");
+        assert_eq!(
+            counter("quiet"),
+            0,
+            "rejection must be attributed to its own group"
+        );
+
+        // An unconfigured name arrives from the client and must not become a
+        // label of its own, or a caller mints a new series per request.
+        let default_before = counter(DEFAULT_RESOURCE_GROUP_NAME);
+        handle
+            .check_busy_threshold(Duration::from_millis(100), b"../../etc/passwd\n{injected}")
+            .expect_err("the estimate is over the threshold");
+        assert_eq!(
+            counter("../../etc/passwd\n{injected}"),
+            0,
+            "an unconfigured group name must never reach the label"
+        );
+        assert_eq!(
+            counter(DEFAULT_RESOURCE_GROUP_NAME),
+            default_before + 1,
+            "it is counted against the default group instead"
+        );
+
+        running_tasks[0].sub(500);
+    }
+
+    #[test]
     fn test_auto_adjust_disable_notifies_pool_size_change() {
         use std::sync::mpsc::sync_channel;
 
@@ -2134,7 +2324,7 @@ mod tests {
         };
 
         let mut runner = ReadPoolConfigRunner {
-            interval: READ_POOL_THREAD_CHECK_DURATION,
+            interval: CONTROL_TICK,
             sender: tx,
             handle,
             cpu_time_tracker: ReadPoolCpuTimeTracker::new("test"),

--- a/src/read_pool.rs
+++ b/src/read_pool.rs
@@ -21,7 +21,7 @@ use online_config::{ConfigChange, ConfigManager, ConfigValue, Result as CfgResul
 use prometheus::{core::Metric, Histogram, IntCounter, IntGauge};
 use resource_control::{
     with_resource_limiter, AdmissionDecision, ControlledFuture, ResourceController,
-    ResourceGroupManager, ResourceLimiter, TaskPriority,
+    ResourceGroupManager, ResourceLimiter, TaskPriority, READ_POOL_CPU_VEC,
 };
 use thiserror::Error;
 use tikv_util::{
@@ -773,11 +773,6 @@ impl Runnable for ReadPoolConfigRunner {
             }
             Task::AutoAdjust(s) => {
                 self.auto_adjust = s;
-                // when auto adjust is disabled, reset to the config pool size.
-                if !s && self.cur_thread_count != self.core_thread_count {
-                    self.handle.scale_pool_size(self.core_thread_count);
-                    self.cur_thread_count = self.core_thread_count;
-                }
             }
             Task::MaxTasksPerWorker(s) => {
                 self.handle.set_max_tasks_per_worker(s);
@@ -811,7 +806,28 @@ impl ReadPoolConfigRunner {
 
     // Adjust pool size using based on thread utilization or cpu utilization.
     fn adjust_pool_size(&mut self) {
+        let resource_manager = match &self.handle {
+            // The runner only exists for the unified (Yatp) pool; see
+            // running_tasks(). `resource_manager` is None only when
+            // resource-control.enabled is false, which is startup-only.
+            ReadPoolHandle::Yatp {
+                resource_manager, ..
+            } => resource_manager.clone(),
+            _ => unreachable!(),
+        };
+
+        // Pool sizing is gated entirely on auto_adjust: with it off the pool
+        // stays at its configured size, exactly as before this change. Note
+        // this also makes fair scheduling inert, since its release signal is
+        // the pool recovering to core_thread_count — see
+        // `Config::enable_fair_scheduling`.
         if !self.auto_adjust {
+            self.reset_thread_count();
+            // Release anything deprioritized while auto-adjustment was on, so
+            // a stale flag can't outlive the pool movement that set it.
+            if let Some(rm) = resource_manager.as_ref() {
+                rm.reset_group_priorities();
+            }
             return;
         }
 
@@ -825,14 +841,39 @@ impl ReadPoolConfigRunner {
                 return;
             }
         };
-        let target_cpu_cores = if self.cpu_threshold > 0.0 {
+
+        let mut target_cpu_cores = if self.cpu_threshold > 0.0 {
             self.cpu_threshold * SysQuota::cpu_cores_quota()
         } else {
             SysQuota::cpu_cores_quota()
         };
 
-        // Base scaling conditions (process CPU, thread usage, task queue depth)
+        // Fold the ResourceGroupManager's foreground-pressure-driven target
+        // into the local ceiling — whichever is tighter wins. It returns no
+        // ceiling when fair scheduling is off.
+        if let Some(rm) = resource_manager.as_ref() {
+            let rm_target_cpu =
+                rm.compute_read_pool_target_cpu(read_pool_cpu, self.interval.as_secs_f64());
+            target_cpu_cores = target_cpu_cores.min(rm_target_cpu);
+        }
+        READ_POOL_CPU_VEC
+            .with_label_values(&["target"])
+            .set(target_cpu_cores * 100.0);
+
+        // Scaling out is otherwise a purely local decision (process CPU,
+        // thread usage, task queue depth, or read_pool_cpu vs
+        // target_cpu_cores). Additionally defer to the ResourceGroupManager's
+        // idle signal so the pool doesn't grow while it's still trying to
+        // protect foreground latency; it always allows scale-out when fair
+        // scheduling is off.
+        let scale_out_allowed = match resource_manager.as_ref() {
+            Some(rm) => rm.read_pool_scale_up_allowed(),
+            None => true,
+        };
+
+        // Thread-utilization ladder (process CPU, thread usage, queue depth).
         let busy_thread_scale_out = self.cur_thread_count < self.max_thread_count
+            && scale_out_allowed
             && process_cpu * (self.cur_thread_count as f64 + 1.0) / (self.cur_thread_count as f64)
                 < target_cpu_cores
             && thread_usage > self.cur_thread_count as f64 * READ_POOL_THREAD_HIGH_THRESHOLD
@@ -843,10 +884,10 @@ impl ReadPoolConfigRunner {
             && running_tasks < self.cur_thread_count as i64 * RUNNING_TASKS_PER_THREAD_THRESHOLD;
 
         let leeway = 0.1;
-        let busy_cpu_scale_in =
-            self.cpu_threshold > 0.0 && read_pool_cpu > (leeway + 1.0) * target_cpu_cores;
+        let busy_cpu_scale_in = read_pool_cpu > (leeway + 1.0) * target_cpu_cores;
         let busy_cpu_scale_out = read_pool_cpu < (1.0 - leeway) * target_cpu_cores
-            && self.cur_thread_count < self.core_thread_count;
+            && self.cur_thread_count < self.core_thread_count
+            && scale_out_allowed;
 
         let new_thread_count = if busy_cpu_scale_in {
             // CPU threshold takes precedence over busy thread scaling conditions
@@ -868,11 +909,34 @@ impl ReadPoolConfigRunner {
             self.cur_thread_count
         };
 
+        self.set_thread_count(new_thread_count);
+
+        // While we haven't scaled back up to core_thread_count, keep noisy
+        // resource groups deprioritized. Once recovered, release everyone —
+        // which also clears any flags left over from when fair scheduling was
+        // last enabled, since deprioritizing is a no-op while it is off.
+        if let Some(rm) = resource_manager.as_ref() {
+            if self.cur_thread_count < self.core_thread_count {
+                rm.deprioritize_over_quota_groups();
+            } else {
+                rm.reset_group_priorities();
+            }
+        }
+    }
+
+    /// Resizes the pool, no-op if it is already at `new_thread_count`.
+    fn set_thread_count(&mut self, new_thread_count: usize) {
         if new_thread_count != self.cur_thread_count {
             self.handle.scale_pool_size(new_thread_count);
             self.notify_pool_size_change(new_thread_count);
             self.cur_thread_count = new_thread_count;
         }
+    }
+
+    /// Restores the pool to its configured size, used when auto-adjustment is
+    /// turned off and the ladder is no longer allowed to move it.
+    fn reset_thread_count(&mut self) {
+        self.set_thread_count(self.core_thread_count);
     }
 
     fn notify_pool_size_change(&self, new_thread_count: usize) {
@@ -1364,6 +1428,431 @@ mod tests {
     }
 
     #[test]
+    fn test_read_pool_pressure_scale_down_with_resource_manager() {
+        use tikv_util::worker::Worker;
+
+        let config = UnifiedReadPoolConfig {
+            min_thread_count: 1,
+            max_thread_count: 8,
+            max_tasks_per_worker: 4,
+            // cpu_threshold left at its 0.0 default on purpose: covers the
+            // default-config path.
+            auto_adjust_pool_size: true,
+            ..Default::default()
+        };
+        // Two-phase scheduling must be enabled for adjust_pool_size to fold
+        // the ResourceGroupManager's target CPU into target_cpu_cores at all.
+        let rm_config = resource_control::config::Config {
+            enable_fair_scheduling: true,
+            ..Default::default()
+        };
+        let resource_manager = Arc::new(ResourceGroupManager::new(rm_config));
+
+        let engine = TestEngineBuilder::new().build().unwrap();
+        let pool = build_yatp_read_pool(
+            &config,
+            DummyReporter,
+            engine,
+            None,
+            Some(resource_manager.clone()),
+            CleanupMethod::InPlace,
+            false,
+        );
+
+        let handle = pool.handle();
+        let worker = Worker::new("test-worker");
+        let mut runner = ReadPoolConfigRunner {
+            interval: Duration::from_secs(10),
+            sender: std::sync::mpsc::sync_channel(10).0,
+            handle: handle.clone(),
+            cpu_time_tracker: ReadPoolCpuTimeTracker::new("test-pool"),
+            process_stats: ProcessStat::cur_proc_stat().unwrap(),
+            min_thread_count: config.min_thread_count,
+            core_thread_count: 8,
+            cur_thread_count: 8,
+            max_thread_count: config.max_thread_count,
+            auto_adjust: true,
+            cpu_threshold: config.cpu_threshold,
+        };
+
+        // Drive online_adjust_resource_quota so read_pool_cpu_pressure() > 0,
+        // matching how the real GroupQuotaAdjustWorker tick would set it.
+        resource_manager.set_bg_cpu_at_floor(true);
+        resource_manager.online_adjust_resource_quota(90.0);
+        assert!(resource_manager.read_pool_cpu_pressure() > 0.0);
+
+        runner.cpu_time_tracker.set_test_cpu_utilization(4.0);
+
+        let before_first_tick = runner.cur_thread_count;
+        runner.adjust_pool_size();
+
+        assert!(
+            runner.cur_thread_count < before_first_tick && runner.cur_thread_count > 1,
+            "a single tick should reduce the pool gradually, not collapse it straight to the \
+             minimum; before: {}, after: {}",
+            before_first_tick,
+            runner.cur_thread_count
+        );
+
+        // Repeated ticks keep reducing cur_thread_count relative to itself
+        // each time (via the read pool's own cur_thread_count * ratio math),
+        // until it stabilizes at floor(0.9 * 4.0) = 3 — the target ceiling's
+        // own floor, since the fixed test reading never drops further to
+        // push the ceiling down any more.
+        for _ in 0..20 {
+            runner.adjust_pool_size();
+        }
+        assert_eq!(
+            runner.cur_thread_count, 3,
+            "sustained pressure should converge to and stabilize at the target ceiling's floor, got {}",
+            runner.cur_thread_count
+        );
+
+        worker.stop();
+    }
+
+    #[test]
+    fn test_read_pool_scale_out_blocked_until_resource_manager_allows_it() {
+        use tikv_util::worker::Worker;
+
+        let config = UnifiedReadPoolConfig {
+            min_thread_count: 1,
+            max_thread_count: 8,
+            max_tasks_per_worker: 4,
+            cpu_threshold: 0.0,
+            auto_adjust_pool_size: true,
+            ..Default::default()
+        };
+        // Two-phase scheduling must be enabled for adjust_pool_size to defer
+        // to the resource manager's read_pool_scale_up_allowed() signal.
+        let rm_config = resource_control::config::Config {
+            enable_fair_scheduling: true,
+            ..Default::default()
+        };
+        let resource_manager = Arc::new(ResourceGroupManager::new(rm_config));
+
+        let engine = TestEngineBuilder::new().build().unwrap();
+        let pool = build_yatp_read_pool(
+            &config,
+            DummyReporter,
+            engine,
+            None,
+            Some(resource_manager.clone()),
+            CleanupMethod::InPlace,
+            false,
+        );
+
+        let handle = pool.handle();
+        let worker = Worker::new("test-worker");
+        let mut runner = ReadPoolConfigRunner {
+            interval: Duration::from_secs(10),
+            sender: std::sync::mpsc::sync_channel(10).0,
+            handle: handle.clone(),
+            cpu_time_tracker: ReadPoolCpuTimeTracker::new("test-pool"),
+            process_stats: ProcessStat::cur_proc_stat().unwrap(),
+            // min_thread_count == cur_thread_count so busy_thread_scale_in
+            // (unrelated to the resource manager) can't confound the result.
+            min_thread_count: 2,
+            core_thread_count: 8,
+            cur_thread_count: 2,
+            max_thread_count: config.max_thread_count,
+            auto_adjust: true,
+            cpu_threshold: config.cpu_threshold,
+        };
+
+        // Comfortably idle read-pool CPU: with no ResourceGroupManager, this
+        // alone would trigger busy_cpu_scale_out. read_pool_scale_up_allowed()
+        // defaults to false, so scheduling must block the grow.
+        assert!(!resource_manager.read_pool_scale_up_allowed());
+        runner.cpu_time_tracker.set_test_cpu_utilization(0.01);
+
+        runner.adjust_pool_size();
+
+        assert_eq!(
+            runner.cur_thread_count, 2,
+            "scheduling should block scale-out until the resource manager allows it, got {}",
+            runner.cur_thread_count
+        );
+
+        // Once the resource manager reports the system is comfortably idle,
+        // scale-out proceeds normally.
+        resource_manager.online_adjust_resource_quota(0.0);
+        assert!(resource_manager.read_pool_scale_up_allowed());
+
+        runner.adjust_pool_size();
+
+        assert_eq!(
+            runner.cur_thread_count, 3,
+            "scale-out should proceed once the resource manager allows it, got {}",
+            runner.cur_thread_count
+        );
+
+        worker.stop();
+    }
+
+    // Runner with auto-adjust off. Every other read pool test enables it,
+    // which is why the fair-scheduling coupling went unnoticed.
+    fn test_runner(
+        auto_adjust: bool,
+        resource_manager: Option<Arc<ResourceGroupManager>>,
+    ) -> (ReadPoolConfigRunner, tikv_util::worker::Worker) {
+        use tikv_util::worker::Worker;
+
+        let config = UnifiedReadPoolConfig {
+            min_thread_count: 1,
+            max_thread_count: 8,
+            max_tasks_per_worker: 4,
+            auto_adjust_pool_size: auto_adjust,
+            ..Default::default()
+        };
+        let engine = TestEngineBuilder::new().build().unwrap();
+        let pool = build_yatp_read_pool(
+            &config,
+            DummyReporter,
+            engine,
+            None,
+            resource_manager,
+            CleanupMethod::InPlace,
+            false,
+        );
+        let handle = pool.handle();
+        let worker = Worker::new("test-worker");
+        let runner = ReadPoolConfigRunner {
+            interval: Duration::from_secs(10),
+            sender: std::sync::mpsc::sync_channel(10).0,
+            handle,
+            cpu_time_tracker: ReadPoolCpuTimeTracker::new("test-pool"),
+            process_stats: ProcessStat::cur_proc_stat().unwrap(),
+            min_thread_count: config.min_thread_count,
+            core_thread_count: 8,
+            cur_thread_count: 8,
+            max_thread_count: config.max_thread_count,
+            auto_adjust,
+            cpu_threshold: config.cpu_threshold,
+        };
+        (runner, worker)
+    }
+
+    #[test]
+    fn test_phase1_group_released_when_auto_adjust_is_off() {
+        // Auto-adjust off makes fair scheduling inert, so a flag set while it
+        // was on must not outlive it: the pool no longer moves, and pool
+        // movement is what would otherwise release the group.
+        let rm_config = resource_control::config::Config {
+            enable_fair_scheduling: true,
+            ..Default::default()
+        };
+        let resource_manager = Arc::new(ResourceGroupManager::new(rm_config));
+        let ctl = resource_manager.derive_controller("read".into(), true);
+
+        let group = tikv_util::resource_control::DEFAULT_RESOURCE_GROUP_NAME;
+        resource_manager.record_ru_consumption(group, 1000);
+
+        let phase0 = ctl.get_priority(group.as_bytes(), CommandPri::Normal);
+        ctl.set_group_phase(group.as_bytes(), true);
+        let phase1 = ctl.get_priority(group.as_bytes(), CommandPri::Normal);
+        assert!(phase1 > phase0, "sanity: group should be in phase 1");
+
+        let (mut runner, worker) = test_runner(false, Some(resource_manager.clone()));
+        runner.adjust_pool_size();
+
+        let after = ctl.get_priority(group.as_bytes(), CommandPri::Normal);
+        assert!(
+            after < phase1,
+            "auto-adjust off should release phase 1; phase1: {}, after: {}",
+            phase1,
+            after
+        );
+
+        worker.stop();
+    }
+
+    #[test]
+    fn test_raw_auto_scaling_without_resource_manager() {
+        // Auto-adjust on with no resource manager still runs the original
+        // thread-utilization ladder; with it off the pool must not move. Same
+        // conditions either way, so the only variable is the gate itself.
+        let (mut runner, worker) = test_runner(true, None);
+        let before = runner.cur_thread_count;
+        runner.adjust_pool_size();
+        assert_eq!(
+            runner.cur_thread_count,
+            before - 1,
+            "an idle pool should scale in by one step"
+        );
+        worker.stop();
+
+        let (mut runner, worker) = test_runner(false, None);
+        let before = runner.cur_thread_count;
+        runner.adjust_pool_size();
+        assert_eq!(
+            runner.cur_thread_count, before,
+            "auto-adjust off must leave the pool at its configured size"
+        );
+        worker.stop();
+    }
+
+    #[test]
+    fn test_no_scaling_when_both_fair_scheduling_and_auto_adjust_are_off() {
+        // Control: with both off there is nothing to maintain, so the pool
+        // must stay put.
+        let rm_config = resource_control::config::Config {
+            enable_fair_scheduling: false,
+            ..Default::default()
+        };
+        let resource_manager = Arc::new(ResourceGroupManager::new(rm_config));
+        let (mut runner, worker) = test_runner(false, Some(resource_manager));
+
+        runner.cpu_time_tracker.set_test_cpu_utilization(4.0);
+        let before = runner.cur_thread_count;
+
+        runner.adjust_pool_size();
+
+        assert_eq!(
+            runner.cur_thread_count, before,
+            "pool must not scale when both fair scheduling and auto-adjust are off"
+        );
+
+        worker.stop();
+    }
+
+    #[test]
+    fn test_auto_adjust_off_pins_thread_count_with_fair_scheduling_on() {
+        // The thread ladder is bounded (min == max == core_thread_count) rather
+        // than gated on auto_adjust, so an idle pool must not drift. Without
+        // that bound the idle thread usage here trips busy_thread_scale_in.
+        let rm_config = resource_control::config::Config {
+            enable_fair_scheduling: true,
+            ..Default::default()
+        };
+        let resource_manager = Arc::new(ResourceGroupManager::new(rm_config));
+        let (mut runner, worker) = test_runner(false, Some(resource_manager));
+        // A wider configured range than core: only the effective bound stops
+        // the ladder from using it.
+        runner.min_thread_count = 1;
+        runner.max_thread_count = 16;
+
+        // No foreground pressure, so there is no CPU ceiling and the thread
+        // ladder is the only thing that could move the pool.
+        let before = runner.cur_thread_count;
+        for _ in 0..5 {
+            runner.adjust_pool_size();
+        }
+
+        assert_eq!(
+            runner.cur_thread_count, before,
+            "auto-adjust off must pin the pool at core_thread_count, got {}",
+            runner.cur_thread_count
+        );
+
+        worker.stop();
+    }
+
+    #[test]
+    fn test_phase1_group_released_when_fair_scheduling_is_disabled() {
+        // With auto-adjust off too the tick returns early, so the release has
+        // to happen on that path or the flag goes live again on re-enable.
+        let rm_config = resource_control::config::Config {
+            enable_fair_scheduling: true,
+            ..Default::default()
+        };
+        let resource_manager = Arc::new(ResourceGroupManager::new(rm_config));
+        let ctl = resource_manager.derive_controller("read".into(), true);
+
+        let group = tikv_util::resource_control::DEFAULT_RESOURCE_GROUP_NAME;
+        resource_manager.record_ru_consumption(group, 1000);
+
+        let phase0 = ctl.get_priority(group.as_bytes(), CommandPri::Normal);
+        ctl.set_group_phase(group.as_bytes(), true);
+        let phase1 = ctl.get_priority(group.as_bytes(), CommandPri::Normal);
+        assert!(phase1 > phase0, "sanity: group should be in phase 1");
+
+        // Disable fair scheduling, as an online config update would.
+        resource_manager
+            .get_config()
+            .update(|c| -> Result<(), ()> {
+                c.enable_fair_scheduling = false;
+                Ok(())
+            })
+            .unwrap();
+
+        let (mut runner, worker) = test_runner(true, Some(resource_manager.clone()));
+        // Pin the thread ladder so it can't shrink the pool and send the tick
+        // down the deprioritize branch instead of the release one.
+        runner.min_thread_count = runner.core_thread_count;
+        runner.adjust_pool_size();
+
+        // Re-enable: a stale flag would come back deprioritized here.
+        resource_manager
+            .get_config()
+            .update(|c| -> Result<(), ()> {
+                c.enable_fair_scheduling = true;
+                Ok(())
+            })
+            .unwrap();
+
+        let after = ctl.get_priority(group.as_bytes(), CommandPri::Normal);
+        assert!(
+            after < phase1,
+            "disabling fair scheduling should clear phase 1; phase1: {}, after: {}",
+            phase1,
+            after
+        );
+
+        worker.stop();
+    }
+
+    #[test]
+    fn test_phase1_group_released_when_pool_recovers() {
+        // A group deprioritized while the pool was scaled in must be released
+        // once the pool is back at core_thread_count.
+        let rm_config = resource_control::config::Config {
+            enable_fair_scheduling: true,
+            ..Default::default()
+        };
+        let resource_manager = Arc::new(ResourceGroupManager::new(rm_config));
+        let ctl = resource_manager.derive_controller("read".into(), true);
+
+        // set_group_phase only touches already-registered groups; the default
+        // one always is. record_ru_consumption puts it in the RU trackers,
+        // which reset_group_priorities iterates.
+        let group = tikv_util::resource_control::DEFAULT_RESOURCE_GROUP_NAME;
+        resource_manager.record_ru_consumption(group, 1000);
+
+        let before_phase1 = ctl.get_priority(group.as_bytes(), CommandPri::Normal);
+        ctl.set_group_phase(group.as_bytes(), true);
+        let phase1_priority = ctl.get_priority(group.as_bytes(), CommandPri::Normal);
+        // The phase bit sits well above the virtual-time tag, so it dominates
+        // any drift between reads.
+        assert!(
+            phase1_priority > before_phase1,
+            "sanity: entering phase 1 should raise the encoded priority; \
+             phase0: {}, phase1: {}",
+            before_phase1,
+            phase1_priority
+        );
+
+        let (mut runner, worker) = test_runner(true, Some(resource_manager.clone()));
+        // Pin the thread ladder so the pool stays at core_thread_count and the
+        // tick takes the release branch.
+        runner.min_thread_count = runner.core_thread_count;
+        assert_eq!(runner.cur_thread_count, runner.core_thread_count);
+
+        runner.adjust_pool_size();
+
+        let released_priority = ctl.get_priority(group.as_bytes(), CommandPri::Normal);
+        assert!(
+            released_priority < phase1_priority,
+            "group should be released from phase 1 once the pool is back at \
+             core_thread_count; phase1: {}, after: {}",
+            phase1_priority,
+            released_priority
+        );
+
+        worker.stop();
+    }
+
+    #[test]
     fn test_yatp_task_poll_duration_metric() {
         let count_metric = |name: &str| -> u64 {
             let mut sum = 0;
@@ -1609,5 +2098,76 @@ mod tests {
         // shut down cleanly.
         let _ = block_tx.send(());
         thread::sleep(Duration::from_millis(300));
+    }
+
+    #[test]
+    fn test_auto_adjust_disable_notifies_pool_size_change() {
+        use std::sync::mpsc::sync_channel;
+
+        let config = UnifiedReadPoolConfig {
+            min_thread_count: 2,
+            max_thread_count: 8,
+            max_tasks_per_worker: 10,
+            ..Default::default()
+        };
+
+        let engine = TestEngineBuilder::new().build().unwrap();
+        let pool = build_yatp_read_pool(
+            &config,
+            DummyReporter,
+            engine,
+            None,
+            None,
+            CleanupMethod::InPlace,
+            false,
+        );
+        let handle = pool.handle();
+
+        let (tx, rx) = sync_channel(10);
+
+        let core_thread_count = config.max_thread_count;
+        let max_thread_count = config.max_thread_count;
+        let process_stats = match tikv_util::sys::cpu_time::ProcessStat::cur_proc_stat() {
+            Ok(process_stats) => process_stats,
+            Err(_) => return,
+        };
+
+        let mut runner = ReadPoolConfigRunner {
+            interval: READ_POOL_THREAD_CHECK_DURATION,
+            sender: tx,
+            handle,
+            cpu_time_tracker: ReadPoolCpuTimeTracker::new("test"),
+            process_stats,
+            min_thread_count: core_thread_count,
+            core_thread_count,
+            max_thread_count,
+            cur_thread_count: core_thread_count,
+            auto_adjust: true,
+            cpu_threshold: READ_POOL_THREAD_HIGH_THRESHOLD,
+        };
+
+        runner.cur_thread_count = 5;
+        runner.run(Task::AutoAdjust(false));
+
+        // The config change only records the flag now; sizing the pool belongs
+        // to adjust_pool_size.
+        assert_eq!(runner.cur_thread_count, 5);
+        assert!(
+            rx.try_recv().is_err(),
+            "disabling auto-adjust should not resize the pool by itself"
+        );
+
+        // With no resource manager this takes the early-return path, which
+        // restores the configured size.
+        runner.adjust_pool_size();
+
+        match rx.recv_timeout(Duration::from_millis(100)) {
+            Ok(size) => assert_eq!(size, core_thread_count),
+            Err(_) => {
+                panic!("No pool size change notification received when auto-adjust was disabled.")
+            }
+        }
+
+        assert_eq!(runner.cur_thread_count, core_thread_count);
     }
 }

--- a/src/read_pool.rs
+++ b/src/read_pool.rs
@@ -215,6 +215,7 @@ impl ReadPoolHandle {
                                 group_name,
                             ),
                             resource_limiter,
+                            false,
                         )),
                         extras,
                     )

--- a/src/read_pool.rs
+++ b/src/read_pool.rs
@@ -14,18 +14,19 @@ use std::{
 use file_system::{set_io_type, IoType};
 use futures::{
     channel::oneshot,
-    future::{FutureExt, TryFutureExt},
+    future::{BoxFuture, FutureExt, TryFutureExt},
 };
 use kvproto::{errorpb, kvrpcpb::CommandPri};
 use online_config::{ConfigChange, ConfigManager, ConfigValue, Result as CfgResult};
 use prometheus::{core::Metric, Histogram, IntCounter, IntGauge};
 use resource_control::{
-    with_resource_limiter, ControlledFuture, ResourceController, ResourceLimiter, TaskPriority,
+    with_resource_limiter, AdmissionDecision, ControlledFuture, ResourceController,
+    ResourceGroupManager, ResourceLimiter, TaskPriority,
 };
 use thiserror::Error;
 use tikv_util::{
-    resource_control::{TaskMetadata, priority_from_task_meta},
-    sys::{SysQuota, cpu_time::ProcessStat, thread::matches_thread_name_prefix},
+    resource_control::{priority_from_task_meta, TaskMetadata},
+    sys::{cpu_time::ProcessStat, SysQuota},
     time::Instant,
     worker::{Runnable, RunnableWithTimer, Scheduler, Worker},
     yatp_pool::{self, CleanupMethod, FuturePool, PoolTicker, YatpPoolBuilder},
@@ -68,6 +69,7 @@ pub enum ReadPool {
         max_tasks: usize,
         pool_size: usize,
         resource_ctl: Option<Arc<ResourceController>>,
+        resource_manager: Option<Arc<ResourceGroupManager>>,
         time_slice_inspector: Arc<TimeSliceInspector>,
     },
 }
@@ -91,6 +93,7 @@ impl ReadPool {
                 max_tasks,
                 pool_size,
                 resource_ctl,
+                resource_manager,
                 time_slice_inspector,
             } => ReadPoolHandle::Yatp {
                 remote: pool.remote().clone(),
@@ -99,6 +102,7 @@ impl ReadPool {
                 max_tasks: *max_tasks,
                 pool_size: *pool_size,
                 resource_ctl: resource_ctl.clone(),
+                resource_manager: resource_manager.clone(),
                 time_slice_inspector: time_slice_inspector.clone(),
             },
         }
@@ -119,8 +123,68 @@ pub enum ReadPoolHandle {
         max_tasks: usize,
         pool_size: usize,
         resource_ctl: Option<Arc<ResourceController>>,
+        resource_manager: Option<Arc<ResourceGroupManager>>,
         time_slice_inspector: Arc<TimeSliceInspector>,
     },
+}
+
+/// Runs admission control then, if the task is allowed through, enqueues it.
+/// Admission is checked before the capacity/eviction check so that a rejected
+/// or timed-out delayed task never causes an already-queued task to be dropped.
+async fn admission_and_enqueue(
+    resource_manager: Option<Arc<ResourceGroupManager>>,
+    resource_limiter: Option<Arc<ResourceLimiter>>,
+    task_priority: TaskPriority,
+    gauge: IntGauge,
+    max_tasks: usize,
+    remote: Remote<TaskCell>,
+    task_cell: TaskCell,
+    running_tasks: Vec<IntGauge>,
+    resource_ctl: Option<Arc<ResourceController>>,
+    estimated_priority: u64,
+) -> Result<(), ReadPoolError> {
+    // Admission control runs before any eviction so that a rejected or
+    // timed-out delayed task never causes an already-queued task to be dropped.
+    let delay = match (resource_manager.as_deref(), resource_limiter.as_deref()) {
+        (Some(rm), Some(limiter)) => match rm.admission_decision(true, limiter) {
+            AdmissionDecision::Reject => return Err(ReadPoolError::Rejected),
+            AdmissionDecision::Delay(d) => {
+                if task_priority == TaskPriority::High {
+                    warn!("admission delay on high-priority read task";
+                          "group" => limiter.name(),
+                          "delay" => ?d);
+                }
+                Some((d, resource_manager))
+            }
+            AdmissionDecision::Allow => None,
+        },
+        _ => None,
+    };
+    if let Some((d, slot)) = delay {
+        let mut _guard = slot.as_ref().map(|rm| rm.delay_slot_guard());
+        futures_timer::Delay::new(d).await;
+        if let Some(guard) = _guard.as_mut() {
+            guard.release();
+        }
+    }
+    // After admission (and any sleep), check pool capacity and evict if needed.
+    if gauge.get() as usize >= max_tasks {
+        if let Some(ref _resource_ctl) = resource_ctl {
+            if let Some(mut evicted) = remote.try_evict_lowest(estimated_priority) {
+                let evicted_prio = priority_from_task_meta(evicted.mut_extras().metadata());
+                running_tasks[evicted_prio as usize].dec();
+                UNIFIED_READ_POOL_EVICTED_TASKS.inc();
+                drop(evicted);
+            } else {
+                return Err(ReadPoolError::UnifiedReadPoolFull);
+            }
+        } else {
+            return Err(ReadPoolError::UnifiedReadPoolFull);
+        }
+    }
+    gauge.inc();
+    remote.spawn(task_cell);
+    Ok(())
 }
 
 impl ReadPoolHandle {
@@ -131,7 +195,7 @@ impl ReadPoolHandle {
         task_id: u64,
         metadata: TaskMetadata<'_>,
         resource_limiter: Option<Arc<ResourceLimiter>>,
-    ) -> Result<(), ReadPoolError>
+    ) -> BoxFuture<'static, Result<(), ReadPoolError>>
     where
         F: Future<Output = ()> + Send + 'static,
     {
@@ -146,76 +210,56 @@ impl ReadPoolHandle {
                     CommandPri::Normal => read_pool_normal,
                     CommandPri::Low => read_pool_low,
                 };
-
-                pool.spawn(f)?;
+                let res = pool.spawn(f).map_err(ReadPoolError::from);
+                futures::future::ready(res).boxed()
             }
             ReadPoolHandle::Yatp {
                 remote,
                 running_tasks,
                 max_tasks,
                 resource_ctl,
+                resource_manager,
                 ..
             } => {
                 let task_priority = TaskPriority::from(metadata.override_priority());
                 let running_task_gauge = running_tasks[task_priority as usize].clone();
-                // Note that the running task number limit is not strict.
-                // If several tasks are spawned at the same time while the running task number
-                // is close to the limit, they may all pass this check and the number of running
-                // tasks may exceed the limit.
-                if running_task_gauge.get() as usize >= *max_tasks {
-                    // When resource control is enabled, attempt to evict the
-                    // lowest-priority queued task if the incoming task has
-                    // strictly higher priority. This implements queue fairness:
-                    // important tasks can preempt less important queued tasks
-                    // when the pool is full.
-                    if let Some(ref ctl) = resource_ctl {
-                        let estimated_priority = ctl.peek_priority_of(&metadata, priority);
-                        if let Some(mut evicted) = remote.try_evict_lowest(estimated_priority) {
-                            // Decrement the running_tasks counter for the
-                            // evicted task's priority level. The evicted task's
-                            // future (which contains the running_tasks.dec()
-                            // closure) will be dropped without executing.
-                            let evicted_prio =
-                                priority_from_task_meta(evicted.mut_extras().metadata());
-                            running_tasks[evicted_prio as usize].dec();
-                            UNIFIED_READ_POOL_EVICTED_TASKS.inc();
-                            // Dropping the evicted TaskCell destroys the future
-                            // inside it. That future holds the oneshot::Sender
-                            // used by spawn_handle (or by coprocessor's manual
-                            // channel). When the sender is dropped the
-                            // corresponding receiver gets a Canceled error,
-                            // which callers surface as SchedTooBusy /
-                            // ServerIsBusy back to the client.
-                            drop(evicted);
-                            // Fall through to enqueue the new task below.
-                        } else {
-                            return Err(ReadPoolError::UnifiedReadPoolFull);
-                        }
-                    } else {
-                        return Err(ReadPoolError::UnifiedReadPoolFull);
+
+                let is_background = resource_limiter.as_ref().is_some_and(|l| l.is_background());
+                let fixed_level = if is_background {
+                    // Background tasks always run at low priority in the pool.
+                    Some(2)
+                } else {
+                    match priority {
+                        CommandPri::High => Some(0),
+                        CommandPri::Normal => None,
+                        CommandPri::Low => Some(2),
                     }
-                }
-                running_task_gauge.inc();
-                let fixed_level = match priority {
-                    CommandPri::High => Some(0),
-                    CommandPri::Normal => None,
-                    CommandPri::Low => Some(2),
                 };
                 let group_name = metadata.group_name().to_owned();
+                let estimated_priority = resource_ctl
+                    .as_ref()
+                    .map_or(u64::MAX, |ctl| ctl.peek_priority_of(&metadata, priority));
                 let mut extras = Extras::new_multilevel(task_id, fixed_level);
                 extras.set_metadata(metadata.to_vec());
+                // Clone gauge: one for inc (after admission), one inside the
+                // future for dec (when the task completes).
+                let gauge_for_spawn = running_task_gauge.clone();
                 let task_cell = if let Some(resource_ctl) = resource_ctl {
+                    let inner = ControlledFuture::new(
+                        f.map(move |_| {
+                            running_task_gauge.dec();
+                        }),
+                        resource_ctl.clone(),
+                        group_name.clone(),
+                    );
                     TaskCell::new(
                         TrackedFuture::new(with_resource_limiter(
-                            ControlledFuture::new(
-                                f.map(move |_| {
-                                    running_task_gauge.dec();
-                                }),
-                                resource_ctl.clone(),
-                                group_name,
-                            ),
-                            resource_limiter,
-                            false,
+                            inner,
+                            resource_limiter.clone(),
+                            true, // skip compaction pressure for foreground jobs
+                            true, // measure-only: build debt, never sleep inside pool
+                            resource_manager.clone(),
+                            0, // read path: no write bytes
                         )),
                         extras,
                     )
@@ -227,10 +271,21 @@ impl ReadPoolHandle {
                         extras,
                     )
                 };
-                remote.spawn(task_cell);
+                admission_and_enqueue(
+                    resource_manager.clone(),
+                    resource_limiter,
+                    task_priority,
+                    gauge_for_spawn,
+                    *max_tasks,
+                    remote.clone(),
+                    task_cell,
+                    running_tasks.to_vec(),
+                    resource_ctl.clone(),
+                    estimated_priority,
+                )
+                .boxed()
             }
         }
-        Ok(())
     }
 
     pub fn spawn_handle<F, T>(
@@ -246,7 +301,7 @@ impl ReadPoolHandle {
         T: Send + 'static,
     {
         let (tx, rx) = oneshot::channel::<T>();
-        let res = self.spawn(
+        let spawn_fut = self.spawn(
             f.map(move |res| {
                 let _ = tx.send(res);
             }),
@@ -256,7 +311,7 @@ impl ReadPoolHandle {
             resource_limiter,
         );
         async move {
-            res?;
+            spawn_fut.await?;
             rx.map_err(ReadPoolError::from).await
         }
     }
@@ -482,6 +537,7 @@ pub fn build_yatp_read_pool<E: Engine, R: FlowStatsReporter>(
     reporter: R,
     engine: E,
     resource_ctl: Option<Arc<ResourceController>>,
+    resource_manager: Option<Arc<ResourceGroupManager>>,
     cleanup_method: CleanupMethod,
     enable_task_wait_metrics: bool,
 ) -> ReadPool {
@@ -491,6 +547,7 @@ pub fn build_yatp_read_pool<E: Engine, R: FlowStatsReporter>(
         reporter,
         engine,
         resource_ctl,
+        resource_manager,
         cleanup_method,
         unified_read_pool_name,
         enable_task_wait_metrics,
@@ -502,6 +559,7 @@ pub fn build_yatp_read_pool_with_name<E: Engine, R: FlowStatsReporter>(
     reporter: R,
     engine: E,
     resource_ctl: Option<Arc<ResourceController>>,
+    resource_manager: Option<Arc<ResourceGroupManager>>,
     cleanup_method: CleanupMethod,
     unified_read_pool_name: String,
     enable_task_wait_metrics: bool,
@@ -555,6 +613,7 @@ pub fn build_yatp_read_pool_with_name<E: Engine, R: FlowStatsReporter>(
             .saturating_mul(config.max_thread_count),
         pool_size: config.max_thread_count,
         resource_ctl,
+        resource_manager,
         time_slice_inspector,
     }
 }
@@ -915,6 +974,9 @@ pub enum ReadPoolError {
     #[error("Unified read pool is full")]
     UnifiedReadPoolFull,
 
+    #[error("Request rejected by admission control")]
+    Rejected,
+
     #[error("{0}")]
     Canceled(#[from] oneshot::Canceled),
 }
@@ -981,6 +1043,7 @@ mod tests {
             DummyReporter,
             engine,
             None,
+            None,
             CleanupMethod::InPlace,
             name.to_owned(),
             false,
@@ -1000,23 +1063,20 @@ mod tests {
         let (task3, _tx3) = gen_task();
         let (task4, _tx4) = gen_task();
 
-        handle
-            .spawn(task1, CommandPri::Normal, 1, TaskMetadata::default(), None)
+        block_on(handle.spawn(task1, CommandPri::Normal, 1, TaskMetadata::default(), None))
             .unwrap();
-        handle
-            .spawn(task2, CommandPri::Normal, 2, TaskMetadata::default(), None)
+        block_on(handle.spawn(task2, CommandPri::Normal, 2, TaskMetadata::default(), None))
             .unwrap();
 
         thread::sleep(Duration::from_millis(300));
-        match handle.spawn(task3, CommandPri::Normal, 3, TaskMetadata::default(), None) {
+        match block_on(handle.spawn(task3, CommandPri::Normal, 3, TaskMetadata::default(), None)) {
             Err(ReadPoolError::UnifiedReadPoolFull) => {}
             _ => panic!("should return full error"),
         }
         tx1.send(()).unwrap();
 
         thread::sleep(Duration::from_millis(300));
-        handle
-            .spawn(task4, CommandPri::Normal, 4, TaskMetadata::default(), None)
+        block_on(handle.spawn(task4, CommandPri::Normal, 4, TaskMetadata::default(), None))
             .unwrap();
         assert_eq!(
             UNIFIED_READ_POOL_RUNNING_TASKS
@@ -1042,6 +1102,7 @@ mod tests {
             DummyReporter,
             engine,
             None,
+            None,
             CleanupMethod::InPlace,
             false,
         );
@@ -1061,15 +1122,13 @@ mod tests {
         let (task4, _tx4) = gen_task();
         let (task5, _tx5) = gen_task();
 
-        handle
-            .spawn(task1, CommandPri::Normal, 1, TaskMetadata::default(), None)
+        block_on(handle.spawn(task1, CommandPri::Normal, 1, TaskMetadata::default(), None))
             .unwrap();
-        handle
-            .spawn(task2, CommandPri::Normal, 2, TaskMetadata::default(), None)
+        block_on(handle.spawn(task2, CommandPri::Normal, 2, TaskMetadata::default(), None))
             .unwrap();
 
         thread::sleep(Duration::from_millis(300));
-        match handle.spawn(task3, CommandPri::Normal, 3, TaskMetadata::default(), None) {
+        match block_on(handle.spawn(task3, CommandPri::Normal, 3, TaskMetadata::default(), None)) {
             Err(ReadPoolError::UnifiedReadPoolFull) => {}
             _ => panic!("should return full error"),
         }
@@ -1077,12 +1136,11 @@ mod tests {
         handle.scale_pool_size(3);
         assert_eq!(handle.get_normal_pool_size(), 3);
 
-        handle
-            .spawn(task4, CommandPri::Normal, 4, TaskMetadata::default(), None)
+        block_on(handle.spawn(task4, CommandPri::Normal, 4, TaskMetadata::default(), None))
             .unwrap();
 
         thread::sleep(Duration::from_millis(300));
-        match handle.spawn(task5, CommandPri::Normal, 5, TaskMetadata::default(), None) {
+        match block_on(handle.spawn(task5, CommandPri::Normal, 5, TaskMetadata::default(), None)) {
             Err(ReadPoolError::UnifiedReadPoolFull) => {}
             _ => panic!("should return full error"),
         }
@@ -1104,6 +1162,7 @@ mod tests {
             DummyReporter,
             engine,
             None,
+            None,
             CleanupMethod::InPlace,
             false,
         );
@@ -1123,15 +1182,13 @@ mod tests {
         let (task4, _tx4) = gen_task();
         let (task5, _tx5) = gen_task();
 
-        handle
-            .spawn(task1, CommandPri::Normal, 1, TaskMetadata::default(), None)
+        block_on(handle.spawn(task1, CommandPri::Normal, 1, TaskMetadata::default(), None))
             .unwrap();
-        handle
-            .spawn(task2, CommandPri::Normal, 2, TaskMetadata::default(), None)
+        block_on(handle.spawn(task2, CommandPri::Normal, 2, TaskMetadata::default(), None))
             .unwrap();
 
         thread::sleep(Duration::from_millis(300));
-        match handle.spawn(task3, CommandPri::Normal, 3, TaskMetadata::default(), None) {
+        match block_on(handle.spawn(task3, CommandPri::Normal, 3, TaskMetadata::default(), None)) {
             Err(ReadPoolError::UnifiedReadPoolFull) => {}
             _ => panic!("should return full error"),
         }
@@ -1152,12 +1209,11 @@ mod tests {
         handle.scale_pool_size(1);
         assert_eq!(handle.get_normal_pool_size(), 1);
 
-        handle
-            .spawn(task4, CommandPri::Normal, 4, TaskMetadata::default(), None)
+        block_on(handle.spawn(task4, CommandPri::Normal, 4, TaskMetadata::default(), None))
             .unwrap();
 
         thread::sleep(Duration::from_millis(300));
-        match handle.spawn(task5, CommandPri::Normal, 5, TaskMetadata::default(), None) {
+        match block_on(handle.spawn(task5, CommandPri::Normal, 5, TaskMetadata::default(), None)) {
             Err(ReadPoolError::UnifiedReadPoolFull) => {}
             _ => panic!("should return full error"),
         }
@@ -1248,6 +1304,7 @@ mod tests {
             DummyReporter,
             engine,
             None,
+            None,
             CleanupMethod::InPlace,
             false,
         );
@@ -1320,12 +1377,12 @@ mod tests {
 
         for control in [false, true] {
             let name = format!("test_yatp_task_poll_duration_metric_{}", control);
-            let resource_manager = if control {
-                let resource_manager = ResourceGroupManager::default();
-                let resource_ctl = resource_manager.derive_controller(name.clone(), true);
-                Some(resource_ctl)
+            let (resource_ctl, resource_manager) = if control {
+                let rm = Arc::new(ResourceGroupManager::default());
+                let ctl = rm.derive_controller(name.clone(), true);
+                (Some(ctl), Some(rm))
             } else {
-                None
+                (None, None)
             };
             let config = UnifiedReadPoolConfig {
                 min_thread_count: 1,
@@ -1340,6 +1397,7 @@ mod tests {
                 &config,
                 DummyReporter,
                 engine,
+                resource_ctl,
                 resource_manager,
                 CleanupMethod::InPlace,
                 name.clone(),
@@ -1360,11 +1418,9 @@ mod tests {
             let (task1, tx1) = gen_task();
             let (task2, tx2) = gen_task();
 
-            handle
-                .spawn(task1, CommandPri::Normal, 1, TaskMetadata::default(), None)
+            block_on(handle.spawn(task1, CommandPri::Normal, 1, TaskMetadata::default(), None))
                 .unwrap();
-            handle
-                .spawn(task2, CommandPri::Normal, 2, TaskMetadata::default(), None)
+            block_on(handle.spawn(task2, CommandPri::Normal, 2, TaskMetadata::default(), None))
                 .unwrap();
 
             tx1.send(()).unwrap();
@@ -1413,7 +1469,7 @@ mod tests {
         //   eviction comparison. "high_group" (priority=16) produces a numerically
         //   smaller value than "low_group" (priority=1), meaning it is scheduled first
         //   and can evict low_group tasks.
-        let resource_manager = ResourceGroupManager::default();
+        let resource_manager = Arc::new(ResourceGroupManager::default());
         let low_group = new_resource_group_ru("low_group".into(), 5000, 1);
         resource_manager.add_resource_group(low_group);
         let high_group = new_resource_group_ru("high_group".into(), 5000, 16);
@@ -1435,6 +1491,7 @@ mod tests {
             DummyReporter,
             engine,
             Some(resource_ctl),
+            Some(resource_manager),
             CleanupMethod::InPlace,
             name.to_owned(),
             false,
@@ -1465,15 +1522,14 @@ mod tests {
         let task1 = async move {
             let _ = block_rx.recv();
         };
-        handle
-            .spawn(
-                task1,
-                CommandPri::Normal,
-                1,
-                TaskMetadata::from_ctx(&low_ctx),
-                None,
-            )
-            .unwrap();
+        block_on(handle.spawn(
+            task1,
+            CommandPri::Normal,
+            1,
+            TaskMetadata::from_ctx(&low_ctx),
+            None,
+        ))
+        .unwrap();
 
         // Wait for task1 to be picked up and block the worker.
         thread::sleep(Duration::from_millis(300));
@@ -1484,43 +1540,40 @@ mod tests {
         let (task3, _tx3) = gen_task();
         let (task4, _tx4) = gen_task();
 
-        handle
-            .spawn(
-                task2,
-                CommandPri::Normal,
-                2,
-                TaskMetadata::from_ctx(&low_ctx),
-                None,
-            )
-            .unwrap();
-        handle
-            .spawn(
-                task3,
-                CommandPri::Normal,
-                3,
-                TaskMetadata::from_ctx(&low_ctx),
-                None,
-            )
-            .unwrap();
-        handle
-            .spawn(
-                task4,
-                CommandPri::Normal,
-                4,
-                TaskMetadata::from_ctx(&low_ctx),
-                None,
-            )
-            .unwrap();
+        block_on(handle.spawn(
+            task2,
+            CommandPri::Normal,
+            2,
+            TaskMetadata::from_ctx(&low_ctx),
+            None,
+        ))
+        .unwrap();
+        block_on(handle.spawn(
+            task3,
+            CommandPri::Normal,
+            3,
+            TaskMetadata::from_ctx(&low_ctx),
+            None,
+        ))
+        .unwrap();
+        block_on(handle.spawn(
+            task4,
+            CommandPri::Normal,
+            4,
+            TaskMetadata::from_ctx(&low_ctx),
+            None,
+        ))
+        .unwrap();
 
         // Verify pool is full: spawning another low-priority task should fail.
         let (task_low5, _tx_low5) = gen_task();
-        match handle.spawn(
+        match block_on(handle.spawn(
             task_low5,
             CommandPri::Normal,
             5,
             TaskMetadata::from_ctx(&low_ctx),
             None,
-        ) {
+        )) {
             Err(ReadPoolError::UnifiedReadPoolFull) => {}
             other => panic!(
                 "expected UnifiedReadPoolFull for low-priority task, got {:?}",
@@ -1537,15 +1590,14 @@ mod tests {
             ..Default::default()
         };
 
-        handle
-            .spawn(
-                task_high,
-                CommandPri::High,
-                6,
-                TaskMetadata::from_ctx(&high_ctx),
-                None,
-            )
-            .expect("high-priority task should succeed via eviction");
+        block_on(handle.spawn(
+            task_high,
+            CommandPri::High,
+            6,
+            TaskMetadata::from_ctx(&high_ctx),
+            None,
+        ))
+        .expect("high-priority task should succeed via eviction");
 
         // The eviction metric should have been incremented.
         assert!(

--- a/src/server/gc_worker/compaction_runner.rs
+++ b/src/server/gc_worker/compaction_runner.rs
@@ -294,12 +294,23 @@ impl<S: GcSafePointProvider, R: RegionInfoProvider + 'static, E: KvEngine>
                 tracker.reset_if_needed();
             }
 
-            // Sleep for remaining time in check interval, or start next round immediately
-            if elapsed < check_interval {
-                let remaining_sleep = check_interval - elapsed;
-                if self.sleep_or_stop(remaining_sleep) {
-                    break;
-                }
+            // Sleep for remaining time in check interval, or start next round
+            // immediately. When MVCC-read-aware scoring is enabled, enforce a
+            // minimum gap so the tracker can accumulate meaningful stats after
+            // the reset.
+            const MIN_GAP_BETWEEN_ROUNDS: Duration = Duration::from_secs(20);
+            let remaining_sleep = if elapsed < check_interval {
+                check_interval - elapsed
+            } else {
+                Duration::ZERO
+            };
+            let sleep_duration = if config.auto_compaction.mvcc_read_aware_enabled {
+                remaining_sleep.max(MIN_GAP_BETWEEN_ROUNDS)
+            } else {
+                remaining_sleep
+            };
+            if sleep_duration > Duration::ZERO && self.sleep_or_stop(sleep_duration) {
+                break;
             }
         }
         debug!("compaction-runner stopped");

--- a/src/server/service/diagnostics/sys.rs
+++ b/src/server/service/diagnostics/sys.rs
@@ -682,6 +682,8 @@ mod tests {
 
     #[test]
     #[cfg(target_os = "linux")]
+    // this test verifies that memory quota matches /proc/meminfo which is not true for docker
+    #[cfg(not(feature = "docker_test"))]
     fn test_memory() {
         let mut mem_total_kb: u64 = 0;
         {

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -247,7 +247,7 @@ macro_rules! handle_request {
             let resource_control_ctx = req.get_context().get_resource_control_context();
             let mut resource_group_priority = ResourcePriority::unknown;
             if let Some(resource_manager) = &self.resource_manager {
-                resource_manager.consume_penalty(resource_control_ctx);
+                resource_manager.consume_penalty(resource_control_ctx, req.get_context().get_request_source());
                 resource_group_priority= ResourcePriority::from(resource_control_ctx.override_priority);
             }
             GRPC_RESOURCE_GROUP_COUNTER_VEC
@@ -553,7 +553,8 @@ impl<E: Engine, L: LockManager, F: KvFormat> Tikv for Service<E, L, F> {
         let resource_control_ctx = req.get_context().get_resource_control_context();
         let mut resource_group_priority = ResourcePriority::unknown;
         if let Some(resource_manager) = &self.resource_manager {
-            resource_manager.consume_penalty(resource_control_ctx);
+            resource_manager
+                .consume_penalty(resource_control_ctx, req.get_context().get_request_source());
             resource_group_priority =
                 ResourcePriority::from(resource_control_ctx.override_priority);
         }
@@ -600,7 +601,8 @@ impl<E: Engine, L: LockManager, F: KvFormat> Tikv for Service<E, L, F> {
         let resource_control_ctx = req.get_context().get_resource_control_context();
         let mut resource_group_priority = ResourcePriority::unknown;
         if let Some(resource_manager) = &self.resource_manager {
-            resource_manager.consume_penalty(resource_control_ctx);
+            resource_manager
+                .consume_penalty(resource_control_ctx, req.get_context().get_request_source());
             resource_group_priority =
                 ResourcePriority::from(resource_control_ctx.override_priority);
         }
@@ -698,7 +700,8 @@ impl<E: Engine, L: LockManager, F: KvFormat> Tikv for Service<E, L, F> {
         let resource_control_ctx = req.get_context().get_resource_control_context();
         let mut resource_group_priority = ResourcePriority::unknown;
         if let Some(resource_manager) = &self.resource_manager {
-            resource_manager.consume_penalty(resource_control_ctx);
+            resource_manager
+                .consume_penalty(resource_control_ctx, req.get_context().get_request_source());
             resource_group_priority =
                 ResourcePriority::from(resource_control_ctx.override_priority);
         }
@@ -1333,7 +1336,7 @@ fn handle_batch_commands_request<E: Engine, L: LockManager, F: KvFormat>(
                     let resource_control_ctx = req.get_context().get_resource_control_context();
                     let mut resource_group_priority = ResourcePriority::unknown;
                     if let Some(resource_manager) = resource_manager {
-                        resource_manager.consume_penalty(resource_control_ctx);
+                        resource_manager.consume_penalty(resource_control_ctx, req.get_context().get_request_source());
                         resource_group_priority = ResourcePriority::from(resource_control_ctx.override_priority);
                     }
 
@@ -1358,7 +1361,7 @@ fn handle_batch_commands_request<E: Engine, L: LockManager, F: KvFormat>(
                     let resource_control_ctx = req.get_context().get_resource_control_context();
                     let mut resource_group_priority = ResourcePriority::unknown;
                     if let Some(resource_manager) = resource_manager {
-                        resource_manager.consume_penalty(resource_control_ctx);
+                        resource_manager.consume_penalty(resource_control_ctx, req.get_context().get_request_source());
                         resource_group_priority = ResourcePriority::from(resource_control_ctx.override_priority);
                     }
                     GRPC_RESOURCE_GROUP_COUNTER_VEC
@@ -1382,7 +1385,7 @@ fn handle_batch_commands_request<E: Engine, L: LockManager, F: KvFormat>(
                     let resource_control_ctx = req.get_context().get_resource_control_context();
                     let mut resource_group_priority = ResourcePriority::unknown;
                     if let Some(resource_manager) = resource_manager {
-                        resource_manager.consume_penalty(resource_control_ctx);
+                        resource_manager.consume_penalty(resource_control_ctx, req.get_context().get_request_source());
                         resource_group_priority = ResourcePriority::from(resource_control_ctx.override_priority );
                     }
                     GRPC_RESOURCE_GROUP_COUNTER_VEC
@@ -1429,7 +1432,7 @@ fn handle_batch_commands_request<E: Engine, L: LockManager, F: KvFormat>(
                     let resource_control_ctx = req.get_context().get_resource_control_context();
                     let mut resource_group_priority = ResourcePriority::unknown;
                     if let Some(resource_manager) = resource_manager {
-                        resource_manager.consume_penalty(resource_control_ctx);
+                        resource_manager.consume_penalty(resource_control_ctx, req.get_context().get_request_source());
                         resource_group_priority = ResourcePriority::from(resource_control_ctx.override_priority);
                     }
                     GRPC_RESOURCE_GROUP_COUNTER_VEC

--- a/src/server/status_server/mod.rs
+++ b/src/server/status_server/mod.rs
@@ -2147,6 +2147,7 @@ mod tests {
             None,
             GrpcServiceManager::dummy(),
             None,
+            ForcePartitionRangeManager::default(),
         )
         .unwrap();
         let addr = "127.0.0.1:0".to_owned();

--- a/src/server/status_server/mod.rs
+++ b/src/server/status_server/mod.rs
@@ -59,6 +59,7 @@ use tikv_util::{
     logger::set_log_level,
     metrics::{dump, dump_to},
     timer::GLOBAL_TIMER_HANDLE,
+    GLOBAL_SERVER_READINESS,
 };
 use tokio::{
     io::{AsyncRead, AsyncWrite},
@@ -717,6 +718,26 @@ where
         Self::metrics_to_resp(req, should_simplify)
     }
 
+    fn handle_ready_request(req: Request<Body>) -> hyper::Result<Response<Body>> {
+        let verbose = req
+            .uri()
+            .query()
+            .map_or(false, |query| query.contains("verbose"));
+
+        let status_code = if GLOBAL_SERVER_READINESS.is_ready() {
+            StatusCode::OK
+        } else {
+            StatusCode::INTERNAL_SERVER_ERROR
+        };
+
+        let body = if verbose {
+            GLOBAL_SERVER_READINESS.to_json()
+        } else {
+            "".to_string()
+        };
+        Ok(make_response(status_code, body))
+    }
+
     fn start_serve<I, C>(&mut self, builder: HyperBuilder<I>)
     where
         I: Accept<Conn = C, Error = std::io::Error> + Send + 'static,
@@ -789,6 +810,9 @@ where
                                 Self::handle_get_metrics(req, &cfg_controller)
                             }
                             (Method::GET, "/status") => Ok(Response::default()),
+                            (Method::GET, "/ready") => {
+                                Self::handle_ready_request(req)
+                            }
                             (Method::GET, "/debug/pprof/heap_list") => {
                                 Ok(make_response(
                                     StatusCode::GONE,
@@ -1318,7 +1342,12 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::{env, io::Read, path::PathBuf, sync::Arc};
+    use std::{
+        env,
+        io::Read,
+        path::PathBuf,
+        sync::{atomic::Ordering, Arc},
+    };
 
     use collections::HashSet;
     use flate2::read::GzDecoder;
@@ -1337,7 +1366,7 @@ mod tests {
     use service::service_manager::GrpcServiceManager;
     use test_util::new_security_cfg;
     use tikv_kv::RaftExtension;
-    use tikv_util::logger::get_log_level;
+    use tikv_util::{logger::get_log_level, GLOBAL_SERVER_READINESS};
 
     use crate::{
         config::{ConfigController, TikvConfig},
@@ -2106,5 +2135,63 @@ mod tests {
             }
             status_server.stop();
         }
+    }
+
+    #[test]
+    fn test_ready_endpoint() {
+        let mut status_server = StatusServer::new(
+            1,
+            ConfigController::default(),
+            Arc::new(SecurityConfig::default()),
+            MockRouter,
+            None,
+            GrpcServiceManager::dummy(),
+            None,
+        )
+        .unwrap();
+        let addr = "127.0.0.1:0".to_owned();
+        let _ = status_server.start(addr);
+        let client = Client::new();
+        let uri = Uri::builder()
+            .scheme("http")
+            .authority(status_server.listening_addr().to_string().as_str())
+            .path_and_query("/ready?verbose")
+            .build()
+            .unwrap();
+        let uri2 = uri.clone();
+        // Set one readiness condition to true.
+        GLOBAL_SERVER_READINESS
+            .connected_to_pd
+            .store(true, Ordering::Relaxed);
+        let handle = status_server.thread_pool.spawn(async move {
+            let resp = client.get(uri).await.unwrap();
+            assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+
+            let body_bytes = hyper::body::to_bytes(resp.into_body()).await.unwrap();
+            let json: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+            assert_eq!(
+                json["connected_to_pd"], true,
+                "connected_to_pd should be false"
+            );
+            assert_eq!(
+                json["raft_peers_caught_up"], false,
+                "raft_peers_caught_up should be false"
+            );
+        });
+        block_on(handle).unwrap();
+
+        // Set the remaining readiness conditions to true.
+        GLOBAL_SERVER_READINESS
+            .raft_peers_caught_up
+            .store(true, Ordering::Relaxed);
+
+        let client = Client::new();
+        let handle2 = status_server.thread_pool.spawn(async move {
+            let resp = client.get(uri2).await.unwrap();
+            assert_eq!(resp.status(), StatusCode::OK);
+        });
+        block_on(handle2).unwrap();
+
+        status_server.stop();
     }
 }

--- a/src/server/status_server/mod.rs
+++ b/src/server/status_server/mod.rs
@@ -1361,7 +1361,7 @@ mod tests {
     use hyper_openssl::HttpsConnector;
     use online_config::OnlineConfig;
     use openssl::ssl::{SslConnector, SslFiletype, SslMethod};
-    use raftstore::store::region_meta::RegionMeta;
+    use raftstore::store::{region_meta::RegionMeta, ForcePartitionRangeManager};
     use security::SecurityConfig;
     use service::service_manager::GrpcServiceManager;
     use test_util::new_security_cfg;

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1908,7 +1908,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
         self.sched
             .get_sched_pool()
             // NOTE: we don't support background resource control for raw api.
-            .spawn("", metadata, pri, future)
+            .spawn("", metadata, pri, future, 0)
             .map_err(|_| Error::from(ErrorInner::SchedTooBusy))
     }
 
@@ -3332,12 +3332,15 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
             err.set_server_is_busy(busy_err);
             return FuturesEither::Left(future::err(Error::from(ErrorInner::Kv(err.into()))));
         }
-        FuturesEither::Right(
-            self.read_pool
+
+        let metadata = metadata.deep_clone();
+        let read_pool = self.read_pool.clone();
+        FuturesEither::Right(async move {
+            read_pool
                 .spawn_handle(future, priority, task_id, metadata, resource_limiter)
                 .map_err(|_| Error::from(ErrorInner::SchedTooBusy))
-                .and_then(|res| future::ready(res)),
-        )
+                .await?
+        })
     }
 
     pub fn update_txn_status_cache(

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -3327,7 +3327,10 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
         Fut: Future<Output = Result<T>> + Send + 'static,
         T: Send + 'static,
     {
-        if let Err(busy_err) = self.read_pool.check_busy_threshold(busy_threshold) {
+        if let Err(busy_err) = self
+            .read_pool
+            .check_busy_threshold(busy_threshold, metadata.group_name())
+        {
             let mut err = kvproto::errorpb::Error::default();
             err.set_server_is_busy(busy_err);
             return FuturesEither::Left(future::err(Error::from(ErrorInner::Kv(err.into()))));

--- a/src/storage/txn/sched_pool.rs
+++ b/src/storage/txn/sched_pool.rs
@@ -133,6 +133,7 @@ impl PriorityQueue {
             with_resource_limiter(
                 ControlledFuture::new(f, self.resource_ctl.clone(), group_name),
                 resource_limiter,
+                false,
             ),
             extras,
         )

--- a/src/storage/txn/sched_pool.rs
+++ b/src/storage/txn/sched_pool.rs
@@ -113,6 +113,7 @@ impl PriorityQueue {
         metadata: TaskMetadata<'_>,
         priority_level: CommandPri,
         f: impl futures::Future<Output = ()> + Send + 'static,
+        write_bytes: u64,
     ) -> Result<(), Full> {
         let fixed_level = match priority_level {
             CommandPri::High => Some(0),
@@ -122,18 +123,22 @@ impl PriorityQueue {
         // TODO: maybe use a better way to generate task_id
         let task_id = rand::random::<u64>();
         let group_name = metadata.group_name().to_owned();
-        let resource_limiter = self.resource_mgr.get_resource_limiter(
-            unsafe { std::str::from_utf8_unchecked(&group_name) },
-            request_source,
-            metadata.override_priority() as u64,
-        );
+        let override_priority = metadata.override_priority() as u64;
         let mut extras = Extras::new_multilevel(task_id, fixed_level);
         extras.set_metadata(metadata.to_vec());
+        let resource_limiter = self.resource_mgr.get_resource_limiter(
+            std::str::from_utf8(&group_name).unwrap_or_default(),
+            request_source,
+            override_priority,
+        );
         self.worker_pool.spawn_with_extras(
             with_resource_limiter(
                 ControlledFuture::new(f, self.resource_ctl.clone(), group_name),
                 resource_limiter,
-                false,
+                true, // skip compaction pressure for foreground jobs
+                true, // measure-only: build debt, never sleep inside pool
+                Some(self.resource_mgr.clone()),
+                write_bytes,
             ),
             extras,
         )
@@ -222,6 +227,7 @@ impl SchedPool {
         metadata: TaskMetadata<'_>,
         priority_level: CommandPri,
         f: impl futures::Future<Output = ()> + Send + 'static,
+        write_bytes: u64,
     ) -> Result<(), Full> {
         match self.queue_type {
             QueueType::Vanilla => self.vanilla.spawn(priority_level, f),
@@ -233,6 +239,7 @@ impl SchedPool {
                         metadata,
                         priority_level,
                         f,
+                        write_bytes,
                     )
                 } else {
                     fail_point!("single_queue_pool_task");

--- a/src/storage/txn/sched_pool.rs
+++ b/src/storage/txn/sched_pool.rs
@@ -113,6 +113,7 @@ impl PriorityQueue {
         metadata: TaskMetadata<'_>,
         priority_level: CommandPri,
         f: impl futures::Future<Output = ()> + Send + 'static,
+        write_bytes: u64,
     ) -> Result<(), Full> {
         let fixed_level = match priority_level {
             CommandPri::High => Some(0),
@@ -122,17 +123,22 @@ impl PriorityQueue {
         // TODO: maybe use a better way to generate task_id
         let task_id = rand::random::<u64>();
         let group_name = metadata.group_name().to_owned();
-        let resource_limiter = self.resource_mgr.get_resource_limiter(
-            unsafe { std::str::from_utf8_unchecked(&group_name) },
-            request_source,
-            metadata.override_priority() as u64,
-        );
+        let override_priority = metadata.override_priority() as u64;
         let mut extras = Extras::new_multilevel(task_id, fixed_level);
         extras.set_metadata(metadata.to_vec());
+        let resource_limiter = self.resource_mgr.get_resource_limiter(
+            std::str::from_utf8(&group_name).unwrap_or_default(),
+            request_source,
+            override_priority,
+        );
         self.worker_pool.spawn_with_extras(
             with_resource_limiter(
                 ControlledFuture::new(f, self.resource_ctl.clone(), group_name),
                 resource_limiter,
+                true, // skip compaction pressure for foreground jobs
+                true, // measure-only: build debt, never sleep inside pool
+                Some(self.resource_mgr.clone()),
+                write_bytes,
             ),
             extras,
         )
@@ -221,6 +227,7 @@ impl SchedPool {
         metadata: TaskMetadata<'_>,
         priority_level: CommandPri,
         f: impl futures::Future<Output = ()> + Send + 'static,
+        write_bytes: u64,
     ) -> Result<(), Full> {
         match self.queue_type {
             QueueType::Vanilla => self.vanilla.spawn(priority_level, f),
@@ -232,6 +239,7 @@ impl SchedPool {
                         metadata,
                         priority_level,
                         f,
+                        write_bytes,
                     )
                 } else {
                     fail_point!("single_queue_pool_task");

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -252,6 +252,9 @@ struct TxnSchedulerInner<L: LockManager> {
     // all tasks are executed in this pool
     sched_worker_pool: SchedPool,
 
+    // resource group manager for Tier-1 high-priority throttle on writes.
+    resource_manager: Option<Arc<ResourceGroupManager>>,
+
     // used to control write flow
     running_write_bytes: CachePadded<AtomicUsize>,
 
@@ -466,6 +469,7 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
                 resource_ctl,
                 resource_manager.clone(),
             ),
+            resource_manager: resource_manager.clone(),
             control_mutex: Arc::new(tokio::sync::Mutex::new(false)),
             lock_mgr,
             concurrency_manager,
@@ -523,6 +527,56 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
         });
     }
 
+    /// Returns true if admission control consumed the command (reject or
+    /// delay); the caller should return without further processing.
+    fn apply_admission_control(
+        &self,
+        cmd: &Command,
+    ) -> Option<resource_control::AdmissionDecision> {
+        let rm = self.inner.resource_manager.as_ref()?;
+        let rc_ctx = cmd.resource_control_ctx();
+        let rg = rc_ctx.get_resource_group_name();
+        let request_source = cmd.ctx().request_source.clone();
+        let limiter =
+            rm.get_resource_limiter(rg, &request_source, rc_ctx.get_override_priority())?;
+        Some(rm.admission_decision(false, &limiter))
+    }
+
+    /// Spawns an async task on the sched pool that sleeps for `delay` then
+    /// calls `schedule_command`. The latch is acquired only after the sleep so
+    /// the delay does not block concurrent writers with overlapping keys.
+    fn schedule_after_admission_delay(
+        &self,
+        cmd: Command,
+        callback: StorageCallback,
+        delay: Duration,
+    ) {
+        let tag = cmd.tag();
+        let sched = self.clone();
+        let cb = SchedulerTaskCallback::NormalRequestCallback(callback);
+        let metadata = TaskMetadata::from_ctx(cmd.resource_control_ctx());
+        let priority = cmd.priority();
+        let write_bytes = cmd.write_bytes() as u64;
+        let request_source = cmd.ctx().request_source.clone();
+        let mem_quota = self.inner.memory_quota.clone();
+        let rm = self.inner.resource_manager.as_ref().unwrap().clone();
+        let execution = async move {
+            let mut guard = rm.delay_slot_guard();
+            futures_timer::Delay::new(delay).await;
+            guard.release();
+            let cid = sched.inner.gen_id();
+            if let Ok(task) = Task::allocate(cid, cmd, mem_quota) {
+                sched.schedule_command(task, cb, None);
+            } else {
+                Self::fail_with_busy(tag, cb);
+            }
+        };
+        self.inner
+            .sched_worker_pool
+            .spawn(&request_source, metadata, priority, execution, write_bytes)
+            .unwrap();
+    }
+
     pub(in crate::storage) fn run_cmd(&self, cmd: Command, callback: StorageCallback) {
         let tag = cmd.tag();
         // write flow control
@@ -533,6 +587,19 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
         if cmd.need_flow_control() && self.inner.too_busy(cmd.ctx().region_id) {
             Self::fail_with_busy(tag, callback.into());
             return;
+        }
+        // Admission control before latch acquisition so a delayed command does
+        // not block concurrent writers sharing the same keys.
+        match self.apply_admission_control(&cmd) {
+            Some(resource_control::AdmissionDecision::Reject) => {
+                Self::fail_with_busy(tag, callback.into());
+                return;
+            }
+            Some(resource_control::AdmissionDecision::Delay(delay)) => {
+                self.schedule_after_admission_delay(cmd, callback, delay);
+                return;
+            }
+            _ => {}
         }
         let cid = self.inner.gen_id();
         if let Ok(task) = Task::allocate(cid, cmd, self.inner.memory_quota.clone()) {
@@ -611,52 +678,53 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
         let ctx = cmd.ctx().clone();
         let deadline = cmd.deadline();
         let sched = self.clone();
+        let execution = async move {
+            match unsafe { with_tls_engine(|engine: &mut E| engine.precheck_write_with_ctx(&ctx)) }
+            {
+                // Precheck failed, try to return err early.
+                Err(e) => {
+                    let cb = sched.inner.try_own_and_take_cb(cid);
+                    // The task is not processing or finished currently. It's safe
+                    // to response early here. In the future, the task will be waked up
+                    // and it will finished with DeadlineExceeded error.
+                    // As the cb is taken here, it will not be executed anymore.
+                    if let Some(cb) = cb {
+                        let pr = ProcessResult::Failed {
+                            err: StorageError::from(e),
+                        };
+                        Self::early_response(
+                            cid,
+                            cb,
+                            pr,
+                            tag,
+                            CommandStageKind::precheck_write_err,
+                        );
+                    }
+                }
+                Ok(()) => {
+                    SCHED_STAGE_COUNTER_VEC.get(tag).precheck_write_ok.inc();
+                    // Check deadline in background.
+                    GLOBAL_TIMER_HANDLE
+                        .delay(deadline.to_std_instant())
+                        .compat()
+                        .await
+                        .unwrap();
+                    let cb = sched.inner.try_own_and_take_cb(cid);
+                    if let Some(cb) = cb {
+                        cb.execute(ProcessResult::Failed {
+                            err: StorageErrorInner::DeadlineExceeded.into(),
+                        })
+                    }
+                }
+            }
+        };
         self.get_sched_pool()
             .spawn(
                 &cmd.ctx().request_source,
                 TaskMetadata::from_ctx(cmd.resource_control_ctx()),
                 cmd.priority(),
-                async move {
-                    match unsafe {
-                        with_tls_engine(|engine: &mut E| engine.precheck_write_with_ctx(&ctx))
-                    } {
-                        // Precheck failed, try to return err early.
-                        Err(e) => {
-                            let cb = sched.inner.try_own_and_take_cb(cid);
-                            // The task is not processing or finished currently. It's safe
-                            // to response early here. In the future, the task will be waked up
-                            // and it will finished with DeadlineExceeded error.
-                            // As the cb is taken here, it will not be executed anymore.
-                            if let Some(cb) = cb {
-                                let pr = ProcessResult::Failed {
-                                    err: StorageError::from(e),
-                                };
-                                Self::early_response(
-                                    cid,
-                                    cb,
-                                    pr,
-                                    tag,
-                                    CommandStageKind::precheck_write_err,
-                                );
-                            }
-                        }
-                        Ok(()) => {
-                            SCHED_STAGE_COUNTER_VEC.get(tag).precheck_write_ok.inc();
-                            // Check deadline in background.
-                            GLOBAL_TIMER_HANDLE
-                                .delay(deadline.to_std_instant())
-                                .compat()
-                                .await
-                                .unwrap();
-                            let cb = sched.inner.try_own_and_take_cb(cid);
-                            if let Some(cb) = cb {
-                                cb.execute(ProcessResult::Failed {
-                                    err: StorageErrorInner::DeadlineExceeded.into(),
-                                })
-                            }
-                        }
-                    }
-                },
+                execution,
+                cmd.write_bytes() as u64,
             )
             .unwrap();
     }
@@ -676,9 +744,15 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
                 // when many queuing tasks fail successively.
                 let this = self.clone();
                 self.get_sched_pool()
-                    .spawn(&request_source, metadata, pri, async move {
-                        this.finish_with_err(cid, err, None);
-                    })
+                    .spawn(
+                        &request_source,
+                        metadata,
+                        pri,
+                        async move {
+                            this.finish_with_err(cid, err, None);
+                        },
+                        0,
+                    )
                     .unwrap();
             }
         }
@@ -717,13 +791,14 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
         let sched = self.clone();
         let metadata = TaskMetadata::from_ctx(task.cmd().resource_control_ctx());
         let request_source = task.cmd().ctx().request_source.clone();
+        let request_source_for_spawn = request_source.clone();
         let priority = task.cmd().priority();
+        let write_bytes = task.cmd().write_bytes();
         let execution = async move {
             fail_point!("scheduler_start_execute");
             if sched.check_task_deadline_exceeded(&task, None) {
                 return;
             }
-
             let tag = task.cmd().tag();
             SCHED_STAGE_COUNTER_VEC.get(tag).snapshot.inc();
 
@@ -799,7 +874,13 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
         });
         SCHED_TXN_RUNNING_COMMANDS.inc();
         self.get_sched_pool()
-            .spawn(&request_source, metadata, priority, execution)
+            .spawn(
+                &request_source_for_spawn,
+                metadata,
+                priority,
+                execution,
+                write_bytes as u64,
+            )
             .unwrap();
     }
 
@@ -1133,9 +1214,15 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
         } else {
             let lock_wait_queues = self.inner.lock_wait_queues.clone();
             self.get_sched_pool()
-                .spawn(request_source, metadata, CommandPri::High, async move {
-                    lock_wait_queues.update_lock_wait(new_acquired_locks);
-                })
+                .spawn(
+                    request_source,
+                    metadata,
+                    CommandPri::High,
+                    async move {
+                        lock_wait_queues.update_lock_wait(new_acquired_locks);
+                    },
+                    0,
+                )
                 .unwrap();
         }
     }
@@ -1153,40 +1240,52 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
         let metadata1 = metadata.deep_clone();
         let rsource = request_source.to_string();
         self.get_sched_pool()
-            .spawn(request_source, metadata, CommandPri::High, async move {
-                for (lock_info, released_lock) in legacy_wake_up_list {
-                    let cb = lock_info.key_cb.unwrap().into_inner();
-                    let e = StorageError::from(Error::from(MvccError::from(
-                        MvccErrorInner::WriteConflict {
-                            start_ts: lock_info.parameters.start_ts,
-                            conflict_start_ts: released_lock.start_ts,
-                            conflict_commit_ts: released_lock.commit_ts,
-                            key: released_lock.key.into_raw().unwrap(),
-                            primary: lock_info.parameters.primary,
-                            reason: kvrpcpb::WriteConflictReason::PessimisticRetry,
-                        },
-                    )));
-                    cb(Err(e.into()), false);
-                }
+            .spawn(
+                request_source,
+                metadata,
+                CommandPri::High,
+                async move {
+                    for (lock_info, released_lock) in legacy_wake_up_list {
+                        let cb = lock_info.key_cb.unwrap().into_inner();
+                        let e = StorageError::from(Error::from(MvccError::from(
+                            MvccErrorInner::WriteConflict {
+                                start_ts: lock_info.parameters.start_ts,
+                                conflict_start_ts: released_lock.start_ts,
+                                conflict_commit_ts: released_lock.commit_ts,
+                                key: released_lock.key.into_raw().unwrap(),
+                                primary: lock_info.parameters.primary,
+                                reason: kvrpcpb::WriteConflictReason::PessimisticRetry,
+                            },
+                        )));
+                        cb(Err(e.into()), false);
+                    }
 
-                for f in delayed_wake_up_futures {
-                    let self2 = self1.clone();
-                    let metadata2 = metadata1.clone();
-                    self1
-                        .get_sched_pool()
-                        .spawn(&rsource, metadata2, CommandPri::High, async move {
-                            let res = f.await;
-                            if let Some(resumable_lock_wait_entry) = res {
-                                self2.schedule_awakened_pessimistic_locks(
-                                    None,
-                                    None,
-                                    smallvec![resumable_lock_wait_entry],
-                                );
-                            }
-                        })
-                        .unwrap();
-                }
-            })
+                    for f in delayed_wake_up_futures {
+                        let self2 = self1.clone();
+                        let metadata2 = metadata1.clone();
+                        self1
+                            .get_sched_pool()
+                            .spawn(
+                                &rsource,
+                                metadata2,
+                                CommandPri::High,
+                                async move {
+                                    let res = f.await;
+                                    if let Some(resumable_lock_wait_entry) = res {
+                                        self2.schedule_awakened_pessimistic_locks(
+                                            None,
+                                            None,
+                                            smallvec![resumable_lock_wait_entry],
+                                        );
+                                    }
+                                },
+                                0,
+                            )
+                            .unwrap();
+                    }
+                },
+                0,
+            )
             .unwrap();
     }
 

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -69,6 +69,7 @@ snmalloc = ["tikv/snmalloc"]
 mem-profiling = ["tikv/mem-profiling"]
 sse = ["tikv/sse"]
 portable = ["tikv/portable"]
+docker_test = []  # Feature flag for Docker-specific tests
 
 [dependencies]
 api_version = { workspace = true }

--- a/tests/integrations/backup/mod.rs
+++ b/tests/integrations/backup/mod.rs
@@ -494,6 +494,8 @@ fn test_backup_raw_meta() {
 }
 
 #[test]
+// this test relies on file permissions which are ignored when run in docker under the root
+#[cfg(not(feature = "docker_test"))]
 fn test_invalid_external_storage() {
     let mut suite = TestSuite::new(1, 144 * 1024 * 1024, ApiVersion::V1);
     // Put some data.

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -956,6 +956,13 @@ fn test_readpool_default_config() {
 }
 
 #[test]
+fn test_compaction_readahead_default_config() {
+    let cfg = TikvConfig::default();
+    assert_eq!(cfg.rocksdb.compaction_readahead_size, ReadableSize::mb(2));
+    assert_eq!(cfg.raftdb.compaction_readahead_size, ReadableSize::mb(2));
+}
+
+#[test]
 fn test_do_not_use_unified_readpool_with_legacy_config() {
     let content = r#"
         [readpool.storage]

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -910,6 +910,10 @@ fn test_serde_custom_tikv_config() {
     value.resource_control = ResourceControlConfig {
         enabled: false,
         priority_ctl_strategy: PriorityCtlStrategy::Aggressive,
+        bg_resource_threshold: 70.0,
+        bg_compaction_pressure_threshold: 70.0,
+        bg_write_io_ceiling: ReadableSize::gb(100),
+        bg_write_io_floor: ReadableSize::mb(10),
     };
 
     let custom = read_file_in_project_dir("integrations/config/test-custom.toml");

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -910,6 +910,17 @@ fn test_serde_custom_tikv_config() {
     value.resource_control = ResourceControlConfig {
         enabled: false,
         priority_ctl_strategy: PriorityCtlStrategy::Aggressive,
+        bg_cpu_throttle_threshold: 60.0,
+        fg_cpu_throttle_threshold: 70.0,
+        bg_compaction_pressure_threshold: 70.0,
+        bg_write_io_ceiling: ReadableSize::gb(100),
+        bg_write_io_floor: ReadableSize::mb(10),
+        enable_fair_scheduling: false,
+        enable_read_admission_control: false,
+        enable_write_admission_control: false,
+        historical_usage_window_mins: 15,
+        baseline_burst_pct: 20.0,
+        admission_max_delayed_count: 10_000,
     };
 
     let custom = read_file_in_project_dir("integrations/config/test-custom.toml");
@@ -942,6 +953,13 @@ fn test_readpool_default_config() {
     let mut expected = TikvConfig::default();
     expected.readpool.unified.max_thread_count = 1;
     assert_eq!(cfg, expected);
+}
+
+#[test]
+fn test_compaction_readahead_default_config() {
+    let cfg = TikvConfig::default();
+    assert_eq!(cfg.rocksdb.compaction_readahead_size, ReadableSize::mb(2));
+    assert_eq!(cfg.raftdb.compaction_readahead_size, ReadableSize::mb(2));
 }
 
 #[test]

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -910,10 +910,17 @@ fn test_serde_custom_tikv_config() {
     value.resource_control = ResourceControlConfig {
         enabled: false,
         priority_ctl_strategy: PriorityCtlStrategy::Aggressive,
-        bg_resource_threshold: 70.0,
+        bg_cpu_throttle_threshold: 60.0,
+        fg_cpu_throttle_threshold: 70.0,
         bg_compaction_pressure_threshold: 70.0,
         bg_write_io_ceiling: ReadableSize::gb(100),
         bg_write_io_floor: ReadableSize::mb(10),
+        enable_fair_scheduling: false,
+        enable_read_admission_control: false,
+        enable_write_admission_control: false,
+        historical_usage_window_mins: 15,
+        baseline_burst_pct: 20.0,
+        admission_max_delayed_count: 10_000,
     };
 
     let custom = read_file_in_project_dir("integrations/config/test-custom.toml");

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -24,7 +24,9 @@ use raftstore::{
     coprocessor::{Config as CopConfig, ConsistencyCheckMethod},
     store::Config as RaftstoreConfig,
 };
-use resource_control::config::{Config as ResourceControlConfig, PriorityCtlStrategy};
+use resource_control::config::{
+    Config as ResourceControlConfig, NoisyDetection, PriorityCtlStrategy,
+};
 use security::SecurityConfig;
 use slog::Level;
 use test_util::assert_eq_debug;
@@ -910,6 +912,7 @@ fn test_serde_custom_tikv_config() {
     value.resource_control = ResourceControlConfig {
         enabled: false,
         priority_ctl_strategy: PriorityCtlStrategy::Aggressive,
+        noisy_detection: NoisyDetection::CurrentUsage,
         bg_cpu_throttle_threshold: 60.0,
         fg_cpu_throttle_threshold: 70.0,
         bg_compaction_pressure_threshold: 70.0,
@@ -921,6 +924,7 @@ fn test_serde_custom_tikv_config() {
         historical_usage_window_mins: 15,
         baseline_burst_pct: 20.0,
         admission_max_delayed_count: 10_000,
+        request_base_cost_micros: 40,
     };
 
     let custom = read_file_in_project_dir("integrations/config/test-custom.toml");

--- a/tests/integrations/config/test-custom.toml
+++ b/tests/integrations/config/test-custom.toml
@@ -689,7 +689,14 @@ split.split-contained-score = 0.5
 [resource-control]
 enabled = false
 priority-ctl-strategy = "aggressive"
-bg-resource-threshold = 70.0
+bg-cpu-throttle-threshold = 60.0
+fg-cpu-throttle-threshold = 70.0
 bg-compaction-pressure-threshold = 70.0
 bg-write-io-ceiling = "100GB"
 bg-write-io-floor = "10MB"
+enable-fair-scheduling = false
+enable-read-admission-control = false
+enable-write-admission-control = false
+historical-usage-window-mins = 15
+baseline-burst-pct = 20.0
+admission-max-delayed-count = 10000

--- a/tests/integrations/config/test-custom.toml
+++ b/tests/integrations/config/test-custom.toml
@@ -689,3 +689,7 @@ split.split-contained-score = 0.5
 [resource-control]
 enabled = false
 priority-ctl-strategy = "aggressive"
+bg-resource-threshold = 70.0
+bg-compaction-pressure-threshold = 70.0
+bg-write-io-ceiling = "100GB"
+bg-write-io-floor = "10MB"

--- a/tests/integrations/config/test-custom.toml
+++ b/tests/integrations/config/test-custom.toml
@@ -689,3 +689,14 @@ split.split-contained-score = 0.5
 [resource-control]
 enabled = false
 priority-ctl-strategy = "aggressive"
+bg-cpu-throttle-threshold = 60.0
+fg-cpu-throttle-threshold = 70.0
+bg-compaction-pressure-threshold = 70.0
+bg-write-io-ceiling = "100GB"
+bg-write-io-floor = "10MB"
+enable-fair-scheduling = false
+enable-read-admission-control = false
+enable-write-admission-control = false
+historical-usage-window-mins = 15
+baseline-burst-pct = 20.0
+admission-max-delayed-count = 10000

--- a/tests/integrations/config/test-custom.toml
+++ b/tests/integrations/config/test-custom.toml
@@ -689,6 +689,7 @@ split.split-contained-score = 0.5
 [resource-control]
 enabled = false
 priority-ctl-strategy = "aggressive"
+noisy-detection = "current-usage"
 bg-cpu-throttle-threshold = 60.0
 fg-cpu-throttle-threshold = 70.0
 bg-compaction-pressure-threshold = 70.0
@@ -700,3 +701,4 @@ enable-write-admission-control = false
 historical-usage-window-mins = 15
 baseline-burst-pct = 20.0
 admission-max-delayed-count = 10000
+request-base-cost-micros = 40


### PR DESCRIPTION
Release 8.5 20260608 v8.5.6

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #xxx

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message

```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `/ready` status endpoint with optional readiness details.
  - Added resource-group fair scheduling, admission control, throttling, delayed/rejected request handling, and related metrics.
  - Added disk-hang fail-fast monitoring and configurable detection timeout.
  - Added Grafana panels for load shedding, TiKV configuration, and CPU usage.
  - S3 multipart uploads now adjust part sizes automatically and retry additional throttling responses.

- **Improvements**
  - Enabled 2 MiB compaction readahead by default.
  - Added configurable S3 multipart upload sizing.
  - Improved server readiness tracking, resource accounting, and Docker-specific test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->