### PR TITLE
flow control: ignore base level pending bytes spikes

### DIFF
--- a/components/engine_panic/src/flow_control_factors.rs
+++ b/components/engine_panic/src/flow_control_factors.rs
@@ -16,4 +16,8 @@ impl FlowControlFactorsExt for PanicEngine {
     fn get_cf_pending_compaction_bytes(&self, cf: &str) -> Result<Option<u64>> {
         panic!()
     }
+
+    fn get_cf_base_level(&self, cf: &str) -> Result<Option<u64>> {
+        panic!()
+    }
 }

--- a/components/engine_rocks/src/flow_control_factors.rs
+++ b/components/engine_rocks/src/flow_control_factors.rs
@@ -29,4 +29,9 @@ impl FlowControlFactorsExt for RocksEngine {
             handle,
         ))
     }
+
+    fn get_cf_base_level(&self, cf: &str) -> Result<Option<u64>> {
+        let handle = util::get_cf_handle(self.as_inner(), cf)?;
+        Ok(crate::util::get_cf_base_level(self.as_inner(), handle))
+    }
 }

--- a/components/engine_rocks/src/rocks_metrics_defs.rs
+++ b/components/engine_rocks/src/rocks_metrics_defs.rs
@@ -17,6 +17,7 @@ pub const ROCKSDB_OLDEST_SNAPSHOT_TIME: &str = "rocksdb.oldest-snapshot-time";
 pub const ROCKSDB_OLDEST_SNAPSHOT_SEQUENCE: &str = "rocksdb.oldest-snapshot-sequence";
 pub const ROCKSDB_NUM_FILES_AT_LEVEL: &str = "rocksdb.num-files-at-level";
 pub const ROCKSDB_NUM_IMMUTABLE_MEM_TABLE: &str = "rocksdb.num-immutable-mem-table";
+pub const ROCKSDB_BASE_LEVEL: &str = "rocksdb.base-level";
 
 pub const ROCKSDB_TITANDB_NUM_BLOB_FILES_AT_LEVEL: &str = "rocksdb.titandb.num-blob-files-at-level";
 pub const ROCKSDB_TITANDB_LIVE_BLOB_SIZE: &str = "rocksdb.titandb.live-blob-size";

--- a/components/engine_rocks/src/util.rs
+++ b/components/engine_rocks/src/util.rs
@@ -248,6 +248,11 @@ pub fn get_cf_pending_compaction_bytes(engine: &DB, handle: &CFHandle) -> Option
     engine.get_property_int_cf(handle, ROCKSDB_PENDING_COMPACTION_BYTES)
 }
 
+/// Gets the base level of given column family.
+pub fn get_cf_base_level(engine: &DB, handle: &CFHandle) -> Option<u64> {
+    engine.get_property_int_cf(handle, ROCKSDB_BASE_LEVEL)
+}
+
 pub struct FixedSuffixSliceTransform {
     pub suffix_len: usize,
 }

--- a/components/engine_traits/src/flow_control_factors.rs
+++ b/components/engine_traits/src/flow_control_factors.rs
@@ -7,4 +7,6 @@ pub trait FlowControlFactorsExt {
     fn get_cf_num_immutable_mem_table(&self, cf: &str) -> Result<Option<u64>>;
 
     fn get_cf_pending_compaction_bytes(&self, cf: &str) -> Result<Option<u64>>;
+
+    fn get_cf_base_level(&self, cf: &str) -> Result<Option<u64>>;
 }

--- a/src/storage/txn/flow_controller/singleton_flow_controller.rs
+++ b/src/storage/txn/flow_controller/singleton_flow_controller.rs
@@ -622,16 +622,16 @@ impl<E: FlowControlFactorStore + Send + 'static> FlowChecker<E> {
         // Because pending compaction bytes changes dramatically, take the
         // logarithm of pending compaction bytes to make the values fall into
         // a relative small range
-        let mut num = (pending_compaction_bytes as f64).log2();
-        if !num.is_finite() {
+        let mut recent_pending_compaction_bytes = (pending_compaction_bytes as f64).log2();
+        if !recent_pending_compaction_bytes.is_finite() {
             // 0.log2() == -inf, which is not expected and may lead to sum always be NaN
-            num = 0.0;
+            recent_pending_compaction_bytes = 0.0;
         }
 
         let checker = self.cf_checkers.get_mut(&cf).unwrap();
         // only be called by v1
         if let Some(long_term_pending_bytes) = checker.long_term_pending_bytes.as_mut() {
-            long_term_pending_bytes.observe(num);
+            long_term_pending_bytes.observe(recent_pending_compaction_bytes);
             SCHED_PENDING_COMPACTION_BYTES_GAUGE
                 .with_label_values(&[&cf])
                 .set((long_term_pending_bytes.get_avg() * RATIO_SCALE_FACTOR as f64) as i64);
@@ -639,7 +639,9 @@ impl<E: FlowControlFactorStore + Send + 'static> FlowChecker<E> {
             // do special check on start, see the comment of the variable definition for
             // detail.
             if checker.on_start_pending_bytes {
-                if num < soft || long_term_pending_bytes.trend() == Trend::Increasing {
+                if recent_pending_compaction_bytes < soft
+                    || long_term_pending_bytes.trend() == Trend::Increasing
+                {
                     // the write is accumulating, still need to throttle
                     checker.on_start_pending_bytes = false;
                 } else {
@@ -648,48 +650,49 @@ impl<E: FlowControlFactorStore + Send + 'static> FlowChecker<E> {
                 }
             }
 
-            let pending_compaction_bytes = long_term_pending_bytes.get_avg();
-            let ignore_unsafe_destroy_range =
-                if let Some(before) = checker.pending_bytes_before_unsafe_destroy_range {
-                    // It assumes that the long term average will eventually come down below the
-                    // soft limit. If the general traffic flow increases during destroy, the long
-                    // term average may never come down and the flow control will be turned off for
-                    // a long time, which would be a rather rare case, so just ignore it.
-                    if pending_compaction_bytes <= before && !self.wait_for_destroy_range_finish {
-                        info!(
-                            "pending compaction bytes is back to normal";
-                            "cf" => &cf,
-                            "pending_compaction_bytes" => pending_compaction_bytes,
-                            "before" => before
-                        );
-                        checker.pending_bytes_before_unsafe_destroy_range = None;
-                    }
-                    true
-                } else {
-                    false
-                };
+            let avg_pending_compaction_bytes = long_term_pending_bytes.get_avg();
+            let ignore_unsafe_destroy_range = if let Some(before) =
+                checker.pending_bytes_before_unsafe_destroy_range
+            {
+                // It assumes that the long term average will eventually come down below the
+                // soft limit. If the general traffic flow increases during destroy, the long
+                // term average may never come down and the flow control will be turned off for
+                // a long time, which would be a rather rare case, so just ignore it.
+                if avg_pending_compaction_bytes <= before && !self.wait_for_destroy_range_finish {
+                    info!(
+                        "pending compaction bytes is back to normal";
+                        "cf" => &cf,
+                        "avg_pending_compaction_bytes" => avg_pending_compaction_bytes,
+                        "before" => before
+                    );
+                    checker.pending_bytes_before_unsafe_destroy_range = None;
+                }
+                true
+            } else {
+                false
+            };
             let ignore_base_level_pending_bytes_jump =
                 Self::should_ignore_base_level_pending_bytes_jump(
                     checker,
                     &cf,
-                    pending_compaction_bytes,
-                    num,
+                    avg_pending_compaction_bytes,
+                    recent_pending_compaction_bytes,
                     soft,
                 );
             let ignore = ignore_unsafe_destroy_range || ignore_base_level_pending_bytes_jump;
 
             for checker in self.cf_checkers.values() {
                 if let Some(long_term_pending_bytes) = checker.long_term_pending_bytes.as_ref() {
-                    if num < long_term_pending_bytes.get_recent() {
+                    if recent_pending_compaction_bytes < long_term_pending_bytes.get_recent() {
                         return;
                     }
                 }
             }
 
-            let mut ratio = if pending_compaction_bytes < soft || ignore {
+            let mut ratio = if avg_pending_compaction_bytes < soft || ignore {
                 0
             } else {
-                let new_ratio = (pending_compaction_bytes - soft) / (hard - soft);
+                let new_ratio = (avg_pending_compaction_bytes - soft) / (hard - soft);
                 let old_ratio = self.discard_ratio.load(Ordering::Relaxed);
 
                 // Because pending compaction bytes changes up and down, so using
@@ -745,9 +748,9 @@ impl<E: FlowControlFactorStore + Send + 'static> FlowChecker<E> {
             return;
         }
         if let Some(long_term_pending_bytes) = checker.long_term_pending_bytes.as_ref() {
-            let pending_compaction_bytes = long_term_pending_bytes.get_avg();
-            if long_term_pending_bytes.get_count() > 0 && pending_compaction_bytes < soft {
-                checker.pending_bytes_before_base_level_change = Some(pending_compaction_bytes);
+            let avg_pending_compaction_bytes = long_term_pending_bytes.get_avg();
+            if long_term_pending_bytes.get_count() > 0 && avg_pending_compaction_bytes < soft {
+                checker.pending_bytes_before_base_level_change = Some(avg_pending_compaction_bytes);
                 checker.pending_bytes_base_level_jump_baseline = None;
             }
         }
@@ -756,16 +759,17 @@ impl<E: FlowControlFactorStore + Send + 'static> FlowChecker<E> {
     fn should_ignore_base_level_pending_bytes_jump(
         checker: &mut CfFlowChecker,
         cf: &str,
-        pending_compaction_bytes: f64,
-        current_pending_compaction_bytes: f64,
+        avg_pending_compaction_bytes: f64,
+        recent_pending_compaction_bytes: f64,
         soft: f64,
     ) -> bool {
         if let Some(baseline) = checker.pending_bytes_base_level_jump_baseline {
-            if pending_compaction_bytes <= baseline {
+            if avg_pending_compaction_bytes <= baseline && recent_pending_compaction_bytes < soft {
                 info!(
                     "pending compaction bytes is back to normal after base level change";
                     "cf" => cf,
-                    "pending_compaction_bytes" => pending_compaction_bytes,
+                    "avg_pending_compaction_bytes" => avg_pending_compaction_bytes,
+                    "recent_pending_compaction_bytes" => recent_pending_compaction_bytes,
                     "baseline" => baseline,
                 );
                 checker.pending_bytes_base_level_jump_baseline = None;
@@ -778,7 +782,8 @@ impl<E: FlowControlFactorStore + Send + 'static> FlowChecker<E> {
             info!(
                 "skip pending compaction bytes jump after base level change";
                 "cf" => cf,
-                "pending_compaction_bytes" => pending_compaction_bytes,
+                "avg_pending_compaction_bytes" => avg_pending_compaction_bytes,
+                "recent_pending_compaction_bytes" => recent_pending_compaction_bytes,
                 "baseline" => baseline,
                 "soft_limit" => soft,
             );
@@ -788,7 +793,7 @@ impl<E: FlowControlFactorStore + Send + 'static> FlowChecker<E> {
         let Some(baseline) = checker.pending_bytes_before_base_level_change.take() else {
             return false;
         };
-        if current_pending_compaction_bytes < soft && pending_compaction_bytes < soft {
+        if recent_pending_compaction_bytes < soft && avg_pending_compaction_bytes < soft {
             return false;
         }
 
@@ -799,7 +804,8 @@ impl<E: FlowControlFactorStore + Send + 'static> FlowChecker<E> {
         info!(
             "start pending compaction bytes jump control after base level change";
             "cf" => cf,
-            "pending_compaction_bytes" => pending_compaction_bytes,
+            "avg_pending_compaction_bytes" => avg_pending_compaction_bytes,
+            "recent_pending_compaction_bytes" => recent_pending_compaction_bytes,
             "baseline" => baseline,
             "soft_limit" => soft,
         );
@@ -1467,6 +1473,63 @@ pub(super) mod tests {
         send_flow_info(&tx, region_id);
         send_flow_info(&tx, region_id);
         assert!(flow_controller.discard_ratio(region_id) > f64::EPSILON);
+    }
+
+    #[test]
+    fn test_flow_controller_pending_compaction_bytes_base_level_change_keeps_high_current() {
+        const GIB: u64 = 1024 * 1024 * 1024;
+
+        let config = FlowControlConfig::default();
+        let soft = (config.soft_pending_compaction_bytes_limit.0 as f64).log2();
+        let stub = EngineStub::new();
+        let discard_ratio = Arc::new(AtomicU32::new(0));
+        let mut checker = FlowChecker::new(
+            Arc::new(VersionTrack::new(config)),
+            stub,
+            discard_ratio.clone(),
+            Arc::new(Limiter::new(f64::INFINITY)),
+        );
+
+        let high_pending_bytes = 555 * GIB;
+        let high_pending_bytes_log = (high_pending_bytes as f64).log2();
+        let before_target = ((41 * GIB) as f64).log2();
+        let low_pending_bytes_log = (before_target * 1024.0 - high_pending_bytes_log) / 1023.0;
+        let baseline;
+        {
+            let cf_checker = checker.cf_checkers.get_mut("default").unwrap();
+            cf_checker.on_start_pending_bytes = false;
+
+            let long_term_pending_bytes = cf_checker.long_term_pending_bytes.as_mut().unwrap();
+            long_term_pending_bytes.observe(high_pending_bytes_log);
+            for _ in 1..1024 {
+                long_term_pending_bytes.observe(low_pending_bytes_log);
+            }
+
+            baseline = long_term_pending_bytes.get_avg();
+            assert!(baseline < soft);
+            assert!(long_term_pending_bytes.get_recent() < soft);
+            cf_checker.pending_bytes_base_level_jump_baseline = Some(baseline);
+        }
+
+        checker.on_pending_compaction_bytes_change_cf(high_pending_bytes, "default".to_string());
+        {
+            let cf_checker = checker.cf_checkers.get("default").unwrap();
+            let long_term_pending_bytes = cf_checker.long_term_pending_bytes.as_ref().unwrap();
+            assert!(long_term_pending_bytes.get_avg() <= baseline + f64::EPSILON);
+            assert!(long_term_pending_bytes.get_recent() >= soft);
+            assert!(cf_checker.pending_bytes_base_level_jump_baseline.is_some());
+        }
+        assert_eq!(discard_ratio.load(Ordering::Relaxed), 0);
+
+        checker.on_pending_compaction_bytes_change_cf(GIB, "default".to_string());
+        assert!(
+            checker
+                .cf_checkers
+                .get("default")
+                .unwrap()
+                .pending_bytes_base_level_jump_baseline
+                .is_none()
+        );
     }
 
     #[test]

--- a/src/storage/txn/flow_controller/singleton_flow_controller.rs
+++ b/src/storage/txn/flow_controller/singleton_flow_controller.rs
@@ -37,6 +37,8 @@ const MAX_THROTTLE_SPEED: f64 = 200.0 * 1024.0 * 1024.0; // 200MB
 
 const EMA_FACTOR: f64 = 0.6; // EMA stands for Exponential Moving Average
 const PENDING_BYTES_JUMP_THRESHOLD: f64 = 2.0;
+const BASE_LEVEL_CHANGE_PENDING_BYTES_JUMP_THRESHOLD_SECS: f64 =
+    SMOOTHER_STALE_RECORD_THRESHOLD as f64;
 
 /// Flow controller is used to throttle the write rate at scheduler level,
 /// aiming to substitute the write stall mechanism of RocksDB. It features in
@@ -240,8 +242,8 @@ struct CfFlowChecker {
     long_term_pending_bytes:
         Option<Smoother<f64, 1024, SMOOTHER_STALE_RECORD_THRESHOLD, SMOOTHER_TIME_RANGE_THRESHOLD>>,
     pending_bytes_before_unsafe_destroy_range: Option<f64>,
-    pending_bytes_before_base_level_transition: Option<f64>,
-    pending_bytes_base_level_jump_detected: bool,
+    pending_bytes_before_base_level_change: Option<(f64, Instant)>,
+    pending_bytes_base_level_jump_baseline: Option<f64>,
     last_base_level: Option<u64>,
 
     // On start related markers. Because after restart, the memtable, l0 files
@@ -280,8 +282,8 @@ impl CfFlowChecker {
                 None
             },
             pending_bytes_before_unsafe_destroy_range: None,
-            pending_bytes_before_base_level_transition: None,
-            pending_bytes_base_level_jump_detected: false,
+            pending_bytes_before_base_level_change: None,
+            pending_bytes_base_level_jump_baseline: None,
             last_base_level: None,
             on_start_memtable: true,
             on_start_l0_files: true,
@@ -620,55 +622,11 @@ impl<E: FlowControlFactorStore + Send + 'static> FlowChecker<E> {
             // 0.log2() == -inf, which is not expected and may lead to sum always be NaN
             num = 0.0;
         }
-        let has_l0_or_memtable_pressure = self.has_l0_or_memtable_pressure(&cf, &control_cfg);
-        let checker = self.cf_checkers.get_mut(&cf).unwrap();
-        let ignore_base_level_transition = if let Some(before) =
-            checker.pending_bytes_before_base_level_transition
-        {
-            if checker.on_start_pending_bytes || has_l0_or_memtable_pressure {
-                checker.pending_bytes_before_base_level_transition = None;
-                checker.pending_bytes_base_level_jump_detected = false;
-                false
-            } else if num <= before {
-                if checker.pending_bytes_base_level_jump_detected {
-                    info!(
-                        "pending compaction bytes is back to normal after base level transition";
-                        "cf" => &cf,
-                        "pending_compaction_bytes" => num,
-                        "before" => before,
-                    );
-                }
-                checker.pending_bytes_before_base_level_transition = None;
-                checker.pending_bytes_base_level_jump_detected = false;
-                false
-            } else if checker.pending_bytes_base_level_jump_detected
-                || (num >= soft && num >= before + PENDING_BYTES_JUMP_THRESHOLD)
-            {
-                checker.pending_bytes_base_level_jump_detected = true;
-                SCHED_THROTTLE_ACTION_COUNTER
-                    .with_label_values(&[&cf, "pending_bytes_base_level_jump"])
-                    .inc();
-                info!(
-                    "ignore pending compaction bytes jump after base level transition";
-                    "cf" => &cf,
-                    "pending_compaction_bytes" => num,
-                    "before" => before,
-                    "soft_limit" => soft,
-                );
-                true
-            } else {
-                checker.pending_bytes_before_base_level_transition = None;
-                checker.pending_bytes_base_level_jump_detected = false;
-                false
-            }
-        } else {
-            false
-        };
-
-        if ignore_base_level_transition {
+        if self.should_skip_base_level_pending_bytes_jump(&cf, num, soft) {
             return;
         }
 
+        let checker = self.cf_checkers.get_mut(&cf).unwrap();
         // only be called by v1
         if let Some(long_term_pending_bytes) = checker.long_term_pending_bytes.as_mut() {
             long_term_pending_bytes.observe(num);
@@ -750,7 +708,7 @@ impl<E: FlowControlFactorStore + Send + 'static> FlowChecker<E> {
         checker.last_base_level = current_base_level;
         if let (Some(last), Some(current)) = (previous_base_level, current_base_level) {
             if last != current {
-                self.mark_base_level_transition(cf);
+                self.mark_base_level_change(cf);
                 info!(
                     "rocksdb base level changed";
                     "cf" => cf,
@@ -763,7 +721,7 @@ impl<E: FlowControlFactorStore + Send + 'static> FlowChecker<E> {
         false
     }
 
-    pub(super) fn mark_base_level_transition(&mut self, cf: &str) {
+    pub(super) fn mark_base_level_change(&mut self, cf: &str) {
         let soft = (self
             .config_tracker
             .value()
@@ -774,22 +732,90 @@ impl<E: FlowControlFactorStore + Send + 'static> FlowChecker<E> {
         if let Some(long_term_pending_bytes) = checker.long_term_pending_bytes.as_ref() {
             let pending_compaction_bytes = long_term_pending_bytes.get_recent();
             if long_term_pending_bytes.get_count() > 0 && pending_compaction_bytes < soft {
-                checker.pending_bytes_before_base_level_transition = Some(pending_compaction_bytes);
-                checker.pending_bytes_base_level_jump_detected = false;
+                checker.pending_bytes_before_base_level_change =
+                    Some((pending_compaction_bytes, Instant::now_coarse()));
+                checker.pending_bytes_base_level_jump_baseline = None;
             }
         }
     }
 
-    pub(super) fn has_l0_or_memtable_pressure(
-        &self,
+    fn should_skip_base_level_pending_bytes_jump(
+        &mut self,
         cf: &str,
-        control_cfg: &FlowControlConfig,
+        pending_compaction_bytes: f64,
+        soft: f64,
     ) -> bool {
-        let checker = self.cf_checkers.get(cf).unwrap();
-        checker.long_term_num_l0_files.get_recent() > control_cfg.l0_files_threshold
-            || checker.long_term_num_l0_files.get_avg() > control_cfg.l0_files_threshold as f64
-            || checker.last_num_memtables.get_recent() > control_cfg.memtables_threshold
-            || checker.last_num_memtables.get_avg() > control_cfg.memtables_threshold as f64
+        let checker = self.cf_checkers.get_mut(cf).unwrap();
+        if checker.on_start_pending_bytes {
+            checker.pending_bytes_before_base_level_change = None;
+            checker.pending_bytes_base_level_jump_baseline = None;
+            return false;
+        }
+
+        if let Some(baseline) = checker.pending_bytes_base_level_jump_baseline {
+            if pending_compaction_bytes <= baseline {
+                info!(
+                    "pending compaction bytes is back to normal after base level change";
+                    "cf" => cf,
+                    "pending_compaction_bytes" => pending_compaction_bytes,
+                    "baseline" => baseline,
+                );
+                checker.pending_bytes_base_level_jump_baseline = None;
+                return false;
+            }
+
+            SCHED_THROTTLE_ACTION_COUNTER
+                .with_label_values(&[cf, "pending_bytes_base_level_jump"])
+                .inc();
+            info!(
+                "skip pending compaction bytes jump after base level change";
+                "cf" => cf,
+                "pending_compaction_bytes" => pending_compaction_bytes,
+                "baseline" => baseline,
+                "soft_limit" => soft,
+            );
+            return true;
+        }
+
+        let Some((baseline, base_level_change_time)) =
+            checker.pending_bytes_before_base_level_change
+        else {
+            return false;
+        };
+        if base_level_change_time.saturating_elapsed_secs()
+            > BASE_LEVEL_CHANGE_PENDING_BYTES_JUMP_THRESHOLD_SECS
+        {
+            checker.pending_bytes_before_base_level_change = None;
+            return false;
+        }
+        if pending_compaction_bytes < soft {
+            return false;
+        }
+        checker.pending_bytes_before_base_level_change = None;
+        let previous_pending_compaction_bytes = checker
+            .long_term_pending_bytes
+            .as_ref()
+            .map_or(0.0, |pending_bytes| pending_bytes.get_recent());
+        if pending_compaction_bytes < baseline + PENDING_BYTES_JUMP_THRESHOLD
+            || pending_compaction_bytes
+                < previous_pending_compaction_bytes + PENDING_BYTES_JUMP_THRESHOLD
+        {
+            return false;
+        }
+
+        checker.pending_bytes_base_level_jump_baseline = Some(baseline);
+        SCHED_THROTTLE_ACTION_COUNTER
+            .with_label_values(&[cf, "pending_bytes_base_level_jump"])
+            .inc();
+        info!(
+            "start pending compaction bytes jump control after base level change";
+            "cf" => cf,
+            "pending_compaction_bytes" => pending_compaction_bytes,
+            "baseline" => baseline,
+            "previous_pending_compaction_bytes" => previous_pending_compaction_bytes,
+            "soft_limit" => soft,
+        );
+        true
     }
 
     fn on_memtable_change(&mut self, cf: &str) {
@@ -1456,7 +1482,7 @@ pub(super) mod tests {
     }
 
     #[test]
-    fn test_flow_controller_pending_compaction_bytes_base_level_transition_spike() {
+    fn test_flow_controller_pending_compaction_bytes_base_level_change_spike() {
         let region_id = 0;
         let stub = EngineStub::new();
         let (tx, rx) = mpsc::sync_channel(0);
@@ -1477,6 +1503,12 @@ pub(super) mod tests {
         stub.0.base_level.store(2, Ordering::Relaxed);
         stub.0
             .pending_compaction_bytes
+            .store(120 * 1024 * 1024 * 1024, Ordering::Relaxed);
+        send_flow_info(&tx, region_id);
+        assert!(flow_controller.discard_ratio(region_id) < f64::EPSILON);
+
+        stub.0
+            .pending_compaction_bytes
             .store(1_000_000 * 1024 * 1024 * 1024, Ordering::Relaxed);
         send_flow_info(&tx, region_id);
         assert!(flow_controller.discard_ratio(region_id) < f64::EPSILON);
@@ -1491,7 +1523,7 @@ pub(super) mod tests {
     }
 
     #[test]
-    fn test_flow_controller_pending_compaction_bytes_base_level_transition_recover() {
+    fn test_flow_controller_pending_compaction_bytes_base_level_change_recover() {
         let region_id = 0;
         let stub = EngineStub::new();
         let (tx, rx) = mpsc::sync_channel(0);
@@ -1523,17 +1555,40 @@ pub(super) mod tests {
             .store(100 * 1024 * 1024 * 1024, Ordering::Relaxed);
         send_flow_info(&tx, region_id);
         assert!(flow_controller.discard_ratio(region_id) < f64::EPSILON);
+    }
 
-        stub.0.base_level.store(3, Ordering::Relaxed);
+    #[test]
+    fn test_flow_controller_pending_compaction_bytes_base_level_change_without_jump() {
+        let region_id = 0;
+        let stub = EngineStub::new();
+        let (tx, rx) = mpsc::sync_channel(0);
+        let flow_controller =
+            EngineFlowController::new(&FlowControlConfig::default(), stub.clone(), rx);
+        let flow_controller = FlowController::Singleton(flow_controller);
+
+        stub.0.base_level.store(1, Ordering::Relaxed);
         stub.0
             .pending_compaction_bytes
             .store(100 * 1024 * 1024 * 1024, Ordering::Relaxed);
         send_flow_info(&tx, region_id);
         assert!(flow_controller.discard_ratio(region_id) < f64::EPSILON);
 
+        stub.0.base_level.store(2, Ordering::Relaxed);
         stub.0
             .pending_compaction_bytes
-            .store(1_000_000 * 1024 * 1024 * 1024, Ordering::Relaxed);
+            .store(150 * 1024 * 1024 * 1024, Ordering::Relaxed);
+        send_flow_info(&tx, region_id);
+        assert!(flow_controller.discard_ratio(region_id) < f64::EPSILON);
+
+        stub.0
+            .pending_compaction_bytes
+            .store(250 * 1024 * 1024 * 1024, Ordering::Relaxed);
+        send_flow_info(&tx, region_id);
+        assert!(flow_controller.discard_ratio(region_id) < f64::EPSILON);
+
+        stub.0
+            .pending_compaction_bytes
+            .store(1000 * 1024 * 1024 * 1024, Ordering::Relaxed);
         send_flow_info(&tx, region_id);
         assert!(flow_controller.discard_ratio(region_id) > f64::EPSILON);
     }

--- a/src/storage/txn/flow_controller/singleton_flow_controller.rs
+++ b/src/storage/txn/flow_controller/singleton_flow_controller.rs
@@ -36,9 +36,6 @@ const MIN_THROTTLE_SPEED: f64 = 16.0 * 1024.0; // 16KB
 const MAX_THROTTLE_SPEED: f64 = 200.0 * 1024.0 * 1024.0; // 200MB
 
 const EMA_FACTOR: f64 = 0.6; // EMA stands for Exponential Moving Average
-const PENDING_BYTES_JUMP_THRESHOLD: f64 = 2.0;
-const BASE_LEVEL_CHANGE_PENDING_BYTES_JUMP_THRESHOLD_SECS: f64 =
-    SMOOTHER_STALE_RECORD_THRESHOLD as f64;
 
 /// Flow controller is used to throttle the write rate at scheduler level,
 /// aiming to substitute the write stall mechanism of RocksDB. It features in
@@ -242,7 +239,7 @@ struct CfFlowChecker {
     long_term_pending_bytes:
         Option<Smoother<f64, 1024, SMOOTHER_STALE_RECORD_THRESHOLD, SMOOTHER_TIME_RANGE_THRESHOLD>>,
     pending_bytes_before_unsafe_destroy_range: Option<f64>,
-    pending_bytes_before_base_level_change: Option<(f64, Instant)>,
+    pending_bytes_before_base_level_change: Option<f64>,
     pending_bytes_base_level_jump_baseline: Option<f64>,
     last_base_level: Option<u64>,
 
@@ -426,8 +423,7 @@ impl<E: FlowControlFactorStore + Send + 'static> FlowChecker<E> {
             }
             Ok(FlowInfo::Compaction(cf, ..)) => {
                 if current_cfg.enable {
-                    self.on_base_level_change(&cf);
-                    self.on_pending_compaction_bytes_change(cf);
+                    self.on_compaction_flow_info(cf);
                 }
             }
             Ok(FlowInfo::BeforeUnsafeDestroyRange(..)) => {
@@ -600,10 +596,19 @@ impl<E: FlowControlFactorStore + Send + 'static> FlowChecker<E> {
         (rate, cf_throttle_flags)
     }
 
-    pub fn on_pending_compaction_bytes_change(&mut self, cf: String) -> u64 {
-        let pending_compaction_bytes = self.engine.pending_compaction_bytes(self.region_id, &cf);
+    pub(super) fn pending_compaction_bytes(&self, cf: &str) -> u64 {
+        self.engine.pending_compaction_bytes(self.region_id, cf)
+    }
+
+    pub(super) fn on_compaction_flow_info(&mut self, cf: String) -> (u64, bool) {
+        let mut base_level_changed = self.on_base_level_change(&cf);
+        let mut pending_compaction_bytes = self.pending_compaction_bytes(&cf);
+        if self.on_base_level_change(&cf) {
+            base_level_changed = true;
+            pending_compaction_bytes = self.pending_compaction_bytes(&cf);
+        }
         self.on_pending_compaction_bytes_change_cf(pending_compaction_bytes, cf);
-        pending_compaction_bytes
+        (pending_compaction_bytes, base_level_changed)
     }
 
     pub fn on_pending_compaction_bytes_change_cf(
@@ -621,9 +626,6 @@ impl<E: FlowControlFactorStore + Send + 'static> FlowChecker<E> {
         if !num.is_finite() {
             // 0.log2() == -inf, which is not expected and may lead to sum always be NaN
             num = 0.0;
-        }
-        if self.should_skip_base_level_pending_bytes_jump(&cf, num, soft) {
-            return;
         }
 
         let checker = self.cf_checkers.get_mut(&cf).unwrap();
@@ -666,7 +668,15 @@ impl<E: FlowControlFactorStore + Send + 'static> FlowChecker<E> {
                 } else {
                     false
                 };
-            let ignore = ignore_unsafe_destroy_range;
+            let ignore_base_level_pending_bytes_jump =
+                Self::should_ignore_base_level_pending_bytes_jump(
+                    checker,
+                    &cf,
+                    pending_compaction_bytes,
+                    num,
+                    soft,
+                );
+            let ignore = ignore_unsafe_destroy_range || ignore_base_level_pending_bytes_jump;
 
             for checker in self.cf_checkers.values() {
                 if let Some(long_term_pending_bytes) = checker.long_term_pending_bytes.as_ref() {
@@ -729,29 +739,27 @@ impl<E: FlowControlFactorStore + Send + 'static> FlowChecker<E> {
             .0 as f64)
             .log2();
         let checker = self.cf_checkers.get_mut(cf).unwrap();
+        if checker.on_start_pending_bytes
+            || checker.pending_bytes_base_level_jump_baseline.is_some()
+        {
+            return;
+        }
         if let Some(long_term_pending_bytes) = checker.long_term_pending_bytes.as_ref() {
-            let pending_compaction_bytes = long_term_pending_bytes.get_recent();
+            let pending_compaction_bytes = long_term_pending_bytes.get_avg();
             if long_term_pending_bytes.get_count() > 0 && pending_compaction_bytes < soft {
-                checker.pending_bytes_before_base_level_change =
-                    Some((pending_compaction_bytes, Instant::now_coarse()));
+                checker.pending_bytes_before_base_level_change = Some(pending_compaction_bytes);
                 checker.pending_bytes_base_level_jump_baseline = None;
             }
         }
     }
 
-    fn should_skip_base_level_pending_bytes_jump(
-        &mut self,
+    fn should_ignore_base_level_pending_bytes_jump(
+        checker: &mut CfFlowChecker,
         cf: &str,
         pending_compaction_bytes: f64,
+        current_pending_compaction_bytes: f64,
         soft: f64,
     ) -> bool {
-        let checker = self.cf_checkers.get_mut(cf).unwrap();
-        if checker.on_start_pending_bytes {
-            checker.pending_bytes_before_base_level_change = None;
-            checker.pending_bytes_base_level_jump_baseline = None;
-            return false;
-        }
-
         if let Some(baseline) = checker.pending_bytes_base_level_jump_baseline {
             if pending_compaction_bytes <= baseline {
                 info!(
@@ -777,29 +785,10 @@ impl<E: FlowControlFactorStore + Send + 'static> FlowChecker<E> {
             return true;
         }
 
-        let Some((baseline, base_level_change_time)) =
-            checker.pending_bytes_before_base_level_change
-        else {
+        let Some(baseline) = checker.pending_bytes_before_base_level_change.take() else {
             return false;
         };
-        if base_level_change_time.saturating_elapsed_secs()
-            > BASE_LEVEL_CHANGE_PENDING_BYTES_JUMP_THRESHOLD_SECS
-        {
-            checker.pending_bytes_before_base_level_change = None;
-            return false;
-        }
-        if pending_compaction_bytes < soft {
-            return false;
-        }
-        checker.pending_bytes_before_base_level_change = None;
-        let previous_pending_compaction_bytes = checker
-            .long_term_pending_bytes
-            .as_ref()
-            .map_or(0.0, |pending_bytes| pending_bytes.get_recent());
-        if pending_compaction_bytes < baseline + PENDING_BYTES_JUMP_THRESHOLD
-            || pending_compaction_bytes
-                < previous_pending_compaction_bytes + PENDING_BYTES_JUMP_THRESHOLD
-        {
+        if current_pending_compaction_bytes < soft && pending_compaction_bytes < soft {
             return false;
         }
 
@@ -812,7 +801,6 @@ impl<E: FlowControlFactorStore + Send + 'static> FlowChecker<E> {
             "cf" => cf,
             "pending_compaction_bytes" => pending_compaction_bytes,
             "baseline" => baseline,
-            "previous_pending_compaction_bytes" => previous_pending_compaction_bytes,
             "soft_limit" => soft,
         );
         true
@@ -1503,18 +1491,13 @@ pub(super) mod tests {
         stub.0.base_level.store(2, Ordering::Relaxed);
         stub.0
             .pending_compaction_bytes
-            .store(120 * 1024 * 1024 * 1024, Ordering::Relaxed);
-        send_flow_info(&tx, region_id);
-        assert!(flow_controller.discard_ratio(region_id) < f64::EPSILON);
-
-        stub.0
-            .pending_compaction_bytes
             .store(1_000_000 * 1024 * 1024 * 1024, Ordering::Relaxed);
         send_flow_info(&tx, region_id);
         assert!(flow_controller.discard_ratio(region_id) < f64::EPSILON);
 
-        // Raw pending bytes returns to normal. The average is still polluted by
-        // the spike, so it should stay ignored until it drains.
+        // Raw pending bytes returns to normal. The spike sample has been
+        // observed by the smoother, so it should stay ignored until the
+        // long-term average drains.
         stub.0
             .pending_compaction_bytes
             .store(100 * 1024 * 1024 * 1024, Ordering::Relaxed);
@@ -1535,7 +1518,9 @@ pub(super) mod tests {
         stub.0
             .pending_compaction_bytes
             .store(100 * 1024 * 1024 * 1024, Ordering::Relaxed);
-        send_flow_info(&tx, region_id);
+        for _ in 0..2 {
+            send_flow_info(&tx, region_id);
+        }
         assert!(flow_controller.discard_ratio(region_id) < f64::EPSILON);
 
         stub.0.base_level.store(2, Ordering::Relaxed);

--- a/src/storage/txn/flow_controller/singleton_flow_controller.rs
+++ b/src/storage/txn/flow_controller/singleton_flow_controller.rs
@@ -683,6 +683,9 @@ impl<E: FlowControlFactorStore + Send + 'static> FlowChecker<E> {
                 );
             let ignore = ignore_unsafe_destroy_range || ignore_base_level_pending_bytes_jump;
 
+            // The discard ratio is global. Let the CF with the largest recent
+            // pending bytes sample update it, so a less pressured CF does not
+            // overwrite the ratio chosen by the current bottleneck.
             for checker in self.cf_checkers.values() {
                 if let Some(long_term_pending_bytes) = checker.long_term_pending_bytes.as_ref() {
                     if recent_pending_compaction_bytes < long_term_pending_bytes.get_recent() {

--- a/src/storage/txn/flow_controller/singleton_flow_controller.rs
+++ b/src/storage/txn/flow_controller/singleton_flow_controller.rs
@@ -603,14 +603,14 @@ impl<E: FlowControlFactorStore + Send + 'static> FlowChecker<E> {
     pub(super) fn on_pending_compaction_bytes_change(&mut self, cf: String) -> (u64, bool) {
         // Check the base level around pending bytes so a RocksDB version switch
         // during the pending bytes read is not missed.
-        let mut base_level_changed = self.detect_base_level_change(&cf);
+        let mut base_level_increased = self.detect_base_level_increase(&cf);
         let mut pending_compaction_bytes = self.pending_compaction_bytes(&cf);
-        if self.detect_base_level_change(&cf) {
-            base_level_changed = true;
+        if self.detect_base_level_increase(&cf) {
+            base_level_increased = true;
             pending_compaction_bytes = self.pending_compaction_bytes(&cf);
         }
         self.on_pending_compaction_bytes_change_cf(pending_compaction_bytes, cf);
-        (pending_compaction_bytes, base_level_changed)
+        (pending_compaction_bytes, base_level_increased)
     }
 
     pub fn on_pending_compaction_bytes_change_cf(
@@ -719,21 +719,37 @@ impl<E: FlowControlFactorStore + Send + 'static> FlowChecker<E> {
         }
     }
 
-    pub(super) fn detect_base_level_change(&mut self, cf: &str) -> bool {
+    pub(super) fn detect_base_level_increase(&mut self, cf: &str) -> bool {
         let current_base_level = self.engine.base_level(self.region_id, cf);
         let checker = self.cf_checkers.get_mut(cf).unwrap();
         let previous_base_level = checker.last_base_level;
         checker.last_base_level = current_base_level;
         if let (Some(last), Some(current)) = (previous_base_level, current_base_level) {
             if last != current {
-                self.record_base_level_change_baseline(cf);
+                // With dynamic level bytes, RocksDB starts an empty CF with the base
+                // level at the last level. In TiKV's usual L0..L6 layout, the base
+                // level begins at L6, then moves toward lower-numbered levels as
+                // data grows: 6 -> 5 -> 4 -> 3 -> 2 -> 1.
+                //
+                // A base-level decrease is usually not the problematic direction.
+                // It makes more levels active and lets RocksDB spread the LSM over
+                // a wider target-size ladder. The suspicious direction is a
+                // base-level increase, such as 1 -> 2. It means the active LSM has
+                // one fewer level, so level targets around the old base can be
+                // recomputed downward. That can make RocksDB's estimated pending
+                // compaction bytes jump even when raw bytes did not really grow.
+                let base_level_increased = current > last;
+                if base_level_increased {
+                    self.record_base_level_change_baseline(cf);
+                }
                 info!(
                     "rocksdb base level changed";
                     "cf" => cf,
                     "last_base_level" => last,
                     "current_base_level" => current,
+                    "base_level_increased" => base_level_increased,
                 );
-                return true;
+                return base_level_increased;
             }
         }
         false
@@ -754,7 +770,11 @@ impl<E: FlowControlFactorStore + Send + 'static> FlowChecker<E> {
         }
         if let Some(long_term_pending_bytes) = checker.long_term_pending_bytes.as_ref() {
             let avg_pending_compaction_bytes = long_term_pending_bytes.get_avg();
-            if long_term_pending_bytes.get_count() > 0 && avg_pending_compaction_bytes < soft {
+            let last_observed_pending_compaction_bytes = long_term_pending_bytes.get_recent();
+            if long_term_pending_bytes.get_count() > 0
+                && avg_pending_compaction_bytes < soft
+                && last_observed_pending_compaction_bytes < soft
+            {
                 checker.pending_bytes_before_base_level_change = Some(avg_pending_compaction_bytes);
                 checker.pending_bytes_base_level_jump_baseline = None;
             }
@@ -1530,6 +1550,110 @@ pub(super) mod tests {
                 .pending_bytes_base_level_jump_baseline
                 .is_none()
         );
+    }
+
+    #[test]
+    fn test_flow_controller_pending_compaction_bytes_base_level_change_keeps_existing_pressure() {
+        const GIB: u64 = 1024 * 1024 * 1024;
+
+        let config = FlowControlConfig::default();
+        let soft = (config.soft_pending_compaction_bytes_limit.0 as f64).log2();
+        let stub = EngineStub::new();
+        let discard_ratio = Arc::new(AtomicU32::new(0));
+        let mut checker = FlowChecker::new(
+            Arc::new(VersionTrack::new(config)),
+            stub.clone(),
+            discard_ratio.clone(),
+            Arc::new(Limiter::new(f64::INFINITY)),
+        );
+
+        stub.0.base_level.store(1, Ordering::Relaxed);
+        assert!(!checker.detect_base_level_increase("default"));
+
+        let low_pending_bytes_log = ((100 * GIB) as f64).log2();
+        let high_pending_bytes = 555 * GIB;
+        let high_pending_bytes_log = (high_pending_bytes as f64).log2();
+        {
+            let cf_checker = checker.cf_checkers.get_mut("default").unwrap();
+            cf_checker.on_start_pending_bytes = false;
+
+            let long_term_pending_bytes = cf_checker.long_term_pending_bytes.as_mut().unwrap();
+            for _ in 0..10 {
+                long_term_pending_bytes.observe(low_pending_bytes_log);
+            }
+            long_term_pending_bytes.observe(high_pending_bytes_log);
+
+            assert!(long_term_pending_bytes.get_avg() < soft);
+            assert!(long_term_pending_bytes.get_recent() >= soft);
+        }
+
+        stub.0.base_level.store(2, Ordering::Relaxed);
+        assert!(checker.detect_base_level_increase("default"));
+        assert!(
+            checker
+                .cf_checkers
+                .get("default")
+                .unwrap()
+                .pending_bytes_before_base_level_change
+                .is_none()
+        );
+
+        for _ in 0..10 {
+            checker
+                .on_pending_compaction_bytes_change_cf(high_pending_bytes, "default".to_string());
+        }
+        assert!(discard_ratio.load(Ordering::Relaxed) > 0);
+    }
+
+    #[test]
+    fn test_flow_controller_pending_compaction_bytes_base_level_decrease_does_not_ignore_jump() {
+        const GIB: u64 = 1024 * 1024 * 1024;
+
+        let config = FlowControlConfig::default();
+        let soft = (config.soft_pending_compaction_bytes_limit.0 as f64).log2();
+        let stub = EngineStub::new();
+        let discard_ratio = Arc::new(AtomicU32::new(0));
+        let mut checker = FlowChecker::new(
+            Arc::new(VersionTrack::new(config)),
+            stub.clone(),
+            discard_ratio.clone(),
+            Arc::new(Limiter::new(f64::INFINITY)),
+        );
+
+        stub.0.base_level.store(2, Ordering::Relaxed);
+        assert!(!checker.detect_base_level_increase("default"));
+
+        let low_pending_bytes_log = ((100 * GIB) as f64).log2();
+        let high_pending_bytes = 555 * GIB;
+        {
+            let cf_checker = checker.cf_checkers.get_mut("default").unwrap();
+            cf_checker.on_start_pending_bytes = false;
+
+            let long_term_pending_bytes = cf_checker.long_term_pending_bytes.as_mut().unwrap();
+            for _ in 0..10 {
+                long_term_pending_bytes.observe(low_pending_bytes_log);
+            }
+
+            assert!(long_term_pending_bytes.get_avg() < soft);
+            assert!(long_term_pending_bytes.get_recent() < soft);
+        }
+
+        stub.0.base_level.store(1, Ordering::Relaxed);
+        assert!(!checker.detect_base_level_increase("default"));
+        assert!(
+            checker
+                .cf_checkers
+                .get("default")
+                .unwrap()
+                .pending_bytes_before_base_level_change
+                .is_none()
+        );
+
+        for _ in 0..10 {
+            checker
+                .on_pending_compaction_bytes_change_cf(high_pending_bytes, "default".to_string());
+        }
+        assert!(discard_ratio.load(Ordering::Relaxed) > 0);
     }
 
     #[test]

--- a/src/storage/txn/flow_controller/singleton_flow_controller.rs
+++ b/src/storage/txn/flow_controller/singleton_flow_controller.rs
@@ -423,7 +423,7 @@ impl<E: FlowControlFactorStore + Send + 'static> FlowChecker<E> {
             }
             Ok(FlowInfo::Compaction(cf, ..)) => {
                 if current_cfg.enable {
-                    self.on_compaction_flow_info(cf);
+                    self.on_pending_compaction_bytes_change(cf);
                 }
             }
             Ok(FlowInfo::BeforeUnsafeDestroyRange(..)) => {
@@ -600,7 +600,7 @@ impl<E: FlowControlFactorStore + Send + 'static> FlowChecker<E> {
         self.engine.pending_compaction_bytes(self.region_id, cf)
     }
 
-    pub(super) fn on_compaction_flow_info(&mut self, cf: String) -> (u64, bool) {
+    pub(super) fn on_pending_compaction_bytes_change(&mut self, cf: String) -> (u64, bool) {
         // Check the base level around pending bytes so a RocksDB version switch
         // during the pending bytes read is not missed.
         let mut base_level_changed = self.detect_base_level_change(&cf);

--- a/src/storage/txn/flow_controller/singleton_flow_controller.rs
+++ b/src/storage/txn/flow_controller/singleton_flow_controller.rs
@@ -784,20 +784,15 @@ impl<E: FlowControlFactorStore + Send + 'static> FlowChecker<E> {
             SCHED_THROTTLE_ACTION_COUNTER
                 .with_label_values(&[cf, "pending_bytes_base_level_jump"])
                 .inc();
-            info!(
-                "skip pending compaction bytes jump after base level change";
-                "cf" => cf,
-                "avg_pending_compaction_bytes" => avg_pending_compaction_bytes,
-                "recent_pending_compaction_bytes" => recent_pending_compaction_bytes,
-                "baseline" => baseline,
-                "soft_limit" => soft,
-            );
             return true;
         }
 
         let Some(baseline) = checker.pending_bytes_before_base_level_change.take() else {
             return false;
         };
+        // RocksDB computes base level and estimated pending bytes in the same
+        // VersionStorageInfo. If this post-change sample is still below the soft
+        // limit, later jumps should not be attributed to this transition.
         if recent_pending_compaction_bytes < soft && avg_pending_compaction_bytes < soft {
             return false;
         }

--- a/src/storage/txn/flow_controller/singleton_flow_controller.rs
+++ b/src/storage/txn/flow_controller/singleton_flow_controller.rs
@@ -244,8 +244,8 @@ struct CfFlowChecker {
     // post-change raw pending-bytes sample crosses the soft limit.
     base_level_jump_candidate_baseline_log2: Option<f64>,
     // Active baseline for a base-level pending-bytes jump guard. While this is
-    // set, pending-bytes flow control is suppressed until avg returns to this
-    // baseline and the recent sample is below the soft limit.
+    // set, pending-bytes flow control is suppressed until both avg and recent
+    // samples are below the soft limit.
     base_level_jump_guard_baseline_log2: Option<f64>,
     last_base_level: Option<u64>,
 
@@ -602,6 +602,13 @@ impl<E: FlowControlFactorStore + Send + 'static> FlowChecker<E> {
         self.limiter.set_speed_limit(f64::INFINITY);
         SCHED_DISCARD_RATIO_GAUGE.set(0);
         self.discard_ratio.store(0, Ordering::Relaxed);
+        self.wait_for_destroy_range_finish = false;
+        for cf_checker in self.cf_checkers.values_mut() {
+            cf_checker.pending_bytes_before_unsafe_destroy_range = None;
+            cf_checker.base_level_jump_candidate_baseline_log2 = None;
+            cf_checker.base_level_jump_guard_baseline_log2 = None;
+            cf_checker.last_base_level = None;
+        }
     }
 
     pub fn update_statistics(&mut self) -> (f64, HashMap<&str, i64>) {
@@ -913,12 +920,15 @@ impl<E: FlowControlFactorStore + Send + 'static> FlowChecker<E> {
         // - base-level change is always finished because there is no separate external
         //   "operation finished" event to wait for.
         //
-        // Even when clearing is allowed, the average alone is not enough to prove
-        // recovery. A small number of high recent samples can still be hidden by
-        // old low samples in the smoother and would raise the average later after
-        // the guard is cleared.
+        // Even when clearing is allowed, the average alone is not enough to
+        // prove recovery. A small number of high recent samples can still be
+        // hidden by old low samples in the smoother and would raise the average
+        // later after the guard is cleared. However, requiring avg to return to
+        // the old baseline can keep the guard armed forever when the baseline
+        // was zero or very low. Once both avg and recent are below soft, clearing
+        // the guard cannot expose pending-bytes flow control pressure.
         if source_finished
-            && avg_pending_compaction_bytes_log2 <= baseline_log2
+            && avg_pending_compaction_bytes_log2 < soft_limit_log2
             && recent_pending_compaction_bytes_log2 < soft_limit_log2
         {
             info!(
@@ -1606,13 +1616,10 @@ pub(super) mod tests {
     }
 
     #[test]
-    fn test_flow_controller_pending_compaction_bytes_unsafe_destroy_keeps_high_current() {
-        const GIB: u64 = 1024 * 1024 * 1024;
-
+    fn test_flow_controller_reset_statistics_clears_pending_bytes_jump_state() {
         let config = FlowControlConfig::default();
-        let soft = (config.soft_pending_compaction_bytes_limit.0 as f64).log2();
         let stub = EngineStub::new();
-        let discard_ratio = Arc::new(AtomicU32::new(0));
+        let discard_ratio = Arc::new(AtomicU32::new(RATIO_SCALE_FACTOR));
         let mut checker = FlowChecker::new(
             Arc::new(VersionTrack::new(config)),
             stub,
@@ -1620,107 +1627,92 @@ pub(super) mod tests {
             Arc::new(Limiter::new(f64::INFINITY)),
         );
 
-        let high_pending_bytes = 555 * GIB;
-        let high_pending_bytes_log = (high_pending_bytes as f64).log2();
-        let before_target = ((41 * GIB) as f64).log2();
-        let low_pending_bytes_log = (before_target * 1024.0 - high_pending_bytes_log) / 1023.0;
-        let baseline;
+        checker.wait_for_destroy_range_finish = true;
         {
             let cf_checker = checker.cf_checkers.get_mut("default").unwrap();
-            cf_checker.on_start_pending_bytes = false;
-
-            let long_term_pending_bytes = cf_checker.long_term_pending_bytes.as_mut().unwrap();
-            long_term_pending_bytes.observe(high_pending_bytes_log);
-            for _ in 1..1024 {
-                long_term_pending_bytes.observe(low_pending_bytes_log);
-            }
-
-            baseline = long_term_pending_bytes.get_avg();
-            assert!(baseline < soft);
-            assert!(long_term_pending_bytes.get_recent() < soft);
-            cf_checker.pending_bytes_before_unsafe_destroy_range = Some(baseline);
+            cf_checker.pending_bytes_before_unsafe_destroy_range = Some(1.0);
+            cf_checker.base_level_jump_candidate_baseline_log2 = Some(2.0);
+            cf_checker.base_level_jump_guard_baseline_log2 = Some(3.0);
+            cf_checker.last_base_level = Some(2);
         }
 
-        checker.on_pending_compaction_bytes_change_cf(high_pending_bytes, "default".to_string());
-        {
-            let cf_checker = checker.cf_checkers.get("default").unwrap();
-            let long_term_pending_bytes = cf_checker.long_term_pending_bytes.as_ref().unwrap();
-            assert!(long_term_pending_bytes.get_avg() <= baseline + f64::EPSILON);
-            assert!(long_term_pending_bytes.get_recent() >= soft);
-            assert!(
-                cf_checker
-                    .pending_bytes_before_unsafe_destroy_range
-                    .is_some()
-            );
-        }
+        checker.reset_statistics();
+
+        assert!(!checker.wait_for_destroy_range_finish);
         assert_eq!(discard_ratio.load(Ordering::Relaxed), 0);
-
-        checker.on_pending_compaction_bytes_change_cf(GIB, "default".to_string());
+        let cf_checker = checker.cf_checkers.get("default").unwrap();
         assert!(
-            checker
-                .cf_checkers
-                .get("default")
-                .unwrap()
+            cf_checker
                 .pending_bytes_before_unsafe_destroy_range
                 .is_none()
         );
+        assert!(cf_checker.base_level_jump_candidate_baseline_log2.is_none());
+        assert!(cf_checker.base_level_jump_guard_baseline_log2.is_none());
+        assert!(cf_checker.last_base_level.is_none());
     }
 
     #[test]
-    fn test_flow_controller_pending_compaction_bytes_base_level_change_keeps_high_current() {
-        const GIB: u64 = 1024 * 1024 * 1024;
-
+    fn test_flow_controller_pending_compaction_bytes_jump_guard_recovery() {
         let config = FlowControlConfig::default();
-        let soft = (config.soft_pending_compaction_bytes_limit.0 as f64).log2();
-        let stub = EngineStub::new();
-        let discard_ratio = Arc::new(AtomicU32::new(0));
-        let mut checker = FlowChecker::new(
-            Arc::new(VersionTrack::new(config)),
-            stub,
-            discard_ratio.clone(),
-            Arc::new(Limiter::new(f64::INFINITY)),
-        );
+        let soft_limit_log2 = (config.soft_pending_compaction_bytes_limit.0 as f64).log2();
 
-        let high_pending_bytes = 555 * GIB;
-        let high_pending_bytes_log = (high_pending_bytes as f64).log2();
-        let before_target = ((41 * GIB) as f64).log2();
-        let low_pending_bytes_log = (before_target * 1024.0 - high_pending_bytes_log) / 1023.0;
-        let baseline;
-        {
-            let cf_checker = checker.cf_checkers.get_mut("default").unwrap();
-            cf_checker.on_start_pending_bytes = false;
+        for source in [
+            PendingBytesJumpSource::UnsafeDestroyRange,
+            PendingBytesJumpSource::BaseLevelChange,
+        ] {
+            let mut cf_checker = CfFlowChecker::new(true);
 
-            let long_term_pending_bytes = cf_checker.long_term_pending_bytes.as_mut().unwrap();
-            long_term_pending_bytes.observe(high_pending_bytes_log);
-            for _ in 1..1024 {
-                long_term_pending_bytes.observe(low_pending_bytes_log);
+            match source {
+                PendingBytesJumpSource::UnsafeDestroyRange => {
+                    cf_checker.pending_bytes_before_unsafe_destroy_range = Some(1.0);
+                }
+                PendingBytesJumpSource::BaseLevelChange => {
+                    cf_checker.base_level_jump_guard_baseline_log2 = Some(1.0);
+                }
             }
+            assert!(FlowChecker::<EngineStub>::should_ignore_pending_bytes_jump(
+                &mut cf_checker,
+                "default",
+                1.0,
+                soft_limit_log2 + 1.0,
+                soft_limit_log2,
+                true,
+                source,
+            ));
 
-            baseline = long_term_pending_bytes.get_avg();
-            assert!(baseline < soft);
-            assert!(long_term_pending_bytes.get_recent() < soft);
-            cf_checker.base_level_jump_guard_baseline_log2 = Some(baseline);
+            match source {
+                PendingBytesJumpSource::UnsafeDestroyRange => {
+                    cf_checker.pending_bytes_before_unsafe_destroy_range = Some(0.0);
+                }
+                PendingBytesJumpSource::BaseLevelChange => {
+                    cf_checker.base_level_jump_guard_baseline_log2 = Some(0.0);
+                }
+            }
+            assert!(
+                !FlowChecker::<EngineStub>::should_ignore_pending_bytes_jump(
+                    &mut cf_checker,
+                    "default",
+                    soft_limit_log2 - 1.0,
+                    soft_limit_log2 - 1.0,
+                    soft_limit_log2,
+                    true,
+                    source,
+                )
+            );
+
+            match source {
+                PendingBytesJumpSource::UnsafeDestroyRange => {
+                    assert!(
+                        cf_checker
+                            .pending_bytes_before_unsafe_destroy_range
+                            .is_none()
+                    );
+                }
+                PendingBytesJumpSource::BaseLevelChange => {
+                    assert!(cf_checker.base_level_jump_guard_baseline_log2.is_none());
+                }
+            }
         }
-
-        checker.on_pending_compaction_bytes_change_cf(high_pending_bytes, "default".to_string());
-        {
-            let cf_checker = checker.cf_checkers.get("default").unwrap();
-            let long_term_pending_bytes = cf_checker.long_term_pending_bytes.as_ref().unwrap();
-            assert!(long_term_pending_bytes.get_avg() <= baseline + f64::EPSILON);
-            assert!(long_term_pending_bytes.get_recent() >= soft);
-            assert!(cf_checker.base_level_jump_guard_baseline_log2.is_some());
-        }
-        assert_eq!(discard_ratio.load(Ordering::Relaxed), 0);
-
-        checker.on_pending_compaction_bytes_change_cf(GIB, "default".to_string());
-        assert!(
-            checker
-                .cf_checkers
-                .get("default")
-                .unwrap()
-                .base_level_jump_guard_baseline_log2
-                .is_none()
-        );
     }
 
     #[test]
@@ -1856,43 +1848,6 @@ pub(super) mod tests {
         // Raw pending bytes returns to normal. The spike sample has been
         // observed by the smoother, so it should stay ignored until the
         // long-term average drains.
-        stub.0
-            .pending_compaction_bytes
-            .store(100 * 1024 * 1024 * 1024, Ordering::Relaxed);
-        send_flow_info(&tx, region_id);
-        assert!(flow_controller.discard_ratio(region_id) < f64::EPSILON);
-    }
-
-    #[test]
-    fn test_flow_controller_pending_compaction_bytes_base_level_change_recover() {
-        let region_id = 0;
-        let stub = EngineStub::new();
-        let (tx, rx) = mpsc::sync_channel(0);
-        let flow_controller =
-            EngineFlowController::new(&FlowControlConfig::default(), stub.clone(), rx);
-        let flow_controller = FlowController::Singleton(flow_controller);
-
-        stub.0.base_level.store(1, Ordering::Relaxed);
-        stub.0
-            .pending_compaction_bytes
-            .store(100 * 1024 * 1024 * 1024, Ordering::Relaxed);
-        for _ in 0..2 {
-            send_flow_info(&tx, region_id);
-        }
-        assert!(flow_controller.discard_ratio(region_id) < f64::EPSILON);
-
-        stub.0.base_level.store(2, Ordering::Relaxed);
-        stub.0
-            .pending_compaction_bytes
-            .store(1_000_000 * 1024 * 1024 * 1024, Ordering::Relaxed);
-        send_flow_info(&tx, region_id);
-        assert!(flow_controller.discard_ratio(region_id) < f64::EPSILON);
-
-        for _ in 0..20 {
-            send_flow_info(&tx, region_id);
-        }
-        assert!(flow_controller.discard_ratio(region_id) < f64::EPSILON);
-
         stub.0
             .pending_compaction_bytes
             .store(100 * 1024 * 1024 * 1024, Ordering::Relaxed);

--- a/src/storage/txn/flow_controller/singleton_flow_controller.rs
+++ b/src/storage/txn/flow_controller/singleton_flow_controller.rs
@@ -601,9 +601,11 @@ impl<E: FlowControlFactorStore + Send + 'static> FlowChecker<E> {
     }
 
     pub(super) fn on_compaction_flow_info(&mut self, cf: String) -> (u64, bool) {
-        let mut base_level_changed = self.on_base_level_change(&cf);
+        // Check the base level around pending bytes so a RocksDB version switch
+        // during the pending bytes read is not missed.
+        let mut base_level_changed = self.detect_base_level_change(&cf);
         let mut pending_compaction_bytes = self.pending_compaction_bytes(&cf);
-        if self.on_base_level_change(&cf) {
+        if self.detect_base_level_change(&cf) {
             base_level_changed = true;
             pending_compaction_bytes = self.pending_compaction_bytes(&cf);
         }
@@ -714,14 +716,14 @@ impl<E: FlowControlFactorStore + Send + 'static> FlowChecker<E> {
         }
     }
 
-    pub(super) fn on_base_level_change(&mut self, cf: &str) -> bool {
+    pub(super) fn detect_base_level_change(&mut self, cf: &str) -> bool {
         let current_base_level = self.engine.base_level(self.region_id, cf);
         let checker = self.cf_checkers.get_mut(cf).unwrap();
         let previous_base_level = checker.last_base_level;
         checker.last_base_level = current_base_level;
         if let (Some(last), Some(current)) = (previous_base_level, current_base_level) {
             if last != current {
-                self.mark_base_level_change(cf);
+                self.record_base_level_change_baseline(cf);
                 info!(
                     "rocksdb base level changed";
                     "cf" => cf,
@@ -734,7 +736,7 @@ impl<E: FlowControlFactorStore + Send + 'static> FlowChecker<E> {
         false
     }
 
-    pub(super) fn mark_base_level_change(&mut self, cf: &str) {
+    pub(super) fn record_base_level_change_baseline(&mut self, cf: &str) {
         let soft = (self
             .config_tracker
             .value()

--- a/src/storage/txn/flow_controller/singleton_flow_controller.rs
+++ b/src/storage/txn/flow_controller/singleton_flow_controller.rs
@@ -239,8 +239,14 @@ struct CfFlowChecker {
     long_term_pending_bytes:
         Option<Smoother<f64, 1024, SMOOTHER_STALE_RECORD_THRESHOLD, SMOOTHER_TIME_RANGE_THRESHOLD>>,
     pending_bytes_before_unsafe_destroy_range: Option<f64>,
-    pending_bytes_before_base_level_change_log2: Option<f64>,
-    pending_bytes_base_level_jump_baseline_log2: Option<f64>,
+    // Candidate avg pending-bytes baseline captured before a base-level
+    // increase. It is promoted to the active guard only if the first
+    // post-change raw pending-bytes sample crosses the soft limit.
+    base_level_jump_candidate_baseline_log2: Option<f64>,
+    // Active baseline for a base-level pending-bytes jump guard. While this is
+    // set, pending-bytes flow control is suppressed until avg returns to this
+    // baseline and the recent sample is below the soft limit.
+    base_level_jump_guard_baseline_log2: Option<f64>,
     last_base_level: Option<u64>,
 
     // On start related markers. Because after restart, the memtable, l0 files
@@ -252,6 +258,30 @@ struct CfFlowChecker {
     on_start_memtable: bool,
     on_start_l0_files: bool,
     on_start_pending_bytes: bool,
+}
+
+#[derive(Clone, Copy)]
+enum PendingBytesJumpSource {
+    UnsafeDestroyRange,
+    BaseLevelChange,
+}
+
+impl PendingBytesJumpSource {
+    fn as_str(self) -> &'static str {
+        match self {
+            PendingBytesJumpSource::UnsafeDestroyRange => "unsafe_destroy_range",
+            PendingBytesJumpSource::BaseLevelChange => "base_level_change",
+        }
+    }
+
+    fn ignored_sample_counter_label(self) -> Option<&'static str> {
+        match self {
+            // Unsafe destroy range records the jump once when the destroy range
+            // finishes. Do not turn that counter into a per-sample metric.
+            PendingBytesJumpSource::UnsafeDestroyRange => None,
+            PendingBytesJumpSource::BaseLevelChange => Some("pending_bytes_base_level_jump"),
+        }
+    }
 }
 
 impl Default for CfFlowChecker {
@@ -279,8 +309,8 @@ impl CfFlowChecker {
                 None
             },
             pending_bytes_before_unsafe_destroy_range: None,
-            pending_bytes_before_base_level_change_log2: None,
-            pending_bytes_base_level_jump_baseline_log2: None,
+            base_level_jump_candidate_baseline_log2: None,
+            base_level_jump_guard_baseline_log2: None,
             last_base_level: None,
             on_start_memtable: true,
             on_start_l0_files: true,
@@ -293,7 +323,9 @@ pub trait FlowControlFactorStore {
     fn num_files_at_level(&self, region_id: u64, cf: &str, level: usize) -> u64;
     fn num_immutable_mem_table(&self, region_id: u64, cf: &str) -> u64;
     fn pending_compaction_bytes(&self, region_id: u64, cf: &str) -> u64;
-    fn base_level(&self, region_id: u64, cf: &str) -> Option<u64>;
+    fn base_level(&self, _region_id: u64, _cf: &str) -> Option<u64> {
+        None
+    }
     fn cf_names(&self, region_id: u64) -> Vec<String>;
 }
 
@@ -611,7 +643,7 @@ impl<E: FlowControlFactorStore + Send + 'static> FlowChecker<E> {
         self.engine.pending_compaction_bytes(self.region_id, cf)
     }
 
-    pub(super) fn on_pending_compaction_bytes_change(&mut self, cf: String) -> (u64, bool) {
+    pub(super) fn on_pending_compaction_bytes_change(&mut self, cf: String) -> u64 {
         // Check the base level around pending bytes so a RocksDB version switch
         // during the pending bytes read is not missed.
         let mut base_level_increased = self.detect_base_level_increase(&cf);
@@ -620,8 +652,25 @@ impl<E: FlowControlFactorStore + Send + 'static> FlowChecker<E> {
             base_level_increased = true;
             pending_compaction_bytes = self.pending_compaction_bytes(&cf);
         }
+        if base_level_increased {
+            // Try to arm the guard with the first pending-bytes sample read after
+            // the base-level increase, before that sample is observed by the
+            // smoother.
+            self.try_arm_base_level_pending_bytes_jump_guard(&cf, pending_compaction_bytes);
+        }
         self.on_pending_compaction_bytes_change_cf(pending_compaction_bytes, cf);
-        (pending_compaction_bytes, base_level_increased)
+        pending_compaction_bytes
+    }
+
+    fn log2_or_zero(value: u64) -> f64 {
+        let log2 = (value as f64).log2();
+        if log2.is_finite() {
+            log2
+        } else {
+            // The input is u64, so the only non-finite case is 0.log2() == -inf.
+            // Treat it as no pending bytes; this also keeps the smoother sum finite.
+            0.0
+        }
     }
 
     pub fn on_pending_compaction_bytes_change_cf(
@@ -635,11 +684,7 @@ impl<E: FlowControlFactorStore + Send + 'static> FlowChecker<E> {
         // Because pending compaction bytes changes dramatically, take the
         // logarithm of pending compaction bytes to make the values fall into
         // a relative small range
-        let mut recent_pending_compaction_bytes_log2 = (pending_compaction_bytes as f64).log2();
-        if !recent_pending_compaction_bytes_log2.is_finite() {
-            // 0.log2() == -inf, which is not expected and may lead to sum always be NaN
-            recent_pending_compaction_bytes_log2 = 0.0;
-        }
+        let recent_pending_compaction_bytes_log2 = Self::log2_or_zero(pending_compaction_bytes);
 
         let checker = self.cf_checkers.get_mut(&cf).unwrap();
         // only be called by v1
@@ -664,36 +709,31 @@ impl<E: FlowControlFactorStore + Send + 'static> FlowChecker<E> {
             }
 
             let avg_pending_compaction_bytes_log2 = long_term_pending_bytes.get_avg();
-            let ignore_unsafe_destroy_range =
-                if let Some(before) = checker.pending_bytes_before_unsafe_destroy_range {
-                    // It assumes that the long term average will eventually come down below the
-                    // soft limit. If the general traffic flow increases during destroy, the long
-                    // term average may never come down and the flow control will be turned off for
-                    // a long time, which would be a rather rare case, so just ignore it.
-                    if avg_pending_compaction_bytes_log2 <= before
-                        && !self.wait_for_destroy_range_finish
-                    {
-                        info!(
-                            "pending compaction bytes is back to normal";
-                            "cf" => &cf,
-                            "pending_compaction_bytes_log2" => avg_pending_compaction_bytes_log2,
-                            "before_log2" => before
-                        );
-                        checker.pending_bytes_before_unsafe_destroy_range = None;
-                    }
-                    true
-                } else {
-                    false
-                };
-            let ignore_base_level_pending_bytes_jump =
-                Self::should_ignore_base_level_pending_bytes_jump(
+            // Unsafe destroy range has a begin/end event pair. While the range
+            // deletion is still running, keep the guard armed even if the current
+            // samples look normal; the delete-files phase may still make RocksDB's
+            // pending bytes estimate unstable. Once the end event arrives, the
+            // source is finished and the normal recovery rule can clear the guard.
+            let unsafe_destroy_range_finished = !self.wait_for_destroy_range_finish;
+            let ignore = [
+                (
+                    PendingBytesJumpSource::UnsafeDestroyRange,
+                    unsafe_destroy_range_finished,
+                ),
+                (PendingBytesJumpSource::BaseLevelChange, true),
+            ]
+            .into_iter()
+            .any(|(source, source_finished)| {
+                Self::should_ignore_pending_bytes_jump(
                     checker,
                     &cf,
                     avg_pending_compaction_bytes_log2,
                     recent_pending_compaction_bytes_log2,
                     soft_limit_log2,
-                );
-            let ignore = ignore_unsafe_destroy_range || ignore_base_level_pending_bytes_jump;
+                    source_finished,
+                    source,
+                )
+            });
 
             // The discard ratio is global. Let the CF with the largest recent
             // pending bytes sample update it, so a less pressured CF does not
@@ -777,9 +817,8 @@ impl<E: FlowControlFactorStore + Send + 'static> FlowChecker<E> {
             .log2();
         let checker = self.cf_checkers.get_mut(cf).unwrap();
         if checker.on_start_pending_bytes
-            || checker
-                .pending_bytes_base_level_jump_baseline_log2
-                .is_some()
+            || checker.base_level_jump_guard_baseline_log2.is_some()
+            || checker.base_level_jump_candidate_baseline_log2.is_some()
         {
             return;
         }
@@ -790,65 +829,116 @@ impl<E: FlowControlFactorStore + Send + 'static> FlowChecker<E> {
                 && avg_pending_compaction_bytes_log2 < soft_limit_log2
                 && last_observed_pending_compaction_bytes_log2 < soft_limit_log2
             {
-                checker.pending_bytes_before_base_level_change_log2 =
+                checker.base_level_jump_candidate_baseline_log2 =
                     Some(avg_pending_compaction_bytes_log2);
-                checker.pending_bytes_base_level_jump_baseline_log2 = None;
+                checker.base_level_jump_guard_baseline_log2 = None;
             }
         }
     }
 
-    fn should_ignore_base_level_pending_bytes_jump(
-        checker: &mut CfFlowChecker,
+    // A candidate baseline is recorded before the base-level increase. This
+    // function consumes that candidate and arms the active guard only when the
+    // first post-change raw pending-bytes sample is already above soft.
+    fn try_arm_base_level_pending_bytes_jump_guard(
+        &mut self,
         cf: &str,
-        avg_pending_compaction_bytes_log2: f64,
-        recent_pending_compaction_bytes_log2: f64,
-        soft_limit_log2: f64,
-    ) -> bool {
-        if let Some(baseline_log2) = checker.pending_bytes_base_level_jump_baseline_log2 {
-            if avg_pending_compaction_bytes_log2 <= baseline_log2
-                && recent_pending_compaction_bytes_log2 < soft_limit_log2
-            {
-                info!(
-                    "pending compaction bytes is back to normal after base level change";
-                    "cf" => cf,
-                    "avg_pending_compaction_bytes_log2" => avg_pending_compaction_bytes_log2,
-                    "recent_pending_compaction_bytes_log2" => recent_pending_compaction_bytes_log2,
-                    "baseline_log2" => baseline_log2,
-                );
-                checker.pending_bytes_base_level_jump_baseline_log2 = None;
-                return false;
-            }
+        pending_compaction_bytes: u64,
+    ) {
+        let soft_limit_log2 = (self
+            .config_tracker
+            .value()
+            .soft_pending_compaction_bytes_limit
+            .0 as f64)
+            .log2();
+        let recent_pending_compaction_bytes_log2 = Self::log2_or_zero(pending_compaction_bytes);
 
-            SCHED_THROTTLE_ACTION_COUNTER
-                .with_label_values(&[cf, "pending_bytes_base_level_jump"])
-                .inc();
-            return true;
-        }
-
-        let Some(baseline_log2) = checker.pending_bytes_before_base_level_change_log2.take() else {
-            return false;
+        let checker = self.cf_checkers.get_mut(cf).unwrap();
+        let Some(baseline_log2) = checker.base_level_jump_candidate_baseline_log2.take() else {
+            return;
         };
-        // RocksDB computes base level and estimated pending bytes in the same
-        // VersionStorageInfo. If this post-change sample is still below the soft
-        // limit, later jumps should not be attributed to this transition.
-        if recent_pending_compaction_bytes_log2 < soft_limit_log2
-            && avg_pending_compaction_bytes_log2 < soft_limit_log2
-        {
-            return false;
+        // The pre-change baseline is recorded only when both avg and recent
+        // samples are below soft. If this first post-change raw sample is still
+        // below soft, the new average cannot cross soft either, so later jumps
+        // should not be attributed to this base-level transition.
+        if recent_pending_compaction_bytes_log2 < soft_limit_log2 {
+            return;
         }
 
-        checker.pending_bytes_base_level_jump_baseline_log2 = Some(baseline_log2);
+        if checker.base_level_jump_guard_baseline_log2.is_some() {
+            return;
+        }
+        checker.base_level_jump_guard_baseline_log2 = Some(baseline_log2);
         SCHED_THROTTLE_ACTION_COUNTER
             .with_label_values(&[cf, "pending_bytes_base_level_jump"])
             .inc();
         info!(
             "start pending compaction bytes jump control after base level change";
             "cf" => cf,
-            "avg_pending_compaction_bytes_log2" => avg_pending_compaction_bytes_log2,
             "recent_pending_compaction_bytes_log2" => recent_pending_compaction_bytes_log2,
             "baseline_log2" => baseline_log2,
             "soft_limit_log2" => soft_limit_log2,
         );
+    }
+
+    fn should_ignore_pending_bytes_jump(
+        checker: &mut CfFlowChecker,
+        cf: &str,
+        avg_pending_compaction_bytes_log2: f64,
+        recent_pending_compaction_bytes_log2: f64,
+        soft_limit_log2: f64,
+        source_finished: bool,
+        source: PendingBytesJumpSource,
+    ) -> bool {
+        let guard_baseline_log2 = match source {
+            PendingBytesJumpSource::UnsafeDestroyRange => {
+                &mut checker.pending_bytes_before_unsafe_destroy_range
+            }
+            PendingBytesJumpSource::BaseLevelChange => {
+                &mut checker.base_level_jump_guard_baseline_log2
+            }
+        };
+        let Some(baseline_log2) = *guard_baseline_log2 else {
+            return false;
+        };
+
+        // This only checks an already armed guard. The arm condition is
+        // source-specific and handled by the trigger path before this point:
+        // unsafe destroy range arms after its end event observes a jump, while
+        // base-level change arms before the post-change pending bytes sample is
+        // observed by the smoother.
+        //
+        // source_finished gates only the finish path:
+        // - unsafe destroy range is not finished while the range deletion is running;
+        // - unsafe destroy range is finished after the end event;
+        // - base-level change is always finished because there is no separate external
+        //   "operation finished" event to wait for.
+        //
+        // Even when clearing is allowed, the average alone is not enough to prove
+        // recovery. A small number of high recent samples can still be hidden by
+        // old low samples in the smoother and would raise the average later after
+        // the guard is cleared.
+        if source_finished
+            && avg_pending_compaction_bytes_log2 <= baseline_log2
+            && recent_pending_compaction_bytes_log2 < soft_limit_log2
+        {
+            info!(
+                "pending compaction bytes jump guard finished";
+                "cf" => cf,
+                "source" => source.as_str(),
+                "avg_pending_compaction_bytes_log2" => avg_pending_compaction_bytes_log2,
+                "recent_pending_compaction_bytes_log2" => recent_pending_compaction_bytes_log2,
+                "baseline_log2" => baseline_log2,
+                "soft_limit_log2" => soft_limit_log2,
+            );
+            *guard_baseline_log2 = None;
+            return false;
+        }
+
+        if let Some(label) = source.ignored_sample_counter_label() {
+            SCHED_THROTTLE_ACTION_COUNTER
+                .with_label_values(&[cf, label])
+                .inc();
+        }
         true
     }
 
@@ -1516,6 +1606,67 @@ pub(super) mod tests {
     }
 
     #[test]
+    fn test_flow_controller_pending_compaction_bytes_unsafe_destroy_keeps_high_current() {
+        const GIB: u64 = 1024 * 1024 * 1024;
+
+        let config = FlowControlConfig::default();
+        let soft = (config.soft_pending_compaction_bytes_limit.0 as f64).log2();
+        let stub = EngineStub::new();
+        let discard_ratio = Arc::new(AtomicU32::new(0));
+        let mut checker = FlowChecker::new(
+            Arc::new(VersionTrack::new(config)),
+            stub,
+            discard_ratio.clone(),
+            Arc::new(Limiter::new(f64::INFINITY)),
+        );
+
+        let high_pending_bytes = 555 * GIB;
+        let high_pending_bytes_log = (high_pending_bytes as f64).log2();
+        let before_target = ((41 * GIB) as f64).log2();
+        let low_pending_bytes_log = (before_target * 1024.0 - high_pending_bytes_log) / 1023.0;
+        let baseline;
+        {
+            let cf_checker = checker.cf_checkers.get_mut("default").unwrap();
+            cf_checker.on_start_pending_bytes = false;
+
+            let long_term_pending_bytes = cf_checker.long_term_pending_bytes.as_mut().unwrap();
+            long_term_pending_bytes.observe(high_pending_bytes_log);
+            for _ in 1..1024 {
+                long_term_pending_bytes.observe(low_pending_bytes_log);
+            }
+
+            baseline = long_term_pending_bytes.get_avg();
+            assert!(baseline < soft);
+            assert!(long_term_pending_bytes.get_recent() < soft);
+            cf_checker.pending_bytes_before_unsafe_destroy_range = Some(baseline);
+        }
+
+        checker.on_pending_compaction_bytes_change_cf(high_pending_bytes, "default".to_string());
+        {
+            let cf_checker = checker.cf_checkers.get("default").unwrap();
+            let long_term_pending_bytes = cf_checker.long_term_pending_bytes.as_ref().unwrap();
+            assert!(long_term_pending_bytes.get_avg() <= baseline + f64::EPSILON);
+            assert!(long_term_pending_bytes.get_recent() >= soft);
+            assert!(
+                cf_checker
+                    .pending_bytes_before_unsafe_destroy_range
+                    .is_some()
+            );
+        }
+        assert_eq!(discard_ratio.load(Ordering::Relaxed), 0);
+
+        checker.on_pending_compaction_bytes_change_cf(GIB, "default".to_string());
+        assert!(
+            checker
+                .cf_checkers
+                .get("default")
+                .unwrap()
+                .pending_bytes_before_unsafe_destroy_range
+                .is_none()
+        );
+    }
+
+    #[test]
     fn test_flow_controller_pending_compaction_bytes_base_level_change_keeps_high_current() {
         const GIB: u64 = 1024 * 1024 * 1024;
 
@@ -1548,7 +1699,7 @@ pub(super) mod tests {
             baseline = long_term_pending_bytes.get_avg();
             assert!(baseline < soft);
             assert!(long_term_pending_bytes.get_recent() < soft);
-            cf_checker.pending_bytes_base_level_jump_baseline_log2 = Some(baseline);
+            cf_checker.base_level_jump_guard_baseline_log2 = Some(baseline);
         }
 
         checker.on_pending_compaction_bytes_change_cf(high_pending_bytes, "default".to_string());
@@ -1557,11 +1708,7 @@ pub(super) mod tests {
             let long_term_pending_bytes = cf_checker.long_term_pending_bytes.as_ref().unwrap();
             assert!(long_term_pending_bytes.get_avg() <= baseline + f64::EPSILON);
             assert!(long_term_pending_bytes.get_recent() >= soft);
-            assert!(
-                cf_checker
-                    .pending_bytes_base_level_jump_baseline_log2
-                    .is_some()
-            );
+            assert!(cf_checker.base_level_jump_guard_baseline_log2.is_some());
         }
         assert_eq!(discard_ratio.load(Ordering::Relaxed), 0);
 
@@ -1571,7 +1718,7 @@ pub(super) mod tests {
                 .cf_checkers
                 .get("default")
                 .unwrap()
-                .pending_bytes_base_level_jump_baseline_log2
+                .base_level_jump_guard_baseline_log2
                 .is_none()
         );
     }
@@ -1618,7 +1765,7 @@ pub(super) mod tests {
                 .cf_checkers
                 .get("default")
                 .unwrap()
-                .pending_bytes_before_base_level_change_log2
+                .base_level_jump_candidate_baseline_log2
                 .is_none()
         );
 
@@ -1669,7 +1816,7 @@ pub(super) mod tests {
                 .cf_checkers
                 .get("default")
                 .unwrap()
-                .pending_bytes_before_base_level_change_log2
+                .base_level_jump_candidate_baseline_log2
                 .is_none()
         );
 

--- a/src/storage/txn/flow_controller/singleton_flow_controller.rs
+++ b/src/storage/txn/flow_controller/singleton_flow_controller.rs
@@ -239,8 +239,8 @@ struct CfFlowChecker {
     long_term_pending_bytes:
         Option<Smoother<f64, 1024, SMOOTHER_STALE_RECORD_THRESHOLD, SMOOTHER_TIME_RANGE_THRESHOLD>>,
     pending_bytes_before_unsafe_destroy_range: Option<f64>,
-    pending_bytes_before_base_level_change: Option<f64>,
-    pending_bytes_base_level_jump_baseline: Option<f64>,
+    pending_bytes_before_base_level_change_log2: Option<f64>,
+    pending_bytes_base_level_jump_baseline_log2: Option<f64>,
     last_base_level: Option<u64>,
 
     // On start related markers. Because after restart, the memtable, l0 files
@@ -279,8 +279,8 @@ impl CfFlowChecker {
                 None
             },
             pending_bytes_before_unsafe_destroy_range: None,
-            pending_bytes_before_base_level_change: None,
-            pending_bytes_base_level_jump_baseline: None,
+            pending_bytes_before_base_level_change_log2: None,
+            pending_bytes_base_level_jump_baseline_log2: None,
             last_base_level: None,
             on_start_memtable: true,
             on_start_l0_files: true,
@@ -630,21 +630,21 @@ impl<E: FlowControlFactorStore + Send + 'static> FlowChecker<E> {
         cf: String,
     ) {
         let control_cfg = self.config_tracker.value().clone();
-        let hard = (control_cfg.hard_pending_compaction_bytes_limit.0 as f64).log2();
-        let soft = (control_cfg.soft_pending_compaction_bytes_limit.0 as f64).log2();
+        let hard_limit_log2 = (control_cfg.hard_pending_compaction_bytes_limit.0 as f64).log2();
+        let soft_limit_log2 = (control_cfg.soft_pending_compaction_bytes_limit.0 as f64).log2();
         // Because pending compaction bytes changes dramatically, take the
         // logarithm of pending compaction bytes to make the values fall into
         // a relative small range
-        let mut recent_pending_compaction_bytes = (pending_compaction_bytes as f64).log2();
-        if !recent_pending_compaction_bytes.is_finite() {
+        let mut recent_pending_compaction_bytes_log2 = (pending_compaction_bytes as f64).log2();
+        if !recent_pending_compaction_bytes_log2.is_finite() {
             // 0.log2() == -inf, which is not expected and may lead to sum always be NaN
-            recent_pending_compaction_bytes = 0.0;
+            recent_pending_compaction_bytes_log2 = 0.0;
         }
 
         let checker = self.cf_checkers.get_mut(&cf).unwrap();
         // only be called by v1
         if let Some(long_term_pending_bytes) = checker.long_term_pending_bytes.as_mut() {
-            long_term_pending_bytes.observe(recent_pending_compaction_bytes);
+            long_term_pending_bytes.observe(recent_pending_compaction_bytes_log2);
             SCHED_PENDING_COMPACTION_BYTES_GAUGE
                 .with_label_values(&[&cf])
                 .set((long_term_pending_bytes.get_avg() * RATIO_SCALE_FACTOR as f64) as i64);
@@ -652,7 +652,7 @@ impl<E: FlowControlFactorStore + Send + 'static> FlowChecker<E> {
             // do special check on start, see the comment of the variable definition for
             // detail.
             if checker.on_start_pending_bytes {
-                if recent_pending_compaction_bytes < soft
+                if recent_pending_compaction_bytes_log2 < soft_limit_log2
                     || long_term_pending_bytes.trend() == Trend::Increasing
                 {
                     // the write is accumulating, still need to throttle
@@ -663,34 +663,35 @@ impl<E: FlowControlFactorStore + Send + 'static> FlowChecker<E> {
                 }
             }
 
-            let avg_pending_compaction_bytes = long_term_pending_bytes.get_avg();
-            let ignore_unsafe_destroy_range = if let Some(before) =
-                checker.pending_bytes_before_unsafe_destroy_range
-            {
-                // It assumes that the long term average will eventually come down below the
-                // soft limit. If the general traffic flow increases during destroy, the long
-                // term average may never come down and the flow control will be turned off for
-                // a long time, which would be a rather rare case, so just ignore it.
-                if avg_pending_compaction_bytes <= before && !self.wait_for_destroy_range_finish {
-                    info!(
-                        "pending compaction bytes is back to normal";
-                        "cf" => &cf,
-                        "pending_compaction_bytes_log2" => avg_pending_compaction_bytes,
-                        "before_log2" => before
-                    );
-                    checker.pending_bytes_before_unsafe_destroy_range = None;
-                }
-                true
-            } else {
-                false
-            };
+            let avg_pending_compaction_bytes_log2 = long_term_pending_bytes.get_avg();
+            let ignore_unsafe_destroy_range =
+                if let Some(before) = checker.pending_bytes_before_unsafe_destroy_range {
+                    // It assumes that the long term average will eventually come down below the
+                    // soft limit. If the general traffic flow increases during destroy, the long
+                    // term average may never come down and the flow control will be turned off for
+                    // a long time, which would be a rather rare case, so just ignore it.
+                    if avg_pending_compaction_bytes_log2 <= before
+                        && !self.wait_for_destroy_range_finish
+                    {
+                        info!(
+                            "pending compaction bytes is back to normal";
+                            "cf" => &cf,
+                            "pending_compaction_bytes_log2" => avg_pending_compaction_bytes_log2,
+                            "before_log2" => before
+                        );
+                        checker.pending_bytes_before_unsafe_destroy_range = None;
+                    }
+                    true
+                } else {
+                    false
+                };
             let ignore_base_level_pending_bytes_jump =
                 Self::should_ignore_base_level_pending_bytes_jump(
                     checker,
                     &cf,
-                    avg_pending_compaction_bytes,
-                    recent_pending_compaction_bytes,
-                    soft,
+                    avg_pending_compaction_bytes_log2,
+                    recent_pending_compaction_bytes_log2,
+                    soft_limit_log2,
                 );
             let ignore = ignore_unsafe_destroy_range || ignore_base_level_pending_bytes_jump;
 
@@ -699,16 +700,17 @@ impl<E: FlowControlFactorStore + Send + 'static> FlowChecker<E> {
             // overwrite the ratio chosen by the current bottleneck.
             for checker in self.cf_checkers.values() {
                 if let Some(long_term_pending_bytes) = checker.long_term_pending_bytes.as_ref() {
-                    if recent_pending_compaction_bytes < long_term_pending_bytes.get_recent() {
+                    if recent_pending_compaction_bytes_log2 < long_term_pending_bytes.get_recent() {
                         return;
                     }
                 }
             }
 
-            let mut ratio = if avg_pending_compaction_bytes < soft || ignore {
+            let mut ratio = if avg_pending_compaction_bytes_log2 < soft_limit_log2 || ignore {
                 0
             } else {
-                let new_ratio = (avg_pending_compaction_bytes - soft) / (hard - soft);
+                let new_ratio = (avg_pending_compaction_bytes_log2 - soft_limit_log2)
+                    / (hard_limit_log2 - soft_limit_log2);
                 let old_ratio = self.discard_ratio.load(Ordering::Relaxed);
 
                 // Because pending compaction bytes changes up and down, so using
@@ -767,7 +769,7 @@ impl<E: FlowControlFactorStore + Send + 'static> FlowChecker<E> {
     }
 
     pub(super) fn record_base_level_change_baseline(&mut self, cf: &str) {
-        let soft = (self
+        let soft_limit_log2 = (self
             .config_tracker
             .value()
             .soft_pending_compaction_bytes_limit
@@ -775,19 +777,22 @@ impl<E: FlowControlFactorStore + Send + 'static> FlowChecker<E> {
             .log2();
         let checker = self.cf_checkers.get_mut(cf).unwrap();
         if checker.on_start_pending_bytes
-            || checker.pending_bytes_base_level_jump_baseline.is_some()
+            || checker
+                .pending_bytes_base_level_jump_baseline_log2
+                .is_some()
         {
             return;
         }
         if let Some(long_term_pending_bytes) = checker.long_term_pending_bytes.as_ref() {
-            let avg_pending_compaction_bytes = long_term_pending_bytes.get_avg();
-            let last_observed_pending_compaction_bytes = long_term_pending_bytes.get_recent();
+            let avg_pending_compaction_bytes_log2 = long_term_pending_bytes.get_avg();
+            let last_observed_pending_compaction_bytes_log2 = long_term_pending_bytes.get_recent();
             if long_term_pending_bytes.get_count() > 0
-                && avg_pending_compaction_bytes < soft
-                && last_observed_pending_compaction_bytes < soft
+                && avg_pending_compaction_bytes_log2 < soft_limit_log2
+                && last_observed_pending_compaction_bytes_log2 < soft_limit_log2
             {
-                checker.pending_bytes_before_base_level_change = Some(avg_pending_compaction_bytes);
-                checker.pending_bytes_base_level_jump_baseline = None;
+                checker.pending_bytes_before_base_level_change_log2 =
+                    Some(avg_pending_compaction_bytes_log2);
+                checker.pending_bytes_base_level_jump_baseline_log2 = None;
             }
         }
     }
@@ -795,20 +800,22 @@ impl<E: FlowControlFactorStore + Send + 'static> FlowChecker<E> {
     fn should_ignore_base_level_pending_bytes_jump(
         checker: &mut CfFlowChecker,
         cf: &str,
-        avg_pending_compaction_bytes: f64,
-        recent_pending_compaction_bytes: f64,
-        soft: f64,
+        avg_pending_compaction_bytes_log2: f64,
+        recent_pending_compaction_bytes_log2: f64,
+        soft_limit_log2: f64,
     ) -> bool {
-        if let Some(baseline) = checker.pending_bytes_base_level_jump_baseline {
-            if avg_pending_compaction_bytes <= baseline && recent_pending_compaction_bytes < soft {
+        if let Some(baseline_log2) = checker.pending_bytes_base_level_jump_baseline_log2 {
+            if avg_pending_compaction_bytes_log2 <= baseline_log2
+                && recent_pending_compaction_bytes_log2 < soft_limit_log2
+            {
                 info!(
                     "pending compaction bytes is back to normal after base level change";
                     "cf" => cf,
-                    "avg_pending_compaction_bytes" => avg_pending_compaction_bytes,
-                    "recent_pending_compaction_bytes" => recent_pending_compaction_bytes,
-                    "baseline" => baseline,
+                    "avg_pending_compaction_bytes_log2" => avg_pending_compaction_bytes_log2,
+                    "recent_pending_compaction_bytes_log2" => recent_pending_compaction_bytes_log2,
+                    "baseline_log2" => baseline_log2,
                 );
-                checker.pending_bytes_base_level_jump_baseline = None;
+                checker.pending_bytes_base_level_jump_baseline_log2 = None;
                 return false;
             }
 
@@ -818,27 +825,29 @@ impl<E: FlowControlFactorStore + Send + 'static> FlowChecker<E> {
             return true;
         }
 
-        let Some(baseline) = checker.pending_bytes_before_base_level_change.take() else {
+        let Some(baseline_log2) = checker.pending_bytes_before_base_level_change_log2.take() else {
             return false;
         };
         // RocksDB computes base level and estimated pending bytes in the same
         // VersionStorageInfo. If this post-change sample is still below the soft
         // limit, later jumps should not be attributed to this transition.
-        if recent_pending_compaction_bytes < soft && avg_pending_compaction_bytes < soft {
+        if recent_pending_compaction_bytes_log2 < soft_limit_log2
+            && avg_pending_compaction_bytes_log2 < soft_limit_log2
+        {
             return false;
         }
 
-        checker.pending_bytes_base_level_jump_baseline = Some(baseline);
+        checker.pending_bytes_base_level_jump_baseline_log2 = Some(baseline_log2);
         SCHED_THROTTLE_ACTION_COUNTER
             .with_label_values(&[cf, "pending_bytes_base_level_jump"])
             .inc();
         info!(
             "start pending compaction bytes jump control after base level change";
             "cf" => cf,
-            "avg_pending_compaction_bytes" => avg_pending_compaction_bytes,
-            "recent_pending_compaction_bytes" => recent_pending_compaction_bytes,
-            "baseline" => baseline,
-            "soft_limit" => soft,
+            "avg_pending_compaction_bytes_log2" => avg_pending_compaction_bytes_log2,
+            "recent_pending_compaction_bytes_log2" => recent_pending_compaction_bytes_log2,
+            "baseline_log2" => baseline_log2,
+            "soft_limit_log2" => soft_limit_log2,
         );
         true
     }
@@ -1539,7 +1548,7 @@ pub(super) mod tests {
             baseline = long_term_pending_bytes.get_avg();
             assert!(baseline < soft);
             assert!(long_term_pending_bytes.get_recent() < soft);
-            cf_checker.pending_bytes_base_level_jump_baseline = Some(baseline);
+            cf_checker.pending_bytes_base_level_jump_baseline_log2 = Some(baseline);
         }
 
         checker.on_pending_compaction_bytes_change_cf(high_pending_bytes, "default".to_string());
@@ -1548,7 +1557,11 @@ pub(super) mod tests {
             let long_term_pending_bytes = cf_checker.long_term_pending_bytes.as_ref().unwrap();
             assert!(long_term_pending_bytes.get_avg() <= baseline + f64::EPSILON);
             assert!(long_term_pending_bytes.get_recent() >= soft);
-            assert!(cf_checker.pending_bytes_base_level_jump_baseline.is_some());
+            assert!(
+                cf_checker
+                    .pending_bytes_base_level_jump_baseline_log2
+                    .is_some()
+            );
         }
         assert_eq!(discard_ratio.load(Ordering::Relaxed), 0);
 
@@ -1558,7 +1571,7 @@ pub(super) mod tests {
                 .cf_checkers
                 .get("default")
                 .unwrap()
-                .pending_bytes_base_level_jump_baseline
+                .pending_bytes_base_level_jump_baseline_log2
                 .is_none()
         );
     }
@@ -1605,7 +1618,7 @@ pub(super) mod tests {
                 .cf_checkers
                 .get("default")
                 .unwrap()
-                .pending_bytes_before_base_level_change
+                .pending_bytes_before_base_level_change_log2
                 .is_none()
         );
 
@@ -1656,7 +1669,7 @@ pub(super) mod tests {
                 .cf_checkers
                 .get("default")
                 .unwrap()
-                .pending_bytes_before_base_level_change
+                .pending_bytes_before_base_level_change_log2
                 .is_none()
         );
 

--- a/src/storage/txn/flow_controller/singleton_flow_controller.rs
+++ b/src/storage/txn/flow_controller/singleton_flow_controller.rs
@@ -36,6 +36,7 @@ const MIN_THROTTLE_SPEED: f64 = 16.0 * 1024.0; // 16KB
 const MAX_THROTTLE_SPEED: f64 = 200.0 * 1024.0 * 1024.0; // 200MB
 
 const EMA_FACTOR: f64 = 0.6; // EMA stands for Exponential Moving Average
+const PENDING_BYTES_JUMP_THRESHOLD: f64 = 2.0;
 
 /// Flow controller is used to throttle the write rate at scheduler level,
 /// aiming to substitute the write stall mechanism of RocksDB. It features in
@@ -239,6 +240,9 @@ struct CfFlowChecker {
     long_term_pending_bytes:
         Option<Smoother<f64, 1024, SMOOTHER_STALE_RECORD_THRESHOLD, SMOOTHER_TIME_RANGE_THRESHOLD>>,
     pending_bytes_before_unsafe_destroy_range: Option<f64>,
+    pending_bytes_before_base_level_transition: Option<f64>,
+    pending_bytes_base_level_jump_detected: bool,
+    last_base_level: Option<u64>,
 
     // On start related markers. Because after restart, the memtable, l0 files
     // and compaction pending bytes may be high on start. If throttle on start
@@ -276,6 +280,9 @@ impl CfFlowChecker {
                 None
             },
             pending_bytes_before_unsafe_destroy_range: None,
+            pending_bytes_before_base_level_transition: None,
+            pending_bytes_base_level_jump_detected: false,
+            last_base_level: None,
             on_start_memtable: true,
             on_start_l0_files: true,
             on_start_pending_bytes: true,
@@ -287,6 +294,7 @@ pub trait FlowControlFactorStore {
     fn num_files_at_level(&self, region_id: u64, cf: &str, level: usize) -> u64;
     fn num_immutable_mem_table(&self, region_id: u64, cf: &str) -> u64;
     fn pending_compaction_bytes(&self, region_id: u64, cf: &str) -> u64;
+    fn base_level(&self, region_id: u64, cf: &str) -> Option<u64>;
     fn cf_names(&self, region_id: u64) -> Vec<String>;
 }
 
@@ -315,6 +323,9 @@ impl<E: FlowControlFactorsExt + CfNamesExt> FlowControlFactorStore for E {
             Ok(Some(n)) => n,
             _ => 0,
         }
+    }
+    fn base_level(&self, _region_id: u64, cf: &str) -> Option<u64> {
+        self.get_cf_base_level(cf).unwrap_or_default()
     }
 }
 
@@ -413,6 +424,7 @@ impl<E: FlowControlFactorStore + Send + 'static> FlowChecker<E> {
             }
             Ok(FlowInfo::Compaction(cf, ..)) => {
                 if current_cfg.enable {
+                    self.on_base_level_change(&cf);
                     self.on_pending_compaction_bytes_change(cf);
                 }
             }
@@ -608,7 +620,54 @@ impl<E: FlowControlFactorStore + Send + 'static> FlowChecker<E> {
             // 0.log2() == -inf, which is not expected and may lead to sum always be NaN
             num = 0.0;
         }
+        let has_l0_or_memtable_pressure = self.has_l0_or_memtable_pressure(&cf, &control_cfg);
         let checker = self.cf_checkers.get_mut(&cf).unwrap();
+        let ignore_base_level_transition = if let Some(before) =
+            checker.pending_bytes_before_base_level_transition
+        {
+            if checker.on_start_pending_bytes || has_l0_or_memtable_pressure {
+                checker.pending_bytes_before_base_level_transition = None;
+                checker.pending_bytes_base_level_jump_detected = false;
+                false
+            } else if num <= before {
+                if checker.pending_bytes_base_level_jump_detected {
+                    info!(
+                        "pending compaction bytes is back to normal after base level transition";
+                        "cf" => &cf,
+                        "pending_compaction_bytes" => num,
+                        "before" => before,
+                    );
+                }
+                checker.pending_bytes_before_base_level_transition = None;
+                checker.pending_bytes_base_level_jump_detected = false;
+                false
+            } else if checker.pending_bytes_base_level_jump_detected
+                || (num >= soft && num >= before + PENDING_BYTES_JUMP_THRESHOLD)
+            {
+                checker.pending_bytes_base_level_jump_detected = true;
+                SCHED_THROTTLE_ACTION_COUNTER
+                    .with_label_values(&[&cf, "pending_bytes_base_level_jump"])
+                    .inc();
+                info!(
+                    "ignore pending compaction bytes jump after base level transition";
+                    "cf" => &cf,
+                    "pending_compaction_bytes" => num,
+                    "before" => before,
+                    "soft_limit" => soft,
+                );
+                true
+            } else {
+                checker.pending_bytes_before_base_level_transition = None;
+                checker.pending_bytes_base_level_jump_detected = false;
+                false
+            }
+        } else {
+            false
+        };
+
+        if ignore_base_level_transition {
+            return;
+        }
 
         // only be called by v1
         if let Some(long_term_pending_bytes) = checker.long_term_pending_bytes.as_mut() {
@@ -630,24 +689,26 @@ impl<E: FlowControlFactorStore + Send + 'static> FlowChecker<E> {
             }
 
             let pending_compaction_bytes = long_term_pending_bytes.get_avg();
-            let ignore = if let Some(before) = checker.pending_bytes_before_unsafe_destroy_range {
-                // It assumes that the long term average will eventually come down below the
-                // soft limit. If the general traffic flow increases during destroy, the long
-                // term average may never come down and the flow control will be turned off for
-                // a long time, which would be a rather rare case, so just ignore it.
-                if pending_compaction_bytes <= before && !self.wait_for_destroy_range_finish {
-                    info!(
-                        "pending compaction bytes is back to normal";
-                        "cf" => &cf,
-                        "pending_compaction_bytes" => pending_compaction_bytes,
-                        "before" => before
-                    );
-                    checker.pending_bytes_before_unsafe_destroy_range = None;
-                }
-                true
-            } else {
-                false
-            };
+            let ignore_unsafe_destroy_range =
+                if let Some(before) = checker.pending_bytes_before_unsafe_destroy_range {
+                    // It assumes that the long term average will eventually come down below the
+                    // soft limit. If the general traffic flow increases during destroy, the long
+                    // term average may never come down and the flow control will be turned off for
+                    // a long time, which would be a rather rare case, so just ignore it.
+                    if pending_compaction_bytes <= before && !self.wait_for_destroy_range_finish {
+                        info!(
+                            "pending compaction bytes is back to normal";
+                            "cf" => &cf,
+                            "pending_compaction_bytes" => pending_compaction_bytes,
+                            "before" => before
+                        );
+                        checker.pending_bytes_before_unsafe_destroy_range = None;
+                    }
+                    true
+                } else {
+                    false
+                };
+            let ignore = ignore_unsafe_destroy_range;
 
             for checker in self.cf_checkers.values() {
                 if let Some(long_term_pending_bytes) = checker.long_term_pending_bytes.as_ref() {
@@ -680,6 +741,55 @@ impl<E: FlowControlFactorStore + Send + 'static> FlowChecker<E> {
             }
             self.discard_ratio.store(ratio, Ordering::Relaxed);
         }
+    }
+
+    pub(super) fn on_base_level_change(&mut self, cf: &str) -> bool {
+        let current_base_level = self.engine.base_level(self.region_id, cf);
+        let checker = self.cf_checkers.get_mut(cf).unwrap();
+        let previous_base_level = checker.last_base_level;
+        checker.last_base_level = current_base_level;
+        if let (Some(last), Some(current)) = (previous_base_level, current_base_level) {
+            if last != current {
+                self.mark_base_level_transition(cf);
+                info!(
+                    "rocksdb base level changed";
+                    "cf" => cf,
+                    "last_base_level" => last,
+                    "current_base_level" => current,
+                );
+                return true;
+            }
+        }
+        false
+    }
+
+    pub(super) fn mark_base_level_transition(&mut self, cf: &str) {
+        let soft = (self
+            .config_tracker
+            .value()
+            .soft_pending_compaction_bytes_limit
+            .0 as f64)
+            .log2();
+        let checker = self.cf_checkers.get_mut(cf).unwrap();
+        if let Some(long_term_pending_bytes) = checker.long_term_pending_bytes.as_ref() {
+            let pending_compaction_bytes = long_term_pending_bytes.get_recent();
+            if long_term_pending_bytes.get_count() > 0 && pending_compaction_bytes < soft {
+                checker.pending_bytes_before_base_level_transition = Some(pending_compaction_bytes);
+                checker.pending_bytes_base_level_jump_detected = false;
+            }
+        }
+    }
+
+    pub(super) fn has_l0_or_memtable_pressure(
+        &self,
+        cf: &str,
+        control_cfg: &FlowControlConfig,
+    ) -> bool {
+        let checker = self.cf_checkers.get(cf).unwrap();
+        checker.long_term_num_l0_files.get_recent() > control_cfg.l0_files_threshold
+            || checker.long_term_num_l0_files.get_avg() > control_cfg.l0_files_threshold as f64
+            || checker.last_num_memtables.get_recent() > control_cfg.memtables_threshold
+            || checker.last_num_memtables.get_avg() > control_cfg.memtables_threshold as f64
     }
 
     fn on_memtable_change(&mut self, cf: &str) {
@@ -929,6 +1039,7 @@ pub(super) mod tests {
     pub struct EngineStubInner {
         pub pending_compaction_bytes: AtomicU64,
         pub num_l0_files: AtomicU64,
+        pub base_level: AtomicU64,
         pub num_memtables: AtomicU64,
     }
 
@@ -937,6 +1048,7 @@ pub(super) mod tests {
             Self(Arc::new(EngineStubInner {
                 pending_compaction_bytes: AtomicU64::new(0),
                 num_l0_files: AtomicU64::new(0),
+                base_level: AtomicU64::new(0),
                 num_memtables: AtomicU64::new(0),
             }))
         }
@@ -972,6 +1084,13 @@ pub(super) mod tests {
             Ok(Some(
                 self.0.pending_compaction_bytes.load(Ordering::Relaxed),
             ))
+        }
+
+        fn get_cf_base_level(&self, _cf: &str) -> Result<Option<u64>> {
+            match self.0.base_level.load(Ordering::Relaxed) {
+                0 => Ok(None),
+                n => Ok(Some(n)),
+            }
         }
     }
 
@@ -1332,6 +1451,89 @@ pub(super) mod tests {
         // compaction bytes.
         send_flow_info(&tx, region_id);
         send_flow_info(&tx, region_id);
+        send_flow_info(&tx, region_id);
+        assert!(flow_controller.discard_ratio(region_id) > f64::EPSILON);
+    }
+
+    #[test]
+    fn test_flow_controller_pending_compaction_bytes_base_level_transition_spike() {
+        let region_id = 0;
+        let stub = EngineStub::new();
+        let (tx, rx) = mpsc::sync_channel(0);
+        let flow_controller =
+            EngineFlowController::new(&FlowControlConfig::default(), stub.clone(), rx);
+        let flow_controller = FlowController::Singleton(flow_controller);
+
+        stub.0.base_level.store(1, Ordering::Relaxed);
+        stub.0
+            .pending_compaction_bytes
+            .store(100 * 1024 * 1024 * 1024, Ordering::Relaxed);
+        send_flow_info(&tx, region_id);
+        assert!(flow_controller.discard_ratio(region_id) < f64::EPSILON);
+
+        // Simulate dynamic level bytes moving the base level from L1 to L2. The
+        // pending compaction bytes estimate may jump even though L0/memtable
+        // pressure does not increase.
+        stub.0.base_level.store(2, Ordering::Relaxed);
+        stub.0
+            .pending_compaction_bytes
+            .store(1_000_000 * 1024 * 1024 * 1024, Ordering::Relaxed);
+        send_flow_info(&tx, region_id);
+        assert!(flow_controller.discard_ratio(region_id) < f64::EPSILON);
+
+        // Raw pending bytes returns to normal. The average is still polluted by
+        // the spike, so it should stay ignored until it drains.
+        stub.0
+            .pending_compaction_bytes
+            .store(100 * 1024 * 1024 * 1024, Ordering::Relaxed);
+        send_flow_info(&tx, region_id);
+        assert!(flow_controller.discard_ratio(region_id) < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_flow_controller_pending_compaction_bytes_base_level_transition_recover() {
+        let region_id = 0;
+        let stub = EngineStub::new();
+        let (tx, rx) = mpsc::sync_channel(0);
+        let flow_controller =
+            EngineFlowController::new(&FlowControlConfig::default(), stub.clone(), rx);
+        let flow_controller = FlowController::Singleton(flow_controller);
+
+        stub.0.base_level.store(1, Ordering::Relaxed);
+        stub.0
+            .pending_compaction_bytes
+            .store(100 * 1024 * 1024 * 1024, Ordering::Relaxed);
+        send_flow_info(&tx, region_id);
+        assert!(flow_controller.discard_ratio(region_id) < f64::EPSILON);
+
+        stub.0.base_level.store(2, Ordering::Relaxed);
+        stub.0
+            .pending_compaction_bytes
+            .store(1_000_000 * 1024 * 1024 * 1024, Ordering::Relaxed);
+        send_flow_info(&tx, region_id);
+        assert!(flow_controller.discard_ratio(region_id) < f64::EPSILON);
+
+        for _ in 0..20 {
+            send_flow_info(&tx, region_id);
+        }
+        assert!(flow_controller.discard_ratio(region_id) < f64::EPSILON);
+
+        stub.0
+            .pending_compaction_bytes
+            .store(100 * 1024 * 1024 * 1024, Ordering::Relaxed);
+        send_flow_info(&tx, region_id);
+        assert!(flow_controller.discard_ratio(region_id) < f64::EPSILON);
+
+        stub.0.base_level.store(3, Ordering::Relaxed);
+        stub.0
+            .pending_compaction_bytes
+            .store(100 * 1024 * 1024 * 1024, Ordering::Relaxed);
+        send_flow_info(&tx, region_id);
+        assert!(flow_controller.discard_ratio(region_id) < f64::EPSILON);
+
+        stub.0
+            .pending_compaction_bytes
+            .store(1_000_000 * 1024 * 1024 * 1024, Ordering::Relaxed);
         send_flow_info(&tx, region_id);
         assert!(flow_controller.discard_ratio(region_id) > f64::EPSILON);
     }

--- a/src/storage/txn/flow_controller/tablet_flow_controller.rs
+++ b/src/storage/txn/flow_controller/tablet_flow_controller.rs
@@ -189,10 +189,8 @@ impl FlowInfoDispatcher {
                             let mut checkers = flow_checkers.as_ref().write().unwrap();
                             if let Some(checker) = checkers.get_mut(&region_id) {
                                 let base_level_changed = checker.on_base_level_change(&cf);
-                                if base_level_changed
-                                    && !checker.has_l0_or_memtable_pressure(&cf, &config.value())
-                                {
-                                    pending_compaction_checker.mark_base_level_transition(&cf);
+                                if base_level_changed {
+                                    pending_compaction_checker.mark_base_level_change(&cf);
                                 }
                                 let current_pending_bytes =
                                     checker.on_pending_compaction_bytes_change(cf.clone());
@@ -460,8 +458,8 @@ impl<E: FlowControlFactorStore + Send + 'static> CompactionPendingBytesChecker<E
             .on_pending_compaction_bytes_change_cf(self.total_pending_compaction_bytes(&cf), cf);
     }
 
-    pub fn mark_base_level_transition(&mut self, cf: &str) {
-        self.checker.mark_base_level_transition(cf);
+    pub fn mark_base_level_change(&mut self, cf: &str) {
+        self.checker.mark_base_level_change(cf);
     }
 }
 
@@ -661,7 +659,7 @@ mod tests {
     }
 
     #[test]
-    fn test_tablet_flow_controller_pending_compaction_bytes_base_level_transition_spike() {
+    fn test_tablet_flow_controller_pending_compaction_bytes_base_level_change_spike() {
         let (_dir, flow_controller, tx, reg) = create_tablet_flow_controller();
         let region_id = 5_u64;
         let tablet_suffix = 5_u64;

--- a/src/storage/txn/flow_controller/tablet_flow_controller.rs
+++ b/src/storage/txn/flow_controller/tablet_flow_controller.rs
@@ -41,6 +41,16 @@ impl<EK: Clone> TabletFlowFactorStore<EK> {
             .and_then(|mut c| c.latest().and_then(|t| f(t).ok().flatten()))
             .unwrap_or(0)
     }
+
+    fn query_opt(
+        &self,
+        region_id: u64,
+        f: impl Fn(&EK) -> engine_traits::Result<Option<u64>>,
+    ) -> Option<u64> {
+        self.registry
+            .get(region_id)
+            .and_then(|mut c| c.latest().and_then(|t| f(t).ok().flatten()))
+    }
 }
 
 impl<EK: CfNamesExt + FlowControlFactorsExt + Clone> FlowControlFactorStore
@@ -60,6 +70,9 @@ impl<EK: CfNamesExt + FlowControlFactorsExt + Clone> FlowControlFactorStore
     }
     fn pending_compaction_bytes(&self, region_id: u64, cf: &str) -> u64 {
         self.query(region_id, |t| t.get_cf_pending_compaction_bytes(cf))
+    }
+    fn base_level(&self, region_id: u64, cf: &str) -> Option<u64> {
+        self.query_opt(region_id, |t| t.get_cf_base_level(cf))
     }
 }
 
@@ -175,6 +188,12 @@ impl FlowInfoDispatcher {
                             }
                             let mut checkers = flow_checkers.as_ref().write().unwrap();
                             if let Some(checker) = checkers.get_mut(&region_id) {
+                                let base_level_changed = checker.on_base_level_change(&cf);
+                                if base_level_changed
+                                    && !checker.has_l0_or_memtable_pressure(&cf, &config.value())
+                                {
+                                    pending_compaction_checker.mark_base_level_transition(&cf);
+                                }
                                 let current_pending_bytes =
                                     checker.on_pending_compaction_bytes_change(cf.clone());
                                 pending_compaction_checker.report_pending_compaction_bytes(
@@ -440,6 +459,10 @@ impl<E: FlowControlFactorStore + Send + 'static> CompactionPendingBytesChecker<E
         self.checker
             .on_pending_compaction_bytes_change_cf(self.total_pending_compaction_bytes(&cf), cf);
     }
+
+    pub fn mark_base_level_transition(&mut self, cf: &str) {
+        self.checker.mark_base_level_transition(cf);
+    }
 }
 
 #[cfg(test)]
@@ -635,5 +658,30 @@ mod tests {
             &tx,
             region_id,
         );
+    }
+
+    #[test]
+    fn test_tablet_flow_controller_pending_compaction_bytes_base_level_transition_spike() {
+        let (_dir, flow_controller, tx, reg) = create_tablet_flow_controller();
+        let region_id = 5_u64;
+        let tablet_suffix = 5_u64;
+        let tablet_context = TabletContext::with_infinite_region(region_id, Some(tablet_suffix));
+        let mut cached = reg.load(tablet_context, false).unwrap();
+        let stub = cached.latest().unwrap().clone();
+        tx.send(FlowInfo::Created(region_id)).unwrap();
+
+        stub.0.base_level.store(1, Ordering::Relaxed);
+        stub.0
+            .pending_compaction_bytes
+            .store(100 * 1024 * 1024 * 1024, Ordering::Relaxed);
+        send_flow_info(&tx, region_id);
+        assert!(flow_controller.discard_ratio(region_id) < f64::EPSILON);
+
+        stub.0.base_level.store(2, Ordering::Relaxed);
+        stub.0
+            .pending_compaction_bytes
+            .store(1_000_000 * 1024 * 1024 * 1024, Ordering::Relaxed);
+        send_flow_info(&tx, region_id);
+        assert!(flow_controller.discard_ratio(region_id) < f64::EPSILON);
     }
 }

--- a/src/storage/txn/flow_controller/tablet_flow_controller.rs
+++ b/src/storage/txn/flow_controller/tablet_flow_controller.rs
@@ -41,16 +41,6 @@ impl<EK: Clone> TabletFlowFactorStore<EK> {
             .and_then(|mut c| c.latest().and_then(|t| f(t).ok().flatten()))
             .unwrap_or(0)
     }
-
-    fn query_opt(
-        &self,
-        region_id: u64,
-        f: impl Fn(&EK) -> engine_traits::Result<Option<u64>>,
-    ) -> Option<u64> {
-        self.registry
-            .get(region_id)
-            .and_then(|mut c| c.latest().and_then(|t| f(t).ok().flatten()))
-    }
 }
 
 impl<EK: CfNamesExt + FlowControlFactorsExt + Clone> FlowControlFactorStore
@@ -70,9 +60,6 @@ impl<EK: CfNamesExt + FlowControlFactorsExt + Clone> FlowControlFactorStore
     }
     fn pending_compaction_bytes(&self, region_id: u64, cf: &str) -> u64 {
         self.query(region_id, |t| t.get_cf_pending_compaction_bytes(cf))
-    }
-    fn base_level(&self, region_id: u64, cf: &str) -> Option<u64> {
-        self.query_opt(region_id, |t| t.get_cf_base_level(cf))
     }
 }
 
@@ -188,12 +175,8 @@ impl FlowInfoDispatcher {
                             }
                             let mut checkers = flow_checkers.as_ref().write().unwrap();
                             if let Some(checker) = checkers.get_mut(&region_id) {
-                                let (current_pending_bytes, base_level_increased) =
+                                let current_pending_bytes =
                                     checker.on_pending_compaction_bytes_change(cf.clone());
-                                if base_level_increased {
-                                    pending_compaction_checker
-                                        .record_base_level_change_baseline(&cf);
-                                }
                                 pending_compaction_checker.report_pending_compaction_bytes(
                                     region_id,
                                     cf.clone(),
@@ -457,10 +440,6 @@ impl<E: FlowControlFactorStore + Send + 'static> CompactionPendingBytesChecker<E
         self.checker
             .on_pending_compaction_bytes_change_cf(self.total_pending_compaction_bytes(&cf), cf);
     }
-
-    pub fn record_base_level_change_baseline(&mut self, cf: &str) {
-        self.checker.record_base_level_change_baseline(cf);
-    }
 }
 
 #[cfg(test)]
@@ -656,103 +635,5 @@ mod tests {
             &tx,
             region_id,
         );
-    }
-
-    #[test]
-    fn test_tablet_flow_controller_pending_compaction_bytes_base_level_change_spike() {
-        let (_dir, flow_controller, tx, reg) = create_tablet_flow_controller();
-        let region_id = 5_u64;
-        let tablet_suffix = 5_u64;
-        let tablet_context = TabletContext::with_infinite_region(region_id, Some(tablet_suffix));
-        let mut cached = reg.load(tablet_context, false).unwrap();
-        let stub = cached.latest().unwrap().clone();
-        tx.send(FlowInfo::Created(region_id)).unwrap();
-
-        stub.0.base_level.store(1, Ordering::Relaxed);
-        stub.0
-            .pending_compaction_bytes
-            .store(100 * 1024 * 1024 * 1024, Ordering::Relaxed);
-        send_flow_info(&tx, region_id);
-        assert!(flow_controller.discard_ratio(region_id) < f64::EPSILON);
-
-        stub.0.base_level.store(2, Ordering::Relaxed);
-        stub.0
-            .pending_compaction_bytes
-            .store(1_000_000 * 1024 * 1024 * 1024, Ordering::Relaxed);
-        send_flow_info(&tx, region_id);
-        assert!(flow_controller.discard_ratio(region_id) < f64::EPSILON);
-    }
-
-    #[test]
-    fn test_tablet_flow_controller_pending_compaction_bytes_base_level_change_keeps_pressure() {
-        const GIB: u64 = 1024 * 1024 * 1024;
-
-        let (_dir, flow_controller, tx, reg) = create_tablet_flow_controller();
-        let region_id = 5_u64;
-        let tablet_suffix = 5_u64;
-        let tablet_context = TabletContext::with_infinite_region(region_id, Some(tablet_suffix));
-        let mut cached = reg.load(tablet_context, false).unwrap();
-        let stub = cached.latest().unwrap().clone();
-        tx.send(FlowInfo::Created(region_id)).unwrap();
-
-        stub.0.base_level.store(1, Ordering::Relaxed);
-        stub.0
-            .pending_compaction_bytes
-            .store(100 * GIB, Ordering::Relaxed);
-        for _ in 0..10 {
-            send_flow_info(&tx, region_id);
-        }
-        assert!(flow_controller.discard_ratio(region_id) < f64::EPSILON);
-
-        // Pending bytes is already above the soft limit before the base-level
-        // change, but the long-term average is still below it.
-        stub.0
-            .pending_compaction_bytes
-            .store(555 * GIB, Ordering::Relaxed);
-        send_flow_info(&tx, region_id);
-        assert!(flow_controller.discard_ratio(region_id) < f64::EPSILON);
-
-        stub.0.base_level.store(2, Ordering::Relaxed);
-        send_flow_info(&tx, region_id);
-        assert!(flow_controller.discard_ratio(region_id) < f64::EPSILON);
-
-        for _ in 0..10 {
-            send_flow_info(&tx, region_id);
-        }
-        assert!(flow_controller.discard_ratio(region_id) > f64::EPSILON);
-    }
-
-    #[test]
-    fn test_tablet_flow_controller_pending_compaction_bytes_base_level_decrease() {
-        const GIB: u64 = 1024 * 1024 * 1024;
-
-        let (_dir, flow_controller, tx, reg) = create_tablet_flow_controller();
-        let region_id = 5_u64;
-        let tablet_suffix = 5_u64;
-        let tablet_context = TabletContext::with_infinite_region(region_id, Some(tablet_suffix));
-        let mut cached = reg.load(tablet_context, false).unwrap();
-        let stub = cached.latest().unwrap().clone();
-        tx.send(FlowInfo::Created(region_id)).unwrap();
-
-        stub.0.base_level.store(2, Ordering::Relaxed);
-        stub.0
-            .pending_compaction_bytes
-            .store(100 * GIB, Ordering::Relaxed);
-        for _ in 0..10 {
-            send_flow_info(&tx, region_id);
-        }
-        assert!(flow_controller.discard_ratio(region_id) < f64::EPSILON);
-
-        stub.0.base_level.store(1, Ordering::Relaxed);
-        stub.0
-            .pending_compaction_bytes
-            .store(555 * GIB, Ordering::Relaxed);
-        send_flow_info(&tx, region_id);
-        assert!(flow_controller.discard_ratio(region_id) < f64::EPSILON);
-
-        for _ in 0..10 {
-            send_flow_info(&tx, region_id);
-        }
-        assert!(flow_controller.discard_ratio(region_id) > f64::EPSILON);
     }
 }

--- a/src/storage/txn/flow_controller/tablet_flow_controller.rs
+++ b/src/storage/txn/flow_controller/tablet_flow_controller.rs
@@ -188,9 +188,9 @@ impl FlowInfoDispatcher {
                             }
                             let mut checkers = flow_checkers.as_ref().write().unwrap();
                             if let Some(checker) = checkers.get_mut(&region_id) {
-                                let (current_pending_bytes, base_level_changed) =
+                                let (current_pending_bytes, base_level_increased) =
                                     checker.on_pending_compaction_bytes_change(cf.clone());
-                                if base_level_changed {
+                                if base_level_increased {
                                     pending_compaction_checker
                                         .record_base_level_change_baseline(&cf);
                                 }
@@ -681,5 +681,78 @@ mod tests {
             .store(1_000_000 * 1024 * 1024 * 1024, Ordering::Relaxed);
         send_flow_info(&tx, region_id);
         assert!(flow_controller.discard_ratio(region_id) < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_tablet_flow_controller_pending_compaction_bytes_base_level_change_keeps_pressure() {
+        const GIB: u64 = 1024 * 1024 * 1024;
+
+        let (_dir, flow_controller, tx, reg) = create_tablet_flow_controller();
+        let region_id = 5_u64;
+        let tablet_suffix = 5_u64;
+        let tablet_context = TabletContext::with_infinite_region(region_id, Some(tablet_suffix));
+        let mut cached = reg.load(tablet_context, false).unwrap();
+        let stub = cached.latest().unwrap().clone();
+        tx.send(FlowInfo::Created(region_id)).unwrap();
+
+        stub.0.base_level.store(1, Ordering::Relaxed);
+        stub.0
+            .pending_compaction_bytes
+            .store(100 * GIB, Ordering::Relaxed);
+        for _ in 0..10 {
+            send_flow_info(&tx, region_id);
+        }
+        assert!(flow_controller.discard_ratio(region_id) < f64::EPSILON);
+
+        // Pending bytes is already above the soft limit before the base-level
+        // change, but the long-term average is still below it.
+        stub.0
+            .pending_compaction_bytes
+            .store(555 * GIB, Ordering::Relaxed);
+        send_flow_info(&tx, region_id);
+        assert!(flow_controller.discard_ratio(region_id) < f64::EPSILON);
+
+        stub.0.base_level.store(2, Ordering::Relaxed);
+        send_flow_info(&tx, region_id);
+        assert!(flow_controller.discard_ratio(region_id) < f64::EPSILON);
+
+        for _ in 0..10 {
+            send_flow_info(&tx, region_id);
+        }
+        assert!(flow_controller.discard_ratio(region_id) > f64::EPSILON);
+    }
+
+    #[test]
+    fn test_tablet_flow_controller_pending_compaction_bytes_base_level_decrease() {
+        const GIB: u64 = 1024 * 1024 * 1024;
+
+        let (_dir, flow_controller, tx, reg) = create_tablet_flow_controller();
+        let region_id = 5_u64;
+        let tablet_suffix = 5_u64;
+        let tablet_context = TabletContext::with_infinite_region(region_id, Some(tablet_suffix));
+        let mut cached = reg.load(tablet_context, false).unwrap();
+        let stub = cached.latest().unwrap().clone();
+        tx.send(FlowInfo::Created(region_id)).unwrap();
+
+        stub.0.base_level.store(2, Ordering::Relaxed);
+        stub.0
+            .pending_compaction_bytes
+            .store(100 * GIB, Ordering::Relaxed);
+        for _ in 0..10 {
+            send_flow_info(&tx, region_id);
+        }
+        assert!(flow_controller.discard_ratio(region_id) < f64::EPSILON);
+
+        stub.0.base_level.store(1, Ordering::Relaxed);
+        stub.0
+            .pending_compaction_bytes
+            .store(555 * GIB, Ordering::Relaxed);
+        send_flow_info(&tx, region_id);
+        assert!(flow_controller.discard_ratio(region_id) < f64::EPSILON);
+
+        for _ in 0..10 {
+            send_flow_info(&tx, region_id);
+        }
+        assert!(flow_controller.discard_ratio(region_id) > f64::EPSILON);
     }
 }

--- a/src/storage/txn/flow_controller/tablet_flow_controller.rs
+++ b/src/storage/txn/flow_controller/tablet_flow_controller.rs
@@ -189,7 +189,7 @@ impl FlowInfoDispatcher {
                             let mut checkers = flow_checkers.as_ref().write().unwrap();
                             if let Some(checker) = checkers.get_mut(&region_id) {
                                 let (current_pending_bytes, base_level_changed) =
-                                    checker.on_compaction_flow_info(cf.clone());
+                                    checker.on_pending_compaction_bytes_change(cf.clone());
                                 if base_level_changed {
                                     pending_compaction_checker
                                         .record_base_level_change_baseline(&cf);

--- a/src/storage/txn/flow_controller/tablet_flow_controller.rs
+++ b/src/storage/txn/flow_controller/tablet_flow_controller.rs
@@ -191,7 +191,8 @@ impl FlowInfoDispatcher {
                                 let (current_pending_bytes, base_level_changed) =
                                     checker.on_compaction_flow_info(cf.clone());
                                 if base_level_changed {
-                                    pending_compaction_checker.mark_base_level_change(&cf);
+                                    pending_compaction_checker
+                                        .record_base_level_change_baseline(&cf);
                                 }
                                 pending_compaction_checker.report_pending_compaction_bytes(
                                     region_id,
@@ -457,8 +458,8 @@ impl<E: FlowControlFactorStore + Send + 'static> CompactionPendingBytesChecker<E
             .on_pending_compaction_bytes_change_cf(self.total_pending_compaction_bytes(&cf), cf);
     }
 
-    pub fn mark_base_level_change(&mut self, cf: &str) {
-        self.checker.mark_base_level_change(cf);
+    pub fn record_base_level_change_baseline(&mut self, cf: &str) {
+        self.checker.record_base_level_change_baseline(cf);
     }
 }
 

--- a/src/storage/txn/flow_controller/tablet_flow_controller.rs
+++ b/src/storage/txn/flow_controller/tablet_flow_controller.rs
@@ -188,12 +188,11 @@ impl FlowInfoDispatcher {
                             }
                             let mut checkers = flow_checkers.as_ref().write().unwrap();
                             if let Some(checker) = checkers.get_mut(&region_id) {
-                                let base_level_changed = checker.on_base_level_change(&cf);
+                                let (current_pending_bytes, base_level_changed) =
+                                    checker.on_compaction_flow_info(cf.clone());
                                 if base_level_changed {
                                     pending_compaction_checker.mark_base_level_change(&cf);
                                 }
-                                let current_pending_bytes =
-                                    checker.on_pending_compaction_bytes_change(cf.clone());
                                 pending_compaction_checker.report_pending_compaction_bytes(
                                     region_id,
                                     cf.clone(),


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: close #19667

What's Changed:

```commit-message
flow control: ignore base level pending bytes spikes

RocksDB estimated pending compaction bytes can jump when dynamic level
bytes changes the base level. TiKV flow control uses pending compaction
bytes as one throttling signal, so a transient estimate jump can pollute
the long-term pending-bytes smoother and cause unnecessary request drops.

Track RocksDB base level per CF and record the pending-bytes baseline when
the base level changes while pending bytes is still below the soft limit.
If a later pending-bytes sample reaches the soft limit, treat it as a
base-level estimate jump and skip pending-bytes flow control until the
long-term average returns to the recorded baseline and the recent sample is
below the soft limit.

The guard is not enabled when pending bytes was already above the soft
limit before the base-level change, so existing compaction pressure is still
throttled normally. L0 and memtable flow-control signals are left unchanged.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note

```release-note
Fix unnecessary TiKV flow control caused by transient RocksDB pending
compaction bytes spikes during base-level transitions.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Flow control now accounts for per-column-family base-level changes in RocksDB.
  * Added support for querying and exposing a column family’s base level, including a new RocksDB metric for it.

* **Bug Fixes**
  * Improved handling of compaction-pending-byte spikes caused by base-level transitions.
  * Reduced unnecessary throttling by distinguishing real pressure from base-level increases/decreases and restoring normal behavior after recovery.

* **Tests**
  * Expanded coverage for base-level change scenarios, guard resets, and “eventually resumes” behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->