### PR TITLE
raftstore: downgrade StepLocalMsg in handle raft message err to DEBUG and add metric

### DIFF
--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -60,7 +60,7 @@ use tikv_util::{
     store::{find_peer, find_peer_by_id, is_learner, region_on_same_stores},
     sys::disk::DiskUsage,
     time::{Instant as TiInstant, SlowTimer, monotonic_raw_now},
-    trace, warn,
+    trace, warn, warn_or_debug,
     worker::{ScheduleError, Scheduler},
 };
 use tracker::GLOBAL_TRACKERS;
@@ -715,12 +715,34 @@ where
                     if !self.ctx.coprocessor_host.on_raft_message(&msg.msg) {
                         continue;
                     }
+                    let msg_region_id = msg.msg.get_region_id();
+                    let msg_type = msg.msg.get_message().get_msg_type();
+                    let from_peer_id = msg.msg.get_from_peer().get_id();
+                    let from_store_id = msg.msg.get_from_peer().get_store_id();
+                    let to_peer_id = msg.msg.get_to_peer().get_id();
+                    let to_store_id = msg.msg.get_to_peer().get_store_id();
                     if let Err(e) = self.on_raft_message(msg) {
-                        warn!(
+                        // StepLocalMsg is a benign, high-frequency no-op: a local-type
+                        // message received over the network (e.g. the MsgUnreachable echo
+                        // of a memory-pressure rejected append). Downgrade it to DEBUG
+                        // with a metric; all other errors stay at WARN.
+                        let is_step_local = matches!(&e, Error::Raft(raft::Error::StepLocalMsg));
+                        if is_step_local {
+                            self.ctx.raft_metrics.message_dropped.step_local_msg.inc();
+                        }
+                        warn_or_debug!(
+                            !is_step_local;
                             "handle raft message err";
                             "err" => ?e,
+                            "error_code" => %e.error_code(),
                             "region_id" => self.fsm.region_id(),
                             "peer_id" => self.fsm.peer_id(),
+                            "msg_region_id" => msg_region_id,
+                            "msg_type" => ?msg_type,
+                            "from_peer_id" => from_peer_id,
+                            "from_store_id" => from_store_id,
+                            "to_peer_id" => to_peer_id,
+                            "to_store_id" => to_store_id,
                         );
                     }
                 }

--- a/components/raftstore/src/store/metrics.rs
+++ b/components/raftstore/src/store/metrics.rs
@@ -183,6 +183,7 @@ make_static_metric! {
         non_witness,
         recovery,
         unsafe_vote,
+        step_local_msg,
     }
 
     pub label_enum ProposalType {

--- a/components/tikv_util/src/log.rs
+++ b/components/tikv_util/src/log.rs
@@ -107,6 +107,18 @@ macro_rules! info_or_error{
   };
 }
 
+/// Logs a warn or debug level message using the slog global logger.
+#[macro_export]
+macro_rules! warn_or_debug{
+  ($cond:expr; $($args:tt)+) => {
+        if $cond {
+            warn!($($args)+)
+        } else {
+            debug!($($args)+)
+        }
+  };
+}
+
 use std::fmt::{self, Display, Write};
 
 use slog::{BorrowedKV, KV, OwnedKVList, Record};


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: Close #19734

What's Changed:

- Split the `handle raft message err` catch-all WARN in `components/raftstore/src/store/fsm/peer.rs` by error type. `Raft(StepLocalMsg)` — a benign no-op where raft-rs rejects a local-type message received over the network (the dominant source is the `MsgUnreachable` a follower echoes back to the leader after rejecting a `MsgAppend` under memory pressure) — is downgraded to DEBUG and bumps a new `message_dropped` reason `step_local_msg`. All other errors (snapshot / merge / `StepPeerNotFound` / real step failures) stay at WARN.
- Both paths now also carry `error_code` and message routing fields (`msg_type`, `from/to peer/store`) for easier diagnosis of which message triggered the error. These fields are extracted before `on_raft_message` (which consumes the message), costing a few protobuf getters per raft message; the overhead is negligible relative to message processing and only buys context when an error actually occurs.
- Add a `warn_or_debug!` macro in `components/tikv_util/src/log.rs` (symmetric to the existing `info_or_debug!`) so the log level is selected without duplicating the field list across the two branches.

No raft message processing logic is changed; this only adjusts log level/visibility and adds one low-cardinality metric reason. Behavior remains covered by the existing raftstore message-handling tests.

```commit-message
raftstore: downgrade StepLocalMsg in handle raft message err to DEBUG and add metric

`handle raft message err` is a catch-all WARN that on_raft_message emits on
any error without distinguishing the error type. During an incident almost
all of its volume is `Raft(StepLocalMsg)`: real-world data shows this single
source line at ~34M lines/day (2.6% of the daily log delta), peaking at
>2,400 lines/s, ~99% of it StepLocalMsg.

StepLocalMsg is a benign no-op: raft-rs rejecting a local-type message
(MsgHup/MsgBeat/MsgUnreachable/...) received over the network, without
touching any raft state. The dominant source is TiKV's own memory-protection
path: when a follower rejects a MsgAppend under memory pressure it echoes a
MsgUnreachable back to the leader, whose raft-rs then returns StepLocalMsg.

Split the catch-all by error type: StepLocalMsg drops to DEBUG and bumps a
new `message_dropped` reason `step_local_msg`; all other errors (snapshot /
merge / StepPeerNotFound / real step failures) stay at WARN. Both paths now
also carry error_code and message routing fields (msg_type, from/to
peer/store) for easier diagnosis.

Add a `warn_or_debug!` macro (symmetric to the existing `info_or_debug!`) to
select the level without duplicating the log fields.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [x] Need to cherry-pick to the release branch

### Check List

Tests

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note

```release-note
Reduce the raftstore `handle raft message err` WARN log noise: the benign high-frequency `Raft(StepLocalMsg)` case (a local-type message received over the network, e.g. the MsgUnreachable echo of a memory-pressure rejected append) is downgraded to DEBUG and counted by a new `message_dropped` metric reason `step_local_msg`; all other errors remain at WARN. The log lines now also include error_code and message routing fields.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced diagnostics for raft message handling failures with detailed context about affected messages
  * Refined error logging to reduce noise by applying appropriate severity levels to different error categories
  * Extended metrics collection to provide better insights into dropped message patterns

<!-- end of auto-generated comment: release notes by coderabbit.ai -->