### PR TITLE
tikv-ctl: skip logging for local options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8657,6 +8657,7 @@ dependencies = [
  "structopt",
  "tempfile",
  "tikv",
+ "tikv_alloc",
  "tikv_util",
  "time 0.2.27",
  "tokio",

--- a/cmd/tikv-ctl/Cargo.toml
+++ b/cmd/tikv-ctl/Cargo.toml
@@ -71,6 +71,9 @@ tokio = { version = "1.5", features = ["rt-multi-thread", "time"] }
 toml = "0.5"
 txn_types = { workspace = true }
 
+[dev-dependencies]
+tikv_alloc = { workspace = true }
+
 [build-dependencies]
 cc = "1.0"
 time = { workspace = true }

--- a/cmd/tikv-ctl/src/main.rs
+++ b/cmd/tikv-ctl/src/main.rs
@@ -75,6 +75,25 @@ fn main() {
 
     let opt = Opt::from_args();
 
+    if opt.cmd.is_none() {
+        // Handle local operations before initializing runtime subsystems.
+        if let Some(hex) = opt.hex_to_escaped.as_deref() {
+            println!("{}", escape(&from_hex(hex).unwrap()));
+        } else if let Some(escaped) = opt.escaped_to_hex.as_deref() {
+            println!("{}", hex::encode_upper(unescape(escaped)));
+        } else if let Some(encoded) = opt.decode.as_deref() {
+            match Key::from_encoded(unescape(encoded)).into_raw() {
+                Ok(k) => println!("{}", escape(&k)),
+                Err(e) => println!("decode meets error: {}", e),
+            };
+        } else if let Some(decoded) = opt.encode.as_deref() {
+            println!("{}", Key::from_raw(&unescape(decoded)));
+        } else {
+            Opt::clap().print_help().ok();
+        }
+        return;
+    }
+
     // Initialize logger.
     init_ctl_logger(&opt.log_level, &opt.log_format);
 
@@ -98,27 +117,9 @@ fn main() {
     );
     let mgr = new_security_mgr(&opt);
 
-    let cmd = match opt.cmd {
-        Some(cmd) => cmd,
-        None => {
-            // Deal with arguments about key utils.
-            if let Some(hex) = opt.hex_to_escaped.as_deref() {
-                println!("{}", escape(&from_hex(hex).unwrap()));
-            } else if let Some(escaped) = opt.escaped_to_hex.as_deref() {
-                println!("{}", hex::encode_upper(unescape(escaped)));
-            } else if let Some(encoded) = opt.decode.as_deref() {
-                match Key::from_encoded(unescape(encoded)).into_raw() {
-                    Ok(k) => println!("{}", escape(&k)),
-                    Err(e) => println!("decode meets error: {}", e),
-                };
-            } else if let Some(decoded) = opt.encode.as_deref() {
-                println!("{}", Key::from_raw(&unescape(decoded)));
-            } else {
-                Opt::clap().print_help().ok();
-            }
-            return;
-        }
-    };
+    let cmd = opt
+        .cmd
+        .expect("no-command path returned before initialization");
 
     match cmd {
         Cmd::External(args) => {

--- a/cmd/tikv-ctl/tests/cli.rs
+++ b/cmd/tikv-ctl/tests/cli.rs
@@ -1,0 +1,47 @@
+// Copyright 2026 TiKV Project Authors. Licensed under Apache-2.0.
+
+#[allow(unused_extern_crates)]
+extern crate tikv_alloc;
+
+use std::process::Command;
+
+const ENGINE_LOG_DIR: &str = "ctl-engine-info-log";
+
+fn assert_no_engine_log_dir(args: &[&str]) {
+    let cwd = tempfile::tempdir().expect("create temporary directory");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_tikv-ctl"))
+        .args(args)
+        .current_dir(cwd.path())
+        .output()
+        .expect("run tikv-ctl");
+
+    assert!(
+        output.status.success(),
+        "tikv-ctl {args:?} failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    assert!(
+        !cwd.path().join(ENGINE_LOG_DIR).exists(),
+        "tikv-ctl {args:?} created {ENGINE_LOG_DIR}",
+    );
+}
+
+#[test]
+fn local_invocations_do_not_create_engine_log_dir() {
+    let cases: &[&[&str]] = &[
+        &[],
+        &["--help"],
+        &["--version"],
+        &["--to-escaped", "74"],
+        &["--to-hex", "t"],
+        &["--encode", "t"],
+        &["--decode", r"t\000\000\000\000\000\000\000\370"],
+    ];
+
+    for args in cases {
+        assert_no_engine_log_dir(args);
+    }
+}


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: ref #13927

What's Changed:

Bare `tikv-ctl` and the top-level key conversion options initialized TiKV logging, configuration, and security state before doing local-only work. That created `ctl-engine-info-log` in the current working directory even though no engine command ran.

**Fix:** handle no-subcommand operations immediately after argument parsing, before runtime initialization. Actual subcommands keep the existing initialization sequence.

Top-level `--help` and `--version` already exit during argument parsing, but the regression test keeps them side-effect free.

```commit-message
Avoid initializing TiKV logging, configuration, and security state for
no-subcommand operations.

This keeps help and key-conversion paths free from unrelated filesystem
side effects while preserving initialization for actual commands.
```

### Related changes

* [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`
* [ ] Need to cherry-pick to the release branch

### Check List

Tests

* [x] Unit test
* [x] Integration test
* [x] Manual test
* [ ] No code

The integration test covers bare `tikv-ctl`, `--help`, `--version`, and all top-level key conversion options. Before the change, bare invocation and key utilities created `ctl-engine-info-log`; after the change, these local-only invocations do not create it.

The integration test links `tikv_alloc` as a dev-dependency so the new test executable satisfies TiKV's allocator binary check.

Commands run:

```text
env CXXFLAGS='-include cstdint' ./scripts/env cargo test -p tikv-ctl --test cli -- --nocapture
env CXXFLAGS='-include cstdint' ./scripts/env cargo test -p tikv-ctl -- --nocapture
make format
env CXXFLAGS='-include cstdint' make clippy
```

`CXXFLAGS=-include cstdint` is a local native-build workaround, not part of the source change.

`make dev` was also attempted. After this PR's allocator check was fixed, the remaining failures were two unrelated AWS S3 multipart tests.

Side effects

* [ ] Performance regression: Consumes more CPU
* [ ] Performance regression: Consumes more Memory
* [ ] Breaking backward compatibility

No-subcommand local operations no longer load TiKV configuration, initialize logging, construct the security manager, or emit `fips::log_status()` through the logger. Actual subcommands and external-command handling are unchanged.

### Release note

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration tests to validate command-line interface behavior and functionality.

* **Chores**
  * Updated development dependencies to enhance testing infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->