### PR TITLE
deny: replace `structopt` with `clap-v3` derives to resolve RUSTSEC-2022-0104

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2393,6 +2393,7 @@ version = "0.0.1"
 dependencies = [
  "aws",
  "azure",
+ "clap 3.1.6",
  "cloud",
  "encryption",
  "file_system",
@@ -2403,7 +2404,6 @@ dependencies = [
  "rust-ini",
  "slog",
  "slog-global",
- "structopt",
  "tikv_util",
 ]
 
@@ -2663,6 +2663,7 @@ dependencies = [
  "aws",
  "azure",
  "chrono",
+ "clap 3.1.6",
  "cloud",
  "encryption",
  "fail",
@@ -2683,7 +2684,6 @@ dependencies = [
  "serde_json",
  "slog",
  "slog-global",
- "structopt",
  "tempfile",
  "tikv_alloc",
  "tikv_util",
@@ -3028,9 +3028,9 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "cargo_metadata",
+ "clap 3.1.6",
  "lazy_static",
  "regex",
- "structopt",
 ]
 
 [[package]]
@@ -7660,30 +7660,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
-name = "structopt"
-version = "0.3.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "126d630294ec449fae0b16f964e35bf3c74f940da9dca17ee9b905f7b3112eb8"
-dependencies = [
- "clap 2.33.0",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65e51c492f9e23a220534971ff5afc14037289de430e3c83f9daf6a1b6ae91e8"
-dependencies = [
- "heck 0.3.1",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.103",
-]
-
-[[package]]
 name = "strum"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8625,7 +8601,7 @@ dependencies = [
  "api_version",
  "base64 0.13.0",
  "cc",
- "clap 2.33.0",
+ "clap 3.1.6",
  "collections",
  "compact-log-backup",
  "crypto",
@@ -8654,7 +8630,6 @@ dependencies = [
  "server",
  "slog",
  "slog-global",
- "structopt",
  "tempfile",
  "tikv",
  "tikv_util",

--- a/cmd/tikv-ctl/Cargo.toml
+++ b/cmd/tikv-ctl/Cargo.toml
@@ -37,7 +37,7 @@ nortcheck = ["engine_rocks/nortcheck"]
 [dependencies]
 api_version = { workspace = true }
 base64 = "0.13.0"
-clap = { workspace = true }
+clap = { version = "3.1.6", default-features = false, features = ["std", "cargo", "derive", "suggestions"] }
 collections = { workspace = true }
 compact-log-backup = { workspace = true }
 crypto = { workspace = true }
@@ -66,7 +66,6 @@ serde_json = "1.0"
 server = { workspace = true }
 slog = { workspace = true }
 slog-global = { workspace = true }
-structopt = "0.3"
 tempfile = "3.0"
 tikv = { workspace = true }
 tikv_util = { workspace = true }

--- a/cmd/tikv-ctl/src/cmd.rs
+++ b/cmd/tikv-ctl/src/cmd.rs
@@ -1,128 +1,130 @@
 // Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::{borrow::ToOwned, str, string::ToString, sync::LazyLock};
+use std::{borrow::ToOwned, str, sync::LazyLock};
 
-use clap::{AppSettings, crate_authors};
+use clap::{Parser, Subcommand, crate_authors};
 use compact_log_backup::ShardConfig;
 use engine_traits::{CF_DEFAULT, SstCompressionType};
 use raft_engine::ReadableSize;
-use structopt::StructOpt;
-
 const RAW_KEY_HINT: &str = "Raw key (generally starts with \"z\") in escaped form";
 static VERSION_INFO: LazyLock<String> = LazyLock::new(|| {
     let build_timestamp = option_env!("TIKV_BUILD_TIME");
     tikv::tikv_version_info(build_timestamp)
 });
 
-#[derive(StructOpt)]
-#[structopt(
+#[derive(Parser)]
+#[clap(
     name = "TiKV Control (tikv-ctl)",
     about = "A tool for interacting with TiKV deployments.",
     author = crate_authors!(),
     version = &**VERSION_INFO,
     long_version = &**VERSION_INFO,
-    setting = AppSettings::DontCollapseArgsInUsage,
+    dont_collapse_args_in_usage = true,
 )]
 pub struct Opt {
-    #[structopt(long)]
+    #[clap(long)]
     /// Set the address of pd
     pub pd: Option<String>,
 
-    #[structopt(long, default_value = "warn")]
+    #[clap(long, default_value = "warn")]
     /// Set the log level
     pub log_level: String,
 
-    #[structopt(long, default_value = "text")]
+    #[clap(long, default_value = "text")]
     pub log_format: String,
 
-    #[structopt(long)]
+    #[clap(long)]
     /// Set the remote host
     pub host: Option<String>,
 
-    #[structopt(long)]
+    #[clap(long)]
     /// Set the CA certificate path
     pub ca_path: Option<String>,
 
-    #[structopt(long)]
+    #[clap(long)]
     /// Set the certificate path
     pub cert_path: Option<String>,
 
-    #[structopt(long)]
+    #[clap(long)]
     /// Set the private key path
     pub key_path: Option<String>,
 
-    #[structopt(long)]
+    #[clap(long)]
     /// TiKV config path, by default it's <deploy-dir>/conf/tikv.toml
     pub config: Option<String>,
 
-    #[structopt(long)]
+    #[clap(long)]
     /// TiKV data-dir, check <deploy-dir>/scripts/run.sh to get it
     pub data_dir: Option<String>,
 
-    #[structopt(long)]
+    #[clap(long)]
     /// Skip paranoid checks when open rocksdb
     pub skip_paranoid_checks: bool,
 
     #[allow(dead_code)]
-    #[structopt(
+    #[clap(
         long,
-        validator = |_| Err("DEPRECATED!!! Use --data-dir and --config instead".to_owned()),
+        validator = |_: &str| -> Result<(), String> {
+            Err("DEPRECATED!!! Use --data-dir and --config instead".to_owned())
+        },
     )]
     /// Set the rocksdb path
     pub db: Option<String>,
 
     #[allow(dead_code)]
-    #[structopt(
+    #[clap(
         long,
-        validator = |_| Err("DEPRECATED!!! Use --data-dir and --config instead".to_owned()),
+        validator = |_: &str| -> Result<(), String> {
+            Err("DEPRECATED!!! Use --data-dir and --config instead".to_owned())
+        },
     )]
     /// Set the raft rocksdb path
     pub raftdb: Option<String>,
 
-    #[structopt(conflicts_with = "escaped-to-hex", long = "to-escaped")]
+    #[clap(conflicts_with = "escaped-to-hex", long = "to-escaped")]
     /// Convert a hex key to escaped key
     pub hex_to_escaped: Option<String>,
 
-    #[structopt(conflicts_with = "hex-to-escaped", long = "to-hex")]
+    #[clap(conflicts_with = "hex-to-escaped", long = "to-hex")]
     /// Convert an escaped key to hex key
     pub escaped_to_hex: Option<String>,
 
-    #[structopt(
+    #[clap(
         conflicts_with_all = &["hex-to-escaped", "escaped-to-hex"],
         long,
     )]
     /// Decode a key in escaped format
     pub decode: Option<String>,
 
-    #[structopt(
+    #[clap(
         conflicts_with_all = &["hex-to-escaped", "escaped-to-hex"],
         long,
     )]
     /// Encode a key in escaped format
     pub encode: Option<String>,
 
-    #[structopt(subcommand)]
+    #[clap(subcommand)]
     pub cmd: Option<Cmd>,
 }
 
-#[derive(StructOpt)]
+#[derive(Subcommand)]
 pub enum Cmd {
     /// Print a raft log entry
     Raft {
-        #[structopt(subcommand)]
+        #[clap(subcommand)]
         cmd: RaftCmd,
     },
     /// Print region size
     Size {
-        #[structopt(short = "r")]
+        #[clap(short = 'r')]
         /// Set the region id, if not specified, print all regions
         region: Option<u64>,
 
-        #[structopt(
-            short = "c",
-            use_delimiter = true,
-            require_delimiter = true,
-            value_delimiter = ",",
+        #[clap(
+            short = 'c',
+            use_value_delimiter = true,
+            require_value_delimiter = true,
+            value_delimiter = ',',
             default_value = "default,write,lock"
         )]
         /// Set the cf name, if not specified, print all cf
@@ -130,37 +132,37 @@ pub enum Cmd {
     },
     /// Print the range db range
     Scan {
-        #[structopt(
-            short = "f",
+        #[clap(
+            short = 'f',
             long,
             help = RAW_KEY_HINT,
         )]
         from: String,
 
-        #[structopt(
-            short = "t",
+        #[clap(
+            short = 't',
             long,
             help = RAW_KEY_HINT,
         )]
         to: Option<String>,
 
-        #[structopt(long)]
+        #[clap(long)]
         /// Set the scan limit
         limit: Option<u64>,
 
-        #[structopt(long)]
+        #[clap(long)]
         /// Set the scan start_ts as filter
         start_ts: Option<u64>,
 
-        #[structopt(long)]
+        #[clap(long)]
         /// Set the scan commit_ts as filter
         commit_ts: Option<u64>,
 
-        #[structopt(
+        #[clap(
             long,
-            use_delimiter = true,
-            require_delimiter = true,
-            value_delimiter = ",",
+            use_value_delimiter = true,
+            require_value_delimiter = true,
+            value_delimiter = ',',
             default_value = CF_DEFAULT,
         )]
         /// Column family names, combined from default/lock/write
@@ -168,27 +170,27 @@ pub enum Cmd {
     },
     /// Print all raw keys in the range
     RawScan {
-        #[structopt(
-            short = "f",
+        #[clap(
+            short = 'f',
             long,
             default_value = "",
             help = RAW_KEY_HINT,
         )]
         from: String,
 
-        #[structopt(
-            short = "t",
+        #[clap(
+            short = 't',
             long,
             default_value = "",
             help = RAW_KEY_HINT,
         )]
         to: String,
 
-        #[structopt(long, default_value = "30")]
+        #[clap(long, default_value = "30")]
         /// Limit the number of keys to scan
         limit: usize,
 
-        #[structopt(
+        #[clap(
             long,
             default_value = "default",
             possible_values = &["default", "lock", "write"],
@@ -198,71 +200,73 @@ pub enum Cmd {
     },
     /// Print the raw value
     Print {
-        #[structopt(
-            short = "c",
+        #[clap(
+            short = 'c',
             default_value = CF_DEFAULT,
             possible_values = &["default", "lock", "write"],
         )]
         /// The column family name.
         cf: String,
 
-        #[structopt(
-            short = "k",
+        #[clap(
+            short = 'k',
             help = RAW_KEY_HINT,
         )]
         key: String,
     },
     /// Print the mvcc value
     Mvcc {
-        #[structopt(
-            short = "k",
+        #[clap(
+            short = 'k',
             help = RAW_KEY_HINT,
         )]
         key: String,
 
-        #[structopt(
+        #[clap(
             long,
-            use_delimiter = true,
-            require_delimiter = true,
-            value_delimiter = ",",
+            use_value_delimiter = true,
+            require_value_delimiter = true,
+            value_delimiter = ',',
             default_value = CF_DEFAULT,
         )]
         /// Column family names, combined from default/lock/write
         show_cf: Vec<String>,
 
-        #[structopt(long)]
+        #[clap(long)]
         /// Set start_ts as filter
         start_ts: Option<u64>,
 
-        #[structopt(long)]
+        #[clap(long)]
         /// Set commit_ts as filter
         commit_ts: Option<u64>,
     },
     /// Calculate difference of region keys from different dbs
     Diff {
-        #[structopt(short = "r")]
+        #[clap(short = 'r')]
         /// Specify region id
         region: u64,
 
         #[allow(dead_code)]
-        #[structopt(
+        #[clap(
             conflicts_with = "to_host",
             long,
-            validator = |_| Err("DEPRECATED!!! Use --to-data-dir and --to-config instead".to_owned()),
+            validator = |_: &str| -> Result<(), String> {
+                Err("DEPRECATED!!! Use --to-data-dir and --to-config instead".to_owned())
+            },
         )]
         /// To which db path
         to_db: Option<String>,
 
-        #[structopt(conflicts_with = "to_host", long)]
+        #[clap(conflicts_with = "to_host", long)]
         /// data-dir of the target TiKV
         to_data_dir: Option<String>,
 
-        #[structopt(conflicts_with = "to_host", long)]
+        #[clap(conflicts_with = "to_host", long)]
         /// config of the target TiKV
         to_config: Option<String>,
 
-        #[structopt(
-            required_unless = "to_data_dir",
+        #[clap(
+            required_unless_present = "to_data_dir",
             conflicts_with = "to_db",
             long,
             conflicts_with = "to_db"
@@ -272,46 +276,46 @@ pub enum Cmd {
     },
     /// Compact a column family in a specified range
     Compact {
-        #[structopt(
-            short = "d",
+        #[clap(
+            short = 'd',
             default_value = "kv",
             possible_values = &["kv", "raft"],
         )]
         /// Which db to compact
         db: String,
 
-        #[structopt(
-            short = "c",
+        #[clap(
+            short = 'c',
             default_value = CF_DEFAULT,
             possible_values = &["default", "lock", "write"],
         )]
         /// The column family name.
         cf: String,
 
-        #[structopt(
-            short = "f",
+        #[clap(
+            short = 'f',
             long,
             help = RAW_KEY_HINT,
         )]
         from: Option<String>,
 
-        #[structopt(
-            short = "t",
+        #[clap(
+            short = 't',
             long,
             help = RAW_KEY_HINT,
         )]
         to: Option<String>,
 
-        #[structopt(short = "n", long, default_value = "8")]
+        #[clap(short = 'n', long, default_value = "8")]
         /// Number of threads in one compaction
         threads: u32,
 
-        #[structopt(short = "r", long)]
+        #[clap(short = 'r', long)]
         /// Set the region id
         region: Option<u64>,
 
-        #[structopt(
-            short = "b",
+        #[clap(
+            short = 'b',
             long,
             default_value = "default",
             possible_values = &["skip", "force", "default"],
@@ -321,92 +325,92 @@ pub enum Cmd {
     },
     /// Set some regions on the node to tombstone by manual
     Tombstone {
-        #[structopt(
-            short = "r",
-            use_delimiter = true,
-            require_delimiter = true,
-            value_delimiter = ","
+        #[clap(
+            short = 'r',
+            use_value_delimiter = true,
+            require_value_delimiter = true,
+            value_delimiter = ','
         )]
         /// The target regions, separated with commas if multiple
         regions: Vec<u64>,
 
-        #[structopt(
-            short = "p",
-            use_delimiter = true,
-            require_delimiter = true,
-            value_delimiter = ","
+        #[clap(
+            short = 'p',
+            use_value_delimiter = true,
+            require_value_delimiter = true,
+            value_delimiter = ','
         )]
         /// PD endpoints
         pd: Option<Vec<String>>,
 
-        #[structopt(long)]
+        #[clap(long)]
         /// force execute without pd
         force: bool,
     },
     /// Recover mvcc data on one node by deleting corrupted keys
     RecoverMvcc {
-        #[structopt(short = "a", long)]
+        #[clap(short = 'a', long)]
         /// Recover the whole db
         all: bool,
 
-        #[structopt(
-            required_unless = "all",
+        #[clap(
+            required_unless_present = "all",
             conflicts_with = "all",
-            short = "r",
-            use_delimiter = true,
-            require_delimiter = true,
-            value_delimiter = ","
+            short = 'r',
+            use_value_delimiter = true,
+            require_value_delimiter = true,
+            value_delimiter = ','
         )]
         /// The target regions, separated with commas if multiple
         regions: Vec<u64>,
 
-        #[structopt(
-            required_unless = "all",
-            short = "p",
-            use_delimiter = true,
-            require_delimiter = true,
-            value_delimiter = ","
+        #[clap(
+            required_unless_present = "all",
+            short = 'p',
+            use_value_delimiter = true,
+            require_value_delimiter = true,
+            value_delimiter = ','
         )]
         /// PD endpoints
         pd: Vec<String>,
 
-        #[structopt(long, default_value_if("all", None, "4"), requires = "all")]
+        #[clap(long, default_value_if("all", None, Some("4")), requires = "all")]
         /// The number of threads to do recover, only for --all mode
         threads: Option<usize>,
 
-        #[structopt(short = "R", long)]
+        #[clap(short = 'R', long)]
         /// Skip write RocksDB
         read_only: bool,
     },
     /// Unsafely recover when the store can not start normally, this recover may
     /// lose data
     UnsafeRecover {
-        #[structopt(subcommand)]
+        #[clap(subcommand)]
         cmd: UnsafeRecoverCmd,
     },
     /// Recreate a region with given metadata, but alloc new id for it
     RecreateRegion {
-        #[structopt(
-            short = "p",
-            use_delimiter = true,
-            require_delimiter = true,
-            value_delimiter = ","
+        #[clap(
+            short = 'p',
+            use_value_delimiter = true,
+            require_value_delimiter = true,
+            value_delimiter = ','
         )]
         /// PD endpoints
         pd: Vec<String>,
 
-        #[structopt(short = "r")]
+        #[clap(short = 'r')]
         /// The origin region id
         region: u64,
     },
     /// Print the metrics
     Metrics {
-        #[structopt(
-            short = "t",
+        #[clap(
+            short = 't',
             long,
-            use_delimiter = true,
-            require_delimiter = true,
-            value_delimiter = ",",
+            use_value_delimiter = true,
+            require_value_delimiter = true,
+            value_delimiter = ',',
             default_value = crate::executor::METRICS_PROMETHEUS,
             possible_values = &["prometheus", "jemalloc", "rocksdb_raft", "rocksdb_kv"],
         )]
@@ -417,7 +421,7 @@ pub enum Cmd {
     },
     /// Force a consistency-check for a specified region
     ConsistencyCheck {
-        #[structopt(short = "r")]
+        #[clap(short = 'r')]
         /// The target region
         region: u64,
     },
@@ -427,37 +431,37 @@ pub enum Cmd {
     /// Eg. tikv-ctl --host ip:port modify-tikv-config -n
     /// rocksdb.defaultcf.disable-auto-compactions -v true
     ModifyTikvConfig {
-        #[structopt(short = "n")]
+        #[clap(short = 'n')]
         /// The config name are same as the name used on config file.
         /// eg. raftstore.messages-per-tick, raftdb.max-background-jobs
         config_name: String,
 
-        #[structopt(short = "v")]
+        #[clap(short = 'v')]
         /// The config value, eg. 8, true, 1h, 8MB
         config_value: String,
     },
     /// Dump snapshot meta file
     DumpSnapMeta {
-        #[structopt(short = "f", long)]
+        #[clap(short = 'f', long)]
         /// Output meta file path
         file: String,
     },
     /// Compact the whole cluster in a specified range in one or more column
     /// families
     CompactCluster {
-        #[structopt(
-            short = "d",
+        #[clap(
+            short = 'd',
             default_value = "kv",
             possible_values = &["kv", "raft"],
         )]
         /// The db to use
         db: String,
 
-        #[structopt(
-            short = "c",
-            use_delimiter = true,
-            require_delimiter = true,
-            value_delimiter = ",",
+        #[clap(
+            short = 'c',
+            use_value_delimiter = true,
+            require_value_delimiter = true,
+            value_delimiter = ',',
             default_value = CF_DEFAULT,
             possible_values = &["default", "lock", "write"],
         )]
@@ -465,26 +469,26 @@ pub enum Cmd {
         /// raft db, can only be default
         cf: Vec<String>,
 
-        #[structopt(
-            short = "f",
+        #[clap(
+            short = 'f',
             long,
             help = RAW_KEY_HINT,
         )]
         from: Option<String>,
 
-        #[structopt(
-            short = "t",
+        #[clap(
+            short = 't',
             long,
             help = RAW_KEY_HINT,
         )]
         to: Option<String>,
 
-        #[structopt(short = "n", long, default_value = "8")]
+        #[clap(short = 'n', long, default_value = "8")]
         /// Number of threads in one compaction
         threads: u32,
 
-        #[structopt(
-            short = "b",
+        #[clap(
+            short = 'b',
             long,
             default_value = "default",
             possible_values = &["skip", "force", "default"],
@@ -494,33 +498,33 @@ pub enum Cmd {
     },
     /// Show region properties
     RegionProperties {
-        #[structopt(short = "r")]
+        #[clap(short = 'r')]
         /// The target region id
         region: u64,
     },
     /// Show range properties
     RangeProperties {
-        #[structopt(long, default_value = "")]
+        #[clap(long, default_value = "")]
         /// hex start key (not starts with "z")
         start: String,
 
-        #[structopt(long, default_value = "")]
+        #[clap(long, default_value = "")]
         /// hex end key (not starts with "z")
         end: String,
     },
     /// Split the region
     SplitRegion {
-        #[structopt(short = "r")]
+        #[clap(short = 'r')]
         /// The target region id
         region: u64,
 
-        #[structopt(short = "k")]
+        #[clap(short = 'k')]
         /// The key to split it, in unencoded escaped format
         key: String,
     },
     /// Inject failures to TiKV and recovery
     Fail {
-        #[structopt(subcommand)]
+        #[clap(subcommand)]
         cmd: FailCmd,
     },
     /// Print the store id and api version
@@ -529,17 +533,17 @@ pub enum Cmd {
     Cluster {},
     /// Decrypt an encrypted file
     DecryptFile {
-        #[structopt(long)]
+        #[clap(long)]
         /// input file path
         file: String,
 
-        #[structopt(long)]
+        #[clap(long)]
         /// output file path
         out_file: String,
     },
     /// Dump encryption metadata
     EncryptionMeta {
-        #[structopt(subcommand)]
+        #[clap(subcommand)]
         cmd: EncryptionMetaCmd,
     },
     /// Delete encryption keys that are no longer associated with physical
@@ -547,33 +551,33 @@ pub enum Cmd {
     CleanupEncryptionMeta {},
     /// Print bad ssts related infos
     BadSsts {
-        #[structopt(long)]
+        #[clap(long)]
         /// specify manifest, if not set, it will look up manifest file in db
         /// path
         manifest: Option<String>,
 
-        #[structopt(long, value_delimiter = ",")]
+        #[clap(long, value_delimiter = ',')]
         /// PD endpoints
         pd: String,
     },
     /// Reset data in a TiKV to a certain version
     ResetToVersion {
-        #[structopt(short = "v")]
+        #[clap(short = 'v')]
         /// The version to reset TiKV to
         version: u64,
     },
     /// Control for Raft Engine
     /// Usage: tikv-ctl raft-engine-ctl -- --help
     RaftEngineCtl {
-        #[structopt(last = true)]
+        #[clap(last = true)]
         args: Vec<String>,
     },
-    #[structopt(external_subcommand)]
+    #[clap(external_subcommand)]
     External(Vec<String>),
     /// Usage: tikv-ctl show-cluster-id --config <config-path>
     ShowClusterId {
         /// Data directory path of the given TiKV instance.
-        #[structopt(long)]
+        #[clap(long)]
         data_dir: String,
     },
     /// Usage: tikv-ctl fork-readonly-tikv
@@ -586,15 +590,15 @@ pub enum Cmd {
     /// NOTE: The remained TiKV can't run concurrently with the agent.
     ReuseReadonlyRemains {
         /// Data directory path of the remained TiKV.
-        #[structopt(long)]
+        #[clap(long)]
         data_dir: String,
 
         /// Data directory to create the agent.
-        #[structopt(long)]
+        #[clap(long)]
         agent_dir: String,
 
         /// Reuse snapshot files of the remained TiKV: symlink or copy.
-        #[structopt(long, default_value = "symlink")]
+        #[clap(long, default_value = "symlink")]
         snaps: String,
 
         /// Reuse rocksdb files of the remained TiKV: symlink or copy.
@@ -602,7 +606,7 @@ pub enum Cmd {
         /// NOTE: the last one WAL file will still be copied even if `symlink`
         /// is specified, because the last one WAL file isn't read-only when
         /// opening a RocksDB instance.
-        #[structopt(long, default_value = "symlink")]
+        #[clap(long, default_value = "symlink")]
         rocksdb_files: String,
     },
     /// flashback data in cluster to a certain version
@@ -610,30 +614,30 @@ pub enum Cmd {
     /// NOTE: Should use `./pd-ctl config set halt-scheduling true` to halt PD
     /// scheduling before flashback.
     Flashback {
-        #[structopt(short = "v")]
+        #[clap(short = 'v')]
         /// the version to flashback
         version: u64,
 
-        #[structopt(
-            short = "r",
+        #[clap(
+            short = 'r',
             aliases = &["region"],
-            use_delimiter = true,
-            require_delimiter = true,
-            value_delimiter = ","
+            use_value_delimiter = true,
+            require_value_delimiter = true,
+            value_delimiter = ','
         )]
         /// specific regions to flashback
         regions: Option<Vec<u64>>,
 
-        #[structopt(long, default_value = "")]
+        #[clap(long, default_value = "")]
         /// hex start key
         start: String,
 
-        #[structopt(long, default_value = "")]
+        #[clap(long, default_value = "")]
         /// hex end key
         end: String,
     },
     CompactLogBackup {
-        #[structopt(
+        #[clap(
             short,
             long,
             default_value = "compaction",
@@ -642,7 +646,7 @@ pub enum Cmd {
             )
         )]
         name: String,
-        #[structopt(
+        #[clap(
             long,
             value_name = "INDEX/TOTAL",
             help(
@@ -656,7 +660,7 @@ pub enum Cmd {
             )
         )]
         shard: Option<ShardConfig>,
-        #[structopt(
+        #[clap(
             long = "from",
             help(
                 "from when we need to include files into the compaction.\
@@ -664,7 +668,7 @@ pub enum Cmd {
             )
         )]
         from_ts: u64,
-        #[structopt(
+        #[clap(
             long = "until",
             help(
                 "optional upper timestamp bound for selecting files into the compaction. \
@@ -673,7 +677,7 @@ pub enum Cmd {
             )
         )]
         until_ts: Option<u64>,
-        #[structopt(
+        #[clap(
             long = "cal-shift-ts",
             help(
                 "extend the default CF scan lower bound to the minimum min_begin_default_ts in \
@@ -681,15 +685,15 @@ pub enum Cmd {
             )
         )]
         cal_shift_ts: bool,
-        #[structopt(
-            short = "N",
+        #[clap(
+            short = 'N',
             long = "concurrency",
             default_value = "32",
             help("how many compactions can be executed concurrently.")
         )]
         max_concurrent_compactions: u64,
-        #[structopt(
-            short = "s",
+        #[clap(
+            short = 's',
             long = "storage-base64",
             help(
                 "the base-64 encoded protocol buffer message `StorageBackend`. \
@@ -697,7 +701,7 @@ pub enum Cmd {
             )
         )]
         storage_base64: String,
-        #[structopt(
+        #[clap(
             long,
             default_value = "lz4",
             help(
@@ -705,7 +709,7 @@ pub enum Cmd {
             )
         )]
         compression: SstCompressionType,
-        #[structopt(
+        #[clap(
             long,
             help(
                 "the compression level. it definition and effect varies by the algorithm we choose."
@@ -713,7 +717,7 @@ pub enum Cmd {
         )]
         compression_level: Option<i32>,
 
-        #[structopt(
+        #[clap(
             long,
             help(
                 "deprecated stub; no longer supported. use a different --name or manually clean the target compaction prefix instead."
@@ -721,7 +725,7 @@ pub enum Cmd {
         )]
         force_regenerate: bool,
 
-        #[structopt(
+        #[clap(
             long,
             default_value = "16M",
             help(
@@ -730,21 +734,21 @@ pub enum Cmd {
         )]
         minimal_compaction_size: ReadableSize,
 
-        #[structopt(
+        #[clap(
             long,
             default_value = "128",
             help("specify the maximum count of running tasks to download a metadata")
         )]
         prefetch_running_count: u64,
 
-        #[structopt(
+        #[clap(
             long,
             default_value = "1024",
             help("specify the maximum count of spawning tasks to download a metadata")
         )]
         prefetch_buffer_count: u64,
 
-        #[structopt(
+        #[clap(
             long,
             default_value = "0",
             help(
@@ -754,7 +758,7 @@ pub enum Cmd {
         )]
         physical_file_cache_capacity: ReadableSize,
 
-        #[structopt(
+        #[clap(
             long = "gcp-v2-enable",
             parse(try_from_str),
             default_value = "true",
@@ -765,17 +769,17 @@ pub enum Cmd {
     },
     /// Get the state of a region's RegionReadProgress.
     GetRegionReadProgress {
-        #[structopt(short = "r", long)]
+        #[clap(short = 'r', long)]
         /// The target region id
         region: u64,
 
-        #[structopt(long)]
+        #[clap(long)]
         /// When specified, prints the locks associated with the transaction
         /// that has the smallest 'start_ts' in the resolver, which is
         /// preventing the 'resolved_ts' from advancing.
         log: bool,
 
-        #[structopt(long, requires = "log")]
+        #[clap(long, requires = "log")]
         /// The smallest start_ts of the target transaction. Namely, only the
         /// transaction whose start_ts is greater than or equal to this value
         /// can be recorded in TiKV logs.
@@ -783,37 +787,37 @@ pub enum Cmd {
     },
 }
 
-#[derive(StructOpt)]
+#[derive(Subcommand)]
 pub enum RaftCmd {
     /// Print the raft log entry info
     Log {
-        #[structopt(required_unless = "key", conflicts_with = "key", short = "r")]
+        #[clap(required_unless_present = "key", conflicts_with = "key", short = 'r')]
         /// Set the region id
         region: Option<u64>,
 
-        #[structopt(required_unless = "key", conflicts_with = "key", short = "i")]
+        #[clap(required_unless_present = "key", conflicts_with = "key", short = 'i')]
         /// Set the raft log index
         index: Option<u64>,
 
-        #[structopt(
-            required_unless_one = &["region", "index"],
+        #[clap(
+            required_unless_present_any = &["region", "index"],
             conflicts_with_all = &["region", "index"],
-            short = "k",
+            short = 'k',
             help = RAW_KEY_HINT,
         )]
         key: Option<String>,
-        #[structopt(short = "b")]
+        #[clap(short = 'b')]
         binary: bool,
     },
     /// print region info
     Region {
-        #[structopt(
-            short = "r",
+        #[clap(
+            short = 'r',
             aliases = &["region"],
             conflicts_with = "all-regions",
-            use_delimiter = true,
-            require_delimiter = true,
-            value_delimiter = ","
+            use_value_delimiter = true,
+            require_value_delimiter = true,
+            value_delimiter = ','
         )]
         /// Print info for these regions
         regions: Option<Vec<u64>>,
@@ -821,29 +825,29 @@ pub enum RaftCmd {
         // `regions` must be None when `all_regions` is present,
         // so we left `all_regions` unused.
         #[allow(dead_code)]
-        #[structopt(long, conflicts_with = "regions")]
+        #[clap(long, conflicts_with = "regions")]
         /// Print info for all regions
         all_regions: bool,
 
-        #[structopt(long, default_value = "")]
+        #[clap(long, default_value = "")]
         /// hex start key
         start: String,
 
-        #[structopt(long, default_value = "")]
+        #[clap(long, default_value = "")]
         /// hex end key
         end: String,
 
-        #[structopt(long, default_value = "16")]
+        #[clap(long, default_value = "16")]
         /// Limit the number of keys to scan
         limit: usize,
 
-        #[structopt(long)]
+        #[clap(long)]
         /// Skip tombstone regions
         skip_tombstone: bool,
     },
 }
 
-#[derive(StructOpt)]
+#[derive(Subcommand)]
 pub enum FailCmd {
     /// Inject failures
     Inject {
@@ -851,7 +855,7 @@ pub enum FailCmd {
         /// E.g. tikv-ctl fail inject a=off b=panic
         args: Vec<String>,
 
-        #[structopt(short = "f")]
+        #[clap(short = 'f')]
         /// Read a file of fail points and actions to inject
         file: Option<String>,
     },
@@ -860,7 +864,7 @@ pub enum FailCmd {
         /// Recover fail points. Eg. tikv-ctl fail recover a b
         args: Vec<String>,
 
-        #[structopt(short = "f")]
+        #[clap(short = 'f')]
         /// Recover from a file of fail points
         file: Option<String>,
     },
@@ -868,66 +872,66 @@ pub enum FailCmd {
     List {},
 }
 
-#[derive(StructOpt)]
+#[derive(Subcommand)]
 pub enum EncryptionMetaCmd {
     /// Dump data keys
     DumpKey {
-        #[structopt(long, use_delimiter = true)]
+        #[clap(long, use_value_delimiter = true)]
         /// List of data key ids. Dump all keys if not provided.
         ids: Option<Vec<u64>>,
     },
     /// Dump file encryption info
     DumpFile {
-        #[structopt(long)]
+        #[clap(long)]
         /// Path to the file. Dump for all files if not provided.
         path: Option<String>,
     },
 }
 
-#[derive(StructOpt)]
+#[derive(Subcommand)]
 pub enum UnsafeRecoverCmd {
     /// Remove the failed machines from the peer list for the regions
     RemoveFailStores {
-        #[structopt(
-            short = "s",
-            use_delimiter = true,
-            require_delimiter = true,
-            value_delimiter = ","
+        #[clap(
+            short = 's',
+            use_value_delimiter = true,
+            require_value_delimiter = true,
+            value_delimiter = ','
         )]
         /// Stores to be removed
         stores: Vec<u64>,
 
-        #[structopt(
-            required_unless = "all-regions",
+        #[clap(
+            required_unless_present = "all-regions",
             conflicts_with = "all-regions",
-            short = "r",
-            use_delimiter = true,
-            require_delimiter = true,
-            value_delimiter = ","
+            short = 'r',
+            use_value_delimiter = true,
+            require_value_delimiter = true,
+            value_delimiter = ','
         )]
         /// Only for these regions
         regions: Option<Vec<u64>>,
 
-        #[structopt(long)]
+        #[clap(long)]
         /// Promote learner to voter
         promote_learner: bool,
 
         // `regions` must be None when `all_regions` is present,
         // so we left `all_regions` unused.
         #[allow(dead_code)]
-        #[structopt(required_unless = "regions", conflicts_with = "regions", long)]
+        #[clap(required_unless_present = "regions", conflicts_with = "regions", long)]
         /// Do the command for all regions
         all_regions: bool,
     },
     /// Remove unapplied raftlogs on the regions
     DropUnappliedRaftlog {
-        #[structopt(
-            required_unless = "all-regions",
+        #[clap(
+            required_unless_present = "all-regions",
             conflicts_with = "all-regions",
-            short = "r",
-            use_delimiter = true,
-            require_delimiter = true,
-            value_delimiter = ","
+            short = 'r',
+            use_value_delimiter = true,
+            require_value_delimiter = true,
+            value_delimiter = ','
         )]
         /// Only for these regions
         regions: Option<Vec<u64>>,
@@ -935,7 +939,7 @@ pub enum UnsafeRecoverCmd {
         // `regions` must be None when `all_regions` is present,
         // so we left `all_regions` unused.
         #[allow(dead_code)]
-        #[structopt(required_unless = "regions", conflicts_with = "regions", long)]
+        #[clap(required_unless_present = "regions", conflicts_with = "regions", long)]
         /// Do the command for all regions
         all_regions: bool,
     },
@@ -943,13 +947,13 @@ pub enum UnsafeRecoverCmd {
 
 #[cfg(test)]
 mod tests {
-    use structopt::StructOpt;
+    use clap::Parser;
 
     use super::{Cmd, Opt};
 
     #[test]
     fn compact_log_backup_gcp_v2_enable_default_true() {
-        let opt = Opt::from_iter_safe([
+        let opt = Opt::try_parse_from([
             "tikv-ctl",
             "compact-log-backup",
             "--from",
@@ -969,7 +973,7 @@ mod tests {
 
     #[test]
     fn compact_log_backup_gcp_v2_enable_false() {
-        let opt = Opt::from_iter_safe([
+        let opt = Opt::try_parse_from([
             "tikv-ctl",
             "compact-log-backup",
             "--from",
@@ -991,7 +995,7 @@ mod tests {
 
     #[test]
     fn compact_log_backup_cal_shift_ts_flag() {
-        let opt = Opt::from_iter_safe([
+        let opt = Opt::try_parse_from([
             "tikv-ctl",
             "compact-log-backup",
             "--from",
@@ -1012,7 +1016,7 @@ mod tests {
 
     #[test]
     fn compact_log_backup_allows_omitting_until() {
-        let opt = Opt::from_iter_safe([
+        let opt = Opt::try_parse_from([
             "tikv-ctl",
             "compact-log-backup",
             "--from",

--- a/cmd/tikv-ctl/src/main.rs
+++ b/cmd/tikv-ctl/src/main.rs
@@ -15,6 +15,7 @@ use std::{
     time::Duration,
 };
 
+use clap::{CommandFactory, ErrorKind, Parser};
 use collections::HashMap;
 use compact_log_backup::{
     TraceResultExt,
@@ -46,7 +47,6 @@ use raft_log_engine::ManagedFileSystem;
 use raftstore::store::util::build_key_range;
 use regex::Regex;
 use security::{SecurityConfig, SecurityManager};
-use structopt::{StructOpt, clap::ErrorKind};
 use tempfile::TempDir;
 use tikv::{
     config::TikvConfig,
@@ -69,11 +69,15 @@ mod executor;
 mod fork_readonly_tikv;
 mod util;
 
+fn exit_with_clap_error(kind: ErrorKind, message: impl std::fmt::Display) -> ! {
+    clap::Error::raw(kind, message).exit()
+}
+
 fn main() {
     // OpenSSL FIPS mode should be enabled at the very start.
     fips::maybe_enable();
 
-    let opt = Opt::from_args();
+    let opt = Opt::parse();
 
     // Initialize logger.
     init_ctl_logger(&opt.log_level, &opt.log_format);
@@ -114,7 +118,7 @@ fn main() {
             } else if let Some(decoded) = opt.encode.as_deref() {
                 println!("{}", Key::from_raw(&unescape(decoded)));
             } else {
-                Opt::clap().print_help().ok();
+                Opt::command().print_help().ok();
             }
             return;
         }
@@ -126,7 +130,7 @@ fn main() {
             match args[0].as_str() {
                 "ldb" => run_ldb_command(args, &cfg),
                 "sst_dump" => run_sst_dump_command(args, &cfg),
-                _ => Opt::clap().print_help().unwrap(),
+                _ => Opt::command().print_help().unwrap(),
             }
         }
         Cmd::RaftEngineCtl { args } => {
@@ -272,20 +276,16 @@ fn main() {
         }
         Cmd::ShowClusterId { data_dir } => {
             if opt.config.is_none() {
-                clap::Error {
-                    message: String::from("(--config) must be specified"),
-                    kind: ErrorKind::MissingRequiredArgument,
-                    info: None,
-                }
-                .exit();
+                exit_with_clap_error(
+                    ErrorKind::MissingRequiredArgument,
+                    "(--config) must be specified",
+                );
             }
             if data_dir.is_empty() {
-                clap::Error {
-                    message: String::from("(--data-dir) must be specified"),
-                    kind: ErrorKind::MissingRequiredArgument,
-                    info: None,
-                }
-                .exit();
+                exit_with_clap_error(
+                    ErrorKind::MissingRequiredArgument,
+                    "(--data-dir) must be specified",
+                );
             }
             cfg.storage.data_dir = data_dir;
             // Disable auto compactions and GCs to avoid modifications.
@@ -313,65 +313,46 @@ fn main() {
             rocksdb_files,
         } => {
             if opt.config.is_none() {
-                clap::Error {
-                    message: String::from("(--config) must be specified"),
-                    kind: ErrorKind::MissingRequiredArgument,
-                    info: None,
-                }
-                .exit();
+                exit_with_clap_error(
+                    ErrorKind::MissingRequiredArgument,
+                    "(--config) must be specified",
+                );
             }
             if data_dir.is_empty() {
-                clap::Error {
-                    message: String::from("(--data-dir) must be specified"),
-                    kind: ErrorKind::MissingRequiredArgument,
-                    info: None,
-                }
-                .exit();
+                exit_with_clap_error(
+                    ErrorKind::MissingRequiredArgument,
+                    "(--data-dir) must be specified",
+                );
             }
             cfg.storage.data_dir = data_dir;
             if cfg.storage.engine == EngineType::RaftKv2 {
-                clap::Error {
-                    message: String::from("storage.engine can only be raftkv"),
-                    kind: ErrorKind::InvalidValue,
-                    info: None,
-                }
-                .exit();
+                exit_with_clap_error(ErrorKind::InvalidValue, "storage.engine can only be raftkv");
             }
             if cfg.raft_engine.config().enable_log_recycle {
-                clap::Error {
-                    message: String::from("raft-engine.enable-log-recycle can only be false"),
-                    kind: ErrorKind::InvalidValue,
-                    info: None,
-                }
-                .exit();
+                exit_with_clap_error(
+                    ErrorKind::InvalidValue,
+                    "raft-engine.enable-log-recycle can only be false",
+                );
             }
             if cfg.raft_engine.config().recovery_mode != RecoveryMode::TolerateTailCorruption {
-                clap::Error {
-                    message: String::from(
-                        "raft-engine.recovery-mode can only be tolerate-tail-corruption",
-                    ),
-                    kind: ErrorKind::InvalidValue,
-                    info: None,
-                }
-                .exit();
+                exit_with_clap_error(
+                    ErrorKind::InvalidValue,
+                    "raft-engine.recovery-mode can only be tolerate-tail-corruption",
+                );
             }
             if snaps != fork_readonly_tikv::SYMLINK && snaps != fork_readonly_tikv::COPY {
-                clap::Error {
-                    message: String::from("(--snaps) can only be symlink or copy"),
-                    kind: ErrorKind::InvalidValue,
-                    info: None,
-                }
-                .exit();
+                exit_with_clap_error(
+                    ErrorKind::InvalidValue,
+                    "(--snaps) can only be symlink or copy",
+                );
             }
             if rocksdb_files != fork_readonly_tikv::SYMLINK
                 && rocksdb_files != fork_readonly_tikv::COPY
             {
-                clap::Error {
-                    message: String::from("(--rocksdb_files) can only be symlink or copy"),
-                    kind: ErrorKind::InvalidValue,
-                    info: None,
-                }
-                .exit();
+                exit_with_clap_error(
+                    ErrorKind::InvalidValue,
+                    "(--rocksdb_files) can only be symlink or copy",
+                );
             }
             fork_readonly_tikv::run(&cfg, &agent_dir, &snaps, &rocksdb_files)
         }
@@ -423,24 +404,20 @@ fn main() {
             let external_storage = match maybe_external_storage {
                 Ok(s) => s,
                 Err(err) => {
-                    clap::Error {
-                        message: format!("(-s, --storage-base64) is invalid: {:?}", err),
-                        kind: ErrorKind::InvalidValue,
-                        info: None,
-                    }
-                    .exit();
+                    exit_with_clap_error(
+                        ErrorKind::InvalidValue,
+                        format!("(-s, --storage-base64) is invalid: {:?}", err),
+                    );
                 }
             };
             let storage =
                 match compact_log::create_storage_with_gcp_v2(&external_storage, gcp_v2_enable) {
                     Ok(storage) => storage,
                     Err(err) => {
-                        clap::Error {
-                            message: format!("failed to create external storage: {}", err),
-                            kind: ErrorKind::Io,
-                            info: None,
-                        }
-                        .exit();
+                        exit_with_clap_error(
+                            ErrorKind::Io,
+                            format!("failed to create external storage: {}", err),
+                        );
                     }
                 };
             let runtime = tokio::runtime::Builder::new_multi_thread()
@@ -462,15 +439,10 @@ fn main() {
                             until_ts
                         }
                         Err(err) => {
-                            clap::Error {
-                                message: format!(
-                                    "failed to load compact-log-backup checkpoint: {}",
-                                    err
-                                ),
-                                kind: ErrorKind::Io,
-                                info: None,
-                            }
-                            .exit();
+                            exit_with_clap_error(
+                                ErrorKind::Io,
+                                format!("failed to load compact-log-backup checkpoint: {}", err),
+                            );
                         }
                     }
                 }
@@ -490,15 +462,13 @@ fn main() {
             };
             let out_prefix = ccfg.recommended_prefix(&name);
             if force_regenerate {
-                clap::Error {
-                    message: format!(
+                exit_with_clap_error(
+                    ErrorKind::ValueValidation,
+                    format!(
                         "--force-regenerate is no longer supported. Please use a different --name to generate a new compaction prefix, or manually clean the existing prefix `{}` before rerunning.",
                         out_prefix
                     ),
-                    kind: ErrorKind::ValueValidation,
-                    info: None,
-                }
-                .exit();
+                );
             }
             let tmp_engine =
                 TemporaryRocks::new(&cfg).expect("failed to create temp engine for writing SSTs.");
@@ -574,12 +544,10 @@ fn main() {
             let host = opt.host.as_deref();
 
             if data_dir.is_none() && host.is_none() {
-                clap::Error {
-                    message: String::from("[host|data-dir] is not specified"),
-                    kind: ErrorKind::MissingRequiredArgument,
-                    info: None,
-                }
-                .exit();
+                exit_with_clap_error(
+                    ErrorKind::MissingRequiredArgument,
+                    "[host|data-dir] is not specified",
+                );
             }
 
             cfg.rocksdb.paranoid_checks = Some(!opt.skip_paranoid_checks);
@@ -910,12 +878,10 @@ fn dump_snap_meta_file(path: &str) {
 
 fn get_pd_rpc_client(pd: Option<String>, mgr: Arc<SecurityManager>) -> RpcClient {
     let pd = pd.unwrap_or_else(|| {
-        clap::Error {
-            message: String::from("--pd is required for this command"),
-            kind: ErrorKind::MissingRequiredArgument,
-            info: None,
-        }
-        .exit();
+        exit_with_clap_error(
+            ErrorKind::MissingRequiredArgument,
+            "--pd is required for this command",
+        );
     });
     let cfg = PdConfig::new(vec![pd]);
     cfg.validate().unwrap();

--- a/components/encryption/export/Cargo.toml
+++ b/components/encryption/export/Cargo.toml
@@ -28,5 +28,5 @@ slog-global = { workspace = true }
 tikv_util = { workspace = true }
 
 [dev-dependencies]
+clap = { version = "3.1.6", default-features = false, features = ["std", "derive"] }
 rust-ini = "0.14.0"
-structopt = "0.3"

--- a/components/encryption/export/examples/ecli.rs
+++ b/components/encryption/export/examples/ecli.rs
@@ -3,6 +3,7 @@
 use std::io::{Read, Write};
 
 use azure::STORAGE_VENDOR_NAME_AZURE;
+use clap::{ArgEnum, Args, Parser, Subcommand};
 use cloud::STORAGE_VENDOR_NAME_GCP;
 pub use cloud::kms::Config as CloudConfig;
 use encryption::{GcpConfig, KmsBackend};
@@ -11,88 +12,85 @@ use file_system::{File, OpenOptions};
 use ini::ini::Ini;
 use kvproto::encryptionpb::EncryptedContent;
 use protobuf::Message;
-use structopt::{StructOpt, clap::arg_enum};
 use tikv_util::box_err;
 
-arg_enum! {
-    #[derive(Debug)]
-    enum Operation {
-        Encrypt,
-        Decrypt,
-    }
+#[derive(ArgEnum, Clone, Debug)]
+enum Operation {
+    Encrypt,
+    Decrypt,
 }
 
-#[derive(StructOpt)]
-#[structopt(rename_all = "kebab-case", name = "ecli", version = "0.1")]
+#[derive(Parser)]
+#[clap(rename_all = "kebab-case", name = "ecli", version = "0.1")]
 /// An example using encryption crate to encrypt and decrypt file.
 pub struct Opt {
     /// encrypt or decrypt.
-    #[structopt(short = "p", long, possible_values = &Operation::variants(), case_insensitive = true)]
+    #[clap(short = 'p', long, arg_enum, ignore_case = true)]
     operation: Operation,
     /// File to encrypt or decrypt.
-    #[structopt(short, long)]
+    #[clap(short, long)]
     file: String,
     /// Path to save plaintext or ciphertext.
-    #[structopt(short, long)]
+    #[clap(short, long)]
     output: String,
     /// Credential file path. For KMS, use ~/.aws/credentials.
-    #[structopt(short, long)]
+    #[clap(short, long)]
     credential_file: Option<String>,
 
-    #[structopt(subcommand)]
+    #[clap(subcommand)]
     command: Command,
 }
 
-#[derive(StructOpt)]
-#[structopt(rename_all = "kebab-case")]
+#[derive(Subcommand)]
+#[clap(rename_all = "kebab-case")]
 enum Command {
     Aws(SubCommandAws),
     Azure(SubCommandAzure),
     Gcp(SubCommandGcp),
 }
 
-#[derive(StructOpt)]
-#[structopt(rename_all = "kebab-case")]
+#[derive(Args)]
+#[clap(rename_all = "kebab-case")]
 /// KMS backend.
 struct SubCommandAws {
     /// KMS key id of backend.
-    #[structopt(long)]
+    #[clap(long)]
     key_id: String,
     /// Remote endpoint
-    #[structopt(long)]
+    #[clap(long)]
     endpoint: Option<String>,
     /// Remote region.
-    #[structopt(long)]
+    #[clap(long)]
     region: Option<String>,
 }
 
-#[derive(StructOpt)]
-#[structopt(rename_all = "kebab-case")]
+#[derive(Args)]
+#[clap(rename_all = "kebab-case")]
 /// Command for KeyVault backend.
 struct SubCommandAzure {
     /// Tenant id.
-    #[structopt(long)]
+    #[clap(long)]
     tenant_id: String,
     /// Client id.
-    #[structopt(long)]
+    #[clap(long)]
     client_id: String,
     /// KMS key id of Azure backend.
-    #[structopt(long)]
+    #[clap(long)]
     key_id: String,
     /// Remote endpoint of KeyVault
-    #[structopt(long)]
+    #[clap(long)]
     url: String,
     /// Secret to access key.
-    #[structopt(short, long)]
+    #[clap(short, long)]
     secret: Option<String>,
 }
 
-#[derive(StructOpt)]
-#[structopt(rename_all = "kebab-case")]
+#[derive(Args)]
+#[clap(rename_all = "kebab-case")]
 /// KMS backend.
 struct SubCommandGcp {
     /// KMS key id of backend.
-    #[structopt(long)]
+    #[clap(long)]
     key_id: String,
 }
 
@@ -159,7 +157,7 @@ fn create_gcp_backend(
 
 #[allow(irrefutable_let_patterns)]
 fn process() -> Result<()> {
-    let opt: Opt = Opt::from_args();
+    let opt: Opt = Opt::parse();
 
     let mut file = File::open(&opt.file)?;
     let mut content = Vec::new();

--- a/components/external_storage/Cargo.toml
+++ b/components/external_storage/Cargo.toml
@@ -46,9 +46,9 @@ uuid = { version = "0.8", features = ["v4", "serde"] }
 walkdir = "2"
 
 [dev-dependencies]
+clap = { version = "3.1.6", default-features = false, features = ["std", "derive"] }
 hyper = { version = "0.14", features = ["server", "tcp"] }
 rust-ini = "0.14.0"
-structopt = "0.3"
 tempfile = "3.1"
 tokio = { version = "1.5", features = ["macros", "rt-multi-thread", "net"] }
 

--- a/components/external_storage/examples/scli.rs
+++ b/components/external_storage/examples/scli.rs
@@ -6,6 +6,7 @@ use std::{
     path::Path,
 };
 
+use clap::{ArgEnum, Parser, Subcommand};
 use external_storage::{
     ExternalStorage, UnpinReader, create_storage, make_azblob_backend, make_gcs_backend,
     make_hdfs_backend, make_local_backend, make_noop_backend, make_s3_backend,
@@ -13,59 +14,56 @@ use external_storage::{
 use futures_util::io::{AllowStdIo, copy};
 use ini::ini::Ini;
 use kvproto::brpb::{AzureBlobStorage, Gcs, S3, StorageBackend};
-use structopt::{StructOpt, clap::arg_enum};
 use tikv_util::stream::block_on_external_io;
 use tokio::runtime::Runtime;
 
-arg_enum! {
-    #[derive(Debug)]
-    enum StorageType {
-        Noop,
-        Local,
-        Hdfs,
-        S3,
-        GCS,
-        Azure,
-    }
+#[derive(ArgEnum, Clone, Debug)]
+enum StorageType {
+    Noop,
+    Local,
+    Hdfs,
+    S3,
+    Gcs,
+    Azure,
 }
 
-#[derive(StructOpt)]
-#[structopt(rename_all = "kebab-case", name = "scli", version = "0.1")]
+#[derive(Parser)]
+#[clap(rename_all = "kebab-case", name = "scli", version = "0.1")]
 /// An example using storage to save and load a file.
 pub struct Opt {
     /// Storage backend.
-    #[structopt(short, long, possible_values = &StorageType::variants(), case_insensitive = true)]
+    #[clap(short, long, arg_enum, ignore_case = true)]
     storage: StorageType,
     /// Local file to load from or save to.
-    #[structopt(short, long)]
+    #[clap(short, long)]
     file: String,
     /// Remote name of the file to load from or save to.
-    #[structopt(short, long)]
+    #[clap(short, long)]
     name: String,
     /// Path to use for local storage.
-    #[structopt(short, long)]
+    #[clap(short, long)]
     path: Option<String>,
     /// Credential file path. For S3, use ~/.aws/credentials.
-    #[structopt(short, long)]
+    #[clap(short, long)]
     credential_file: Option<String>,
     /// Remote endpoint
-    #[structopt(short, long)]
+    #[clap(short, long)]
     endpoint: Option<String>,
     /// Remote region.
-    #[structopt(short, long)]
+    #[clap(short, long)]
     region: Option<String>,
     /// Remote bucket name.
-    #[structopt(short, long)]
+    #[clap(short, long)]
     bucket: Option<String>,
     /// Remote path prefix
-    #[structopt(short = "x", long)]
+    #[clap(short = 'x', long)]
     prefix: Option<String>,
-    #[structopt(subcommand)]
+    #[clap(subcommand)]
     command: Command,
 }
 
-#[derive(StructOpt)]
-#[structopt(rename_all = "kebab-case")]
+#[derive(Subcommand)]
+#[clap(rename_all = "kebab-case")]
 enum Command {
     /// Save file to storage.
     Save,
@@ -164,14 +162,14 @@ fn create_azure_storage(opt: &Opt) -> Result<StorageBackend> {
 }
 
 fn process() -> Result<()> {
-    let opt = Opt::from_args();
+    let opt = Opt::parse();
     let storage: Box<dyn ExternalStorage> = create_storage(
         &(match opt.storage {
             StorageType::Noop => make_noop_backend(),
             StorageType::Local => make_local_backend(Path::new(&opt.path.unwrap())),
             StorageType::Hdfs => make_hdfs_backend(opt.path.unwrap()),
             StorageType::S3 => create_s3_storage(&opt)?,
-            StorageType::GCS => create_gcs_storage(&opt)?,
+            StorageType::Gcs => create_gcs_storage(&opt)?,
             StorageType::Azure => create_azure_storage(&opt)?,
         }),
         Default::default(),

--- a/deny.toml
+++ b/deny.toml
@@ -105,9 +105,6 @@ ignore = [
     #
     # See: https://github.com/http-rs/http-types/issues/534
     "RUSTSEC-2026-0174",
-    # Ignore RUSTSEC-2022-0104 because structopt is only used by tikv-ctl and
-    # does not affect the server runtime. This is safe to ignore.
-    "RUSTSEC-2022-0104",
 ]
 
 # TiKV is licensed under Apache 2.0, according to ASF 3RD PARTY LICENSE POLICY,

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -12,6 +12,6 @@ path = "cli.rs"
 [dependencies]
 anyhow = "1.0"
 cargo_metadata = "0.9"
+clap = { version = "3.1.6", default-features = false, features = ["std", "derive"] }
 lazy_static = "1.3"
 regex = "1.1"
-structopt = "0.3"

--- a/fuzz/cli.rs
+++ b/fuzz/cli.rs
@@ -12,15 +12,15 @@
 //! Adopted from https://github.com/rust-fuzz/targets
 
 use std::{
-    env, fs,
+    env, fmt, fs,
     path::{Path, PathBuf},
     process::{Command, Stdio},
 };
 
 use anyhow::{Context, Result, anyhow};
 use cargo_metadata::MetadataCommand;
+use clap::{ArgEnum, Parser, Subcommand};
 use lazy_static::lazy_static;
-use structopt::{StructOpt, clap::arg_enum};
 
 lazy_static! {
     static ref WORKSPACE_ROOT: PathBuf = MetadataCommand::new()
@@ -41,28 +41,33 @@ lazy_static! {
     static ref SEED_ROOT: PathBuf = FUZZ_ROOT.join("common/seeds");
 }
 
-#[derive(StructOpt, Debug)]
-enum Cli {
+#[derive(Parser, Debug)]
+#[clap(name = "fuzz")]
+struct Cli {
+    #[clap(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand, Debug)]
+#[clap(rename_all = "kebab-case")]
+enum Commands {
     /// List all available targets
-    #[structopt(name = "list-targets")]
     ListTargets,
     /// Run matched fuzz test with specific fuzzer.
-    #[structopt(name = "run")]
     Run {
         /// The fuzzer to use.
+        #[clap(arg_enum, ignore_case = true)]
         fuzzer: Fuzzer,
         /// The target fuzz to run.
         target: String,
     },
 }
 
-arg_enum! {
-    #[derive(Debug, PartialEq, Clone, Copy)]
-    enum Fuzzer {
-        Afl,
-        Honggfuzz,
-        Libfuzzer,
-    }
+#[derive(ArgEnum, Debug, PartialEq, Clone, Copy)]
+enum Fuzzer {
+    Afl,
+    Honggfuzz,
+    Libfuzzer,
 }
 
 impl Fuzzer {
@@ -81,14 +86,25 @@ impl Fuzzer {
     }
 }
 
+impl fmt::Display for Fuzzer {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let name = match self {
+            Fuzzer::Afl => "Afl",
+            Fuzzer::Honggfuzz => "Honggfuzz",
+            Fuzzer::Libfuzzer => "Libfuzzer",
+        };
+        f.write_str(name)
+    }
+}
+
 fn main() -> Result<(), i32> {
-    match Cli::from_args() {
-        Cli::ListTargets => {
+    match Cli::parse().command {
+        Commands::ListTargets => {
             for target in &*FUZZ_TARGETS {
                 println!("{}", target);
             }
         }
-        Cli::Run { fuzzer, target } => {
+        Commands::Run { fuzzer, target } => {
             if let Err(error) = run(fuzzer, &target) {
                 eprintln!("Running fuzzer failed: {}", error);
                 return Err(1);
@@ -341,4 +357,29 @@ fn run_libfuzzer(target: &str) -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+
+    use super::{Cli, Commands, Fuzzer};
+
+    #[test]
+    fn accepts_documented_capitalized_fuzzer_names() {
+        for (input, expected) in [
+            ("Afl", Fuzzer::Afl),
+            ("Honggfuzz", Fuzzer::Honggfuzz),
+            ("Libfuzzer", Fuzzer::Libfuzzer),
+        ] {
+            let cli = Cli::try_parse_from(["fuzz", "run", input, "dummy-target"]).unwrap();
+            match cli.command {
+                Commands::Run { fuzzer, target } => {
+                    assert_eq!(fuzzer, expected);
+                    assert_eq!(target, "dummy-target");
+                }
+                _ => panic!("expected run command"),
+            }
+        }
+    }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number:ref https://github.com/tikv/tikv/issues/19743
<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Replace the remaining structopt-based CLIs with clap v3 derives

The direct structopt dependency triggers RUSTSEC-2022-0104 in cargo deny.
This change migrates the remaining structopt users to clap v3 derive:
tikv-ctl, the encryption and external_storage example CLIs, and the fuzz
helper.

The migration keeps the existing CLI surface intact, including validators,
subcommands, delimiter handling, and help behavior. It also preserves the
documented fuzz fuzzer names by keeping enum parsing case-insensitive, so
inputs such as Honggfuzz still work.

With direct structopt usage removed, this patch drops the temporary
RUSTSEC-2022-0104 ignore from deny.toml and refreshes Cargo.lock.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Manual test:

- make format
- make clippy
- cargo +1.92.0 deny --workspace check advisories --disable-fetch
- cargo test -p fuzz -- --nocapture
- cargo test -p tikv-ctl compact_log_backup -- --nocapture

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None.
```

### Deep Review

#### Problem Summary
- The uncommitted change replaces the `Makefile`'s direct `gcp_v2/fips` activation with a workspace-level `fips` feature and forwards that feature through the crates that own `gcp_v2` dependencies.
- The goal is to make FIPS builds select the GCP v2 `rustls/fips` path through normal Cargo feature propagation instead of hard-coding a transitive package feature in the build script.

#### Solution Walkthrough
- [Cargo.toml](/Users/lucasliang/Workspace/tikv/Cargo.toml:57) adds a root `fips` feature that forwards to `encryption_export/fips`.
- [Makefile](/Users/lucasliang/Workspace/tikv/Makefile:143) changes `ENABLE_FIPS=1` from `gcp_v2/fips` to the new top-level `fips` feature.
- [cmd/tikv-server/Cargo.toml](/Users/lucasliang/Workspace/tikv/cmd/tikv-server/Cargo.toml:21) and [cmd/tikv-ctl/Cargo.toml](/Users/lucasliang/Workspace/tikv/cmd/tikv-ctl/Cargo.toml:19) expose `fips` on the shipped binaries by forwarding to `tikv/fips`.
- [components/encryption/export/Cargo.toml](/Users/lucasliang/Workspace/tikv/components/encryption/export/Cargo.toml:10) and [components/external_storage/Cargo.toml](/Users/lucasliang/Workspace/tikv/components/external_storage/Cargo.toml:10) forward `fips` to `gcp_v2/fips`, which is the actual gate that enables `rustls/fips` in [components/cloud/gcp_v2/Cargo.toml](/Users/lucasliang/Workspace/tikv/components/cloud/gcp_v2/Cargo.toml:8).
- [components/server/Cargo.toml](/Users/lucasliang/Workspace/tikv/components/server/Cargo.toml:24), [components/backup/Cargo.toml](/Users/lucasliang/Workspace/tikv/components/backup/Cargo.toml:30), and [components/backup-stream/Cargo.toml](/Users/lucasliang/Workspace/tikv/components/backup-stream/Cargo.toml:20) add parallel forwarding so direct consumers of those crates can also request the same FIPS path.
- `cargo tree -p tikv-server -e features --features fips -i gcp_v2` and `cargo tree -p tikv-ctl -e features --features fips -i gcp_v2` both resolved `gcp_v2 feature "fips"`, confirming that the binary entrypoints do select the intended transitive feature.

#### Findings (ordered by severity)
- None.

#### Costs and Negative Impacts
- Correctness: Low risk. The patch only changes Cargo feature wiring and `Makefile` feature selection; no runtime Rust logic changed.
- Security: Positive/neutral. The FIPS-sensitive `gcp_v2` path is still activated, but now through first-class workspace features instead of a transitive package-qualified feature.
- Compatibility: Out-of-tree callers that previously enabled `gcp_v2/fips` directly through TiKV's root build invocation will need to switch to `fips`.
- Robustness: Acceptable. The current implementation relies on Cargo feature unification so that `tikv/fips -> encryption_export/fips -> gcp_v2/fips` is sufficient for the shipped binaries.
- Operability: Slightly improved. `ENABLE_FIPS=1` now maps to a repo-level feature name instead of a transitive package path.
- Cognitive Load: Slightly higher because the forwarding chain now spans multiple manifests, but the added comments keep it understandable.
- CPU: No meaningful runtime impact.
- Memory: No meaningful runtime impact.
- Log Volume: No impact.

#### Static Validation
- `make format`: Passed.
- `make clippy`: Passed after rerunning outside the initial sandbox restriction. The first sandboxed attempt failed because `rustup` could not write `~/.rustup/tmp`; the rerun completed successfully. `cargo-deny` emitted warnings already present in the workspace (for example missing license fields on `kvproto` / `tipb` and registry index lookup warnings), but no errors.
- `env RUSTC_WRAPPER= cargo check -p tikv-server --features fips`: Passed.
- `env RUSTC_WRAPPER= cargo check -p tikv-ctl --features fips`: Passed.

#### Engineering Rules Check
- No code-level mismatch against [AGENTS.md](/Users/lucasliang/Workspace/tikv/AGENTS.md:1) was found in this diff.
- Repo-prescribed validation entrypoints were used: `make format` and `make clippy`.
- PR title / description / release-note rules were not assessable because the review scope was the uncommitted working tree rather than a PR.

#### Questions and Assumptions
- Assumed the requested review scope was the current uncommitted working-tree diff against `HEAD`.
- Assumed the current FIPS requirement for this patch is specifically to ensure `gcp_v2` builds with `rustls/fips`. A repository search found `cfg(feature = "fips")` usage in `components/cloud/gcp_v2`, but not in the newly added forwarding crates themselves.
- `cmd/tikv-server` and `cmd/tikv-ctl` currently forward `fips` to `tikv/fips`, not `server/fips`. That is acceptable today because `cargo tree` confirmed `gcp_v2/fips` is still selected, but if future crate-local `fips` behavior is added outside the `tikv -> encryption_export` path, the binary manifests will need to forward those features explicitly.

#### Suggested Tests / Validation
- Run `ENABLE_FIPS=1 make build` or the equivalent Linux FIPS CI job before submission, because the local targeted checks validated feature resolution but did not reproduce the full Docker/FIPS packaging environment.
- Run `make dev` before opening the PR, per [AGENTS.md](/Users/lucasliang/Workspace/tikv/AGENTS.md:105).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated command-line argument parsing implementation across internal tools including tikv-ctl, encryption utilities, and storage examples to enhance code maintainability and remove obsolete security advisories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->