### PR TITLE
cloud/aws: fix flaky multipart S3 tests under parallel execution

### DIFF
--- a/components/cloud/aws/Cargo.toml
+++ b/components/cloud/aws/Cargo.toml
@@ -52,4 +52,4 @@ aws-smithy-runtime = { version = "1.4.0", features = ["test-util", "client"] }
 aws-smithy-types = { version = "1", features = ["hyper-0-14-x", "http-body-0-4-x"] }
 base64 = "0.13"
 futures = "0.3"
-tokio = { version = "1.5", features = ["macros"] }
+tokio = { version = "1.5", features = ["macros", "sync"] }

--- a/components/cloud/aws/src/s3.rs
+++ b/components/cloud/aws/src/s3.rs
@@ -860,7 +860,7 @@ mod tests {
 
     use super::*;
 
-    // Serialize multipart-related test because they assert deltas on the global
+    // Serialize multipart-related tests because they assert deltas on the global
     // metric CLOUD_REQUEST_HISTOGRAM_VEC, which is shared across tests.
     static MULTI_PART_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 

--- a/components/cloud/aws/src/s3.rs
+++ b/components/cloud/aws/src/s3.rs
@@ -860,6 +860,8 @@ mod tests {
 
     use super::*;
 
+    static MULTI_PART_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
     #[test]
     fn test_s3_get_content_md5() {
         // base64 encode md5sum "helloworld"
@@ -905,6 +907,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_s3_storage_multi_part() {
+        let _guard = MULTI_PART_TEST_LOCK.lock().await;
         let magic_contents = "567890";
 
         let bucket_name = StringNonEmpty::required("mybucket".to_string()).unwrap();
@@ -1027,6 +1030,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_s3_storage_multi_part_abort() {
+        let _guard = MULTI_PART_TEST_LOCK.lock().await;
         let magic_contents = "567890";
 
         let bucket_name = StringNonEmpty::required("mybucket".to_string()).unwrap();

--- a/components/cloud/aws/src/s3.rs
+++ b/components/cloud/aws/src/s3.rs
@@ -860,6 +860,8 @@ mod tests {
 
     use super::*;
 
+    // Serialize multipart-related test because they assert deltas on the global
+    // metric CLOUD_REQUEST_HISTOGRAM_VEC, which is shared across tests.
     static MULTI_PART_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
     #[test]


### PR DESCRIPTION
As mentioned in the issue, two specific tests were failing when run in parallel. They were asserting a value as 3, but the result was 6 so some double writing was happening.

Disclaimer: I am using AI assistance for this work but I am not "vibe coding", I am trying to learn and be useful, so if there is something wrong with my approach, let me know what and why and I will work on improving it.

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #19749 

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Add a lock to these specific tests to serialize only them.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ x ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **Tests**
  * Improved S3 multipart upload tests to run safely by preventing concurrent execution and reducing the risk of shared-metric interference.
* **Chores**
  * Updated test tooling to support the added concurrency control used by the S3 multipart test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->