### PR TITLE
raftstore: sample snap gen precheck response INFO logs and add response counter

### DIFF
--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -155,7 +155,9 @@ fn should_log_snap_gen_precheck_response_info(passed: bool, ignored: bool) -> bo
         (false, false) => SNAP_GEN_PRECHECK_REJECTED_RESPONSE_INFO_SAMPLE_RATE,
         (true, false) => SNAP_GEN_PRECHECK_RESPONSE_INFO_SAMPLE_RATE,
     };
-    SNAP_GEN_PRECHECK_RESPONSE_LOG_COUNTER.fetch_add(1, Ordering::Relaxed) % sample_rate == 0
+    SNAP_GEN_PRECHECK_RESPONSE_LOG_COUNTER
+        .fetch_add(1, Ordering::Relaxed)
+        .is_multiple_of(sample_rate)
 }
 
 pub struct DestroyPeerJob {

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -11,7 +11,10 @@ use std::{
     },
     iter::Iterator,
     mem,
-    sync::{Arc, Mutex, atomic::Ordering},
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicU64, Ordering},
+    },
     time::{Duration, Instant},
 };
 
@@ -133,8 +136,27 @@ const REGION_SPLIT_SKIP_MAX_COUNT: usize = 3;
 #[allow(clippy::identity_op)]
 const MAX_BATCH_SIZE_LIMIT: u64 = 1 * 1024 * 1024;
 const UNSAFE_RECOVERY_STATE_TIMEOUT: Duration = Duration::from_secs(60);
+const SNAP_GEN_PRECHECK_RESPONSE_INFO_SAMPLE_RATE: u64 = 100;
+const SNAP_GEN_PRECHECK_REJECTED_RESPONSE_INFO_SAMPLE_RATE: u64 = 10;
+const SNAP_GEN_PRECHECK_IGNORED_RESPONSE_INFO_SAMPLE_RATE: u64 = 1024;
+
+static SNAP_GEN_PRECHECK_RESPONSE_LOG_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 pub const MAX_PROPOSAL_SIZE_RATIO: f64 = 0.4;
+
+#[inline]
+fn should_log_snap_gen_precheck_response_info(passed: bool, ignored: bool) -> bool {
+    // A rejected response means the follower's snapshot-receive concurrency is
+    // saturated, which is worth attention, so keep it more visible than the
+    // high-volume success path. Stale (ignored) responses carry the least
+    // information and are sampled the most aggressively.
+    let sample_rate = match (passed, ignored) {
+        (_, true) => SNAP_GEN_PRECHECK_IGNORED_RESPONSE_INFO_SAMPLE_RATE,
+        (false, false) => SNAP_GEN_PRECHECK_REJECTED_RESPONSE_INFO_SAMPLE_RATE,
+        (true, false) => SNAP_GEN_PRECHECK_RESPONSE_INFO_SAMPLE_RATE,
+    };
+    SNAP_GEN_PRECHECK_RESPONSE_LOG_COUNTER.fetch_add(1, Ordering::Relaxed) % sample_rate == 0
+}
 
 pub struct DestroyPeerJob {
     pub initialized: bool,
@@ -3315,14 +3337,35 @@ where
             ExtraMessageType::MsgSnapGenPrecheckResponse => {
                 let passed = msg.get_extra_msg().get_snap_gen_precheck_passed();
                 fail_point!("snap_gen_precheck_failed", !passed, |_| {});
-                info!(
+                let ignored = !self.fsm.peer.get_store().has_gen_snap_task();
+                let status = match (passed, ignored) {
+                    (true, false) => {
+                        SNAP_GEN_PRECHECK_RESPONSE_COUNTER.passed.inc();
+                        "passed"
+                    }
+                    (false, false) => {
+                        SNAP_GEN_PRECHECK_RESPONSE_COUNTER.rejected.inc();
+                        "rejected"
+                    }
+                    (true, true) => {
+                        SNAP_GEN_PRECHECK_RESPONSE_COUNTER.ignored_passed.inc();
+                        "ignored_passed"
+                    }
+                    (false, true) => {
+                        SNAP_GEN_PRECHECK_RESPONSE_COUNTER.ignored_rejected.inc();
+                        "ignored_rejected"
+                    }
+                };
+                info_or_debug!(
+                    should_log_snap_gen_precheck_response_info(passed, ignored);
                     "snap gen precheck response: {}", passed;
                     "region_id" => self.region_id(),
                     "peer_id" => self.peer().id,
                     "store_id" => self.store_id(),
                     "receiver_peer_id" => msg.get_from_peer().get_id(),
                     "receiver_store_id" => msg.get_from_peer().get_store_id(),
-                    "ignored" => !self.fsm.peer.get_store().has_gen_snap_task(),
+                    "ignored" => ignored,
+                    "status" => status,
                 );
                 if passed {
                     if let Some(gen_task) = self.fsm.peer.mut_store().take_gen_snap_task() {

--- a/components/raftstore/src/store/metrics.rs
+++ b/components/raftstore/src/store/metrics.rs
@@ -96,6 +96,13 @@ make_auto_flush_static_metric! {
         skip_partition,
     }
 
+    pub label_enum SnapGenPrecheckResponseStatus {
+        passed,
+        rejected,
+        ignored_passed,
+        ignored_rejected,
+    }
+
     pub struct RaftEntryFetches : LocalIntCounter {
         "type" => RaftEntryType
     }
@@ -134,6 +141,9 @@ make_auto_flush_static_metric! {
     pub struct CompactionGuardActionVec: LocalIntCounter {
         "cf" => CfNames,
         "type" => CompactionGuardAction,
+    }
+    pub struct SnapGenPrecheckResponseCounter: LocalIntCounter {
+        "status" => SnapGenPrecheckResponseStatus,
     }
 }
 
@@ -1012,6 +1022,19 @@ lazy_static! {
         &["reason"]
     )
     .unwrap();
+
+    pub static ref SNAP_GEN_PRECHECK_RESPONSE_COUNTER_VEC: IntCounterVec =
+        register_int_counter_vec!(
+            "tikv_raftstore_snap_gen_precheck_response_total",
+            "Total number of snapshot generation precheck responses.",
+            &["status"]
+        )
+        .unwrap();
+    pub static ref SNAP_GEN_PRECHECK_RESPONSE_COUNTER: SnapGenPrecheckResponseCounter =
+        auto_flush_from!(
+            SNAP_GEN_PRECHECK_RESPONSE_COUNTER_VEC,
+            SnapGenPrecheckResponseCounter
+        );
 
     pub static ref RAFT_APPLYING_SST_GAUGE: IntGaugeVec = register_int_gauge_vec!(
         "tikv_raft_applying_sst",


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: Close #19732

What's Changed:

- Classify the `snap gen precheck response` log in
  `components/raftstore/src/store/fsm/peer.rs` by `(passed, ignored)` and sample
  the INFO instead of emitting it on every response. The high-volume success path
  (`passed`) is sampled at 1/100; follower `rejected` responses are kept more
  visible at 1/10 (a rejection means the follower's snapshot-receive concurrency
  limiter is saturated — worth attention); stale `ignored` responses are sampled
  at 1/1024. Non-sampled lines drop to DEBUG via `info_or_debug!`, and a `status`
  field is added to the log line.
- Add `tikv_raftstore_snap_gen_precheck_response_total` (counter, label `status`
  with values `passed` / `rejected` / `ignored_passed` / `ignored_rejected`),
  incremented on every response regardless of whether the INFO was sampled, so the
  precheck outcome distribution stays observable through metrics.

No snapshot-generation or precheck decision logic is changed; this only adjusts
log level/visibility and adds one low-cardinality metric. The precheck
approve/take-task behavior remains covered by the existing `snap_gen_precheck_failed`
failpoint test in `tests/failpoints/cases/test_snap.rs`.

```commit-message
raftstore: sample snap gen precheck response INFO logs and add response counter

When many regions enter snapshot catch-up at the same time, the leader emits
one `snap gen precheck response` INFO on every follower-approved precheck. The
success path is amplified by the number of regions: real-world incident data
shows this single source line accounting for ~5% of the daily log delta,
peaking at >6,000 lines/s, almost all of it the normal passed (successful
approval) case.

Classify each response by (passed, ignored) and sample the INFO instead of
emitting it unconditionally:
- passed (high-volume success): 1/100
- rejected (follower snapshot-receive concurrency saturated, the signal worth
  attention): 1/10, kept more visible than the success path
- stale ignored responses: 1/1024
Non-sampled lines drop to DEBUG via info_or_debug!, and a `status` field is
added to the log line for quick classification.

Add tikv_raftstore_snap_gen_precheck_response_total (label: status, values
passed / rejected / ignored_passed / ignored_rejected), incremented on every
response regardless of sampling, so the precheck outcome distribution stays
observable through metrics after the log downgrade. No snapshot or precheck
decision logic is changed.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [x] Need to cherry-pick to the release branch

### Check List

Tests

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note

```release-note
Reduce the raftstore `snap gen precheck response` INFO log noise during snapshot
catch-up storms: responses are now sampled by outcome (successful approvals at a
low rate, follower-rejected responses kept more visible, stale responses sampled
most aggressively) and non-sampled lines are downgraded to DEBUG. Add the
`tikv_raftstore_snap_gen_precheck_response_total` counter (label `status`) so the
precheck outcome distribution stays observable.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added metrics tracking for snapshot generation precheck responses, broken down by status (passed, rejected, and ignored variants).

* **Chores**
  * Implemented sampled logging for snapshot generation precheck diagnostics to reduce logging overhead while keeping key observability signals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->