### PR TITLE
*: add TiKV maintenance guides and PR/review workflow skills

### DIFF
--- a/.agents/skills/deep-review/SKILL.md
+++ b/.agents/skills/deep-review/SKILL.md
@@ -109,6 +109,13 @@ Produce a production-critical review for TiKV that:
      - cognitive load and maintainability
 
 8. Run TiKV static validation from `./Makefile`
+   - If the review target is docs-only, use a docs-only fast path:
+     - docs-only means the diff is confined to `doc/`, `.agents/`, or
+       repository documentation files such as `README.md` and
+       `CONTRIBUTING.md`
+     - skip `make format` and `make clippy`
+     - record both checks as skipped due to docs-only scope
+     - do not claim the code paths passed static validation
    - Run `make format` from the repository root.
    - Then run `make clippy` from the repository root.
    - Treat the `Makefile` behavior as part of the review:

--- a/.agents/skills/deep-review/SKILL.md
+++ b/.agents/skills/deep-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: deep-review
-description: Deep, production-critical review workflow for TiKV changes. Use when asked to review a PR, branch, commit range, or diff in this repository and produce a markdown review report with findings, risk analysis, and TiKV-specific validation results.
+description: Deep, production-critical review workflow for TiKV changes. Use when asked to review a PR, branch, commit range, or diff in this repository and produce a markdown review report with findings, risk analysis, TiKV-specific validation results, and maintenance-guide consistency checks.
 ---
 
 # Deep Review
@@ -13,6 +13,7 @@ Produce a production-critical review for TiKV that:
 - explains how the change works in concrete code terms
 - identifies correctness, safety, performance, and operability risks
 - follows TiKV repository rules from `AGENTS.md`
+- checks whether affected files also require updates to `doc/maintenance-guides`
 - writes the review to a markdown file under the target folder
 - runs the repo-prescribed formatting and lint checks from `./Makefile`
 
@@ -23,12 +24,18 @@ Produce a production-critical review for TiKV that:
 - If the target folder is not provided, use `./target`.
 - If the filename is not provided, use `review-report-YYYYMMDD-<summary>.md`.
 - Do not overwrite an existing report. Choose a distinct filename instead.
+- If the review scope is not explicit, prefer the current branch diff against
+  its configured upstream tracking branch, not blindly `origin/HEAD`.
 
 ## TiKV-Specific Rules
 
 - Treat `make format` and `make clippy` as the authoritative static checks because TiKV’s `Makefile` adds required setup and repository-specific scripts.
 - Do not substitute raw `cargo clippy` for `make clippy` unless the user explicitly asks for a narrower check.
 - Read `AGENTS.md` before judging engineering-rule compliance.
+- Read `doc/maintenance-guides/README.md` and the relevant subsystem guide when the change touches a covered subsystem.
+- Treat the maintenance guides as required review context for non-trivial changes in covered subsystems.
+- If a change modifies ownership boundaries, startup order, data contracts, invariants, observability, reading maps, must-read file order, or change-impact guidance for a covered subsystem, expect the matching guide under `doc/maintenance-guides` to be updated in the same change.
+- If a guide update is required but missing or stale, record that as a review issue or engineering-rule mismatch instead of silently accepting it.
 - When unfamiliar code appears, read the surrounding subsystem rather than inferring from symbol names alone.
 - Respect a dirty worktree. Never revert unrelated user changes while fixing review-discovered issues.
 
@@ -36,12 +43,17 @@ Produce a production-critical review for TiKV that:
 
 1. Confirm inputs
    - Identify the repository root, target output folder, and output filename.
-   - If the review scope is not explicit, use the current branch diff against `origin/HEAD`.
+   - If the review scope is not explicit, identify the current branch's
+     upstream tracking branch first and use that diff.
+   - If no upstream tracking branch exists, only fall back to `origin/HEAD`
+     when it is clearly the intended review base; otherwise stop and ask for
+     guidance.
 
 2. Collect the change set
    - Prefer the diff provided by the user.
-   - Otherwise run `git diff origin/HEAD...HEAD` from the repository root.
-   - If `origin/HEAD` is unavailable or the diff command fails, stop and ask for guidance.
+   - Otherwise run `git diff <upstream>...HEAD` from the repository root.
+   - If the upstream branch is unavailable, or the fallback base is ambiguous,
+     stop and ask for guidance instead of reviewing a likely wrong diff.
 
 3. Understand the intent
    - Read the PR description, issue link, commit messages, or nearby code comments when available.
@@ -59,12 +71,32 @@ Produce a production-critical review for TiKV that:
      - `tests/`
    - Read enough nearby code to understand invariants, concurrency assumptions, error propagation, and test coverage.
 
-5. Explain how the change works
+5. Check maintenance-guide impact
+   - Determine whether the changed files map to one or more covered guides under `doc/maintenance-guides`.
+   - Always read `doc/maintenance-guides/repo-overview.md` for cross-component changes.
+   - For covered subsystems, read the matching guide and use its:
+     - purpose and scope
+     - data/model contracts
+     - observability guidance
+     - must-read file order
+     - change-impact matrix
+   - Decide whether the code change should also update the guide.
+   - A guide update is usually required when the change alters:
+     - ownership or subsystem boundaries
+     - startup or shutdown sequencing
+     - metadata or API contracts
+     - invariants or ordering rules
+     - operational signals, metrics, logs, or health surfaces
+     - reading maps, must-read file order, or change-impact guidance
+   - If the guide was updated in the same change, review the guide update for accuracy and completeness.
+   - If the guide should have been updated but was not, record that explicitly in the review output and tell the user the corresponding guide file should be updated.
+
+6. Explain how the change works
    - Walk through each non-trivial logic change.
    - Explain control flow, data flow, state transitions, and failure paths in plain language.
    - Reference concrete files, symbols, and lines when discussing findings.
 
-6. Evaluate costs and negative impacts
+7. Evaluate costs and negative impacts
    - Explicitly assess:
      - correctness
      - security
@@ -76,7 +108,7 @@ Produce a production-critical review for TiKV that:
      - operability and debuggability
      - cognitive load and maintainability
 
-7. Run TiKV static validation from `./Makefile`
+8. Run TiKV static validation from `./Makefile`
    - Run `make format` from the repository root.
    - Then run `make clippy` from the repository root.
    - Treat the `Makefile` behavior as part of the review:
@@ -84,24 +116,33 @@ Produce a production-critical review for TiKV that:
      - `make clippy` runs repository checks including redact-log, log-style, dashboards, docker-build, license, deny, and finally `scripts/clippy-all`
    - If `make format` or `make clippy` reports code issues in the working tree:
      - inspect the failing files
-     - fix the errors when the fix is local and safe
-     - rerun the failing command
+     - determine whether the failure belongs to the review target or to
+       unrelated dirty-worktree state
+     - record the result in the review output
+   - Do not silently edit the change under review as part of a review-only
+     workflow unless the user explicitly asked for review-plus-fix.
    - If `make clippy` fails in `scripts/deny`, record that separately from Rust lint results because `clippy-all` may not have run yet.
    - If the failure is environmental, toolchain-related, or blocked by unavailable external dependencies:
      - record the exact blocker in the report
      - do not claim the code passed
    - Do not revert unrelated user changes while making fixes.
 
-8. Check engineering rules
+9. Check engineering rules
    - Verify alignment with `AGENTS.md`, especially:
      - repository-specific build and test entrypoints
      - required validation expectations such as `make dev`
      - PR-title, issue-link, and release-note requirements when relevant to the review
+   - Verify alignment with the maintainer contract in `doc/maintenance-guides/README.md` for covered subsystems.
 
-9. Write the review output
+10. Write the review output
    - Write a markdown report under the target folder.
    - If no findings exist, say so explicitly.
    - Still document residual risks, assumptions, and any validation gaps.
+   - Always include a maintenance-guide check that states:
+     - which guide files were relevant
+     - whether guide updates were required
+     - whether the change updated them
+     - which guide files should be updated if missing
 
 ## Review Output Template
 
@@ -116,6 +157,12 @@ Produce a production-critical review for TiKV that:
 
 #### Findings (ordered by severity)
 - [Issue or risk with file/line references]
+
+#### Maintenance Guide Check
+- Relevant guides:
+- Guide update required:
+- Updated in change:
+- If missing, which files should be updated:
 
 #### Costs and Negative Impacts
 - Correctness:
@@ -134,6 +181,7 @@ Produce a production-critical review for TiKV that:
 
 #### Engineering Rules Check
 - [List code or process mismatches against `AGENTS.md`, or "None"]
+- [List maintenance-guide contract mismatches from `doc/maintenance-guides/README.md`, or "None"]
 
 #### Questions and Assumptions
 - [List unknowns or assumptions made]

--- a/.agents/skills/generate-pr-docs/SKILL.md
+++ b/.agents/skills/generate-pr-docs/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: generate-pr-docs
+description: Generate GitHub pull request markdown documents for this TiKV repository. Use when asked to draft or update a PR body, PR summary, or filled markdown document from the current diff, staged changes, branch changes, or a user-provided scope. Always reload `.github/pull_request_template.md` before generating output and preserve every hidden HTML comment block from that template verbatim.
+---
+
+# Generate Pr Docs
+
+## Goal
+
+Generate a TiKV-compatible pull request document in markdown that is ready to
+paste into GitHub.
+
+## Required Reads
+
+- Read `.github/pull_request_template.md` at the start of every invocation.
+- Treat the template file as live input. Never rely on memory of an earlier read.
+- Read `AGENTS.md` before proposing the PR title or check-list values.
+- If the user asks for a PR document about current code changes, inspect the
+  actual diff, staged changes, or changed files before writing the document.
+
+## Workflow
+
+1. Reload the local template
+   - Open `.github/pull_request_template.md` fresh before drafting.
+   - Copy its structure exactly.
+   - Preserve every HTML comment block exactly as written, including wording,
+     spacing, and placement.
+   - Do not delete, paraphrase, reorder, or compress hidden comments.
+
+2. Determine the PR scope from real evidence
+   - Prefer the user-provided summary, diff, branch, or changed-file list.
+   - Otherwise inspect the current repository state.
+   - When the user asks for the current worktree scope, inspect `git status`
+     style evidence and include tracked modifications, staged changes, and
+     untracked files that belong to the intended change.
+   - Prefer the current branch diff against its configured upstream tracking
+     branch.
+   - If the upstream base is ambiguous and the user did not provide scope, stop
+     and ask instead of drafting from the wrong change set.
+   - Read commit messages or touched files when needed so the description is
+     concrete and not generic.
+
+3. Propose the PR title
+   - Follow `AGENTS.md` title rules:
+     - `module: what's changed`
+     - `module1, module2: what's changed`
+     - `*: what's changed`
+   - Use `*:` when the change is repository-wide, mostly documentation/process
+     work, or spans multiple unrelated subsystems.
+   - Do not invent a misleading narrow module tag.
+
+4. Fill the template
+   - Keep the `Issue Number:` line present in the final document.
+   - Use the real issue link if the user provided one.
+   - If no issue number is known, keep a visible placeholder such as
+     `Issue Number: ref #xxx` rather than inventing one.
+   - Fill `What's Changed` from the actual diff and intent.
+   - Keep the `commit-message` fenced block and make it non-empty.
+   - Put the PR commit-message body directly inside that block.
+   - If the commit-message body is still unknown, keep a visible placeholder
+     line such as `<commit message for PRs>` instead of leaving the block empty.
+   - Update `Related changes`, `Check List`, and `Release note` only from known
+     facts.
+   - Keep unchecked boxes when evidence is missing.
+   - Keep the `release-note` fenced block and make it non-empty.
+   - Put the release note text directly inside that block.
+   - If the release note is unknown, keep a visible placeholder line such as
+     `<release notes for PRs>` instead of leaving the block empty.
+   - For documentation-only, maintenance-guide-only, or skill-only changes,
+     mark `No code` and use `None` in the release note unless the user says
+     otherwise.
+
+5. Emit the final output
+   - Output `Suggested PR title: ...` first unless the user asked for body-only
+     output.
+   - Then output the full PR markdown body.
+   - The markdown body must still include every hidden template comment.
+   - When presenting the PR body in chat, prefer an outer four-backtick
+     `markdown` fence so inner triple-backtick blocks remain visible literally.
+   - Ensure the literal markers ` ```commit-message ` and
+     ` ```release-note ` both appear in the final answer.
+   - Do not wrap the whole PR body in an outer triple-backtick fence, because
+     that can swallow the inner fenced blocks.
+   - Use raw markdown output only when the user explicitly asks for it and the
+     renderer will not consume the inner fences.
+   - Do not replace the body with a summary or explanation.
+
+## Output Rules
+
+- Preserve the exact hidden context from `.github/pull_request_template.md`.
+- Do not edit template headings unless the template itself changed.
+- Do not fabricate issue numbers, test evidence, release notes, or side effects.
+- Never emit an empty `commit-message` or `release-note` fenced block.
+- Never break or hide the inner fenced blocks by wrapping the whole PR body in
+  a conflicting outer markdown fence.
+- The final answer must preserve the literal visible lines for both fenced
+  blocks, including their opening and closing backticks.
+- Do not derive current-worktree scope from `git diff` alone when untracked
+  files may be part of the change.
+- If information is unknown, keep a visible placeholder or brief TODO in the
+  visible field instead of changing hidden comments.
+- If the user asks to update an existing PR body, still reload the template
+  first and then merge the confirmed content into that fresh template shape.
+
+## TiKV-Specific Heuristics
+
+- For maintainer-guide or agent-skill changes, describe the developer/reviewer
+  workflow impact explicitly.
+- For maintenance-guide additions or updates, mention that the guides are part
+  of the repository maintenance surface when that is a core part of the change.
+- For `.agents/skills/deep-review` changes, call out review-process or
+  maintenance-guide enforcement changes explicitly.
+- Leave `PR to update pingcap/docs/pingcap/docs-cn` unchecked unless a matching
+  docs PR actually exists.
+- Leave `Need to cherry-pick to the release branch` unchecked unless the user
+  explicitly indicates that release backporting is needed.
+
+## Minimal Output Shape
+
+Use this shape unless the user asks for something narrower:
+
+1. `Suggested PR title: ...`
+2. Full markdown PR body copied from the live template, with filled visible
+   fields and unchanged hidden comments.
+
+## Refusal Condition
+
+- If `.github/pull_request_template.md` cannot be read in the current repo,
+  stop and report that the template must be available before generating the PR
+  document.

--- a/.agents/skills/generate-pr-docs/SKILL.md
+++ b/.agents/skills/generate-pr-docs/SKILL.md
@@ -30,6 +30,8 @@ paste into GitHub.
 2. Determine the PR scope from real evidence
    - Prefer the user-provided summary, diff, branch, or changed-file list.
    - Otherwise inspect the current repository state.
+   - Distinguish staged-only, unstaged-only, and full-worktree scopes instead of
+     collapsing them together implicitly.
    - When the user asks for the current worktree scope, inspect `git status`
      style evidence and include tracked modifications, staged changes, and
      untracked files that belong to the intended change.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,19 @@ make dev
 
 The `make dev` command should pass before submitting a PR.
 
+## Maintenance Guides
+
+The maintainer-oriented guide set lives under `doc/maintenance-guides/`.
+
+- For non-trivial changes in a covered subsystem, read
+  `doc/maintenance-guides/README.md`, then `repo-overview.md`, then the
+  matching subsystem guide before implementing or reviewing the change.
+- Treat these guides as required development and review context, not optional
+  afterthoughts.
+- If a change modifies ownership boundaries, startup or shutdown order, data or
+  metadata contracts, invariants, observability, or the recommended reading
+  map for a covered subsystem, update the matching guide in the same change.
+
 ## Pull Request Instructions
 
 ### PR title

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -163,6 +163,20 @@ See [Rustdoc of TiKV](https://tikv.github.io) for TiKV code documentation.
 
 Thanks for your contributions!
 
+### Maintenance guides
+
+TiKV now maintains a maintainer-oriented guide set under
+[`doc/maintenance-guides/`](./doc/maintenance-guides/README.md).
+
+- For non-trivial changes in a covered subsystem, read the relevant guide set
+  first.
+- If your change modifies ownership boundaries, startup or shutdown sequencing,
+  data or metadata contracts, invariants, observability, or the recommended
+  reading map for a covered subsystem, update the matching guide in the same
+  pull request.
+- The repository overview guide is the right starting point for
+  cross-component changes.
+
 ### Finding something to work on
 
 For beginners, we have prepared many suitable tasks for you. Checkout our [Help Wanted issues](https://github.com/tikv/tikv/issues?q=is%3Aopen+is%3Aissue+label%3Astatus%2Fhelp-wanted) for a list, in which we have also marked the difficulty level.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,10 @@ TiKV is an open-source, distributed, and transactional key-value database. Unlik
 
 The design of TiKV ('Ti' stands for titanium) is inspired by some great distributed systems from Google, such as BigTable, Spanner, and Percolator, and some of the latest achievements in academia in recent years, such as the Raft consensus algorithm.
 
-If you're interested in contributing to TiKV, or want to build it from source, see [CONTRIBUTING.md](./CONTRIBUTING.md).
+If you're interested in contributing to TiKV, or want to build it from source,
+see [CONTRIBUTING.md](./CONTRIBUTING.md). For maintainership-oriented code
+reading and review context, see
+[doc/maintenance-guides/README.md](./doc/maintenance-guides/README.md).
 
 ![cncf_logo](images/cncf.png#gh-light-mode-only)
 ![cncf_logo](images/cncf-white.png#gh-dark-mode-only)

--- a/doc/maintenance-guides/README.md
+++ b/doc/maintenance-guides/README.md
@@ -1,0 +1,143 @@
+# TiKV Maintenance Guides
+
+This directory is a maintainership-oriented index for the TiKV repository. It is
+not a user manual. It is meant to help reviewers and developers answer four
+questions quickly:
+
+1. Which subsystem owns this behavior?
+2. Which files are the real entry points?
+3. Which invariants are easy to break?
+4. Which tests and metrics should move with the change?
+
+## Maintainer Contract
+
+These files are part of the repository's maintenance surface.
+
+- Developers and reviewers should read the relevant guide here first before
+  making or reviewing non-trivial changes.
+- These guides are assistant documents for implementation and review, not
+  optional afterthoughts.
+- If a change modifies ownership boundaries, startup order, data contracts,
+  invariants, operational signals, or the recommended reading map for a covered
+  subsystem, the matching guide in this directory should be updated in the same
+  change.
+- A code change that invalidates these guides but does not update them should be
+  treated as an incomplete maintenance change.
+
+## Standard Section Contract
+
+Each subsystem guide in this directory is expected to cover these domains:
+
+1. Purpose and scope
+2. Architectural views
+3. Process lifecycle and startup sequencing
+4. Data model and metadata contracts
+5. Observability and operational signals
+6. Change management guidance
+7. Reading map and companion docs
+8. Glossary
+9. Must-read file order
+10. Change-impact matrix
+
+The depth varies by subsystem size. Small glue crates can keep some sections
+short, but they should still be present.
+
+## How To Use This Set
+
+- Start with `repo-overview.md` to understand layer boundaries.
+- Open the guide for the subsystem you are touching.
+- Use the "Must-Read File Order", "Change-Impact Matrix", and "Review
+  checklist" sections first.
+- Treat the guide as required context for development or review when the change
+  is non-trivial.
+- Treat every guide as a map, not a complete specification. The source of truth
+  is still the code.
+
+## System Map
+
+- Startup and process wiring: `components/server`
+- Runtime gRPC, Raft transport, status server, GC, debug services: `src/server`
+- `RaftKv2` bridge and tablet-based replica stack:
+  `src/server/raftkv2` + `components/raftstore-v2`
+- Transactional KV, MVCC, raw KV, scheduling, lock waiting: `src/storage`
+- Classic TiDB coprocessor DAG/analyze/checksum path: `src/coprocessor`
+- Plugin-based coprocessor framework: `src/coprocessor_v2`
+- Classic raft-kv replica state machines, routing, snapshots, and
+  split/heartbeat workers: `components/raftstore`
+- Tablet-based replica state machines for `EngineType::RaftKv2`:
+  `components/raftstore-v2`
+- Generic FSM batching framework used heavily by raftstore:
+  `components/batch-system`
+- Resource groups, fairness, admission control, quota adjustment:
+  `components/resource_control`
+- Hybrid disk + region-cache engine glue: `components/hybrid_engine`
+- Region cache engine and background lifecycle: `components/in_memory_engine`
+- Small service-control shim used by server/status server:
+  `components/service`
+
+## Guide Index
+
+### Repository
+
+- [Repository Overview](./repo-overview.md)
+
+### `components/`
+
+- [raftstore](./components/raftstore.md)
+- [raftstore-v2](./components/raftstore-v2.md)
+- [resource_control](./components/resource_control.md)
+- [hybrid_engine](./components/hybrid_engine.md)
+- [in_memory_engine](./components/in_memory_engine.md)
+- [batch-system](./components/batch-system.md)
+- [server](./components/server.md)
+- [service](./components/service.md)
+
+### `src/`
+
+- [coprocessor](./src/coprocessor.md)
+- [coprocessor_v2](./src/coprocessor_v2.md)
+- [server](./src/server.md)
+- [storage](./src/storage.md)
+
+## Cross-Cutting Review Checklist
+
+- Check whether the change touches a `#[PerformanceCriticalPath]` file or a
+  request hot path.
+- Verify whether the change is in a boundary layer:
+  `src/server/service/kv.rs`, `src/storage/mod.rs`,
+  `src/storage/txn/scheduler.rs`, `components/raftstore/src/store/peer.rs`,
+  `components/batch-system/src/batch.rs`.
+- Confirm thread or worker ownership:
+  read pools, background workers, Yatp tasks, raft/apply pollers, status server.
+- Check region-scoped assumptions:
+  region epoch, bounds, leader state, snapshot lifetime, safe point, read ts.
+- Check resource-control hooks:
+  request metadata, quota limiter, fair scheduling, admission control labels.
+- Check observability:
+  metrics, tracing, slow-log, memory accounting, health/status endpoints.
+- Check dynamic config behavior:
+  config structs, config managers, runtime side effects, compatibility.
+- Check failure semantics:
+  timeout, cancellation, retries, undetermined results, backpressure,
+  degraded-service mode.
+- Move tests with the behavior:
+  inline unit tests, failpoints, `components/test_raftstore`,
+  `components/test_storage`, `components/test_coprocessor`.
+
+## Current Scope
+
+- The guide set now covers both the classic `raftstore` path and the
+  `RaftKv2` / `raftstore-v2` path at maintainer-map granularity.
+- The guides focus on maintenance and review, not on external deployment or SQL
+  semantics.
+
+## External Reference Links
+
+These upstream docs are useful orientation material and were used together with
+ the local code while drafting this guide set:
+
+- TiKV overview: `https://tikv.org/docs/latest/concepts/overview/`
+- Deep Dive TiKV: `https://tikv.org/deep-dive/introduction/`
+- TiDB / TiKV overview: `https://docs.pingcap.com/tidb/stable/tikv-overview`
+- TiDB resource control and resource groups:
+  `https://docs.pingcap.com/tidb/stable/tidb-resource-control-overview`

--- a/doc/maintenance-guides/README.md
+++ b/doc/maintenance-guides/README.md
@@ -126,10 +126,33 @@ short, but they should still be present.
 
 ## Current Scope
 
+- The guide set currently includes:
+  - `repo-overview.md`
+  - `components/raftstore.md`
+  - `components/raftstore-v2.md`
+  - `components/resource_control.md`
+  - `components/hybrid_engine.md`
+  - `components/in_memory_engine.md`
+  - `components/batch-system.md`
+  - `components/server.md`
+  - `components/service.md`
+  - `src/coprocessor.md`
+  - `src/coprocessor_v2.md`
+  - `src/server.md`
+  - `src/storage.md`
 - The guide set now covers both the classic `raftstore` path and the
   `RaftKv2` / `raftstore-v2` path at maintainer-map granularity.
 - The guides focus on maintenance and review, not on external deployment or SQL
   semantics.
+- The repository overview discusses additional subsystems for cross-component
+  reasoning, but these do not yet have dedicated subsystem guides:
+  - `components/cdc`
+  - `components/backup`
+  - `components/backup-stream`
+  - `components/engine_rocks`
+  - `components/pd_client`
+  - `components/sst_importer`
+  - `src/import`
 
 ## External Reference Links
 

--- a/doc/maintenance-guides/components/batch-system.md
+++ b/doc/maintenance-guides/components/batch-system.md
@@ -1,0 +1,196 @@
+# `components/batch-system` Maintenance Guide
+
+## Purpose And Scope
+
+`batch-system` is the generic FSM execution framework underneath raftstore. It
+owns mailbox routing, polling, batching, rescheduling, and pool-level metrics.
+
+## Architectural Views
+
+### Execution view
+
+- mailbox delivers messages
+- router finds the target FSM
+- batch groups normal and control FSMs into one polling round
+- pollers and handlers execute the work
+
+## Process Lifecycle And Startup Sequencing
+
+- This subsystem is instantiated by higher-level runtime owners, mainly
+  raftstore.
+- FSM, mailbox, and router ownership must be fully established before pollers
+  start running.
+- Shutdown must use the crate's sentinel and release logic correctly so no FSM
+  is stranded.
+- The main runtime construction path is `batch.rs::create_system`, then the
+  subsystem-specific builders in raftstore such as
+  `components/raftstore/src/store/fsm/store.rs::create_raft_batch_system` and
+  `components/raftstore/src/store/fsm/apply.rs::create_apply_batch_system`.
+- Poller threads execute with explicit IO classification in `batch.rs`. If a
+  patch changes what pollers do synchronously, verify the foreground/background
+  IO assumptions still hold.
+- Shutdown uses the `FsmTypes::Empty` sentinel plus mailbox closing and FSM
+  state clearing. Review `batch.rs`, `mailbox.rs`, and `fsm.rs` together when
+  touching stop-path logic.
+
+## Data Model And Metadata Contracts
+
+- Mailbox ownership and queue length are part of the scheduling contract.
+- Normal FSMs and control FSMs have intentionally different semantics.
+- Reschedule policy is part of the runtime contract between the poller and the
+  caller.
+- `fsm.rs::FsmState` is the core ownership contract. The `NOTIFIED`, `IDLE`,
+  and `DROP` state machine is small but easy to break with seemingly harmless
+  refactors.
+- `mailbox.rs` couples message enqueue and “schedule if idle” behavior. Any
+  change that splits or reorders those steps risks lost wakeups or duplicate
+  scheduling.
+- `batch.rs::Batch::release` depends on queue length checks and mailbox
+  re-taking to preserve message visibility. Reviewers should treat that logic as
+  correctness-sensitive, not only performance-sensitive.
+- Resource control is part of the contract here because `Fsm::Message:
+  ResourceMetered` and `FsmScheduler::consume_msg_resource` affect scheduling
+  fairness and accounting.
+
+## Start Here
+
+- `components/batch-system/src/lib.rs`
+- `components/batch-system/src/batch.rs`
+- `components/batch-system/src/fsm.rs`
+- `components/batch-system/src/mailbox.rs`
+- `components/batch-system/src/router.rs`
+- `components/batch-system/src/scheduler.rs`
+- `components/batch-system/src/config.rs`
+
+## Must-Read File Order
+
+1. `components/batch-system/src/fsm.rs`
+2. `components/batch-system/src/mailbox.rs`
+3. `components/batch-system/src/router.rs`
+4. `components/batch-system/src/batch.rs`
+5. `components/batch-system/src/scheduler.rs`
+6. `components/batch-system/src/metrics.rs`
+
+## Core Concepts
+
+- `Fsm`: the executable state machine abstraction.
+- `Mailbox`: the message queue plus ownership handoff mechanism.
+- `Batch`: one poll-round of normal and control FSMs.
+- `Router`: lookup and message delivery.
+- `Poller` / `PollHandler`: execution hooks used by raftstore.
+
+## Why It Matters
+
+This crate is small, but it sits on a critical path. Tiny changes here can
+shift fairness, latency, shutdown behavior, and queue backpressure for
+raftstore.
+
+## Critical Invariants
+
+- At most one poller owns a given FSM at a time.
+- Release/remove/reschedule paths must preserve pending-message visibility.
+- Control FSM and normal FSM scheduling semantics must remain distinct.
+- Metrics should not distort hot-path behavior.
+- Queue ownership handoff must remain lock-safe and race-safe.
+
+## Observability And Operational Signals
+
+- FSM count, schedule wait duration, poll duration, and reschedule counters
+- queueing and batch-size behavior during load tests
+- Start with `components/batch-system/src/metrics.rs`. The most useful signals
+  are:
+  `tikv_batch_system_fsm_reschedule_total`,
+  `tikv_batch_system_fsm_schedule_wait_seconds`,
+  `tikv_batch_system_fsm_poll_seconds`,
+  `tikv_batch_system_fsm_poll_rounds`,
+  `tikv_batch_system_fsm_count_per_poll`, and
+  `tikv_channel_full_total`.
+- Router broadcast latency is tracked through
+  `tikv_broadcast_normal_duration_seconds`.
+- Many user-visible symptoms surface first in raftstore metrics rather than
+  here, so batch-system signals should usually be read together with raftstore
+  queue, proposal, and apply latency signals.
+
+## Change Management Guidance
+
+- Changes here should be treated as cross-cutting changes because raftstore
+  behavior depends on them heavily.
+- If mailbox, ownership, or scheduling semantics change, update this guide and
+  the `raftstore` guide together.
+- Do not add instrumentation, allocation, or synchronization on the hot path
+  casually. This crate sits beneath both store and apply FSM execution.
+- If a change affects `FsmState`, mailbox closure, or release/remove semantics,
+  require explicit reasoning about why wakeups cannot be lost and why duplicate
+  ownership cannot occur.
+- If a change affects priority or resource accounting, review it with
+  `components/resource_control` in mind rather than only with raftstore in
+  mind.
+
+## Change-Impact Matrix
+
+- FSM ownership or wakeup changes:
+  inspect `fsm.rs`, `mailbox.rs`, and `batch.rs`
+- Router or delivery changes:
+  inspect `router.rs`, mailbox semantics, and raftstore router callers
+- Polling, reschedule, or batch-shape changes:
+  inspect `batch.rs`, `scheduler.rs`, and raftstore poll handlers
+- Priority or resource-accounting changes:
+  inspect `fsm.rs`, `scheduler.rs`, `components/resource_control`, and
+  raftstore apply/store pollers
+
+## Review Checklist
+
+- Does the change alter mailbox ownership or release behavior?
+- Does it alter batch reschedule policy or the polling round shape?
+- Does it add work to the poller hot path?
+- Does it change shutdown signaling or empty-sentinel handling?
+- Does it change priority integration with resource control?
+
+## Observability And Tests
+
+- Tests exist directly in `tests/cases/*`.
+- Benches exist in `benches/router.rs` and `benches/batch-system.rs`.
+- Many regressions show up first as raftstore latency or queueing anomalies, so
+  validation often needs raftstore-level testing too.
+- `components/raftstore/src/store/fsm/store.rs` and `apply.rs` are practical
+  companion reading because they show the intended use pattern of this
+  framework.
+
+## Common Failure Modes
+
+- duplicate ownership of an FSM
+- lost reschedule after release
+- mailbox state drift causing stuck FSMs
+- queue fairness regressions under load
+
+## Reading Map And Companion Docs
+
+Suggested reading order:
+
+1. `fsm.rs`
+2. `mailbox.rs`
+3. `scheduler.rs`
+4. `batch.rs`
+5. `router.rs`
+
+Companion docs:
+
+- `repo-overview.md`
+- `components/raftstore.md`
+
+## Glossary
+
+- FSM:
+  finite state machine polled by the runtime
+- Mailbox:
+  queue plus ownership handoff container for an FSM
+- Poller:
+  worker that executes batched FSM rounds
+- Control FSM:
+  global or coordinating FSM with different routing and lifecycle semantics
+  from normal peer/apply FSMs
+
+## Related Components
+
+- `components/raftstore/src/store/fsm/*` is the main consumer.
+- `components/resource_control` affects execution priority and queueing.

--- a/doc/maintenance-guides/components/hybrid_engine.md
+++ b/doc/maintenance-guides/components/hybrid_engine.md
@@ -1,0 +1,191 @@
+# `components/hybrid_engine` Maintenance Guide
+
+## Purpose And Scope
+
+`hybrid_engine` is a thin composition layer between the disk KV engine and the
+region-cache engine. It does not own storage semantics by itself. It owns how a
+single snapshot or iterator chooses between disk data and cache data.
+
+## Architectural Views
+
+### Composition view
+
+- disk KV engine remains authoritative
+- region cache engine is opportunistic and region-scoped
+- hybrid snapshot chooses the correct backend per CF and snapshot availability
+
+## Process Lifecycle And Startup Sequencing
+
+- This crate is assembled in
+  `components/server/src/common.rs::build_hybrid_engine` after RocksDB and the
+  region-cache engine both exist.
+- The runtime path then depends on observer registration in
+  `components/server/src/server.rs`, where
+  `HybridSnapshotObserver`, `LoadEvictionObserver`, and
+  `RegionCacheWriteBatchObserver` are attached before raftstore starts serving
+  cache-aware traffic.
+- The main steady-state bridge is not direct engine bootstrap but observed
+  snapshot handoff through `src/server/raftkv/mod.rs`, where
+  `HybridEngineSnapshot::from_observed_snapshot` reconstructs the combined
+  snapshot from the disk snapshot and the optional cache pin.
+- If startup wiring changes, review both creation and observer-installation
+  order. A cache-capable `HybridEngine` without the matching observers is
+  usually a correctness bug, not only a performance regression.
+
+## Data Model And Metadata Contracts
+
+- Snapshot context includes region and read-ts information.
+- Sequence number must align between disk snapshot and cache snapshot.
+- Cache-backed access is valid only for region-scoped data CF reads.
+- The high-risk contract is that cache visibility is derived from the disk
+  snapshot sequence number. `components/hybrid_engine/src/snapshot.rs` treats
+  the disk snapshot as the authoritative sequence-number source and only
+  switches data-CF reads to cache when the cache snapshot was created for that
+  same sequence number.
+- `from_observed_snapshot` depends on the `ObservedSnapshot` downcast produced
+  by `observer/snapshot.rs`. If that type or ownership model changes, the
+  downcast path and pin-drop semantics must be revalidated together.
+- `engine_iterator.rs` and `db_vector.rs` preserve the “same API, different
+  backing store” contract. Iterator and point-get behavior must remain
+  indistinguishable except for metrics and performance.
+
+## Start Here
+
+- `components/hybrid_engine/src/lib.rs`
+- `components/hybrid_engine/src/engine.rs`
+- `components/hybrid_engine/src/snapshot.rs`
+- `components/hybrid_engine/src/engine_iterator.rs`
+- `components/hybrid_engine/src/observer/mod.rs`
+- `components/hybrid_engine/src/observer/write_batch.rs`
+- `components/hybrid_engine/src/observer/snapshot.rs`
+- `components/hybrid_engine/src/observer/load_eviction.rs`
+
+## Must-Read File Order
+
+1. `components/hybrid_engine/src/engine.rs`
+2. `components/hybrid_engine/src/snapshot.rs`
+3. `components/hybrid_engine/src/engine_iterator.rs`
+4. `components/hybrid_engine/src/observer/snapshot.rs`
+5. `components/hybrid_engine/src/observer/write_batch.rs`
+6. `components/hybrid_engine/src/observer/load_eviction.rs`
+7. `src/server/raftkv/mod.rs`
+
+## Main Responsibilities
+
+- hold both a disk engine and a region-cache engine
+- create a `HybridEngineSnapshot`
+- choose cache-backed reads only when a valid region-cache snapshot exists
+- expose write-batch and snapshot observers that keep the cache coherent with
+  raftstore activity
+
+## Core Contracts
+
+- Disk engine is still the authoritative full database.
+- Region cache only accelerates eligible region-scoped reads.
+- Cache snapshots are only valid if:
+  - the cache engine is enabled
+  - the caller provides region context
+  - the cache snapshot can be created for the requested read ts and sequence
+    number
+- Data-CF reads may come from cache; non-data CFs still use disk snapshots.
+
+## Observability And Operational Signals
+
+- `components/hybrid_engine/src/metrics.rs` and
+  `components/hybrid_engine/src/engine_iterator.rs` are the first places to
+  inspect for hybrid read-path instrumentation.
+- Hit or fallback behavior is still interpreted mostly through
+  `components/in_memory_engine/src/metrics.rs` and coprocessor/storage metrics,
+  not through a large metric surface in this crate itself.
+- If hybrid reads start diverging from expected behavior, triage in this order:
+  `src/server/raftkv/mod.rs`, `observer/snapshot.rs`, `snapshot.rs`,
+  `engine_iterator.rs`, then the corresponding in-memory-engine metrics and
+  logs.
+
+## Change Management Guidance
+
+- Keep this crate thin. If the change adds policy or lifecycle logic, verify
+  whether that logic belongs in `in_memory_engine`, raftstore observers, or the
+  storage bridge instead.
+- If snapshot-selection rules change, update both this guide and the related
+  cache-engine guide.
+- Any change that touches observed snapshot conversion, iterator fallback, or
+  observer registration must be reviewed as a cross-component change spanning
+  `components/server`, `src/server/raftkv`, `components/in_memory_engine`, and
+  raftstore observers.
+- The TODO in `components/hybrid_engine/src/lib.rs` matters for maintenance:
+  this crate may eventually be merged or reduced further. Do not build new
+  subsystem ownership here unless there is a strong reason.
+
+## Change-Impact Matrix
+
+- Snapshot reconstruction or cache fallback changes:
+  inspect `snapshot.rs`, `engine_iterator.rs`, and `src/server/raftkv/mod.rs`
+- Observer or pin-lifetime changes:
+  inspect `observer/snapshot.rs`, `observer/write_batch.rs`,
+  `components/server`, and raftstore observer registration
+- Cache-eligibility or read-path changes:
+  inspect `snapshot.rs`, `components/in_memory_engine`, and coprocessor/storage
+  read callers
+
+## Review Checklist
+
+- Does the change preserve fallback to disk when cache snapshots are missing or
+  invalid?
+- Does it preserve sequence-number alignment between disk and cache snapshots?
+- Does it affect observer registration or the semantics of write mirroring?
+- Does it incorrectly widen cache usage beyond region-scoped or safe-point-safe
+  reads?
+- Does it accidentally move more logic into this crate than the crate should
+  own? This crate should stay thin.
+
+## Observability And Tests
+
+- Most validation is by unit tests in this crate and by integration with
+  `in_memory_engine` and raftstore observers.
+- `observer/test_write_batch.rs` and tests in `snapshot.rs` are the key local
+  references.
+- `components/test_raftstore/src/server.rs` and
+  `components/test_raftstore/src/util.rs` are good integration anchors because
+  they exercise the observer and hybrid snapshot wiring in a more realistic
+  environment.
+
+## Common Failure Modes
+
+- cache hit on an invalid snapshot
+- stale observer state after write application
+- serving unsupported CFs from cache
+- treating cache as authoritative instead of opportunistic
+
+## Reading Map And Companion Docs
+
+Suggested reading order:
+
+1. `engine.rs`
+2. `snapshot.rs`
+3. `engine_iterator.rs`
+4. `observer/write_batch.rs`
+5. `observer/snapshot.rs`
+6. `observer/load_eviction.rs`
+
+Companion docs:
+
+- `repo-overview.md`
+- `components/in_memory_engine.md`
+- `src/storage.md`
+
+## Glossary
+
+- Hybrid snapshot:
+  snapshot abstraction over disk and cache backends
+- Region cache:
+  optional fast path for region-scoped reads
+- Observed snapshot pin:
+  the raftstore observer-owned object that keeps a cache snapshot valid until
+  the hybrid snapshot reconstructs and drops it
+
+## Related Components
+
+- `components/in_memory_engine` is the actual cache engine implementation.
+- `components/raftstore` provides the observer hooks and region metadata.
+- `src/server/raftkv/mod.rs` and `src/storage` consume hybrid snapshots.

--- a/doc/maintenance-guides/components/in_memory_engine.md
+++ b/doc/maintenance-guides/components/in_memory_engine.md
@@ -1,0 +1,240 @@
+# `components/in_memory_engine` Maintenance Guide
+
+## Purpose And Scope
+
+`in_memory_engine` implements the region cache engine used to accelerate
+region-scoped reads. It owns cached-region lifecycle, skiplist-backed storage,
+safe-point-aware snapshots, background loading and GC, and cache-driven
+eviction.
+
+## Architectural Views
+
+### Storage view
+
+- skiplist-backed cache for data CFs
+- region metadata and snapshot metadata tracked separately from the raw data
+
+### Lifecycle view
+
+- pending/load/active/evict states
+- background workers for load, GC, and memory-driven eviction
+
+## Process Lifecycle And Startup Sequencing
+
+- Created during engine/bootstrap setup.
+- Background workers, range-hint services, and callbacks are attached before
+  cache-assisted runtime behavior is expected.
+- Correct shutdown requires background workers to stop after in-flight snapshot
+  and region cleanup logic has safely drained.
+- The maintainer entry points for lifecycle are
+  `components/in_memory_engine/src/engine.rs::RegionCacheMemoryEngine::new`,
+  `background.rs::BgWorkManager::new`, and
+  `background.rs::PdRangeHintService::start`.
+- Online config updates are applied through
+  `config.rs::InMemoryEngineConfigManager`. Review startup defaults and online
+  reconfiguration together because thresholds like `capacity`,
+  `evict-threshold`, and `stop-load-threshold` are coupled.
+- Shutdown behavior is partly implicit through `Drop` implementations in
+  `background.rs` and `read.rs`. If a patch adds a new background worker or
+  snapshot-holding path without a symmetric stop/drain path, it is probably
+  incomplete.
+
+## Data Model And Metadata Contracts
+
+- Region cache metadata:
+  region bounds, epoch version, safe point, state, active snapshots
+- Snapshot metadata:
+  read ts, region id/epoch, sequence number
+- Memory model:
+  internal encoded keys and skiplist-backed values across relevant CFs
+- The most important contract lives between `region_manager.rs` and `read.rs`:
+  `region_snapshot()` validates region identity, epoch, safe point, and active
+  state before `RegionCacheSnapshot` is created, and snapshot drop feeds back
+  into region-removal eligibility.
+- `read.rs` requires bounded iteration. Callers that do not provide lower and
+  upper bounds are rejected, and callers that exceed snapshot region bounds are
+  rejected. That rule protects both correctness and implementation simplicity.
+- `config.rs::validate` encodes operational contracts that are easy to miss in
+  review: `gc_run_interval` bounds, `load_evict_interval` minimums, capacity
+  derivation from block cache, and threshold ordering.
+- `memory_controller.rs` treats node overhead as an estimated component of total
+  memory use. If write-path accounting or skiplist structure changes, revisit
+  memory-pressure decisions and the eviction thresholds they drive.
+
+## Start Here
+
+- `components/in_memory_engine/src/lib.rs`
+- `components/in_memory_engine/src/engine.rs`
+- `components/in_memory_engine/src/read.rs`
+- `components/in_memory_engine/src/region_manager.rs`
+- `components/in_memory_engine/src/background.rs`
+- `components/in_memory_engine/src/memory_controller.rs`
+- `components/in_memory_engine/src/write_batch.rs`
+- `components/in_memory_engine/src/config.rs`
+
+## Must-Read File Order
+
+1. `components/in_memory_engine/src/engine.rs`
+2. `components/in_memory_engine/src/region_manager.rs`
+3. `components/in_memory_engine/src/read.rs`
+4. `components/in_memory_engine/src/background.rs`
+5. `components/in_memory_engine/src/memory_controller.rs`
+6. `components/in_memory_engine/src/write_batch.rs`
+7. `components/in_memory_engine/src/config.rs`
+8. `components/in_memory_engine/src/metrics.rs`
+
+## Internal Model
+
+### Storage
+
+- The cache is backed by a global skiplist engine across data CFs.
+- Keys are encoded with MVCC-aware internal keys so that snapshots can observe a
+  sequence-number-consistent view.
+
+### Region lifecycle
+
+- `region_manager.rs` tracks per-region metadata and lifecycle.
+- Region states include:
+  `Pending`, `Loading`, `Active`, `LoadingCanceled`, `PendingEvict`, `Evicting`.
+- State transitions are constrained. Many correctness bugs here look like simple
+  lifecycle bugs but become read-consistency bugs quickly.
+
+### Snapshot semantics
+
+- `read.rs` creates `RegionCacheSnapshot`.
+- Snapshot creation validates region id, epoch, safe point, bounds, and
+  sequence number assumptions.
+- Snapshot drop feeds back into region lifecycle and may trigger region cleanup.
+
+### Background work
+
+- `background.rs` schedules region loading, GC, memory checks, delete-range
+  cleanup, label-driven loading, and optional cross-checking.
+- Background tasks also interact with PD for range hints and TSO.
+
+## Critical Invariants
+
+- A cache snapshot must never exceed region bounds.
+- Safe point only moves forward.
+- Cached data is valid only up to the region metadata and sequence number used
+  for the snapshot.
+- Region state transitions must stay legal; ad hoc transitions are a red flag.
+- Eviction and deletion must respect active snapshots and GC tasks.
+- Memory accounting must stay aligned with actual cached data structures.
+
+## Observability And Operational Signals
+
+- Start with `components/in_memory_engine/src/metrics.rs`. The highest-signal
+  metrics include:
+  `tikv_in_memory_engine_memory_usage_bytes`,
+  `tikv_in_memory_engine_load_duration_secs`,
+  `tikv_in_memory_engine_gc_duration_secs`,
+  `tikv_in_memory_engine_eviction_duration_secs`,
+  `tikv_in_memory_engine_cache_count`,
+  `tikv_in_memory_engine_oldest_safe_point`,
+  `tikv_in_memory_engine_newest_safe_point`, and
+  `tikv_safe_point_gap_with_in_memory_engine`.
+- `background.rs` emits the most important operational logs for load, GC,
+  eviction, PD-hint handling, and task scheduling failures.
+- `read.rs` seek/iterator behavior and `statistics.rs` ticker flushing matter
+  when the symptom is query latency rather than obvious cache lifecycle failure.
+- Triage entry points:
+  `engine.rs`, `region_manager.rs`, `background.rs`, `read.rs`,
+  `memory_controller.rs`, `metrics.rs`.
+
+## Change Management Guidance
+
+- Any region-state transition change should be documented here in the same
+  patch.
+- If snapshot or sequence-number rules change, update this guide and the
+  `hybrid_engine` guide together.
+- Treat changes to `RegionState`, safe-point advancement, snapshot drop
+  behavior, or memory-threshold derivation as high-risk correctness changes.
+- If a change introduces a new eviction reason, update
+  `metrics.rs::EvictReasonType`, the associated logs, and this guide together.
+- If config semantics change, review both bootstrap validation and online
+  config dispatch. Silent threshold drift after a live config change is a real
+  operational risk.
+
+## Change-Impact Matrix
+
+- Region-state or snapshot-lifetime changes:
+  inspect `region_manager.rs`, `read.rs`, `background.rs`, and
+  `hybrid_engine`
+- Background load/GC/eviction changes:
+  inspect `background.rs`, `memory_controller.rs`, metrics, and PD hint usage
+- Memory-threshold or accounting changes:
+  inspect `config.rs`, `memory_controller.rs`, write-batch paths, and operator
+  metrics
+- Safe-point or sequence-number changes:
+  inspect `read.rs`, `engine.rs`, `region_manager.rs`, and hybrid snapshot
+  consumers
+
+## Review Checklist
+
+- Does the change affect `RegionState` transitions or snapshot pin/unpin logic?
+- Does it touch background task scheduling, retry, or shutdown behavior?
+- Does it alter safe-point or sequence-number validation?
+- Does it change region-boundary encoding or range deletion semantics?
+- Does it update memory accounting, compaction, or lock tombstone cleanup?
+- Does it require corresponding observer changes in `hybrid_engine` or
+  `raftstore`?
+
+## Observability And Tests
+
+- Key tests are local:
+  - `tests/failpoints/*`
+  - `src/prop_test.rs`
+  - `src/memory_usage_test.rs`
+  - `benches/load_region.rs`
+- Metrics are spread across `metrics.rs`, background tasks, and read paths.
+- `background.rs` contains many lifecycle-heavy tests for GC, split, eviction,
+  load limits, and config changes. It is one of the best change-impact oracles
+  in this subsystem.
+
+## Common Failure Modes
+
+- use-after-drop style logic around snapshot removal and region cleanup
+- stale or over-wide region bounds
+- memory leakage due to skipped delete-range cleanup
+- illegal region-state transitions during load/evict races
+- serving reads under a too-old safe point
+
+## Reading Map And Companion Docs
+
+Suggested reading order:
+
+1. `lib.rs`
+2. `engine.rs`
+3. `region_manager.rs`
+4. `read.rs`
+5. `write_batch.rs`
+6. `background.rs`
+7. `memory_controller.rs`
+
+Companion docs:
+
+- `repo-overview.md`
+- `components/hybrid_engine.md`
+- `src/coprocessor.md`
+
+## Glossary
+
+- Safe point:
+  GC boundary before which old versions may be removed
+- Cache region:
+  region-scoped range eligible for cache operations
+- Snapshot pin:
+  lifetime hold that prevents premature cleanup
+- Stop-load threshold:
+  memory boundary after which new region loads should stop even before hard
+  capacity is hit
+- MVCC amplification:
+  heuristic used by auto load/evict logic to decide whether caching a region is
+  still beneficial
+
+## Related Components
+
+- `components/hybrid_engine` consumes snapshots from this engine.
+- `components/raftstore` provides region metadata and observer integration.
+- `src/coprocessor` is a major beneficiary of cache-backed reads.

--- a/doc/maintenance-guides/components/raftstore-v2.md
+++ b/doc/maintenance-guides/components/raftstore-v2.md
@@ -1,0 +1,218 @@
+# `components/raftstore-v2` Maintenance Guide
+
+## Purpose And Scope
+
+`raftstore-v2` is the tablet-based replica stack used by
+`EngineType::RaftKv2`. It owns router message delivery, batch/FSM execution,
+tablet-backed raft state, operation modules, and PD/tablet background workers.
+
+It is not just a small variant of classic `components/raftstore`. Reviewers
+should treat it as a separate maintenance surface with its own read/write/apply
+paths and its own failure modes.
+
+## Architectural Views
+
+### Stack view
+
+- router and response channels
+- batch/FSM execution
+- raft peer/storage layer
+- operation modules for query/write/split/merge
+- PD and tablet background workers
+
+### Boundary view
+
+- `src/server/raftkv2` is the storage bridge into this crate
+- `components/server/src/server2.rs` wires this stack into process startup
+- `src/storage/config.rs` selects this path via `EngineType::RaftKv2`
+
+## Process Lifecycle And Startup Sequencing
+
+- This crate is started from the `server2.rs` path after engines, PD client,
+  and major runtime helpers exist.
+- Router, store system, and worker construction must stay consistent with
+  `src/server/raftkv2/mod.rs` expectations.
+- Shutdown order matters because peer/store/apply execution, tablet tasks, and
+  response channels all depend on ownership being drained in the right order.
+
+Concrete runtime anchors:
+
+- startup and wiring:
+  `components/server/src/server2.rs`
+- bridge entry:
+  `src/server/raftkv2/mod.rs`
+- crate entry:
+  `components/raftstore-v2/src/lib.rs`
+
+## Data Model And Metadata Contracts
+
+- router message and response-channel contracts
+- peer/store/apply FSM ownership boundaries
+- tablet-backed raft storage and apply state
+- operation-layer request/response semantics
+
+High-risk contracts:
+
+- callback completion and response-stream behavior back to `raftkv2`
+- peer/apply ordering across FSM boundaries
+- tablet state staying aligned with region/raft metadata
+- split/merge/bootstrap/destroy flows keeping router and tablet state coherent
+
+## Start Here
+
+- `components/raftstore-v2/src/lib.rs`
+- `components/raftstore-v2/src/router/mod.rs`
+- `components/raftstore-v2/src/batch/mod.rs`
+- `components/raftstore-v2/src/fsm/mod.rs`
+- `components/raftstore-v2/src/raft/mod.rs`
+- `components/raftstore-v2/src/operation/mod.rs`
+- `components/raftstore-v2/src/worker/pd/mod.rs`
+- `components/raftstore-v2/src/worker/tablet.rs`
+
+## Must-Read File Order
+
+1. `components/raftstore-v2/src/lib.rs`
+2. `components/raftstore-v2/src/router/mod.rs`
+3. `components/raftstore-v2/src/batch/mod.rs`
+4. `components/raftstore-v2/src/fsm/mod.rs`
+5. `components/raftstore-v2/src/raft/mod.rs`
+6. `components/raftstore-v2/src/operation/mod.rs`
+7. `components/raftstore-v2/src/worker/pd/mod.rs`
+8. `components/raftstore-v2/src/worker/tablet.rs`
+9. `src/server/raftkv2/mod.rs`
+10. `components/server/src/server2.rs`
+
+## Internal Structure
+
+### Router and response layer
+
+- `router/*` defines message types, response channels, and router
+  implementation.
+- This is the outer interface consumed by `src/server/raftkv2`.
+
+### Batch and FSM execution
+
+- `batch/*` provides the specialized store batch system.
+- `fsm/*` defines store, peer, and apply FSMs.
+- Message ordering and ownership transfer are core correctness constraints here.
+
+### Raft and operations
+
+- `raft/*` contains peer/storage logic.
+- `operation/*` implements query, write, split/merge, bootstrap, and related
+  behavior on top of the FSM/raft layers.
+
+### Background workers
+
+- `worker/pd/*` owns PD-facing reporting and control paths.
+- `worker/tablet.rs` owns tablet-specific background tasks.
+- `worker/refresh_config.rs` carries runtime config changes.
+
+## Critical Invariants
+
+- Router message types and response channels must preserve the callback and
+  streaming semantics expected by `src/server/raftkv2`.
+- Peer/store/apply FSM ownership must remain single-owner and ordering-safe.
+- Read paths must not silently weaken local-read, read-index, snapshot, or
+  apply guarantees.
+- Tablet-backed state transitions must remain aligned with region/raft
+  metadata.
+- Split/merge/bootstrap/destroy flows must keep router, FSM, and tablet state
+  mutually consistent.
+
+## Observability And Operational Signals
+
+- PD-worker logs and metrics
+- response-channel and router failures
+- tablet-task and refresh-config behavior
+- any divergence surfaced at the `src/server/raftkv2` bridge
+
+Start triage with:
+
+- `components/raftstore-v2/src/router/*`
+- `components/raftstore-v2/src/fsm/*`
+- `components/raftstore-v2/src/worker/pd/*`
+- `src/server/raftkv2/mod.rs`
+
+## Change Management Guidance
+
+- If a change alters callback timing, router semantics, startup/shutdown
+  ordering, tablet-state assumptions, or PD/tablet worker behavior, update this
+  guide in the same patch.
+- When reviewing fixes in classic `raftstore`, explicitly check whether the
+  same issue also exists here.
+- Do not assume parity with classic `raftstore`; verify it in code.
+
+## Change-Impact Matrix
+
+- Router or callback changes:
+  inspect `router/*`, `src/server/raftkv2/mod.rs`, and response channels
+- FSM ordering or apply-path changes:
+  inspect `fsm/*`, `raft/*`, and relevant operation modules
+- Read/write/query-path changes:
+  inspect `operation/*`, `raft/*`, and server bridge behavior
+- Tablet lifecycle or config changes:
+  inspect `worker/tablet.rs`, `worker/refresh_config.rs`, and startup wiring
+- PD/reporting changes:
+  inspect `worker/pd/*` and external-facing metrics/logs
+
+## Review Checklist
+
+- Does the change touch router messages, response channels, or bridge
+  assumptions from `src/server/raftkv2`?
+- Does it modify `fsm/*`, `raft/*`, or `operation/*` in a way that changes
+  callback timing or ordering?
+- Does the same fix also need to exist in classic `components/raftstore`, or
+  vice versa?
+- Does it change tablet lifecycle, PD reporting, or refresh-config behavior
+  without updating the corresponding worker path?
+- Does it add synchronous work, logging, or allocation pressure on a poller or
+  hot read/write path?
+
+## Observability And Tests
+
+- Primary local integration coverage lives in
+  `components/raftstore-v2/tests/integrations/*`
+- Failpoint coverage lives in
+  `components/raftstore-v2/tests/failpoints/*`
+- Cluster harness support lives in
+  `components/test_raftstore-v2`
+
+## Common Failure Modes
+
+- fix applied only to classic `raftstore`, leaving `raftstore-v2` divergent
+- router/response behavior drifting from `raftkv2` expectations
+- peer/apply lifecycle bugs surfacing as missing callback completion
+- tablet/bootstrap state out of sync with region metadata
+- PD worker logic lagging behind split/slowness/runtime-config changes
+
+## Reading Map And Companion Docs
+
+Suggested reading order:
+
+1. `lib.rs`
+2. `router/mod.rs`
+3. `batch/mod.rs`
+4. `fsm/mod.rs`
+5. `raft/mod.rs`
+6. `operation/mod.rs`
+7. `worker/pd/mod.rs`
+8. `worker/tablet.rs`
+
+Companion docs:
+
+- `repo-overview.md`
+- `src/server.md`
+- `src/storage.md`
+- `components/server.md`
+
+## Glossary
+
+- Tablet:
+  per-region local storage unit used by the tablet-based engine path
+- Router:
+  message delivery layer into store/peer/apply execution
+- Apply FSM:
+  apply-side state machine for committed work
+- Response channel:
+  callback/stream bridge back to the caller

--- a/doc/maintenance-guides/components/raftstore.md
+++ b/doc/maintenance-guides/components/raftstore.md
@@ -1,0 +1,275 @@
+# `components/raftstore` Maintenance Guide
+
+## Purpose And Scope
+
+`raftstore` owns the classic raft-kv region replica state machines and most
+region-level distributed systems behavior on that engine path:
+
+- routing raft and admin requests
+- peer/store FSM execution
+- local read decisions
+- snapshot generation and application
+- split/merge and metadata transitions
+- PD heartbeat and region/store statistics
+- raft log storage and peer storage state
+
+This crate is one of the highest-risk maintenance surfaces in TiKV.
+
+## Architectural Views
+
+### Responsibility view
+
+- region replica state machines
+- peer/store/apply coordination
+- local-read and read-index policy
+- snapshot generation/application
+- split/merge and region metadata transitions
+- PD-facing region/store reporting
+
+### Runtime view
+
+- outer layers route requests here through router and transport traits
+- batch/FSM execution drives peer and store polling
+- worker subsystems offload PD, snapshot, split-check, read, and cleanup tasks
+
+## Process Lifecycle And Startup Sequencing
+
+- Startup ownership comes from `components/server` and `src/server/raft_server`.
+- During startup, routers, batch systems, workers, transport, coprocessor host,
+  and metadata delegates are wired before the node begins serving traffic.
+- During shutdown, pollers and workers must drain in an order that preserves
+  callback completion and avoids orphaning peer/store state.
+
+Concrete startup anchors:
+
+- batch-system creation:
+  `store/fsm/mod.rs`
+- store bootstrap and runtime start:
+  `src/server/raft_server.rs`
+- server-side routing bridge:
+  `router.rs`, `src/server/raftkv/mod.rs`
+
+## Data Model And Metadata Contracts
+
+- Region metadata:
+  id, epoch, peers, bounds, merge/split state
+- Raft metadata:
+  term, index, hard/soft state, truncated state, apply state
+- Snapshot metadata:
+  key, apply state, state transitions, snapshot file set
+- Read metadata:
+  lease/read progress, read-index contexts, local reader delegates
+
+High-risk contracts:
+
+- `RaftCmdRequest` header validation against region epoch and peer identity
+- persisted apply/raft state alignment in `peer_storage.rs`
+- callback/result semantics in `store/msg.rs` and `store/fsm/apply.rs`
+
+## Start Here
+
+- `components/raftstore/src/lib.rs`
+- `components/raftstore/src/router.rs`
+- `components/raftstore/src/store/mod.rs`
+- `components/raftstore/src/store/fsm/mod.rs`
+- `components/raftstore/src/store/fsm/apply.rs`
+- `components/raftstore/src/store/peer.rs`
+- `components/raftstore/src/store/peer_storage.rs`
+- `components/raftstore/src/store/msg.rs`
+- `components/raftstore/src/store/worker/mod.rs`
+
+## Must-Read File Order
+
+1. `components/raftstore/src/router.rs`
+2. `components/raftstore/src/store/msg.rs`
+3. `components/raftstore/src/store/fsm/store.rs`
+4. `components/raftstore/src/store/fsm/apply.rs`
+5. `components/raftstore/src/store/peer.rs`
+6. `components/raftstore/src/store/peer_storage.rs`
+7. `components/raftstore/src/store/worker/read.rs`
+8. `components/raftstore/src/store/worker/pd.rs`
+
+## Internal Structure
+
+### Routing and outer interfaces
+
+- `router.rs` defines the router traits and the server-facing router wrapper.
+- `store/msg.rs` is the central message taxonomy:
+  `PeerMsg`, `StoreMsg`, `SignificantMsg`, callbacks, ticks, and request
+  wrappers.
+- `store/transport.rs` defines the internal transport traits.
+
+### Core FSM execution
+
+- `store/fsm/peer.rs` and `store/fsm/store.rs` own the poll-loop behavior for
+  peer FSMs and the store FSM.
+- `store/fsm/apply.rs` owns committed-log apply, callback completion, and
+  apply-state persistence.
+- `store/peer.rs` is the core replica state machine and policy engine.
+- `store/hibernate_state.rs` manages hibernation and wake-up behavior.
+
+### Persistent region/raft state
+
+- `store/peer_storage.rs` owns apply/raft state persistence and snapshot state.
+- `store/entry_storage.rs` owns raft log entry storage and fetch behavior.
+- `store/region_meta.rs` models persisted region and raft metadata.
+
+### Reads, snapshots, and async IO
+
+- `store/read_queue.rs` owns read-index queueing and batching.
+- `store/region_snapshot.rs` is the region-scoped snapshot view.
+- `store/snap/*` owns snapshot files and application helpers.
+- `store/async_io/*` separates read/write background IO from FSM execution.
+
+### Worker sub-systems
+
+- `store/worker/pd.rs`: store and region stats, PD heartbeats
+- `store/worker/split_check.rs`: split detection and buckets
+- `store/worker/snap_gen.rs`: snapshot generation
+- `store/worker/read.rs`: local reader and read delegates
+- `store/worker/refresh_config.rs`: runtime config propagation
+
+### Coprocessor hooks
+
+- `coprocessor/dispatcher.rs` hosts raftstore observers.
+- `coprocessor/region_info_accessor.rs` exposes region metadata for other
+  subsystems.
+
+## Critical Invariants
+
+- Region epoch checks must remain strict. Most stale command and split/merge
+  safety depends on this.
+- A `Peer` must preserve role, applied index, raft log, and lease/read-progress
+  consistency across ticks and messages.
+- Snapshot lifecycle must not leak:
+  generation, transport, application, and cleanup are all coupled.
+- Local reads must only bypass raft when lease and read-progress guarantees are
+  valid.
+- FSM messages must preserve ordering assumptions between peer/store/apply
+  workers.
+- Any write-path change must preserve callback completion and region-error
+  semantics.
+
+## Observability And Operational Signals
+
+- metrics under `store/metrics.rs`, `store/local_metrics.rs`, and worker metrics
+- PD heartbeat and region/store statistics
+- logs around snapshot, split/merge, peer lifecycle, disk-full, and unsafe
+  recovery paths
+- memory accounting for raft entries/messages/apply state
+
+Open these first when triaging:
+
+- `store/metrics.rs`
+- `store/local_metrics.rs`
+- `store/worker/pd.rs`
+- `store/worker/read.rs`
+
+## Change Management Guidance
+
+- Any change to message types, peer/store/apply ordering, snapshot lifecycle,
+  split/merge metadata, or local-read policy should update this guide.
+- Changes in server/storage bridges should also be audited against this crate,
+  and vice versa.
+- Changes to config in `store/config.rs` or runtime reconfiguration in
+  `worker/refresh_config.rs` should update both contract and operational notes
+  here.
+
+## Change-Impact Matrix
+
+- Router/message taxonomy changes:
+  inspect `router.rs`, `store/msg.rs`, `store/transport.rs`, and
+  `src/server/raftkv/mod.rs`
+- Peer state-machine or local-read changes:
+  inspect `store/peer.rs`, `store/read_queue.rs`, `store/worker/read.rs`, and
+  `src/server/service/kv.rs`
+- Apply-path or callback changes:
+  inspect `store/fsm/apply.rs`, `peer_storage.rs`, `store/msg.rs`, and
+  `src/storage`
+- Snapshot or peer-storage changes:
+  inspect `peer_storage.rs`, `store/snap/*`, `store/worker/snap_gen.rs`, and
+  restore/import call sites
+- Split/merge or region-epoch changes:
+  inspect `peer.rs`, split-check workers, PD heartbeat workers, and region
+  metadata call sites
+- Config or scheduling changes:
+  inspect `store/config.rs`, `store/worker/refresh_config.rs`, and
+  `components/batch-system`
+
+## Review Checklist
+
+- Does the change alter `PeerMsg`, `StoreMsg`, tick ordering, or rescheduling?
+- Does it touch `peer.rs`, `peer_storage.rs`, `entry_storage.rs`, or
+  `fsm/*`? Treat as correctness-sensitive by default.
+- Does it affect read-index, lease renewals, or local reader delegation?
+- Does it change split/merge, unsafe recovery, or replication-mode behavior?
+- Does the same fix also need to exist in `components/raftstore-v2` for
+  `EngineType::RaftKv2`?
+- Does it move synchronous work onto a poller thread or add logging in the hot
+  path?
+- Does it create a new snapshot, raft log, or disk IO path without updating
+  cleanup and metrics?
+
+## Observability And Test Surfaces
+
+- Metrics are concentrated under `store/metrics.rs`, `store/local_metrics.rs`,
+  and worker metrics modules.
+- Integration coverage usually lives outside this crate:
+  `components/test_raftstore` is the first place to extend.
+- There are also many inline tests in:
+  `peer.rs`, `peer_storage.rs`, `entry_storage.rs`, `read_queue.rs`,
+  `fsm/apply.rs`, `compaction_guard.rs`, `region_info_accessor.rs`, and others.
+
+## Common Failure Modes
+
+- stale epoch acceptance
+- read served under invalid lease or progress
+- missing callback completion on canceled or rerouted work
+- snapshot state machine stuck in a transient state
+- peer metadata drift after split, merge, or destroy
+- extra CPU or blocking IO on the FSM hot path
+
+## Reading Map And Companion Docs
+
+Suggested reading order:
+
+1. `router.rs`
+2. `store/msg.rs`
+3. `store/fsm/mod.rs`
+4. `store/fsm/apply.rs`
+5. `store/peer.rs`
+6. `store/peer_storage.rs`
+7. `store/read_queue.rs`
+8. `store/worker/read.rs`
+9. `store/worker/pd.rs`
+10. `coprocessor/dispatcher.rs`
+
+Companion docs:
+
+- `repo-overview.md`
+- `src/server.md`
+- `src/storage.md`
+- `PERFORMANCE_CRITICAL_PATH.md`
+- `components/batch-system.md`
+
+## Glossary
+
+- Peer:
+  one region replica state machine on one store
+- Store FSM:
+  the node-level FSM coordinating cross-region tasks
+- Apply:
+  the phase that applies committed raft entries to state
+- Local read:
+  read served without full raft round-trip when lease/progress allow
+- Read index:
+  raft freshness mechanism for reads
+- Hibernate:
+  reduced-activity peer/group mode to cut unnecessary polling
+
+## Related Components
+
+- `components/batch-system` supplies the FSM execution model.
+- `src/server/raftkv` is the storage bridge into raftstore.
+- `components/hybrid_engine` and `components/in_memory_engine` integrate via
+  observers and region metadata.

--- a/doc/maintenance-guides/components/resource_control.md
+++ b/doc/maintenance-guides/components/resource_control.md
@@ -1,0 +1,208 @@
+# `components/resource_control` Maintenance Guide
+
+## Purpose And Scope
+
+`resource_control` owns request-level fairness and resource-isolation logic for
+resource groups. It watches PD metadata, maintains group state, wraps futures
+and channels with accounting, and adjusts limiters over time.
+
+## Architectural Views
+
+### Policy view
+
+- resource-group definition and runtime state
+- limiter implementation
+- fairness and admission control policy
+- PD watch/report control plane
+
+### Runtime view
+
+- hot-path wrappers on futures/channels
+- periodic background adjustment workers
+- asynchronous PD metadata synchronization
+
+## Process Lifecycle And Startup Sequencing
+
+- The owning process starts this subsystem from server bootstrap.
+- Periodic tasks are started by `start_periodic_tasks`:
+  min-virtual-time advancement, PD watch loop, quota adjustment, RU reporting.
+- Shutdown safety depends on the owning worker/runtime lifecycle, so long-lived
+  tasks here should remain cancellation-safe and retry-safe.
+
+Concrete runtime anchors:
+
+- periodic-task setup:
+  `lib.rs::start_periodic_tasks`
+- PD watch and reload loop:
+  `service.rs`
+- quota adjustment:
+  `worker.rs`
+
+## Data Model And Metadata Contracts
+
+- Resource-group definitions come from PD meta storage.
+- Runtime metadata includes:
+  group mode, quotas, virtual-time state, baseline usage, limiter statistics,
+  admission decisions.
+- Background usage reports back to PD as request-unit accounting.
+
+Hot contracts to review carefully:
+
+- group-name identity and default/background-group semantics
+- baseline-window and fairness-phase encoding
+- RU accounting inputs and report-unit interpretation
+
+## Start Here
+
+- `components/resource_control/src/lib.rs`
+- `components/resource_control/src/resource_group.rs`
+- `components/resource_control/src/resource_limiter.rs`
+- `components/resource_control/src/service.rs`
+- `components/resource_control/src/config.rs`
+- `components/resource_control/src/worker.rs`
+- `components/resource_control/src/future.rs`
+- `components/resource_control/src/channel.rs`
+
+## Must-Read File Order
+
+1. `components/resource_control/src/lib.rs`
+2. `components/resource_control/src/config.rs`
+3. `components/resource_control/src/resource_group.rs`
+4. `components/resource_control/src/resource_limiter.rs`
+5. `components/resource_control/src/service.rs`
+6. `components/resource_control/src/worker.rs`
+7. `components/resource_control/src/future.rs`
+8. `components/resource_control/src/channel.rs`
+
+## Main Responsibilities
+
+- maintain `ResourceGroupManager`
+- track per-group quotas and consumption
+- wrap execution with `ControlledFuture` / `with_resource_limiter`
+- watch resource-group definitions from PD meta storage
+- report background RU usage back to PD
+- adjust quotas and throttling behavior periodically
+- expose fair scheduling and admission-control decisions to callers
+
+## Important Design Points
+
+- `service.rs` is the PD-facing control plane. It reloads resource groups,
+  watches config paths, and retries on compaction or transient failures.
+- `resource_group.rs` is the policy core. It contains:
+  - resource group state
+  - virtual-time and baseline logic
+  - admission decisions
+  - fairness/two-phase scheduling helpers
+- `resource_limiter.rs` is the actual limiter and statistics store.
+- `worker.rs` adjusts background quota and related runtime state periodically.
+- `config.rs` defines dynamic policy knobs such as fair scheduling and
+  admission-control thresholds.
+
+## Critical Invariants
+
+- Group configuration must converge safely when PD watch streams restart or the
+  watch revision is compacted.
+- Accounting paths must remain cheap because they can sit on hot request paths.
+- Admission control and fair scheduling must degrade specific traffic classes,
+  not accidentally all traffic.
+- Dynamic config updates must alter runtime behavior, not only the stored config
+  value.
+- Background-group reporting must not silently double-count or regress versioned
+  limiter statistics.
+
+## Observability And Operational Signals
+
+- limiter and scheduling metrics in `metrics.rs`
+- logs on PD watch/reload failures, compaction restarts, and config loads
+- RU reporting cadence and background-group behavior
+
+Start triage with:
+
+- `metrics.rs`
+- `service.rs` watch/reload logs
+- `worker.rs` quota-adjustment logic
+
+## Change Management Guidance
+
+- If policy knobs, admission behavior, or PD metadata contracts change, update
+  this guide in the same patch.
+- If callers in storage/server/batch-system start depending on new semantics,
+  update both ends of the contract.
+- Fairness or admission changes should come with before/after reasoning about
+  who gets delayed, who gets rejected, and under which pressure signal.
+
+## Change-Impact Matrix
+
+- PD watch or config reload changes:
+  inspect `service.rs`, PD client interactions, and caller assumptions about
+  convergence
+- Fairness or baseline changes:
+  inspect `resource_group.rs`, `resource_limiter.rs`, and hot-path consumers in
+  storage/server
+- Request admission or delay/reject changes:
+  inspect `future.rs`, `channel.rs`, `src/server/service/kv.rs`, and
+  `src/storage`
+- Background RU reporting changes:
+  inspect `worker.rs`, limiter statistics, and PD-facing reporting contracts
+- Config knob changes:
+  inspect `config.rs`, runtime update sites, metrics, and reviewer-facing docs
+
+## Review Checklist
+
+- Does the change affect `watch_resource_groups`, reload, or retry behavior?
+- Does it alter fairness phase encoding, priority ordering, or baseline logic?
+- Does it change request rejection versus delay behavior?
+- Does it change accounting units or resource-cost interpretation?
+- Does it create lock contention in the hot path?
+- Does it update metrics and tests for new scheduling outcomes?
+
+## Observability And Tests
+
+- Metrics live under `metrics.rs` and within the group/limiter code.
+- Many unit tests are inline in:
+  `future.rs`, `service.rs`, `worker.rs`, `channel.rs`, and `resource_limiter.rs`.
+- Changes should usually be validated together with the call sites in
+  `src/server`, `src/storage`, and `components/batch-system`.
+
+## Common Failure Modes
+
+- watcher stalls after compaction or transient PD errors
+- starvation due to incorrect priority or baseline math
+- too-aggressive shedding that impacts non-target traffic
+- silently stale background-limiter reporting
+- dynamic-config changes that fail to take effect operationally
+
+## Reading Map And Companion Docs
+
+Suggested reading order:
+
+1. `lib.rs`
+2. `config.rs`
+3. `resource_group.rs`
+4. `resource_limiter.rs`
+5. `service.rs`
+6. `worker.rs`
+7. `future.rs`
+
+Companion docs:
+
+- `repo-overview.md`
+- `src/server.md`
+- `src/storage.md`
+
+## Glossary
+
+- RU:
+  request unit used for resource accounting
+- Baseline:
+  historical usage reference for fairness and admission control
+- Admission control:
+  delay or reject logic under pressure
+- Virtual time:
+  scheduling progress notion used to compare group fairness state
+
+## Related Components
+
+- `src/server/service/kv.rs` consumes resource-group context at the RPC edge.
+- `src/storage` uses resource-control metadata and limiters during scheduling.
+- `components/batch-system` integrates with priority-aware execution.

--- a/doc/maintenance-guides/components/server.md
+++ b/doc/maintenance-guides/components/server.md
@@ -1,0 +1,194 @@
+# `components/server` Maintenance Guide
+
+## Purpose And Scope
+
+`components/server` owns TiKV process construction and orchestration. It is the
+startup and shutdown shell around the runtime subsystems. This crate should be
+read as lifecycle glue, not business logic.
+
+## Architectural Views
+
+### Bootstrap orchestration view
+
+- config validation and process setup
+- engine assembly
+- service and worker registration
+- runtime startup and stop control
+
+### Variant view
+
+- `server.rs` drives the classic path
+- `server2.rs` drives the alternate tablet-based path
+- `common.rs` holds shared process capabilities
+
+## Process Lifecycle And Startup Sequencing
+
+- This crate is the main owner of startup sequencing for a TiKV process.
+- Correct ordering is:
+  config and filesystem setup, engine setup, worker/runtime setup, service
+  registration, runtime start, event-loop control.
+- Correct shutdown is the reverse, with extra care for in-flight service events
+  and worker ownership.
+
+Concrete startup checkpoints:
+
+1. `TikvServerCore::init_config`
+2. `check_conflict_addr`
+3. `init_fs`
+4. engine and utility initialization
+5. service registration and runtime start
+6. status server start
+7. service-event loop
+
+## Data Model And Metadata Contracts
+
+- process-level config and persisted-config contract
+- store path and lock-file contract
+- engine selection contract
+- service event routing contract with `components/service`
+
+High-risk config contracts:
+
+- data-directory and engine-layout compatibility
+- reserved-space behavior for recovery
+- process-wide memory limits and high-water handling
+
+## Start Here
+
+- `components/server/src/lib.rs`
+- `components/server/src/common.rs`
+- `components/server/src/raft_engine_switch.rs`
+- `components/server/src/server.rs`
+- `components/server/src/server2.rs`
+- `components/server/src/setup.rs`
+- `components/server/src/signal_handler.rs`
+
+## Must-Read File Order
+
+1. `components/server/src/common.rs`
+2. `components/server/src/setup.rs`
+3. `components/server/src/server.rs`
+4. `components/server/src/server2.rs`
+5. `components/server/src/raft_engine_switch.rs`
+6. `components/server/src/signal_handler.rs`
+
+## Major Responsibilities
+
+- validate and persist config
+- initialize filesystem, lock files, reserved disk space, and panic markers
+- create engines and engine-related helpers
+- wire classic raftstore or `RaftKv2` / `raftstore-v2`, plus storage,
+  coprocessor, status server, GC worker, CDC, backup, and other services
+- register dynamic-config managers
+- handle service pause/resume and graceful shutdown
+- support both v1 and v2 engine/server startup paths
+
+## Important Structure
+
+- `common.rs` contains reusable server-core facilities used by different startup
+  modes.
+- `server.rs` is the main startup path for the existing raft-kv oriented stack.
+- `server2.rs` is the analogous startup path for the `RaftKv2` /
+  `raftstore-v2` stack.
+- `raft_engine_switch.rs` owns the online raft-engine migration helper path and
+  is easy to miss when changing engine bootstrap behavior.
+- `setup.rs` owns logging and early process environment setup.
+
+## Critical Invariants
+
+- Startup ordering matters. Many subsystems assume other pieces already exist.
+- Shutdown ordering matters. Workers and services must stop after their
+  dependents drain.
+- Config validation must remain backward-compatible with persisted data layout
+  and engine selection.
+- Service pause/resume must stay consistent with the small control plane in
+  `components/service`.
+
+## Observability And Operational Signals
+
+- startup and shutdown logs
+- config persistence and validation output
+- disk-space reservation and lock-file failures
+- memory/high-water signals registered during startup
+
+Start triage with:
+
+- startup logs from `setup.rs` and `common.rs`
+- config-controller state
+- process lifecycle logs in `server.rs`
+
+## Change Management Guidance
+
+- Treat startup ordering and stop ordering as correctness-sensitive.
+- If a new subsystem is started or stopped here, update this guide and the
+  matching runtime guide in the same patch.
+- If a change only updates the startup path but not the operational stop path,
+  it is usually incomplete.
+
+## Change-Impact Matrix
+
+- Startup or dependency-order changes:
+  inspect `common.rs`, `setup.rs`, `server.rs`, and `src/server/raft_server.rs`
+- Service wiring changes:
+  inspect `server.rs` or `server2.rs`, runtime owners in `src/server`, and
+  service-control consumers
+- Engine bootstrap or path-selection changes:
+  inspect `common.rs`, `raft_engine_switch.rs`, `server.rs`, and `server2.rs`
+- Shutdown or signal changes:
+  inspect `signal_handler.rs`, service-event loop handling, and the matching
+  runtime stop paths
+
+## Review Checklist
+
+- Does the change alter startup order or create new cyclic dependencies?
+- Does it register a new worker/service without adding a stop path?
+- Does it change engine selection, data-path validation, or filesystem layout?
+- Does it update only `server.rs` but also need parity in `server2.rs`, or the
+  reverse?
+- Does it alter graceful shutdown semantics?
+- Does it add expensive initialization to the critical startup path?
+
+## Observability And Tests
+
+- There is not much isolated test surface here; validation usually requires
+  wider integration testing or startup smoke checks.
+- Logging, metrics registration, and signal handling are all useful places to
+  verify when process-lifecycle bugs happen.
+
+## Common Failure Modes
+
+- subsystem started before config or dependency is ready
+- service added without a coordinated shutdown path
+- persistent-data-layout mismatch after config changes
+- pause/resume events not reaching the real runtime owner
+
+## Reading Map And Companion Docs
+
+Suggested reading order:
+
+1. `common.rs`
+2. `raft_engine_switch.rs`
+3. `setup.rs`
+4. `server.rs`
+5. `server2.rs`
+6. `signal_handler.rs`
+
+Companion docs:
+
+- `repo-overview.md`
+- `src/server.md`
+- `src/storage.md`
+
+## Glossary
+
+- Graceful shutdown:
+  stop sequence intended to drain or stop subsystems cleanly
+- Persisted config:
+  config material validated against local data layout and prior runs
+- Conflict address lock:
+  temp-file based guard against multiple TiKV instances serving the same addr
+
+## Related Components
+
+- `src/server` is the runtime service stack that this crate wires together.
+- `components/service` supplies the control events used for pause/resume.

--- a/doc/maintenance-guides/components/service.md
+++ b/doc/maintenance-guides/components/service.md
@@ -1,0 +1,143 @@
+# `components/service` Maintenance Guide
+
+## Purpose And Scope
+
+`components/service` is a small control-plane helper crate. It does not own the
+real gRPC service implementations. It owns service-control events and a tiny
+manager used by the runtime and status server.
+
+## Architectural Views
+
+### Control-plane view
+
+- event enum defines the control vocabulary
+- manager tracks local state and emits service events outward
+
+## Process Lifecycle And Startup Sequencing
+
+- The manager is created during server bootstrap and then shared with runtime
+  owners such as the status server and the main control loop.
+- Event handling correctness depends on the outer runtime, but this crate owns
+  the local state machine and idempotent emission behavior.
+- The concrete outer owners today are `components/server/src/server.rs`,
+  `components/server/src/server2.rs`, `components/server/src/signal_handler.rs`,
+  and `src/server/status_server/mod.rs`.
+- `GrpcServiceManager::new` starts in `Serving`, while `dummy()` is test-only.
+  Any change to that default must be reviewed against startup probes, status
+  APIs, and signal handling behavior.
+
+## Data Model And Metadata Contracts
+
+- Service state contract:
+  init, serving, not-serving
+- Event contract:
+  pause, resume, graceful shutdown, exit
+- This crate deliberately keeps a tiny local state model:
+  `GrpcServiceStatus::{Init, Serving, NotServing}` plus
+  `ServiceEvent::{PauseGrpc, ResumeGrpc, GracefulShutdown, Exit}`.
+- The most important contract is idempotent state-to-event mapping in
+  `service_manager.rs`: `pause()` should not emit repeated pause requests when
+  already paused, and `resume()` should not emit repeated resume requests when
+  already serving.
+- `GracefulShutdown` and `Exit` are owned by the outer runtime rather than the
+  manager itself. Do not move process-orchestration policy into this crate.
+
+## Start Here
+
+- `components/service/src/lib.rs`
+- `components/service/src/service_event.rs`
+- `components/service/src/service_manager.rs`
+
+## Must-Read File Order
+
+1. `components/service/src/service_event.rs`
+2. `components/service/src/service_manager.rs`
+3. `components/server/src/server.rs`
+4. `src/server/status_server/mod.rs`
+
+## What It Owns
+
+- `ServiceEvent`: pause, resume, graceful shutdown, exit
+- `GrpcServiceManager`: lightweight state plus event sender
+
+## Why It Matters
+
+This crate is simple, but changes here can break pause/resume or coordinated
+shutdown semantics across the process.
+
+## Critical Invariants
+
+- Event emission must remain idempotent for pause/resume.
+- The local status state should not drift from the events sent to the outer
+  handler.
+- This crate should stay minimal. Do not move real server logic into it.
+
+## Observability And Operational Signals
+
+- operational visibility mainly comes from outer runtime behavior rather than
+  local metrics in this crate
+- There is little local metric surface. Real triage usually starts with:
+  `components/server/src/server.rs` or `server2.rs`,
+  `components/server/src/signal_handler.rs`, and
+  `src/server/status_server/mod.rs`.
+- Failures here usually present as “pause/resume API says success but serving
+  state did not change”, or as shutdown ordering issues rather than as direct
+  metric anomalies.
+
+## Change Management Guidance
+
+- Keep this crate small and contract-focused.
+- If control vocabulary or state behavior changes, update both this guide and
+  the owners in `components/server` and `src/server/status_server`.
+- If a new service-control event is added, document:
+  who emits it, who consumes it, whether it is idempotent, and whether it is a
+  local serving-state transition or a process-level shutdown signal.
+- A patch that changes manager state transitions without updating the HTTP
+  status server and signal-handling consumers is almost certainly incomplete.
+
+## Change-Impact Matrix
+
+- Event vocabulary changes:
+  inspect `service_event.rs`, `components/server`, and status-server consumers
+- Pause/resume state changes:
+  inspect `service_manager.rs`, status-server control endpoints, and runtime
+  handlers
+- Shutdown-signal changes:
+  inspect signal handling and outer process-control loops rather than only this
+  crate
+
+## Review Checklist
+
+- Does the change preserve pause/resume idempotency?
+- Does it affect event ordering seen by `components/server`?
+- Is new state being added here that really belongs in runtime code instead?
+
+## Observability And Tests
+
+- There is little dedicated test surface now; integration behavior is visible
+  through `components/server` and `src/server/status_server`.
+- `GrpcServiceManager::dummy()` is a hint that many tests cover this behavior
+  indirectly through status-server and server integration rather than local unit
+  tests.
+
+## Reading Map And Companion Docs
+
+- `service_event.rs`
+- `service_manager.rs`
+- `components/server.md`
+- `src/server.md`
+
+## Glossary
+
+- Serving:
+  the local state in which the manager considers gRPC available
+- Pause:
+  the control event used to stop serving without full process exit
+- Exit:
+  hard process termination signal in the service event vocabulary, distinct from
+  graceful gRPC pause or drain
+
+## Related Components
+
+- `components/server` consumes these events in its main control loop.
+- `src/server/status_server/mod.rs` exposes pause/resume operations.

--- a/doc/maintenance-guides/repo-overview.md
+++ b/doc/maintenance-guides/repo-overview.md
@@ -1,0 +1,568 @@
+# Repository Overview
+
+This file is the top-level maintenance map for the TiKV repository. It is the
+first file maintainers and reviewers should read before working on a
+cross-component change.
+
+## Purpose And Scope
+
+- Describe the repository at the maintenance boundary level, not at the user
+  feature level.
+- Explain how major subsystems fit together and where ownership boundaries are.
+- Highlight repository-wide invariants, sequencing rules, and failure modes.
+- Serve as an index into the deeper subsystem guides in this directory.
+
+## System Context And External Dependencies
+
+TiKV is a distributed transactional key-value database that normally runs with:
+
+- PD / Placement Driver:
+  cluster metadata, timestamps, scheduling, resource-group metadata, labels
+- TiDB:
+  SQL layer and a major caller of transactional and coprocessor APIs
+- RocksDB and raft-log engine:
+  the main local persistence backends
+- gRPC:
+  request/response transport, raft transport, and administrative RPCs
+- CDC, backup, backup-stream, import/restore tooling:
+  data movement and external integration surfaces
+
+Major local or in-repo infrastructure dependencies include:
+
+- `components/engine_rocks`
+- `components/raft_log_engine`
+- `components/batch-system`
+- `components/pd_client`
+- `components/security`
+- `components/sst_importer`
+- `components/resource_control`
+
+Operationally significant external dependencies that often affect maintenance
+work:
+
+- filesystem and disk layout under the configured data directory
+- TLS / encryption material managed through `components/security` and
+  `components/encryption`
+- dynamic config propagation through PD-backed config registration and watches
+- container or host-level CPU and memory quota reporting used by startup and
+  throttling logic
+
+## Core Components And Boundaries
+
+### Process bootstrap
+
+- `components/server` owns process startup, configuration validation, engine
+  initialization, worker wiring, service registration, graceful pause/resume,
+  and shutdown.
+
+### Network and service edge
+
+- `src/server` owns the runtime-facing boundary:
+  gRPC services, Raft transport, snapshot transport, status HTTP server, debug
+  endpoints, lock manager service, GC worker, and TTL helpers.
+
+### Transaction and storage layer
+
+- `src/storage` owns command scheduling, MVCC, raw KV, latches, lock waiting,
+  flow control, and the `Storage` API used by RPC handlers.
+
+### Raft replication and region state
+
+- `components/raftstore` owns region replicas, raft messages, snapshot/apply
+  lifecycle, split/merge handling, local read decisions, PD heartbeats, and the
+  peer/store FSM structure.
+- `components/batch-system` provides the generic polling and mailbox machinery
+  that classic raftstore is built on.
+
+### Alternate tablet-based replication path
+
+- TiKV also contains a second replication path selected by
+  `storage.engine = partitioned-raft-kv` / `EngineType::RaftKv2`.
+- The bridge is `src/server/raftkv2`, the runtime bootstrap is
+  `components/server/src/server2.rs`, and the replica implementation is
+  `components/raftstore-v2`.
+- This guide set intentionally does not document `components/raftstore-v2`
+  itself yet, but maintainers still need to ask whether a server/storage fix is
+  path-agnostic or requires a matching `RaftKv2` audit.
+
+### Compute pushdown
+
+- `src/coprocessor` is the classic TiDB coprocessor path for DAG, analyze, and
+  checksum requests.
+- `src/coprocessor_v2` is a plugin framework for raw coprocessor extensions.
+
+### Resource governance and cache engines
+
+- `components/resource_control` owns resource groups, fairness, quota limiters,
+  PD metadata watches, and admission control helpers.
+- `components/in_memory_engine` owns region-cache storage and background tasks.
+- `components/hybrid_engine` bridges disk snapshots and the in-memory region
+  cache for read acceleration.
+
+### Data movement and ecosystem integrations
+
+- `components/backup` and `components/backup-stream` own backup and log-backup
+  surfaces.
+- `components/cdc` owns changefeed capture and delivery.
+- `src/import` and `components/sst_importer` own SST import and ingest flows.
+
+Repository boundary rule:
+
+- The top-level ownership lines above are the default review boundaries. If a
+  change crosses one of them, the PR or review should call that out explicitly.
+
+## Architectural Views
+
+### Layered view
+
+1. Process bootstrap and configuration
+2. Network/service edge
+3. Storage API and transactional scheduling
+4. Replication and region state machines
+5. Persistence engines and filesystem integration
+6. Background services and external integrations
+
+### Runtime ownership view
+
+- Main startup and stop orchestration: `components/server`
+- Long-lived RPC services: `src/server`
+- Request scheduling and transactional correctness: `src/storage`
+- Region/peer/store correctness: `components/raftstore`
+- Disk and cache engines: engine crates plus `hybrid_engine` /
+  `in_memory_engine`
+
+### Deployment and dependency view
+
+- TiKV node depends on PD for metadata and timestamps.
+- TiKV participates in Raft groups across nodes.
+- TiKV exposes gRPC and status HTTP surfaces.
+- Optional subsystems such as CDC, backup, and import plug into the same node
+  lifecycle.
+
+## Process Lifecycle And Startup Sequencing
+
+The high-level startup order is:
+
+1. Validate config and process environment.
+2. Initialize logging, filesystem state, lock files, reserved disk space, and
+   panic markers.
+3. Initialize engines and engine-related helpers.
+4. Build workers, read pools, quota limiters, resource control, and
+   coprocessor/runtime services.
+5. Start raftstore and storage bridges.
+6. Start gRPC server, status server, and other auxiliary services.
+7. Enter the service-event loop for pause/resume/shutdown handling.
+
+The high-level shutdown order is the reverse:
+
+1. Stop admitting or pause/resume appropriately.
+2. Drain or stop RPC-facing services.
+3. Stop background workers and runtime helpers.
+4. Stop storage and replication stacks after dependents are done.
+5. Release process-owned resources.
+
+Key maintainership rule:
+
+- Startup and shutdown ordering are correctness concerns, not only operational
+  details. Cross-thread and cross-worker ownership bugs often surface here.
+
+Concrete startup anchors in code:
+
+- process setup and config persistence:
+  `components/server/src/common.rs`, `components/server/src/setup.rs`
+- full classic startup orchestration:
+  `components/server/src/server.rs`
+- runtime gRPC server construction:
+  `src/server/server.rs`
+- classic raftstore bootstrap and store registration:
+  `src/server/raft_server.rs`
+
+## Data Model And Metadata Contracts
+
+Repository-wide metadata and state contracts include:
+
+- Region metadata:
+  region id, epoch, peers, key range, leader/read state
+- Raft metadata:
+  term, log index, apply state, truncated state, snapshot state
+- Transactional metadata:
+  locks, writes, default-CF values, max-ts, causal-ts, lock wait state
+- Snapshot metadata:
+  sequence number, region bound, read ts, cache pin, safe point
+- Resource governance metadata:
+  resource-group definitions, request metadata, RU accounting
+- Store metadata:
+  store id, addresses, labels, advertised endpoints, deployment info
+
+Cross-component rule:
+
+- Any change to a persisted, network-exposed, or dynamically watched metadata
+  contract should trigger review of the matching maintenance guide and usually a
+  doc update in this directory.
+
+Hot metadata classes that deserve explicit reviewer attention:
+
+- `metapb::Store`, `metapb::Region`, and region epoch transitions
+- `RaftCmdRequest` / `RaftCmdResponse` headers and region error semantics
+- `kvrpcpb::Context` and derived request metadata such as resource-group tags
+- storage API version and TTL expectations in `src/storage/config.rs`
+
+## Write Path And Raft Pipeline
+
+Classic write path:
+
+1. `src/server/service/kv.rs` parses RPCs and builds storage calls.
+2. `src/storage/mod.rs` and `src/storage/txn/scheduler.rs` turn requests into
+   scheduled commands.
+3. `src/server/raftkv/mod.rs` bridges storage writes to raftstore commands.
+4. `components/raftstore/src/router.rs` and
+   `components/raftstore/src/store/fsm/*` route work to the peer/store FSMs.
+5. `components/raftstore/src/store/peer.rs` and related apply/write paths drive
+   raft replication and persistence.
+
+Alternate `RaftKv2` write path:
+
+1. `src/server/service/kv.rs` still parses RPCs and calls storage.
+2. `src/storage` still owns scheduling and transactional semantics.
+3. `src/server/raftkv2/mod.rs` bridges writes into the tablet-based path.
+4. `components/raftstore-v2` owns router, batch/FSM execution, and tablet-side
+   persistence.
+
+Review rule:
+
+- If a change touches storage-to-replication bridging or callback semantics,
+  explicitly audit both paths.
+
+Hot files for this pipeline:
+
+- `src/server/service/kv.rs`
+- `src/storage/txn/scheduler.rs`
+- `src/server/raftkv/mod.rs`
+- `components/raftstore/src/store/peer.rs`
+- `components/raftstore/src/store/fsm/apply.rs`
+
+## Read Path And Coprocessor Execution
+
+Classic KV read path:
+
+1. `src/server/service/kv.rs` builds storage or coprocessor requests.
+2. `src/storage` serves raw or MVCC reads, sometimes using `raftkv` snapshots.
+3. `components/raftstore` may serve local reads if lease/read-index rules hold.
+4. `components/hybrid_engine` and `components/in_memory_engine` can satisfy a
+   region-scoped snapshot from the cache engine when available.
+
+Coprocessor path:
+
+1. `src/server/service/kv.rs` forwards coprocessor RPCs.
+2. `src/coprocessor/endpoint.rs` or `src/coprocessor_v2/endpoint.rs` parses
+   and dispatches them.
+3. `src/storage` provides snapshots and raw access.
+4. Classic coprocessor runs built-in executors; v2 calls dynamically loaded
+   plugins.
+
+## Foreground And Background IO, And Determinism
+
+TiKV deliberately separates foreground request work from background work where
+possible.
+
+- Foreground examples:
+  RPC handling, scheduler execution, raft pollers, local reads, coprocessor
+  execution
+- Background examples:
+  PD heartbeats, GC tasks, snapshot generation, compaction-related work, cache
+  loading/eviction, backup, CDC, metrics flushing
+
+Important rule:
+
+- Avoid introducing unnecessary synchronous IO on request hot paths or FSM
+  pollers.
+- Preserve determinism around callback ordering, message ordering, and snapshot
+  semantics even when background offload changes.
+
+Code anchors for IO classification and separation:
+
+- foreground read pools:
+  `src/coprocessor/readpool_impl.rs`, `src/read_pool.rs`
+- filesystem IO typing and rate limiting:
+  `file_system`, `src/storage/config_manager.rs`
+- raftstore worker separation:
+  `components/raftstore/src/store/worker/*`
+
+## Snapshot, Split/Merge, And Restore Semantics
+
+- Snapshot correctness depends on region bounds, sequence number, apply state,
+  and sometimes cache pinning or safe point.
+- Split and merge correctness depends on epoch transitions, metadata updates,
+  and message ordering across peer/store/apply workers.
+- Restore/import flows interact with snapshots and raftstore because ingest must
+  align with region ownership and persistent state.
+
+These are cross-component flows spanning:
+
+- `components/raftstore`
+- `src/server/raftkv*`
+- `src/storage`
+- `src/import`
+- `components/sst_importer`
+
+Maintainer warning:
+
+- Bugs in these flows often present far away from the original code change:
+  stale epoch errors, missing callbacks, duplicate or lost data, or restore
+  failures.
+
+## Engines For Raft And RocksDB Deep Dive
+
+Two key persistence families matter repository-wide:
+
+- RocksDB-backed KV engine via `components/engine_rocks`
+- Raft log engine via `components/raft_log_engine`
+
+Maintainers should remember:
+
+- engine configuration, filesystem integration, background errors, compaction,
+  and snapshot behavior are not isolated implementation details; they influence
+  correctness and operability across server, storage, and raftstore.
+- `src/storage/config.rs` chooses between `RaftKv` and `RaftKv2` stack variants.
+- `components/server/src/common.rs` and startup code wire engine lifecycle and
+  resources.
+
+Useful engine-specific files:
+
+- `components/engine_rocks/src/lib.rs`
+- `components/engine_rocks/src/event_listener.rs`
+- `components/engine_rocks/src/flow_listener.rs`
+- `components/engine_rocks/src/misc.rs`
+- `components/raft_log_engine/src/lib.rs`
+
+## Backup And Restore
+
+- `components/backup` owns backup request processing and writing backup output.
+- `components/backup-stream` owns log backup / continuous backup surfaces.
+- `src/import` and `components/sst_importer` own ingest/import/restore-adjacent
+  SST flows.
+
+Maintenance rule:
+
+- Changes in snapshot, ingest, region ownership, or engine write semantics
+  should be audited for backup/import/restore impact.
+
+Relevant code anchors:
+
+- `components/backup/src/lib.rs`
+- `components/backup-stream/src/lib.rs`
+- `src/import/mod.rs`
+- `components/sst_importer/src/lib.rs`
+
+## CDC Architecture
+
+- `components/cdc` owns change data capture endpoint, observer integration, and
+  service logic.
+- CDC depends on raft/apply timing, old-value handling, and transactional
+  metadata correctness.
+
+Maintenance rule:
+
+- Write-path, old-value, apply-ordering, or resolved-ts changes can affect CDC
+  even if the immediate feature change looks unrelated.
+
+Relevant code anchors:
+
+- `components/cdc/src/lib.rs`
+- `components/cdc/src/observer.rs`
+- `components/cdc/src/endpoint.rs`
+
+## Cross-Component Invariants And Ordering Rules
+
+- Region-scoped operations must respect epoch, key range, and leader/read-index
+  constraints.
+- Snapshot-backed reads must not outlive the underlying safety assumptions:
+  sequence number, safe point, snapshot pinning, or region cache lifetime.
+- Write-path changes must preserve callback behavior:
+  success, region error, timeout, undetermined result, and cancellation.
+- Dynamic config changes must update both config state and runtime side effects.
+- Metrics and logging on hot paths must remain cheap.
+- Background work must not violate ordering guarantees expected by foreground
+  logic.
+
+## Failure Modes And Recovery Playbook
+
+Common repository-wide failure modes:
+
+- cross-thread ownership and shutdown ordering bugs
+- callback completion rules broken on error or cancellation paths
+- range validation bugs around region snapshots and raw scans
+- local read served under invalid lease or stale progress
+- runtime config updated in memory but not applied operationally
+- resource-control or fairness logic causing unintended latency shifts
+- engine background errors or disk-space issues propagating badly
+
+Recovery / triage guidance:
+
+1. Identify the boundary layer where the wrong behavior first became visible.
+2. Check metrics, logs, and status-server endpoints before editing code.
+3. Verify whether the failure is path-specific:
+   classic raftstore, `RaftKv2`, coprocessor, raw KV, CDC, backup, import.
+4. Re-check callback ordering, snapshot assumptions, and dynamic config side
+   effects.
+5. Re-check whether the current maintenance guide is stale relative to the code
+   you are debugging.
+
+## Observability And Operational Signals
+
+Important observability surfaces include:
+
+- Prometheus metrics across server, storage, raftstore, engines, resource
+  control, CDC, backup
+- slow logs and regular logs
+- status server endpoints
+- health controller / gRPC health
+- memory and thread-load tracking
+- engine and filesystem statistics
+
+Operationally important subsystems include:
+
+- `src/server/status_server`
+- `src/server/metrics.rs`
+- raftstore metrics and local metrics
+- coprocessor trackers and wait-time metrics
+- storage scheduler and MVCC metrics
+
+Concrete metric modules worth opening first:
+
+- `components/raftstore/src/store/metrics.rs`
+- `components/raftstore/src/store/local_metrics.rs`
+- `src/storage/metrics.rs`
+- `src/coprocessor/metrics.rs`
+- `src/server/metrics.rs`
+- `components/resource_control/src/metrics.rs`
+- `components/in_memory_engine/src/metrics.rs`
+
+## Change Management Guidance
+
+- Treat this file and the matching subsystem guide as required context for any
+  non-trivial change.
+- If a change modifies:
+  startup order, ownership boundaries, metadata contracts, path-specific
+  behavior, invariants, observability, or reading maps, update the relevant
+  guide in the same change.
+- If a fix touches storage/server boundaries, explicitly evaluate whether
+  `RaftKv2`, CDC, backup/import, or coprocessor paths also need attention.
+- If the guide is missing facts needed for a safe review, the guide itself
+  should be improved as part of the maintenance work.
+
+## Change-Impact Matrix
+
+- Startup, shutdown, or process ownership changes:
+  read `components/server`, `src/server`, worker lifecycle, and service control
+  guides together
+- RPC or request-boundary changes:
+  read `src/server`, `src/storage`, `src/coprocessor`, and resource-control
+  guides together
+- Transaction, MVCC, callback, or lock-wait changes:
+  read `src/storage` first, then `src/server` and replication bridge guides
+- Replica, snapshot, split/merge, local-read, or apply-path changes:
+  read `components/raftstore`, `components/batch-system`,
+  `src/server/raftkv`-related code, and audit whether the same reasoning also
+  applies to `src/server/raftkv2` / `components/raftstore-v2`
+- Cache-engine or hybrid snapshot changes:
+  read `components/in_memory_engine`, `components/hybrid_engine`,
+  `src/coprocessor`, and replication observer wiring together
+- Fairness, admission, or RU-accounting changes:
+  read `components/resource_control`, `src/server/service/kv.rs`,
+  `src/storage`, and `components/batch-system`
+- Import, backup, restore, or CDC changes:
+  audit `src/import`, `components/sst_importer`, `components/backup`,
+  `components/backup-stream`, and `components/cdc` plus the affected storage or
+  raftstore contracts
+
+## Must-Read File Order
+
+Use this faster file order when the goal is review or change-impact analysis
+rather than general onboarding:
+
+1. `src/server/service/kv.rs`
+2. `src/storage/mod.rs`
+3. `src/storage/txn/scheduler.rs`
+4. `src/server/raftkv/mod.rs`
+5. `components/raftstore/src/router.rs`
+6. `components/raftstore/src/store/peer.rs`
+7. `components/raftstore/src/store/fsm/apply.rs`
+8. `src/coprocessor/endpoint.rs`
+9. `components/resource_control/src/lib.rs`
+10. `components/server/src/server.rs`
+
+If the change primarily targets `EngineType::RaftKv2`, swap in these parallel
+anchors early:
+
+- `src/server/raftkv2/mod.rs`
+- `components/raftstore-v2/src/router/mod.rs`
+- `components/raftstore-v2/src/fsm/mod.rs`
+- `components/raftstore-v2/src/raft/mod.rs`
+- `components/raftstore-v2/src/operation/mod.rs`
+
+## Reading Map And Companion Docs
+
+Suggested reading order for new maintainers:
+
+1. `components/server/src/common.rs`
+2. `components/server/src/server.rs`
+3. `src/server/mod.rs`
+4. `src/server/service/kv.rs`
+5. `src/storage/mod.rs`
+6. `src/storage/txn/scheduler.rs`
+7. `src/server/raftkv/mod.rs`
+8. `components/raftstore/src/router.rs`
+9. `components/raftstore/src/store/mod.rs`
+10. `components/raftstore/src/store/fsm/mod.rs`
+11. `src/coprocessor/mod.rs`
+12. `components/resource_control/src/lib.rs`
+13. the matching deeper guide in `doc/maintenance-guides/`
+
+If the work is on the `RaftKv2` / tablet-based stack, also read:
+
+- `src/server/raftkv2/mod.rs`
+- `components/raftstore-v2/src/lib.rs`
+- `components/raftstore-v2/src/router/mod.rs`
+- `components/raftstore-v2/src/fsm/mod.rs`
+
+Useful companion docs in this repo:
+
+- `README.md`
+- `PERFORMANCE_CRITICAL_PATH.md`
+- `CODE_COMMENT_STYLE.md`
+- `doc/http.md`
+- `doc/deploy.md`
+
+Useful external references:
+
+- TiKV overview: `https://tikv.org/docs/latest/concepts/overview/`
+- Deep Dive TiKV: `https://tikv.org/deep-dive/introduction/`
+- TiDB / TiKV overview: `https://docs.pingcap.com/tidb/stable/tikv-overview`
+- TiDB resource control overview:
+  `https://docs.pingcap.com/tidb/stable/tidb-resource-control-overview`
+
+## Glossary
+
+- Region:
+  the key-range shard and replication unit in TiKV
+- Peer:
+  one replica of a region on one store
+- Store:
+  a TiKV node-local storage service identity
+- FSM:
+  finite state machine used in poll-loop execution
+- Local read:
+  serving a read without full raft round-trip when invariants allow it
+- Read index:
+  raft-based read freshness mechanism
+- MVCC:
+  multi-version concurrency control
+- Snapshot:
+  a bounded, point-in-time read view
+- Safe point:
+  GC boundary before which old versions may be removed
+- RU:
+  request unit used by resource control
+- CDC:
+  change data capture

--- a/doc/maintenance-guides/repo-overview.md
+++ b/doc/maintenance-guides/repo-overview.md
@@ -81,9 +81,10 @@ work:
 - The bridge is `src/server/raftkv2`, the runtime bootstrap is
   `components/server/src/server2.rs`, and the replica implementation is
   `components/raftstore-v2`.
-- This guide set intentionally does not document `components/raftstore-v2`
-  itself yet, but maintainers still need to ask whether a server/storage fix is
-  path-agnostic or requires a matching `RaftKv2` audit.
+- This guide set includes a maintainer-map guide for `components/raftstore-v2`
+  under `doc/maintenance-guides/components/raftstore-v2.md`, but maintainers
+  still need to ask whether a server/storage fix is path-agnostic or requires a
+  matching `RaftKv2` audit.
 
 ### Compute pushdown
 

--- a/doc/maintenance-guides/src/coprocessor.md
+++ b/doc/maintenance-guides/src/coprocessor.md
@@ -1,0 +1,206 @@
+# `src/coprocessor` Maintenance Guide
+
+## Purpose And Scope
+
+This module implements the classic TiDB coprocessor path for built-in request
+types:
+
+- DAG requests
+- analyze requests
+- checksum requests
+
+It is a read-heavy hot path and directly impacts query latency.
+
+## Architectural Views
+
+### Request pipeline view
+
+- parse protobuf request
+- build request context
+- get snapshot
+- build request handler
+- execute in read pool
+- collect stats and emit response
+
+## Process Lifecycle And Startup Sequencing
+
+- Endpoint and read pools are created during server startup.
+- Runtime behavior depends on read-pool setup, memory quota, concurrency
+  controls, and storage snapshot access already being available.
+- The main runtime anchors are:
+  `src/coprocessor/readpool_impl.rs::build_read_pool`,
+  `src/coprocessor/endpoint.rs::Endpoint::new`, and
+  `src/server/service/kv.rs` as the RPC entry path.
+- `build_read_pool` sets TLS engine state and marks threads as
+  `IoType::ForegroundRead`. Any change that moves blocking work into or out of
+  this path should be reviewed against foreground IO expectations.
+- Online config is limited but real: `Endpoint::config_manager()` exposes
+  `CopConfigManager`, which currently updates memory quota. If config scope
+  expands, update lifecycle and operational sections in this guide together.
+
+## Data Model And Metadata Contracts
+
+- `ReqContext` is the key runtime metadata contract:
+  context, ranges, deadline, peer, start ts, lock-bypass sets, bounds, cache
+  version, perf level.
+- Request parsing contract differs by request type:
+  DAG, analyze, checksum.
+- `ReqContextInner::new` is where deadline, bypass/access locks, and derived
+  lower/upper bounds are normalized. Reviewers should treat changes there as
+  cross-cutting request-semantic changes.
+- `endpoint.rs::parse_request_and_check_memory_locks` is the main admission and
+  normalization contract. Request parsing, memory-lock checks, API-version
+  dispatch, and handler construction are deliberately coupled there.
+- The hot request handlers differ materially:
+  DAG requests use `dag/*`, analyze requests use `statistics/analyze_context.rs`
+  and `statistics/analyze.rs`, and checksum requests use `checksum.rs`.
+- Cache-match version, flashback allowance, and lock-bypass/access sets are all
+  correctness-sensitive metadata, not optional optimization flags.
+
+## Start Here
+
+- `src/coprocessor/mod.rs`
+- `src/coprocessor/endpoint.rs`
+- `src/coprocessor/readpool_impl.rs`
+- `src/coprocessor/dag/*`
+- `src/coprocessor/statistics/*`
+- `src/coprocessor/interceptors/*`
+- `src/coprocessor/config_manager.rs`
+
+## Must-Read File Order
+
+1. `src/coprocessor/mod.rs`
+2. `src/coprocessor/endpoint.rs`
+3. `src/coprocessor/tracker.rs`
+4. `src/coprocessor/readpool_impl.rs`
+5. `src/coprocessor/interceptors/deadline.rs`
+6. `src/coprocessor/interceptors/concurrency_limiter.rs`
+7. `src/coprocessor/dag/mod.rs`
+8. `src/coprocessor/statistics/analyze_context.rs`
+
+## Main Responsibilities
+
+- parse coprocessor protobuf payloads
+- build `ReqContext`
+- acquire snapshots and perform memory-lock checks
+- construct request handlers
+- execute handlers on read pools
+- enforce request deadlines, concurrency limits, and memory quotas
+- collect execution stats and produce coprocessor responses
+
+## Critical Invariants
+
+- Range bounds in `ReqContext` must stay aligned with the actual request.
+- Memory-lock checks must happen before serving reads that could violate lock
+  semantics.
+- Handler execution must respect request deadline and cancellation behavior.
+- Memory quota and concurrency limiters must remain cheap and correct.
+- Streaming and unary response handling must preserve stats and partial-progress
+  semantics.
+
+## Observability And Operational Signals
+
+- wait-time and snapshot-time metrics
+- request-type metrics and execution summaries
+- slow-log behavior driven by endpoint thresholds
+- Start with `src/coprocessor/metrics.rs`. High-value signals include:
+  `tikv_coprocessor_request_duration_seconds` family,
+  `tikv_coprocessor_request_wait_seconds`,
+  `tikv_coprocessor_request_handler_build_seconds`,
+  `tikv_coprocessor_request_error`,
+  `tikv_coprocessor_scan_keys`,
+  `tikv_coprocessor_scan_details`,
+  `tikv_coprocessor_response_bytes`,
+  `tikv_coprocessor_waiting_for_semaphore`, and
+  `tikv_coprocessor_semaphore_wait_seconds`.
+- `tracker.rs` is the best place to understand slow logs, exec details, request
+  lifetime accounting, and the distinction between schedule wait, snapshot
+  wait, suspend time, and processing time.
+- Triage starting points:
+  `endpoint.rs`, `tracker.rs`, `readpool_impl.rs`, `metrics.rs`,
+  `interceptors/deadline.rs`, `interceptors/concurrency_limiter.rs`.
+
+## Change Management Guidance
+
+- If `ReqContext`, request parsing, timeout behavior, or resource-control
+  integration changes, update this guide in the same patch.
+- Hot-path changes should be reviewed together with performance-critical-path
+  expectations.
+- Treat `endpoint.rs` as both a correctness and latency hotspot. Extra parsing,
+  allocation, or logging there needs justification.
+- If lock checking or extra snapshot access logic changes, review the change
+  with `src/storage` and concurrency-manager semantics in mind, not as a
+  coprocessor-only patch.
+- If a new request type or major execution mode is added, document its parser,
+  handler builder, resource admission path, and observability surface here.
+
+## Change-Impact Matrix
+
+- Request parsing or context changes:
+  inspect `mod.rs`, `endpoint.rs`, and request-type-specific builders
+- Timeout or concurrency admission changes:
+  inspect interceptors, `tracker.rs`, metrics, and read-pool behavior
+- DAG execution changes:
+  inspect `dag/*`, snapshot/store setup, and query-side statistics paths
+- Analyze or checksum changes:
+  inspect `statistics/*` or `checksum.rs` plus exec-detail accounting
+
+## Review Checklist
+
+- Does the change touch `endpoint.rs` parsing or request-type dispatch?
+- Does it affect `ReqContext`, deadline handling, or lock bypass/access sets?
+- Does it change read-pool wiring or per-request resource control?
+- Does it add extra allocation, parsing, or logging to the hot path?
+- Does it change handler stats collection or slow-log behavior?
+
+## Observability And Tests
+
+- Inline tests exist across handler and statistics modules.
+- Performance-sensitive behavior often needs bench or end-to-end query testing.
+- Metrics live in `metrics.rs`, trackers, and read-pool tickers.
+- `endpoint.rs` itself contains many targeted tests for parsing, lock checking,
+  timeout, and snapshot-access behavior. It is one of the most important files
+  to consult when changing request admission semantics.
+
+## Common Failure Modes
+
+- wrong request classification or parser fallback
+- lock-check bypass on paths that should block
+- deadline handling drift between streaming and unary paths
+- memory quota leaks on early-return/error paths
+- concurrency limiter behavior only applied to one pool mode
+
+## Reading Map And Companion Docs
+
+Suggested reading order:
+
+1. `mod.rs`
+2. `endpoint.rs`
+3. `readpool_impl.rs`
+4. `dag/mod.rs`
+5. `statistics/analyze_context.rs`
+6. `interceptors/*`
+
+Companion docs:
+
+- `repo-overview.md`
+- `src/server.md`
+- `src/storage.md`
+
+## Glossary
+
+- DAG request:
+  built-in coprocessor request for pushed-down query execution
+- ReqContext:
+  immutable runtime request context shared through execution
+- Light task threshold:
+  the execution-time budget before a coprocessor future must acquire a
+  semaphore permit in the Yatp path
+- Snapshot wait:
+  request time spent between scheduling and obtaining the storage snapshot
+
+## Related Components
+
+- `src/server/service/kv.rs` is the RPC entry point.
+- `src/storage` provides snapshots and the lock-related behavior.
+- `components/in_memory_engine` can accelerate snapshot-backed reads indirectly.

--- a/doc/maintenance-guides/src/coprocessor_v2.md
+++ b/doc/maintenance-guides/src/coprocessor_v2.md
@@ -1,0 +1,178 @@
+# `src/coprocessor_v2` Maintenance Guide
+
+## Purpose And Scope
+
+`coprocessor_v2` is the plugin-oriented coprocessor framework. It is distinct
+from the classic built-in coprocessor path. It dynamically loads plugins and
+dispatches raw coprocessor requests to them.
+
+## Architectural Views
+
+### Plugin execution view
+
+- request arrives
+- endpoint resolves plugin and version constraints
+- plugin registry supplies loaded plugin
+- raw storage adapter exposes TiKV raw APIs
+- plugin executes user code
+
+## Process Lifecycle And Startup Sequencing
+
+- Plugin registry is created during server startup if configured.
+- Hot-reloading watcher setup must succeed or fail cleanly without corrupting
+  endpoint state.
+- The lifecycle anchors are `src/coprocessor_v2/endpoint.rs::Endpoint::new`
+  and `plugin_registry.rs::PluginRegistry::start_hot_reloading`.
+- Startup is configuration-driven through
+  `Config::coprocessor_plugin_directory`. If that directory is unset, the whole
+  subsystem is intentionally disabled and requests should fail clearly.
+- The file watcher is long-lived state. Any change to watcher ownership,
+  registry lifetime, or background-thread termination should be reviewed as a
+  lifecycle change, not only as a plugin-loading change.
+
+## Data Model And Metadata Contracts
+
+- plugin name and version constraint
+- plugin build-info compatibility contract
+- raw-storage adapter contract for context, range, and error mapping
+- `plugin_registry.rs::err_on_mismatch` enforces the core ABI contract:
+  plugin API version, `rustc`, and target triple must all match TiKV.
+- `endpoint.rs` adds a second contract layer through semver constraint checking
+  on `copr_version_req`.
+- `raw_storage_impl.rs` deliberately exposes only raw KV semantics. It forwards
+  the request `Context`, uses raw APIs, and maps storage errors into
+  `PluginError` forms such as `KeyNotInRegion`, `Timeout`, `Canceled`, or a
+  wrapped opaque error.
+- Hot-reload semantics are intentionally limited. Deletes and overwrites do not
+  imply safe in-place replacement of running plugin code; the current watcher
+  mostly updates path bookkeeping and warns.
+
+## Start Here
+
+- `src/coprocessor_v2/mod.rs`
+- `src/coprocessor_v2/endpoint.rs`
+- `src/coprocessor_v2/plugin_registry.rs`
+- `src/coprocessor_v2/raw_storage_impl.rs`
+- `src/coprocessor_v2/config.rs`
+
+## Must-Read File Order
+
+1. `src/coprocessor_v2/config.rs`
+2. `src/coprocessor_v2/endpoint.rs`
+3. `src/coprocessor_v2/plugin_registry.rs`
+4. `src/coprocessor_v2/raw_storage_impl.rs`
+5. `src/server/service/kv.rs`
+
+## Main Responsibilities
+
+- locate plugins by name
+- validate plugin version constraints
+- watch a configured plugin directory and attempt dynamic plugin loading
+- adapt TiKV raw storage APIs to the plugin API
+- translate storage errors into plugin-facing error forms
+
+## Critical Invariants
+
+- Plugin ABI compatibility checks must remain strict:
+  target, rustc, and coprocessor API version.
+- Plugin-path watching must not leave registry state internally inconsistent,
+  especially because overwrite/delete handling is limited.
+- Request-to-plugin dispatch must preserve region errors and cancellation
+  semantics.
+- Storage adaptation must not silently widen permissions or semantics beyond the
+  raw API it wraps.
+
+## Observability And Operational Signals
+
+- plugin load/reload warnings and failures
+- request-time plugin dispatch errors
+- raw-storage error translation behavior visible at RPC layer
+- There is no large dedicated metric surface in this subsystem today. Logs in
+  `plugin_registry.rs` and request failures returned from `endpoint.rs` are the
+  main operational signals.
+- Triage starting points:
+  `endpoint.rs`, `plugin_registry.rs`, `raw_storage_impl.rs`,
+  `src/server/service/kv.rs`.
+- Distinguish four failure classes during triage:
+  disabled subsystem, plugin not found, compatibility/version mismatch, and
+  storage/runtime failure inside a loaded plugin.
+
+## Change Management Guidance
+
+- If plugin ABI validation, hot-reload behavior, or raw-storage API mapping
+  changes, update this guide in the same patch.
+- Because this subsystem executes externally supplied code, changes here should
+  be reviewed conservatively.
+- Do not weaken compatibility checks for convenience. Rejecting an incompatible
+  plugin early is safer than attempting partial compatibility.
+- Any expansion of the plugin-facing storage API should explicitly document
+  allowed semantics, error mapping, and whether the new call can mutate data.
+- If hot-reload behavior is changed, state clearly whether the system now
+  supports real replacement or still only supports additive loading plus limited
+  path bookkeeping.
+
+## Change-Impact Matrix
+
+- Plugin discovery or directory config changes:
+  inspect `config.rs`, `endpoint.rs`, and startup wiring
+- ABI or compatibility changes:
+  inspect `plugin_registry.rs`, plugin tests, and user-facing failure behavior
+- Hot-reload behavior changes:
+  inspect watcher lifecycle, path tracking, and operational warnings
+- Storage adapter changes:
+  inspect `raw_storage_impl.rs`, `src/storage`, and region-error extraction
+
+## Review Checklist
+
+- Does the change alter hot-reload or plugin-path tracking?
+- Does it weaken compatibility checks or version matching?
+- Does it change raw storage error mapping or region-error extraction?
+- Does it introduce trust assumptions about plugin code or plugin inputs?
+- Does it require new tests for plugin lifecycle or storage adaptation?
+
+## Observability And Tests
+
+- Local unit tests exist in `raw_storage_impl.rs`.
+- Wider validation usually needs `components/test_coprocessor_plugin`.
+- `plugin_registry.rs` also contains local tests around loading and hot-reload
+  mechanics. Use them when touching compatibility checks or watcher behavior.
+
+## Common Failure Modes
+
+- plugin reload path drift after rename or overwrite
+- overwrite/delete behavior assumed to be stronger than the current watcher
+  implementation
+- version mismatch accepted too early or rejected too late
+- storage errors surfaced as opaque plugin failures instead of region errors
+- plugin framework enabled but directory/watch behavior not actually active
+
+## Reading Map And Companion Docs
+
+Suggested reading order:
+
+1. `mod.rs`
+2. `config.rs`
+3. `endpoint.rs`
+4. `plugin_registry.rs`
+5. `raw_storage_impl.rs`
+
+Companion docs:
+
+- `repo-overview.md`
+- `src/server.md`
+- `src/storage.md`
+
+## Glossary
+
+- Plugin registry:
+  runtime loader and index of coprocessor plugins
+- RawStorageImpl:
+  adapter exposing TiKV raw KV APIs to plugins
+- Hot reloading:
+  file-watcher-driven plugin discovery and limited path update behavior, not a
+  guarantee of safe in-place code replacement
+
+## Related Components
+
+- `src/server/service/kv.rs` provides the RPC entry point.
+- `src/storage` is the underlying raw KV implementation exposed to plugins.

--- a/doc/maintenance-guides/src/server.md
+++ b/doc/maintenance-guides/src/server.md
@@ -1,0 +1,237 @@
+# `src/server` Maintenance Guide
+
+## Purpose And Scope
+
+`src/server` is the runtime-facing server stack. It owns the network edge and
+service plumbing after process startup:
+
+- gRPC request handling
+- raft message transport
+- snapshot transport
+- status server and diagnostics
+- GC worker
+- lock-manager service
+- debug and diagnostics services
+- TTL helper services
+
+## Architectural Views
+
+### Runtime edge view
+
+- gRPC service edge
+- storage and coprocessor dispatch
+- raft transport and snapshot transport
+- status and diagnostics HTTP surface
+
+### Service decomposition view
+
+- KV service
+- debug/diagnostics
+- GC worker
+- lock manager
+- status server
+- raft server/bootstrap bridge
+
+## Process Lifecycle And Startup Sequencing
+
+- This module is started by `components/server` after engines and major workers
+  exist.
+- Service construction order matters:
+  transport, storage bridge, coprocessor endpoints, health service, status
+  server, and runtime pools all depend on prior setup.
+- Shutdown order must preserve callback and scheduler safety for in-flight
+  requests.
+
+Concrete runtime anchors:
+
+- gRPC server construction:
+  `server.rs`
+- store bootstrap and raftstore start:
+  `raft_server.rs`
+- status HTTP surface:
+  `status_server/mod.rs`
+- primary RPC implementation:
+  `service/kv.rs`
+
+## Data Model And Metadata Contracts
+
+- gRPC metadata such as store id and resource-group context
+- server config contract for concurrency, quotas, transport, and snapshot
+  settings
+- region/store/cluster identity checks at service boundaries
+
+High-risk service contracts:
+
+- metadata-derived store-id checks
+- request batching and stream callback completion
+- region-error and timeout mapping from storage/raftstore to RPCs
+
+## Start Here
+
+- `src/server/mod.rs`
+- `src/server/service/mod.rs`
+- `src/server/service/kv.rs`
+- `src/server/server.rs`
+- `src/server/debug2.rs`
+- `src/server/raft_server.rs`
+- `src/server/raftkv/mod.rs`
+- `src/server/raftkv2/mod.rs`
+- `src/server/status_server/mod.rs`
+- `src/server/gc_worker/*`
+- `src/server/config.rs`
+
+## Must-Read File Order
+
+1. `src/server/config.rs`
+2. `src/server/service/mod.rs`
+3. `src/server/service/kv.rs`
+4. `src/server/server.rs`
+5. `src/server/raftkv/mod.rs`
+6. `src/server/raftkv2/mod.rs`
+7. `src/server/raft_server.rs`
+8. `src/server/status_server/mod.rs`
+9. `src/server/gc_worker/mod.rs`
+
+## Main Subsystems
+
+### RPC edge
+
+- `service/kv.rs` is the most important file in this module.
+- It maps gRPC methods to storage, coprocessor, GC, and raft paths.
+- It is hot-path code and should be reviewed with latency and allocation in
+  mind.
+
+### Server runtime
+
+- `server.rs` builds and owns the gRPC server runtime and related pools.
+- It wires the request service, snapshot worker, health service, and transport.
+
+### Raft transport and storage bridge
+
+- `raft_server.rs` owns `MultiRaftServer`, store bootstrap, and raftstore
+  runtime startup.
+- `raftkv/mod.rs` is the bridge between storage and raftstore.
+- `raftkv2/mod.rs` is the bridge between storage and `raftstore-v2`.
+- `debug2.rs` is the matching debugger surface for the `RaftKv2` path.
+
+### Status and diagnostics
+
+- `status_server/mod.rs` exposes HTTP endpoints for config, metrics, profiles,
+  resource-manager state, pause/resume, and debugging.
+
+### GC and lock manager
+
+- `gc_worker/*` implements MVCC garbage collection and compaction filter logic.
+- `lock_manager/*` owns the live waiter-manager workers, deadlock detector, and
+  RPC-facing lock-manager runtime.
+- This module sits on top of the storage-side wait-queue contracts in
+  `src/storage/lock_manager/*`.
+
+## Critical Invariants
+
+- Request methods must preserve exact callback and error mapping semantics.
+- Store id / cluster id / region error checks must stay strict at service edges.
+- Raft message rejection logic must stay compatible with memory-pressure policy.
+- Engine-specific behavior must stay aligned when a feature spans both
+  `raftkv` and `raftkv2`.
+- Status-server actions must match the real runtime control plane.
+- GC worker changes must preserve MVCC and safe-point correctness.
+
+## Observability And Operational Signals
+
+- gRPC service metrics and request-duration tracking
+- raft transport rejection and memory-pressure signals
+- status-server endpoints for config, metrics, health, and profiles
+- GC and diagnostics metrics and logs
+
+Start triage with:
+
+- `src/server/metrics.rs`
+- `src/server/status_server/mod.rs`
+- request logs and slow-path logs in `service/kv.rs`
+- health-controller state
+
+## Change Management Guidance
+
+- If request dispatch, transport semantics, status-server controls, or bootstrap
+  behavior changes, update this guide in the same patch.
+- Storage and raftstore boundary changes should be reviewed together with this
+  module.
+- If a new RPC method or control endpoint is added, document who owns the
+  contract and which lower layer is authoritative for errors and callbacks.
+
+## Change-Impact Matrix
+
+- RPC method or callback changes:
+  inspect `service/kv.rs`, storage callers, and response/error mapping
+- Raft bridge changes:
+  inspect `raftkv/mod.rs`, `raftkv2/mod.rs`, and `raft_server.rs`
+- Status or control-plane changes:
+  inspect `status_server/mod.rs`, service manager/control events, and security
+  posture
+- GC or lock-manager changes:
+  inspect `gc_worker/*`, `lock_manager/*`, and storage-side contracts
+
+## Review Checklist
+
+- Does the change touch `service/kv.rs` or `raftkv/mod.rs`?
+- Does it also need a matching `raftkv2/mod.rs` or `debug2.rs` change for the
+  `RaftKv2` path?
+- Does it change request batching, stream behavior, or backpressure?
+- Does it alter memory-pressure rejection or raft append filtering?
+- Does it change bootstrap or store-registration ordering in `raft_server.rs`?
+- Does it add new status-server behavior without security or readiness review?
+- Does it alter dynamic config behavior in `config.rs` or config managers?
+
+## Observability And Tests
+
+- Inline tests exist in `service/kv.rs`, `gc_worker/*`, `status_server/*`, and
+  diagnostics modules.
+- Metrics are extensive and often the fastest signal for regressions.
+- Many runtime issues require end-to-end validation with a running node.
+
+## Common Failure Modes
+
+- incorrect gRPC to storage error mapping
+- partial stream or callback completion on errors
+- startup-time bootstrap edge cases
+- status-server control operations not reaching real runtime owners
+- GC compaction behavior drifting from MVCC rules
+
+## Reading Map And Companion Docs
+
+Suggested reading order:
+
+1. `mod.rs`
+2. `config.rs`
+3. `service/mod.rs`
+4. `service/kv.rs`
+5. `server.rs`
+6. `raftkv/mod.rs`
+7. `raftkv2/mod.rs`
+8. `raft_server.rs`
+9. `status_server/mod.rs`
+10. `gc_worker/mod.rs`
+
+Companion docs:
+
+- `repo-overview.md`
+- `components/server.md`
+- `src/storage.md`
+
+## Glossary
+
+- KvService:
+  primary gRPC service implementation for TiKV RPCs
+- Status server:
+  HTTP surface for metrics, config, debug, and control actions
+- RaftKv:
+  storage bridge from transactional API into classic raftstore
+- Health controller:
+  shared readiness/health state exposed through gRPC and runtime services
+
+## Related Components
+
+- `components/server` wires this module into the process lifecycle.
+- `src/storage` is the main backend for most RPC methods.
+- `components/raftstore` is the backend for raft and region-level operations.

--- a/doc/maintenance-guides/src/storage.md
+++ b/doc/maintenance-guides/src/storage.md
@@ -1,0 +1,240 @@
+# `src/storage` Maintenance Guide
+
+## Purpose And Scope
+
+`src/storage` is TiKV's transaction and storage layer. It is one of the most
+important maintenance surfaces in the repository. It owns:
+
+- the `Storage` API
+- transactional command scheduling
+- MVCC
+- raw KV operations
+- latches and lock waiting
+- flow control
+- storage-related dynamic config
+
+## Architectural Views
+
+### Layer view
+
+- top-level `Storage` API
+- command scheduler
+- MVCC reader/writer logic
+- raw KV logic
+- lock waiting and flow control
+
+### Request execution view
+
+- RPC edge calls `Storage`
+- scheduler admits the command
+- MVCC/raw execution happens on snapshots and engines
+- callbacks complete back to RPC or higher layers
+
+## Process Lifecycle And Startup Sequencing
+
+- Storage is constructed during server startup after engines, read pools,
+  concurrency manager, quota limiter, and relevant runtime helpers exist.
+- Runtime config managers update storage-side behavior after startup.
+- Shutdown must preserve callback and worker ownership safety until all strong
+  references are gone.
+
+Concrete runtime anchors:
+
+- storage construction in server bootstrap
+- scheduler execution in `txn/scheduler.rs`
+- dynamic config side effects in `config_manager.rs`
+
+## Data Model And Metadata Contracts
+
+- MVCC data model across default, lock, and write CFs
+- scheduler task metadata and latch ownership
+- lock-wait metadata and tokens
+- raw KV encoding and optional API-version behavior
+- resource-control metadata consumed during scheduling
+
+High-risk contracts:
+
+- MVCC relationships across default/lock/write CFs
+- `ProcessResult` and callback completion semantics
+- `TxnStatusCache` and max-ts related assumptions
+- raw KV API version and TTL rules from `config.rs`
+
+## Start Here
+
+- `src/storage/mod.rs`
+- `src/storage/txn/scheduler.rs`
+- `src/storage/txn/mod.rs`
+- `src/storage/txn/commands/mod.rs`
+- `src/storage/mvcc/mod.rs`
+- `src/storage/txn/store.rs`
+- `src/storage/raw/store.rs`
+- `src/storage/config.rs`
+- `src/storage/config_manager.rs`
+
+## Must-Read File Order
+
+1. `src/storage/mod.rs`
+2. `src/storage/config.rs`
+3. `src/storage/txn/mod.rs`
+4. `src/storage/txn/scheduler.rs`
+5. `src/storage/txn/commands/mod.rs`
+6. `src/storage/mvcc/mod.rs`
+7. `src/storage/mvcc/reader/reader.rs`
+8. `src/storage/txn/store.rs`
+9. `src/storage/lock_manager/mod.rs`
+10. `src/storage/config_manager.rs`
+
+## Internal Structure
+
+### Top-level API
+
+- `mod.rs` defines `Storage` and many public operations.
+- This is the coordination layer that ties together scheduler, read pool,
+  concurrency manager, quota limiter, and resource control.
+
+### Scheduler and command execution
+
+- `txn/scheduler.rs` owns command admission, latches, task tracking, and worker
+  handoff.
+- `txn/commands/*` defines concrete transactional commands.
+- `txn/task.rs`, `txn/sched_pool.rs`, and `txn/tracker.rs` support execution.
+
+### MVCC
+
+- `mvcc/mod.rs` defines MVCC errors and public surface.
+- `mvcc/reader/*` owns reads, scanners, point getters, and conflict detection.
+- `mvcc/txn.rs` owns write-side MVCC mutation handling.
+
+### Raw KV
+
+- `raw/*` implements raw-key APIs and their optional MVCC wrappers.
+
+### Waiting and flow control
+
+- `lock_manager/*` defines storage-side lock-wait contracts and local wait-queue
+  helpers.
+- The live waiter-manager workers, deadlock detector, and lock-manager RPC
+  service live under `src/server/lock_manager/*`.
+- `txn/flow_controller/*` controls write pressure behavior.
+
+## Critical Invariants
+
+- Command callbacks must complete exactly once with the correct error/result
+  semantics.
+- Latch ownership must serialize conflicting commands without deadlocking the
+  scheduler.
+- MVCC readers and writers must preserve lock, write, and default-CF
+  relationships.
+- Region bounds, snapshot context, and flashback/max-ts safety must remain
+  enforced.
+- Memory quota and pending-write thresholds must remain operationally effective.
+
+## Observability And Operational Signals
+
+- scheduler latency, latch wait, and pending-write signals
+- MVCC conflict, read, and GC-related metrics
+- flow-control and memory-quota behavior
+- lock-wait and deadlock diagnostics
+
+Start triage with:
+
+- `src/storage/metrics.rs`
+- `txn/scheduler.rs`
+- `lock_manager/*`
+- `config_manager.rs`
+
+## Change Management Guidance
+
+- Any change to `Storage` API, callback semantics, MVCC contracts, or dynamic
+  config side effects should update this guide in the same patch.
+- Server and raftstore bridges should be audited whenever storage semantics or
+  error mapping changes.
+- If a change updates config values without updating `config_manager.rs` side
+  effects, the change is usually incomplete.
+
+## Change-Impact Matrix
+
+- Public `Storage` API or callback changes:
+  inspect `mod.rs`, `txn/scheduler.rs`, and RPC-facing callers in `src/server`
+- Scheduler, latch, or task-flow changes:
+  inspect `txn/scheduler.rs`, `txn/task.rs`, `txn/sched_pool.rs`, and metrics
+- MVCC read/write or conflict changes:
+  inspect `mvcc/*`, `txn/store.rs`, and transactional commands
+- Raw KV changes:
+  inspect `raw/*`, API-version handling, and coprocessor_v2 storage adapter
+- Lock-wait or flow-control changes:
+  inspect `lock_manager/*`, `txn/flow_controller/*`, and runtime workers in
+  `src/server`
+- Dynamic config changes:
+  inspect `config.rs`, `config_manager.rs`, and runtime side-effect consumers
+
+## Review Checklist
+
+- Does the change affect `Storage` API behavior or callback contract?
+- Does it touch `txn/scheduler.rs`, latches, or lock-wait queues?
+- Does it modify MVCC conflict detection, lock resolution, or commit-ts rules?
+- Does it alter raw KV behavior shared with plugin coprocessor or external APIs?
+- Does it change snapshot or write assumptions that must still hold across both
+  `raftkv` and `raftkv2` bridges?
+- Does it require a config-manager side effect for dynamic config?
+- Does it change resource-control integration, flow control, or quota-limiter
+  behavior?
+
+## Observability And Tests
+
+- There is heavy inline unit-test coverage across MVCC, txn commands, latches,
+  lock waiting, raw MVCC, and scheduler helpers.
+- Integration tests often belong in `components/test_storage`.
+- Hot-path metrics exist throughout scheduler, MVCC, read pools, and flow
+  control.
+
+## Common Failure Modes
+
+- callback never invoked or invoked twice
+- latch release bugs causing stuck or reordered commands
+- MVCC write/read drift across CFs
+- incorrect region error extraction from lower layers
+- dynamic config updated in memory but not applied to runtime objects
+- lock wait wake-up logic causing starvation or missed wake-ups
+
+## Reading Map And Companion Docs
+
+Suggested reading order:
+
+1. `mod.rs`
+2. `config.rs`
+3. `txn/mod.rs`
+4. `txn/scheduler.rs`
+5. `txn/commands/mod.rs`
+6. `mvcc/mod.rs`
+7. `mvcc/reader/reader.rs`
+8. `txn/store.rs`
+9. `lock_manager/mod.rs`
+10. `config_manager.rs`
+
+Companion docs:
+
+- `repo-overview.md`
+- `src/server.md`
+- `components/raftstore.md`
+- `PERFORMANCE_CRITICAL_PATH.md`
+
+## Glossary
+
+- MVCC:
+  multi-version concurrency control over default/lock/write CFs
+- Latch:
+  scheduler-side serialization primitive for conflicting commands
+- ProcessResult:
+  scheduler-execution result returned back through callbacks
+- Flow control:
+  pressure-management logic that slows or gates write-heavy activity
+
+## Related Components
+
+- `src/server/service/kv.rs` is the main caller.
+- `src/server/raftkv/mod.rs` bridges writes into raftstore.
+- `src/server/lock_manager/*` owns the live lock-manager workers and deadlock
+  service around the storage-side wait-queue contracts.
+- `components/resource_control` and `resource_metering` integrate directly with
+  scheduling and accounting.


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: ref https://github.com/tikv/tikv/issues/19757

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Add a maintainership-oriented guide set under doc/maintenance-guides and update
the local agent workflow so development and review treat those guides as part of
the repository maintenance surface.

This change adds:
- doc/maintenance-guides/README.md as the maintainer contract and entry index
- doc/maintenance-guides/repo-overview.md as the repository-level architecture,
  lifecycle, data-contract, IO, observability, failure-mode, and reading-map guide
- subsystem maintenance guides for:
  - components/raftstore
  - components/raftstore-v2
  - components/resource_control
  - components/hybrid_engine
  - components/in_memory_engine
  - components/batch-system
  - components/server
  - components/service
  - src/coprocessor
  - src/coprocessor_v2
  - src/server
  - src/storage
- a deep-review skill update so reviewers must read relevant maintenance guides,
  check whether guide updates are required for a change, and report missing or
  stale guide updates in the review output
- a generate-pr-docs skill so PR drafting reloads the live local
  .github/pull_request_template.md on each invocation and preserves all hidden
  template comments verbatim

The guide set is organized for maintainers and reviewers rather than end-user
documentation. Each covered guide is structured around purpose and scope,
architectural views, startup sequencing, data and metadata contracts,
observability, change-management guidance, reading maps, glossary,
must-read file order, and change-impact guidance.

This is a documentation and workflow change. It does not modify TiKV runtime
logic, but it raises the review bar by making guide consistency an explicit part
of future development and PR review.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!--
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new maintenance guide set for key TiKV subsystems, with overview, reading order, invariants, observability, and change-impact guidance.
  * Expanded contribution and README guidance to point readers to the new maintenance documentation.
* **Chores**
  * Updated review and PR-document generation workflows to better handle scope detection, validation, and reporting.
  * Added clearer checks for maintenance-guide coverage when reviewing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->