### PR TITLE
*: update rocksdb and fix clippy warnings.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4501,7 +4501,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git#a6b0bb0483986cbcec14530064f53b7f14facfa2"
+source = "git+https://github.com/tikv/rust-rocksdb.git#1c17b59dcb506302ed4684b3628c4a7165e0b86d"
 dependencies = [
  "bindgen 0.65.1",
  "bzip2-sys",
@@ -4520,7 +4520,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/tikv/rust-rocksdb.git#a6b0bb0483986cbcec14530064f53b7f14facfa2"
+source = "git+https://github.com/tikv/rust-rocksdb.git#1c17b59dcb506302ed4684b3628c4a7165e0b86d"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -6718,7 +6718,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git#a6b0bb0483986cbcec14530064f53b7f14facfa2"
+source = "git+https://github.com/tikv/rust-rocksdb.git#1c17b59dcb506302ed4684b3628c4a7165e0b86d"
 dependencies = [
  "libc 0.2.176",
  "librocksdb_sys",
@@ -8666,9 +8666,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemalloc-ctl"
-version = "0.5.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e37706572f4b151dff7a0146e040804e9c26fe3a3118591112f05cf12a4216c1"
+checksum = "661f1f6a57b3a36dc9174a2c10f19513b4866816e13425d3e418b11cc37bc24c"
 dependencies = [
  "libc 0.2.176",
  "paste",
@@ -8677,20 +8677,19 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemalloc-sys"
-version = "0.5.0+5.3.0"
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aeab4310214fe0226df8bfeb893a291a58b19682e8a07e1e1d4483ad4200d315"
+checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
 dependencies = [
  "cc",
- "fs_extra",
  "libc 0.2.176",
 ]
 
 [[package]]
 name = "tikv-jemallocator"
-version = "0.5.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20612db8a13a6c06d57ec83953694185a367e16945f66565e8028d2c0bd76979"
+checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
 dependencies = [
  "libc 0.2.176",
  "tikv-jemalloc-sys",

--- a/clippy.toml
+++ b/clippy.toml
@@ -35,17 +35,6 @@ Adding hooks directly will omit system hooks, please use
 refer to https://github.com/tikv/tikv/pull/12442 and https://github.com/tikv/tikv/pull/15017 for more details.
 """
 
-# See more about RUSTSEC-2020-0071 in deny.toml.
-[[disallowed-methods]]
-path = "time::now"
-reason = "time::now is unsound, see RUSTSEC-2020-0071"
-[[disallowed-methods]]
-path = "time::at"
-reason = "time::at is unsound, see RUSTSEC-2020-0071"
-[[disallowed-methods]]
-path = "time::at_utc"
-reason = "time::at_utc is unsound, see RUSTSEC-2020-0071"
-
 # See more about RUSTSEC-2023-0072 in deny.toml.
 [[disallowed-methods]]
 path = "openssl::x509::store::X509StoreRef::objects"
@@ -92,19 +81,6 @@ openssl::asn1::Asn1GeneralizedTimeRef may call openssl::bio::MemBio::get_buf, \
 see RUSTSEC-2024-0357
 """
 
-# See more about RUSTSEC-2025-0022 in deny.toml.
-[[disallowed-types]]
-path = "openssl::cipher::Cipher::fetch"
-reason = """
-When a Some(...) value was passed to the properties argument of openssl::cipher::Cipher::fetch, \
-a use-after-free would result. See RUSTSEC-2025-0022
-"""
-[[disallowed-types]]
-path = "openssl::md::Md::fetch"
-reason = """
-When a Some(...) value was passed to the properties argument of openssl::md::Md::fetch, \
-a use-after-free would result. See RUSTSEC-2025-0022
-"""
 [[await-holding-invalid-types]]
 path = "dashmap::mapref::one::Ref"
 reason = "https://github.com/tikv/tikv/issues/19238"

--- a/components/tikv_alloc/Cargo.toml
+++ b/components/tikv_alloc/Cargo.toml
@@ -36,16 +36,17 @@ optional = true
 features = ["bundled"]
 
 [dependencies.tikv-jemalloc-ctl]
-version = "0.5.0"
+version = "0.6.1"
 optional = true
+features = ["stats"]
 
 [dependencies.tikv-jemalloc-sys]
-version = "0.5.0"
+version = "0.6.1"
 optional = true
 features = ["stats"]
 
 [dependencies.tikv-jemallocator]
-version = "0.5.0"
+version = "0.6.1"
 optional = true
 features = ["unprefixed_malloc_on_supported_platforms", "stats"]
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: ref https://github.com/tikv/tikv/issues/19721

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

This PR updates the RocksDB library to the latest commit, which includes the bugfix from https://github.com/tikv/rocksdb/pull/430. This fix caps `compaction_readahead_size` by `max_sectors_kb`, resolving a compatibility issue where the setting exceeded the underlying ENV's max_sector_size.

Meanwhile, this PR also removes redundant and stale warnings in `clippy.toml`.

```commit-message
Updates rocksdb lib to the latest commit to fix compaction bugs.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Updates rocksdb lib to the latest commit to fix compaction bugs.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated memory allocator dependencies to the latest version for improved stability.
  * Removed deprecated API warnings from development configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->