### PR TITLE
config: calibrate the default setting of `rocksdb.compaction-readahead-size`

### DIFF
--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -620,9 +620,12 @@
 ## When storage.engine is "partitioned-raft-kv", default value is 0.
 # stats-dump-period = "10m"
 
-## Refer to: https://github.com/facebook/rocksdb/wiki/RocksDB-FAQ
-## If you want to use RocksDB on multi disks or spinning disks, you should set value at least 2MB.
-# compaction-readahead-size = 0
+## RocksDB 8.x compaction no longer relies on the old setup-time file hint path,
+## so TiKV keeps compaction readahead enabled by default instead of forcing it
+## to 0. Refer to: https://github.com/facebook/rocksdb/wiki/RocksDB-FAQ
+## If you want to use RocksDB on multi disks or spinning disks, you should set
+## value at least 2MB.
+# compaction-readahead-size = "2MB"
 
 ## Max buffer size that is used by WritableFileWrite.
 # writable-file-max-buffer-size = "1MB"
@@ -1092,7 +1095,9 @@
 ## Do not set this config the same as `rocksdb.wal-dir`.
 # wal-dir = ""
 
-# compaction-readahead-size = 0
+## Keep compaction readahead enabled by default for the same reason as
+## `rocksdb.compaction-readahead-size`.
+# compaction-readahead-size = "2MB"
 # writable-file-max-buffer-size = "1MB"
 # use-direct-io-for-flush-and-compaction = false
 # enable-pipelined-write = true

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1356,6 +1356,9 @@ pub struct DbConfig {
     pub enable_statistics: bool,
     #[online_config(skip)]
     pub stats_dump_period: Option<ReadableDuration>,
+    // RocksDB 8.x compaction no longer relies on the old setup-time file hint
+    // path, so keep compaction readahead enabled by default instead of forcing
+    // it to 0 from TiKV config.
     pub compaction_readahead_size: ReadableSize,
     #[doc(hidden)]
     #[serde(skip_serializing)]
@@ -1452,7 +1455,7 @@ impl Default for DbConfig {
             max_open_files: 40960,
             enable_statistics: true,
             stats_dump_period: None,
-            compaction_readahead_size: ReadableSize::kb(0),
+            compaction_readahead_size: ReadableSize::mb(2),
             info_log_max_size: ReadableSize::gb(1),
             info_log_roll_time: ReadableDuration::secs(0),
             info_log_keep_log_file_num: 10,
@@ -2017,6 +2020,9 @@ pub struct RaftDbConfig {
     pub enable_statistics: bool,
     #[online_config(skip)]
     pub stats_dump_period: ReadableDuration,
+    // RocksDB 8.x compaction no longer relies on the old setup-time file hint
+    // path, so keep compaction readahead enabled by default instead of forcing
+    // it to 0 from TiKV config.
     pub compaction_readahead_size: ReadableSize,
     #[doc(hidden)]
     #[serde(skip_serializing)]
@@ -2082,7 +2088,7 @@ impl Default for RaftDbConfig {
             max_open_files: 40960,
             enable_statistics: true,
             stats_dump_period: ReadableDuration::minutes(10),
-            compaction_readahead_size: ReadableSize::kb(0),
+            compaction_readahead_size: ReadableSize::mb(2),
             info_log_max_size: ReadableSize::gb(1),
             info_log_roll_time: ReadableDuration::secs(0),
             info_log_keep_log_file_num: 10,

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -964,6 +964,13 @@ fn test_readpool_default_config() {
 }
 
 #[test]
+fn test_compaction_readahead_default_config() {
+    let cfg = TikvConfig::default();
+    assert_eq!(cfg.rocksdb.compaction_readahead_size, ReadableSize::mb(2));
+    assert_eq!(cfg.raftdb.compaction_readahead_size, ReadableSize::mb(2));
+}
+
+#[test]
 fn test_do_not_use_unified_readpool_with_legacy_config() {
     let content = r#"
         [readpool.storage]


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?

Issue Number: ref #19721

What's Changed:

RocksDB 8.x compaction no longer relies on the old setup-time file hint path.
Instead, buffered-I/O compaction prefetch is driven by
`compaction_readahead_size > 0`.

TiKV still defaulted both `rocksdb.compaction-readahead-size` and
`raftdb.compaction-readahead-size` to `0`, which disabled the new RocksDB 8.x
compaction readahead path and could lead to smaller read sizes / higher IOPS
under buffered I/O.

This change:
- updates the default compaction readahead size for both rocksdb and raftdb to
  `2MB`
- updates config template comments to match the new default and explain the
  RocksDB 8.x behavior change
- adds a regression test to pin the new default values


```commit-message
config: change default compaction readahead size to 2MB
```

### Related changes

- [x] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [x] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Fix the default `rocksdb.compaction-readahead-size` and `raftdb.compaction-readahead-size` to `2MB` so TiKV keeps RocksDB 8.x compaction readahead enabled under buffered I/O.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default compaction readahead size configuration from 0 to 2MB for both RocksDB and RaftDB components.
  * Updated configuration documentation and templates to reflect current RocksDB 8.x behavior.

* **Tests**
  * Added integration test to verify default compaction readahead configuration values are correctly set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->