### PR TITLE
fips: fix compilation errors when `ENABLE_FIPS=1`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,9 @@ openssl-vendored = [
   # NB: Enable SM4 support if OpenSSL is built from source and statically linked.
   "encryption_export/sm4",
 ]
+# Forwards the FIPS feature to gcp_v2 (via encryption_export) so FIPS builds
+# enable the rustls/fips path. See components/encryption/export/Cargo.toml.
+fips = ["encryption_export/fips"]
 
 # for testing configure propegate to other crates
 # https://stackoverflow.com/questions/41700543/can-we-share-test-utilites-between-crates

--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ export TIKV_BUILD_GIT_BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD 2> /dev/
 ifeq ($(ENABLE_FIPS),1)
 DOCKER_IMAGE_TAG := ${DOCKER_IMAGE_TAG}-fips
 DOCKER_FILE := ${DOCKER_FILE}.FIPS
-ENABLE_FEATURES += gcp_v2/fips
+ENABLE_FEATURES += fips
 else
 ENABLE_FEATURES += openssl-vendored
 endif

--- a/cmd/tikv-ctl/Cargo.toml
+++ b/cmd/tikv-ctl/Cargo.toml
@@ -16,6 +16,9 @@ sse = ["tikv/sse"]
 mem-profiling = ["tikv/mem-profiling"]
 failpoints = ["tikv/failpoints"]
 openssl-vendored = ["tikv/openssl-vendored"]
+# Enables FIPS mode by forwarding to gcp_v2/fips through the dependency chain
+# (tikv -> encryption_export -> gcp_v2). Used by FIPS Docker builds.
+fips = ["tikv/fips"]
 test-engine-kv-rocksdb = [
   "tikv/test-engine-kv-rocksdb"
 ]

--- a/cmd/tikv-server/Cargo.toml
+++ b/cmd/tikv-server/Cargo.toml
@@ -18,6 +18,9 @@ mem-profiling = ["server/mem-profiling"]
 memory-engine = ["server/memory-engine"]
 failpoints = ["server/failpoints"]
 openssl-vendored = ["tikv/openssl-vendored"]
+# Enables FIPS mode by forwarding to gcp_v2/fips through the dependency chain
+# (server -> tikv -> encryption_export -> gcp_v2). Used by FIPS Docker builds.
+fips = ["server/fips"]
 test-engine-kv-rocksdb = [
   "server/test-engine-kv-rocksdb"
 ]

--- a/components/backup-stream/Cargo.toml
+++ b/components/backup-stream/Cargo.toml
@@ -17,6 +17,8 @@ openssl-vendored = [
   "encryption_export/sm4",
 ]
 backup-stream-debug = []
+# Forwards FIPS to gcp_v2 via external_storage / encryption_export.
+fips = ["external_storage/fips", "encryption_export/fips"]
 
 [[test]]
 name = "integration"

--- a/components/backup/Cargo.toml
+++ b/components/backup/Cargo.toml
@@ -27,6 +27,8 @@ portable = ["tikv/portable"]
 sse = ["tikv/sse"]
 mem-profiling = ["tikv/mem-profiling"]
 failpoints = ["tikv/failpoints"]
+# Forwards FIPS to gcp_v2 via external_storage. See external_storage/Cargo.toml.
+fips = ["external_storage/fips"]
 
 [dependencies]
 api_version = { workspace = true }

--- a/components/encryption/export/Cargo.toml
+++ b/components/encryption/export/Cargo.toml
@@ -7,6 +7,10 @@ license = "Apache-2.0"
 
 [features]
 sm4 = ["encryption/sm4"]
+# Forwards the FIPS feature down to gcp_v2 (which gates rustls/fips). gcp_v2 is
+# only a transitive dependency of the binaries, so the feature must be forwarded
+# through this chain rather than enabled directly as `gcp_v2/fips`.
+fips = ["gcp_v2/fips"]
 
 [dependencies]
 aws = { workspace = true }

--- a/components/external_storage/Cargo.toml
+++ b/components/external_storage/Cargo.toml
@@ -7,6 +7,10 @@ license = "Apache-2.0"
 
 [features]
 failpoints = ["fail/failpoints"]
+# Forwards the FIPS feature down to gcp_v2 (which gates rustls/fips). gcp_v2 is
+# only a transitive dependency of the binaries, so the feature is forwarded
+# through this chain rather than enabled directly as `gcp_v2/fips`.
+fips = ["gcp_v2/fips"]
 
 [dependencies]
 async-compression = { version = "0.4.27", features = ["futures-io", "zstd"] }

--- a/components/server/Cargo.toml
+++ b/components/server/Cargo.toml
@@ -21,6 +21,9 @@ test-engines-rocksdb = ["tikv/test-engines-rocksdb"]
 test-engines-panic = ["tikv/test-engines-panic"]
 nortcheck = ["engine_rocks/nortcheck"]
 backup-stream-debug = ["backup-stream/backup-stream-debug"]
+# Forwards the FIPS feature down to gcp_v2 through every crate that depends on
+# it: tikv -> encryption_export, and backup / backup-stream -> external_storage.
+fips = ["tikv/fips", "backup/fips", "backup-stream/fips"]
 
 [dependencies]
 api_version = { workspace = true }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: ref #19743 

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
forward the FIPS feature to gcp_v2 through first-class workspace features

When ENABLE_FIPS=1, the Makefile used to enable the transitive
package-qualified feature `gcp_v2/fips` directly. This change replaces
that with a top-level `fips` feature and forwards it through the crates
that actually depend on `gcp_v2`.

- add `fips` to the root TiKV crate and switch the Makefile to use it
- forward `fips` through tikv-server, tikv-ctl, server, backup,
  backup-stream, encryption_export, and external_storage
- keep the GCP v2 rustls FIPS path enabled through normal Cargo feature
  propagation instead of direct transitive feature selection

This makes the FIPS build configuration explicit in the workspace and
avoids relying on `gcp_v2/fips` in the build entrypoint.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [x] No code

Manual test steps:

1. `make format`
2. `make clippy`
3. `env RUSTC_WRAPPER= cargo check -p tikv-server --features fips`
4. `env RUSTC_WRAPPER= cargo check -p tikv-ctl --features fips`

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```

### Deep Review

#### Problem Summary
- The uncommitted change replaces the `Makefile`'s direct `gcp_v2/fips` activation with a workspace-level `fips` feature and forwards that feature through the crates that own `gcp_v2` dependencies.
- The goal is to make FIPS builds select the GCP v2 `rustls/fips` path through normal Cargo feature propagation instead of hard-coding a transitive package feature in the build script.

#### Solution Walkthrough
- [Cargo.toml](/Users/lucasliang/Workspace/tikv/Cargo.toml:57) adds a root `fips` feature that forwards to `encryption_export/fips`.
- [Makefile](/Users/lucasliang/Workspace/tikv/Makefile:143) changes `ENABLE_FIPS=1` from `gcp_v2/fips` to the new top-level `fips` feature.
- [cmd/tikv-server/Cargo.toml](/Users/lucasliang/Workspace/tikv/cmd/tikv-server/Cargo.toml:21) and [cmd/tikv-ctl/Cargo.toml](/Users/lucasliang/Workspace/tikv/cmd/tikv-ctl/Cargo.toml:19) expose `fips` on the shipped binaries by forwarding to `tikv/fips`.
- [components/encryption/export/Cargo.toml](/Users/lucasliang/Workspace/tikv/components/encryption/export/Cargo.toml:10) and [components/external_storage/Cargo.toml](/Users/lucasliang/Workspace/tikv/components/external_storage/Cargo.toml:10) forward `fips` to `gcp_v2/fips`, which is the actual gate that enables `rustls/fips` in [components/cloud/gcp_v2/Cargo.toml](/Users/lucasliang/Workspace/tikv/components/cloud/gcp_v2/Cargo.toml:8).
- [components/server/Cargo.toml](/Users/lucasliang/Workspace/tikv/components/server/Cargo.toml:24), [components/backup/Cargo.toml](/Users/lucasliang/Workspace/tikv/components/backup/Cargo.toml:30), and [components/backup-stream/Cargo.toml](/Users/lucasliang/Workspace/tikv/components/backup-stream/Cargo.toml:20) add parallel forwarding so direct consumers of those crates can also request the same FIPS path.
- `cargo tree -p tikv-server -e features --features fips -i gcp_v2` and `cargo tree -p tikv-ctl -e features --features fips -i gcp_v2` both resolved `gcp_v2 feature "fips"`, confirming that the binary entrypoints do select the intended transitive feature.

#### Findings (ordered by severity)
- None.

#### Costs and Negative Impacts
- Correctness: Low risk. The patch only changes Cargo feature wiring and `Makefile` feature selection; no runtime Rust logic changed.
- Security: Positive/neutral. The FIPS-sensitive `gcp_v2` path is still activated, but now through first-class workspace features instead of a transitive package-qualified feature.
- Compatibility: Out-of-tree callers that previously enabled `gcp_v2/fips` directly through TiKV's root build invocation will need to switch to `fips`.
- Robustness: Acceptable. The current implementation relies on Cargo feature unification so that `tikv/fips -> encryption_export/fips -> gcp_v2/fips` is sufficient for the shipped binaries.
- Operability: Slightly improved. `ENABLE_FIPS=1` now maps to a repo-level feature name instead of a transitive package path.
- Cognitive Load: Slightly higher because the forwarding chain now spans multiple manifests, but the added comments keep it understandable.
- CPU: No meaningful runtime impact.
- Memory: No meaningful runtime impact.
- Log Volume: No impact.

#### Static Validation
- `make format`: Passed.
- `make clippy`: Passed after rerunning outside the initial sandbox restriction. The first sandboxed attempt failed because `rustup` could not write `~/.rustup/tmp`; the rerun completed successfully. `cargo-deny` emitted warnings already present in the workspace (for example missing license fields on `kvproto` / `tipb` and registry index lookup warnings), but no errors.
- `env RUSTC_WRAPPER= cargo check -p tikv-server --features fips`: Passed.
- `env RUSTC_WRAPPER= cargo check -p tikv-ctl --features fips`: Passed.

#### Engineering Rules Check
- No code-level mismatch against [AGENTS.md](/Users/lucasliang/Workspace/tikv/AGENTS.md:1) was found in this diff.
- Repo-prescribed validation entrypoints were used: `make format` and `make clippy`.
- PR title / description / release-note rules were not assessable because the review scope was the uncommitted working tree rather than a PR.

#### Questions and Assumptions
- Assumed the requested review scope was the current uncommitted working-tree diff against `HEAD`.
- Assumed the current FIPS requirement for this patch is specifically to ensure `gcp_v2` builds with `rustls/fips`. A repository search found `cfg(feature = "fips")` usage in `components/cloud/gcp_v2`, but not in the newly added forwarding crates themselves.
- `cmd/tikv-server` and `cmd/tikv-ctl` currently forward `fips` to `tikv/fips`, not `server/fips`. That is acceptable today because `cargo tree` confirmed `gcp_v2/fips` is still selected, but if future crate-local `fips` behavior is added outside the `tikv -> encryption_export` path, the binary manifests will need to forward those features explicitly.

#### Suggested Tests / Validation
- Run `ENABLE_FIPS=1 make build` or the equivalent Linux FIPS CI job before submission, because the local targeted checks validated feature resolution but did not reproduce the full Docker/FIPS packaging environment.
- Run `make dev` before opening the PR, per [AGENTS.md](/Users/lucasliang/Workspace/tikv/AGENTS.md:105).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added FIPS (Federal Information Processing Standards) mode support across all components and build configurations to enable regulatory compliance for restricted environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->