### PR TITLE
config: warn about oversized in-memory peer limits

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3856,6 +3856,9 @@ impl TikvConfig {
         let data_dir = data_dir.unwrap_or(&self.storage.data_dir);
         config::canonicalize_sub_path(data_dir, DEFAULT_ROCKSDB_SUB_DIR)
     }
+    fn should_warn_in_memory_peer_size_limit(&self) -> bool {
+        self.pessimistic_txn.in_memory_peer_size_limit.0 > self.raft_store.raft_entry_max_size.0 / 2
+    }
 
     pub fn validate(&mut self) -> Result<(), Box<dyn Error>> {
         // Setting up data paths.
@@ -4042,6 +4045,19 @@ impl TikvConfig {
             warn!(
                 "raftstore.hibernate-regions was enabled but cdc.hibernate-regions-compatible \
                 was disabled, hibernate regions may be broken up if you want to deploy a cdc cluster"
+            );
+        }
+        if self.should_warn_in_memory_peer_size_limit() {
+            let peer_limit = self.pessimistic_txn.in_memory_peer_size_limit.0;
+            let raft_max = self.raft_store.raft_entry_max_size.0;
+            warn!(
+                "pessimistic-txn.in-memory-peer-size-limit ({}) exceeds half of \
+                 raftstore.raft-entry-max-size ({}); flushing in-memory pessimistic locks during \
+                 leader transfer, region split, or region merge may produce an oversized \
+                 Raft entry; and cause 'entry is too large' errors. Consider reducing \
+                 in-memory-peer-size or increasing raft-entry-max-size",
+                ReadableSize(peer_limit),
+                ReadableSize(raft_max),
             );
         }
 
@@ -8328,5 +8344,54 @@ mod tests {
             .unwrap();
         cfg.in_memory_engine.enable = true;
         check_cfg(&cfg);
+    }
+
+    #[test]
+    fn test_in_memory_peer_size_limit_warning_threshold() {
+        let config = r#"
+        [pessimistic-txn]
+        in-memory-peer-size-limit = "4MiB"
+
+        [raftstore]
+        raft-entry-max-size = "8MiB"
+        "#;
+        let mut cfg: TikvConfig = toml::from_str(config).unwrap();
+        assert!(!cfg.should_warn_in_memory_peer_size_limit());
+
+        cfg.pessimistic_txn.in_memory_peer_size_limit.0 =
+            cfg.raft_store.raft_entry_max_size.0 / 2 + 1;
+        assert!(cfg.should_warn_in_memory_peer_size_limit());
+
+        cfg.pessimistic_txn.in_memory_peer_size_limit.0 = cfg.raft_store.raft_entry_max_size.0;
+        assert!(cfg.should_warn_in_memory_peer_size_limit());
+    }
+
+    #[test]
+    fn test_online_config_in_memory_peer_size_limit_warning_threshold() {
+        let (cfg, _dir) = TikvConfig::with_tmp().unwrap();
+        let cfg_controller = ConfigController::new(cfg);
+        assert!(
+            !cfg_controller
+                .get_current()
+                .should_warn_in_memory_peer_size_limit()
+        );
+
+        cfg_controller
+            .update_config("pessimistic-txn.in-memory-peer-size-limit", "5MiB")
+            .unwrap();
+        assert!(
+            cfg_controller
+                .get_current()
+                .should_warn_in_memory_peer_size_limit()
+        );
+
+        cfg_controller
+            .update_config("raftstore.raft-entry-max-size", "16MiB")
+            .unwrap();
+        assert!(
+            !cfg_controller
+                .get_current()
+                .should_warn_in_memory_peer_size_limit()
+        );
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -4054,8 +4054,8 @@ impl TikvConfig {
                 "pessimistic-txn.in-memory-peer-size-limit ({}) exceeds half of \
                  raftstore.raft-entry-max-size ({}); flushing in-memory pessimistic locks during \
                  leader transfer, region split, or region merge may produce an oversized \
-                 Raft entry; and cause 'entry is too large' errors. Consider reducing \
-                 in-memory-peer-size or increasing raft-entry-max-size",
+                 Raft entry and cause 'entry is too large' errors. Consider reducing \
+                 pessimistic-txn.in-memory-peer-size-limit or increasing raftstore.raft-entry-max-size",
                 ReadableSize(peer_limit),
                 ReadableSize(raft_max),
             );


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->
### What is changed and how it works?

Issue Number: close #19488

What's Changed:

- Warn when `pessimistic-txn.in-memory-peer-size-limit` exceeds half of `raftstore.raft-entry-max-size`.
- Apply the check during startup and online configuration updates through `TikvConfig::validate`.
- Add tests for the threshold boundary and online changes to both configuration values.

```commit-message
Warn when pessimistic-txn.in-memory-peer-size-limit exceeds half of
raftstore.raft-entry-max-size. When in-memory-peer-size-limit is set
to a value close to or exceeding raft-entry-max-size TiKV can produce
"entry is too large" errors during region leader transfers, splits or
merges sliently. With this commit TiKV will now emit a warning.

Add coverage for the warning threshold and online configuration updates.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test
- [ ] No code

Manual verification:

- Started TiKV with `in-memory-peer-size-limit=4MiB` and `raft-entry-max-size=8MiB`; no warning was emitted.
- Changed `in-memory-peer-size-limit` online to `5MiB`; the warning was emitted.
  `target/debug/tikv-ctl \
  --host 127.0.0.1:20260 \
  modify-tikv-config \
  -n pessimistic-txn.in-memory-peer-size-limit \
  -v 5MiB`
- Restarted TiKV with `5MiB` and `8MiB`; the warning was emitted during startup.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
TiKV now warns when the per-peer in-memory pessimistic lock limit may produce oversized Raft entries during leader transfers, region splits, or region merges.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a configuration validation warning when the `pessimistic-txn` in-memory peer size limit is configured high enough to risk oversized Raft entries.
  * The warning now shows the effective limit and the raft entry max size, and notes potential impact during leader transfer, split, and merge scenarios.
* **Tests**
  * Added unit tests covering the warning threshold behavior, including both initial config and online config updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->