### PR TITLE
storage: fix flow control prematurely resuming after unsafe destroy range

### DIFF
--- a/src/storage/txn/flow_controller/singleton_flow_controller.rs
+++ b/src/storage/txn/flow_controller/singleton_flow_controller.rs
@@ -629,18 +629,24 @@ impl<E: FlowControlFactorStore + Send + 'static> FlowChecker<E> {
                 }
             }
 
-            let pending_compaction_bytes = long_term_pending_bytes.get_avg();
+            let avg_pending_bytes = long_term_pending_bytes.get_avg();
             let ignore = if let Some(before) = checker.pending_bytes_before_unsafe_destroy_range {
-                // It assumes that the long term average will eventually come down below the
-                // soft limit. If the general traffic flow increases during destroy, the long
-                // term average may never come down and the flow control will be turned off for
-                // a long time, which would be a rather rare case, so just ignore it.
-                if pending_compaction_bytes <= before && !self.wait_for_destroy_range_finish {
+                // Only clear destroy-range jump control after both the long-term
+                // average returns to the pre-destroy level and the current sample
+                // is below the soft limit. The average alone can hide a current
+                // compaction debt spike.
+                let back_to_normal = avg_pending_bytes <= before
+                    && num < soft
+                    && !self.wait_for_destroy_range_finish;
+                if back_to_normal {
                     info!(
                         "pending compaction bytes is back to normal";
                         "cf" => &cf,
-                        "pending_compaction_bytes" => pending_compaction_bytes,
-                        "before" => before
+                        "current_pending_compaction_bytes" => pending_compaction_bytes,
+                        "current_pending_compaction_bytes_log2" => num,
+                        "avg_pending_compaction_bytes_log2" => avg_pending_bytes,
+                        "before_log2" => before,
+                        "soft_limit_log2" => soft
                     );
                     checker.pending_bytes_before_unsafe_destroy_range = None;
                 }
@@ -657,10 +663,10 @@ impl<E: FlowControlFactorStore + Send + 'static> FlowChecker<E> {
                 }
             }
 
-            let mut ratio = if pending_compaction_bytes < soft || ignore {
+            let mut ratio = if avg_pending_bytes < soft || ignore {
                 0
             } else {
-                let new_ratio = (pending_compaction_bytes - soft) / (hard - soft);
+                let new_ratio = (avg_pending_bytes - soft) / (hard - soft);
                 let old_ratio = self.discard_ratio.load(Ordering::Relaxed);
 
                 // Because pending compaction bytes changes up and down, so using
@@ -1334,5 +1340,76 @@ pub(super) mod tests {
         send_flow_info(&tx, region_id);
         send_flow_info(&tx, region_id);
         assert!(flow_controller.discard_ratio(region_id) > f64::EPSILON);
+    }
+
+    #[test]
+    fn test_flow_controller_destroy_range_jump_control_checks_current_pending_bytes() {
+        const GIB: u64 = 1024 * 1024 * 1024;
+
+        let region_id = 0;
+        let cf = "default".to_string();
+        let stub = EngineStub::new();
+        let config = Arc::new(VersionTrack::new(FlowControlConfig::default()));
+        let discard_ratio = Arc::new(AtomicU32::new(0));
+        let limiter = Arc::new(Limiter::new(f64::INFINITY));
+        let mut checker = FlowChecker::new(config, stub.clone(), discard_ratio, limiter);
+
+        let soft = (FlowControlConfig::default()
+            .soft_pending_compaction_bytes_limit
+            .0 as f64)
+            .log2();
+
+        for _ in 0..10 {
+            checker.on_pending_compaction_bytes_change_cf(64 * GIB, cf.clone());
+        }
+
+        checker.on_flow_info_msg(Ok(FlowInfo::BeforeUnsafeDestroyRange(region_id)));
+        let before = checker
+            .cf_checkers
+            .get(&cf)
+            .unwrap()
+            .pending_bytes_before_unsafe_destroy_range
+            .unwrap();
+        assert!(before < soft);
+
+        for _ in 0..20 {
+            checker.on_pending_compaction_bytes_change_cf(GIB, cf.clone());
+        }
+
+        let high_pending_bytes = 512 * GIB;
+        stub.0
+            .pending_compaction_bytes
+            .store(high_pending_bytes, Ordering::Relaxed);
+        checker.on_flow_info_msg(Ok(FlowInfo::AfterUnsafeDestroyRange(region_id)));
+        assert!(
+            checker
+                .cf_checkers
+                .get(&cf)
+                .unwrap()
+                .pending_bytes_before_unsafe_destroy_range
+                .is_some(),
+            "jump control should remain while current pending bytes exceeds soft limit"
+        );
+
+        checker.on_pending_compaction_bytes_change_cf(high_pending_bytes, cf.clone());
+        assert!(
+            checker
+                .cf_checkers
+                .get(&cf)
+                .unwrap()
+                .pending_bytes_before_unsafe_destroy_range
+                .is_some(),
+            "avg alone must not clear jump control when current pending bytes is still high"
+        );
+
+        checker.on_pending_compaction_bytes_change_cf(GIB, cf.clone());
+        assert!(
+            checker
+                .cf_checkers
+                .get(&cf)
+                .unwrap()
+                .pending_bytes_before_unsafe_destroy_range
+                .is_none()
+        );
     }
 }


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: Close #19583

After an unsafe destroy range (e.g. large table drop/truncate), the compaction-bytes flow control is frozen to avoid throttling foreground writes for the delete-driven compaction debt, and it is resumed once the pending compaction bytes recover to the pre-destroy level.

The "back to normal" decision in `on_pending_compaction_bytes_change_cf` previously only checked the **long-term average** (`avg <= before`). As reported in the issue, the long-term average lags behind, so it can fall back to the pre-destroy level while the **current** pending compaction bytes is still far above the soft limit. The production log shows flow control was treated as back-to-normal (`pending_compaction_bytes=35.35` in log2) while RocksDB still estimated ~596 GB pending compaction bytes, so flow control was resumed too early and caused a latency spike.

This PR additionally requires the current sample to be below the soft limit before clearing the destroy-range jump control, which aligns the condition with the jump detection already done in `AfterUnsafeDestroyRange` (which checks both the current and the average). The "back to normal" log is also enriched to print both the current and the average pending compaction bytes.

What's Changed:

```commit-message
storage: fix flow control prematurely resuming after unsafe destroy range

The "pending compaction bytes is back to normal" decision only checked the
long-term average, which lags behind and can fall below the pre-destroy
level while the current pending compaction bytes is still far above the soft
limit, resuming flow control too early. Require the current sample to be
below the soft limit as well, aligning the condition with the jump detection
in AfterUnsafeDestroyRange.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note

```release-note
Fixed an issue where TiKV flow control could be resumed prematurely after an unsafe destroy range (such as dropping or truncating a large table) while pending compaction bytes were still high, causing unnecessary write throttling and latency spikes.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved throttling logic during compaction operations to consider both long-term trends and current conditions for more accurate flow control decisions.
  * Enhanced safeguards to better protect against temporary spikes in storage operations.

* **Tests**
  * Added validation test for flow control behavior during compaction scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->