### PR TITLE
status_server: fix the bug if profiling flag is not reset

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -99,6 +99,12 @@ ignore = [
     # rand::rng() / thread_rng() during logging, which TiKV does not do.
     # TODO: Upgrade rand to >=0.9.3 or >=0.10.1 when possible.
     "RUSTSEC-2026-0097",
+    # Ignore RUSTSEC-2026-0174, as it does not introduce safety issues, only
+    # violating ASCII invariants. Meanwhile, it only affects the `azure` crate,
+    # which can be upgraded after it fixes the issue.
+    #
+    # See: https://github.com/http-rs/http-types/issues/534
+    "RUSTSEC-2026-0174",
 ]
 
 # TiKV is licensed under Apache 2.0, according to ASF 3RD PARTY LICENSE POLICY,

--- a/src/server/status_server/profile.rs
+++ b/src/server/status_server/profile.rs
@@ -18,7 +18,6 @@ use regex::Regex;
 use tempfile::NamedTempFile;
 #[cfg(not(test))]
 use tikv_alloc::dump_prof;
-use tikv_util::defer;
 
 #[cfg(test)]
 pub use self::test_utils::TEST_PROFILE_MUTEX;
@@ -26,8 +25,8 @@ pub use self::test_utils::TEST_PROFILE_MUTEX;
 use self::test_utils::dump_prof;
 
 lazy_static! {
-    // If it's some it means there are already a CPU profiling.
-    static ref CPU_PROFILE_ACTIVE: Mutex<Option<()>> = Mutex::new(None);
+    // If it's true it means there is already an active CPU profiling request.
+    static ref CPU_PROFILE_ACTIVE: Mutex<bool> = Mutex::new(false);
 
     // To normalize thread names.
     static ref THREAD_NAME_RE: Regex =
@@ -37,7 +36,27 @@ lazy_static! {
 
 type OnEndFn<I, T> = Box<dyn FnOnce(I) -> Result<T, String> + Send + 'static>;
 
+struct CpuProfileActiveGuard;
+
+impl CpuProfileActiveGuard {
+    fn new() -> Result<Self, String> {
+        let mut active = CPU_PROFILE_ACTIVE.lock().unwrap();
+        if *active {
+            return Err("Already in CPU Profiling".to_owned());
+        }
+        *active = true;
+        Ok(Self)
+    }
+}
+
+impl Drop for CpuProfileActiveGuard {
+    fn drop(&mut self) {
+        *CPU_PROFILE_ACTIVE.lock().unwrap() = false;
+    }
+}
+
 struct ProfileRunner<I, T> {
+    active_guard: Option<CpuProfileActiveGuard>,
     item: Option<I>,
     on_end: Option<OnEndFn<I, T>>,
     end: BoxFuture<'static, Result<(), String>>,
@@ -55,8 +74,10 @@ impl<I, T> ProfileRunner<I, T> {
         F1: FnOnce() -> Result<I, String>,
         F2: FnOnce(I) -> Result<T, String> + Send + 'static,
     {
+        let active_guard = CpuProfileActiveGuard::new()?;
         let item = on_start()?;
         Ok(ProfileRunner {
+            active_guard: Some(active_guard),
             item: Some(item),
             on_end: Some(Box::new(on_end) as OnEndFn<I, T>),
             end,
@@ -75,6 +96,7 @@ impl<I, T> Future for ProfileRunner<I, T> {
                     (Ok(_), r) => r,
                     (Err(errmsg), _) => Err(errmsg),
                 };
+                drop(self.active_guard.take());
                 Poll::Ready(r)
             }
             Poll::Pending => Poll::Pending,
@@ -99,14 +121,7 @@ pub async fn start_one_cpu_profile<F>(
 where
     F: Future<Output = Result<(), String>> + Send + 'static,
 {
-    if CPU_PROFILE_ACTIVE.lock().unwrap().is_some() {
-        return Err("Already in CPU Profiling".to_owned());
-    }
-
     let on_start = || {
-        let mut activate = CPU_PROFILE_ACTIVE.lock().unwrap();
-        assert!(activate.is_none());
-        *activate = Some(());
         let guard = pprof::ProfilerGuardBuilder::default()
             .frequency(frequency)
             .blocklist(&["libc", "libgcc", "pthread", "vdso"])
@@ -116,9 +131,6 @@ where
     };
 
     let on_end = move |guard: pprof::ProfilerGuard<'static>| {
-        defer! {
-            *CPU_PROFILE_ACTIVE.lock().unwrap() = None
-        }
         let report = guard
             .report()
             .frames_post_processor(move |frames| {
@@ -221,6 +233,8 @@ mod test_utils {
 
 #[cfg(test)]
 mod tests {
+    use std::{sync::mpsc::sync_channel, task::Poll};
+
     use futures::executor::block_on;
     use tikv_util::thread_name_prefix::{GRPC_SERVER_THREAD, RAFTSTORE_THREAD, SNAP_SENDER_THREAD};
     use tokio::runtime;
@@ -264,5 +278,37 @@ mod tests {
 
         drop(tx1);
         block_on(res1).unwrap().unwrap_err();
+    }
+
+    #[test]
+    fn test_profile_runner_clears_active_state_after_abort() {
+        use futures::TryFutureExt;
+
+        let _test_guard = TEST_PROFILE_MUTEX.lock().unwrap();
+        let rt = runtime::Builder::new_multi_thread()
+            .worker_threads(4)
+            .build()
+            .unwrap();
+
+        let (tx, rx) = sync_channel(1);
+        let mut tx = Some(tx);
+        let end = futures::future::poll_fn(move |_| {
+            if let Some(tx) = tx.take() {
+                tx.send(()).unwrap();
+            }
+            Poll::Pending
+        });
+
+        let res = rt.spawn(start_one_cpu_profile(end, 99, false));
+        rx.recv().unwrap();
+        res.abort();
+        assert!(block_on(res).unwrap_err().is_cancelled());
+        assert!(!*CPU_PROFILE_ACTIVE.lock().unwrap());
+
+        let (tx, rx) = futures::channel::oneshot::channel();
+        let rx = rx.map_err(|_| "channel canceled".to_owned());
+        let res = rt.spawn(start_one_cpu_profile(rx, 99, false));
+        drop(tx);
+        assert_eq!(block_on(res).unwrap().unwrap_err(), "channel canceled");
     }
 }


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: Close #19703

What's Changed:

```commit-message
status_server: fix the bug if profiling flag is not reset

The previous CPU profiling active flag was reset by a `defer!` block inside the `on_end` closure. That closure only runs when `ProfileRunner` reaches the normal end path. If the profiling future is aborted or dropped before `on_end` runs, `CPU_PROFILE_ACTIVE` leaks and later CPU profiling requests keep failing with "Already in CPU Profiling".

Replace the closure-local reset with a `CpuProfileActiveGuard` owned by `ProfileRunner`. The guard marks CPU profiling as active when the runner is created and clears the flag from `Drop`, so both normal completion and abort/drop paths reset the state.

Add a regression test that aborts an in-flight profiling task and verifies that a later profiling request can proceed. Also carry the cargo-deny ignore for RUSTSEC-2026-0174, which currently only affects the transitive `azure` crate through ASCII invariant handling and can be removed after the upstream dependency is fixed.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`: N/A
- [ ] Need to cherry-pick to the release branch

Already cherry-picked to `release-8.5-20251208-v8.5.4` in #19704.

### Check List

Tests

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Validation run locally:

```text
git diff --check origin/master..HEAD
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note

```release-note
Fix the CPU profiling flag not being reset when a profiling request is aborted, which caused TiKV to keep reporting "Already in CPU Profiling".
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended RustSec advisory ignore list with updated security configuration.

* **Refactor**
  * Enhanced CPU profiling state management for better resource handling and lifecycle control.

* **Tests**
  * Added test case to verify proper cleanup of CPU profiling state when cancelled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->