### PR TITLE
storage: add max ts invalid update action config

### DIFF
--- a/components/concurrency_manager/src/lib.rs
+++ b/components/concurrency_manager/src/lib.rs
@@ -575,6 +575,11 @@ impl ConcurrencyManager {
         self.action_on_invalid_max_ts.load()
     }
 
+    /// Updates the drift allowance used by future max-ts limit refreshes.
+    ///
+    /// Decreasing the allowance does not immediately tighten the cached drifted
+    /// limit. The cached limit remains monotonic in `set_max_ts_limit` and is
+    /// tightened only after PD TSO or physical time catches up.
     pub fn set_max_ts_drift_allowance(&self, allowance: Duration) {
         self.max_ts_drift_allowance_ms
             .store(allowance.as_millis() as u64, Ordering::SeqCst);

--- a/components/concurrency_manager/src/lib.rs
+++ b/components/concurrency_manager/src/lib.rs
@@ -571,6 +571,10 @@ impl ConcurrencyManager {
         self.action_on_invalid_max_ts.store(action);
     }
 
+    pub fn action_on_invalid_max_ts(&self) -> ActionOnInvalidMaxTs {
+        self.action_on_invalid_max_ts.load()
+    }
+
     pub fn set_max_ts_drift_allowance(&self, allowance: Duration) {
         self.max_ts_drift_allowance_ms
             .store(allowance.as_millis() as u64, Ordering::SeqCst);

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -33,8 +33,7 @@ use backup_stream::{
 use causal_ts::CausalTsProviderImpl;
 use cdc::CdcConfigManager;
 use concurrency_manager::{
-    ActionOnInvalidMaxTs, ConcurrencyManager, DEFAULT_MAX_TS_DRIFT_ALLOWANCE,
-    DEFAULT_MAX_TS_SYNC_INTERVAL, LIMIT_VALID_TIME_MULTIPLIER,
+    ConcurrencyManager, DEFAULT_MAX_TS_SYNC_INTERVAL, LIMIT_VALID_TIME_MULTIPLIER,
 };
 use engine_rocks::{
     RocksCompactedEvent, RocksEngine, RocksStatistics, from_rocks_compression_type,
@@ -427,10 +426,16 @@ where
         let latest_ts = block_on(pd_client.get_tso()).expect("failed to get timestamp from PD");
         let concurrency_manager = ConcurrencyManager::new_with_config(
             latest_ts,
-            DEFAULT_MAX_TS_SYNC_INTERVAL * LIMIT_VALID_TIME_MULTIPLIER,
-            ActionOnInvalidMaxTs::Log,
+            (config.storage.max_ts.cache_sync_interval * LIMIT_VALID_TIME_MULTIPLIER).into(),
+            config
+                .storage
+                .max_ts
+                .action_on_invalid_update
+                .as_str()
+                .try_into()
+                .unwrap(),
             Some(pd_client.clone()),
-            DEFAULT_MAX_TS_DRIFT_ALLOWANCE,
+            config.storage.max_ts.max_drift.0,
         );
 
         // use different quota for front-end and back-end requests

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -32,9 +32,7 @@ use backup_stream::{
 };
 use causal_ts::CausalTsProviderImpl;
 use cdc::CdcConfigManager;
-use concurrency_manager::{
-    ConcurrencyManager, DEFAULT_MAX_TS_SYNC_INTERVAL, LIMIT_VALID_TIME_MULTIPLIER,
-};
+use concurrency_manager::{ConcurrencyManager, LIMIT_VALID_TIME_MULTIPLIER};
 use engine_rocks::{
     RocksCompactedEvent, RocksEngine, RocksStatistics, from_rocks_compression_type,
 };
@@ -1220,7 +1218,7 @@ where
         let cm = self.concurrency_manager.clone();
         let pd_client = self.pd_client.clone();
 
-        let max_ts_sync_interval = DEFAULT_MAX_TS_SYNC_INTERVAL;
+        let max_ts_sync_interval = self.core.config.storage.max_ts.cache_sync_interval.into();
         self.core
             .background_worker
             .spawn_interval_async_task(max_ts_sync_interval, move || {

--- a/components/server/src/server2.rs
+++ b/components/server/src/server2.rs
@@ -33,9 +33,7 @@ use backup_stream::{
 };
 use causal_ts::CausalTsProviderImpl;
 use cdc::CdcConfigManager;
-use concurrency_manager::{
-    ConcurrencyManager, DEFAULT_MAX_TS_SYNC_INTERVAL, LIMIT_VALID_TIME_MULTIPLIER,
-};
+use concurrency_manager::{ConcurrencyManager, LIMIT_VALID_TIME_MULTIPLIER};
 use engine_rocks::{RocksEngine, RocksStatistics, from_rocks_compression_type};
 use engine_traits::{CF_DEFAULT, CF_WRITE, Engines, KvEngine, MiscExt, RaftEngine, TabletRegistry};
 use file_system::{BytesFetcher, MetricsManager as IoMetricsManager, get_io_rate_limiter};
@@ -992,7 +990,7 @@ where
         let cm = self.concurrency_manager.clone();
         let pd_client = self.pd_client.clone();
 
-        let max_ts_sync_interval = DEFAULT_MAX_TS_SYNC_INTERVAL;
+        let max_ts_sync_interval = self.core.config.storage.max_ts.cache_sync_interval.into();
         self.core
             .background_worker
             .spawn_interval_async_task(max_ts_sync_interval, move || {

--- a/components/server/src/server2.rs
+++ b/components/server/src/server2.rs
@@ -34,8 +34,7 @@ use backup_stream::{
 use causal_ts::CausalTsProviderImpl;
 use cdc::CdcConfigManager;
 use concurrency_manager::{
-    ActionOnInvalidMaxTs, ConcurrencyManager, DEFAULT_MAX_TS_DRIFT_ALLOWANCE,
-    DEFAULT_MAX_TS_SYNC_INTERVAL, LIMIT_VALID_TIME_MULTIPLIER,
+    ConcurrencyManager, DEFAULT_MAX_TS_SYNC_INTERVAL, LIMIT_VALID_TIME_MULTIPLIER,
 };
 use engine_rocks::{RocksEngine, RocksStatistics, from_rocks_compression_type};
 use engine_traits::{CF_DEFAULT, CF_WRITE, Engines, KvEngine, MiscExt, RaftEngine, TabletRegistry};
@@ -339,10 +338,16 @@ where
         let latest_ts = block_on(pd_client.get_tso()).expect("failed to get timestamp from PD");
         let concurrency_manager = ConcurrencyManager::new_with_config(
             latest_ts,
-            DEFAULT_MAX_TS_SYNC_INTERVAL * LIMIT_VALID_TIME_MULTIPLIER,
-            ActionOnInvalidMaxTs::Log,
+            (config.storage.max_ts.cache_sync_interval * LIMIT_VALID_TIME_MULTIPLIER).into(),
+            config
+                .storage
+                .max_ts
+                .action_on_invalid_update
+                .as_str()
+                .try_into()
+                .unwrap(),
             Some(pd_client.clone()),
-            DEFAULT_MAX_TS_DRIFT_ALLOWANCE,
+            config.storage.max_ts.max_drift.0,
         );
 
         // use different quota for front-end and back-end requests

--- a/deny.toml
+++ b/deny.toml
@@ -66,6 +66,11 @@ ignore = [
     #
     # TODO: Upgrade clap to v4.x.
     "RUSTSEC-2021-0145",
+    # Ignore RUSTSEC-2022-0104 because structopt is only used by tikv-ctl and
+    # does not affect the server runtime. This is safe to ignore.
+    #
+    # TODO: Replace structopt with clap-v3 derives as in #19744.
+    "RUSTSEC-2022-0104",
     # Ignore RUSTSEC-2024-0006 as it only included by "rusoto_credential" crate.
     #
     # TODO: Upgrade shlex@0.1.1 to v1.3.x.
@@ -102,6 +107,12 @@ ignore = [
     # raft-engine revision in this workspace still hard-pins serde = 1.0.228,
     # so this cannot be resolved with a lockfile-only update.
     "RUSTSEC-2026-0009",
+    # Ignore RUSTSEC-2026-0186 temporarily. memmap2 is pulled in transitively by
+    # raft-engine and symbolic-common, so release-8.5 cannot resolve it with a
+    # local code change in this PR.
+    #
+    # TODO: Upgrade memmap2 to >= 0.9.11 when dependency constraints allow it.
+    "RUSTSEC-2026-0186",
     # azure_core transitively depends on http-types/rand, which triggers
     # RUSTSEC-2026-0097 (unsound with custom logger). Upstream dependency
     # constraints prevent upgrading at the moment.

--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -313,6 +313,18 @@
 ## Set to 0 to disable this feature if you want to panic immediately when encountering such an error.
 # background-error-recovery-window = "1h"
 
+[storage.max-ts]
+## Maximum max_ts deviation allowed from PD TSO.
+# max-drift = "60s"
+
+## How often to refresh the max_ts limit from PD. It is not dynamically configurable.
+# cache-sync-interval = "15s"
+
+## What TiKV does when it confirms an invalid max_ts update.
+## Available values are "error", "log", and "panic". The default "error" rejects
+## the bad request without panicking TiKV and can be changed online if needed.
+# action-on-invalid-update = "error"
+
 ## Block cache is used by RocksDB to cache uncompressed blocks. Big block cache can speed up read.
 ## It is recommended to turn on shared block cache. Since only the total cache size need to be
 ## set, it is easier to config. In most cases it should be able to auto-balance cache usage

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -5641,6 +5641,7 @@ mod tests {
         incoming.gc.max_write_bytes_per_sec = ReadableSize::mb(100);
         incoming.rocksdb.defaultcf.block_cache_size = Some(ReadableSize::mb(500));
         incoming.storage.io_rate_limit.import_priority = file_system::IoPriority::High;
+        incoming.storage.max_ts.action_on_invalid_update = "log".to_owned();
         let diff = old.diff(&incoming);
         let mut change = HashMap::new();
         change.insert(
@@ -5655,6 +5656,10 @@ mod tests {
         change.insert(
             "storage.io-rate-limit.import-priority".to_owned(),
             "high".to_owned(),
+        );
+        change.insert(
+            "storage.max-ts.action-on-invalid-update".to_owned(),
+            "log".to_owned(),
         );
         let res = to_config_change(change).unwrap();
         assert_eq!(diff, res);
@@ -7654,6 +7659,10 @@ mod tests {
             (
                 "raftstore.raft_store_max_leader_lease",
                 "raft_store.raft_store_max_leader_lease",
+            ),
+            (
+                "storage.max-ts.action-on-invalid-update",
+                "storage.max_ts.action_on_invalid_update",
             ),
         ];
 

--- a/src/storage/config.rs
+++ b/src/storage/config.rs
@@ -539,7 +539,7 @@ mod tests {
         let cfg = MaxTsConfig::default();
         assert_eq!(cfg.action_on_invalid_update, "error");
         assert_ne!(cfg.action_on_invalid_update, "panic");
-        assert!(ActionOnInvalidMaxTs::try_from(cfg.action_on_invalid_update.as_str()).is_ok());
+        ActionOnInvalidMaxTs::try_from(cfg.action_on_invalid_update.as_str()).unwrap();
     }
 
     #[test]

--- a/src/storage/config.rs
+++ b/src/storage/config.rs
@@ -442,13 +442,21 @@ impl Default for MaxTsConfig {
 impl MaxTsConfig {
     fn validate(&mut self) -> Result<(), Box<dyn Error>> {
         if self.max_drift <= self.cache_sync_interval {
-            return Err(format!(
+            let msg = format!(
                 "storage.max-ts.max-drift {:?} is smaller than or equal to storage.max-ts.cache-sync-interval {:?}",
                 self.max_drift, self.cache_sync_interval,
-            )
-            .into());
+            );
+            error!("{}", msg);
+            return Err(msg.into());
         }
-        ActionOnInvalidMaxTs::try_from(self.action_on_invalid_update.as_str())?;
+        if let Err(e) = ActionOnInvalidMaxTs::try_from(self.action_on_invalid_update.as_str()) {
+            error!(
+                "storage.max-ts.action-on-invalid-update is set to an invalid value {}, \
+                reject config change",
+                self.action_on_invalid_update,
+            );
+            return Err(e.into());
+        }
         Ok(())
     }
 }

--- a/src/storage/config.rs
+++ b/src/storage/config.rs
@@ -4,6 +4,9 @@
 
 use std::{borrow::ToOwned, cmp::max, error::Error, path::Path};
 
+use concurrency_manager::{
+    ActionOnInvalidMaxTs, DEFAULT_MAX_TS_DRIFT_ALLOWANCE, DEFAULT_MAX_TS_SYNC_INTERVAL,
+};
 use engine_rocks::raw::{Cache, LRUCacheOptions, MemoryAllocator};
 use file_system::{IoPriority, IoRateLimitMode, IoRateLimiter, IoType};
 use kvproto::kvrpcpb::ApiVersion;
@@ -61,6 +64,8 @@ const DEFAULT_TXN_STATUS_CACHE_CAPACITY: usize = 40_000 * 128;
 // occur in tests.
 const FALLBACK_BLOCK_CACHE_CAPACITY: ReadableSize = ReadableSize::mb(128);
 
+pub const DEFAULT_ACTION_ON_INVALID_MAX_TS_UPDATE: &str = "error";
+
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 pub enum EngineType {
@@ -111,6 +116,8 @@ pub struct Config {
     pub block_cache: BlockCacheConfig,
     #[online_config(submodule)]
     pub io_rate_limit: IoRateLimitConfig,
+    #[online_config(submodule)]
+    pub max_ts: MaxTsConfig,
 }
 
 impl Default for Config {
@@ -138,6 +145,7 @@ impl Default for Config {
             flow_control: FlowControlConfig::default(),
             block_cache: BlockCacheConfig::default(),
             io_rate_limit: IoRateLimitConfig::default(),
+            max_ts: MaxTsConfig::default(),
             background_error_recovery_window: ReadableDuration::hours(1),
             memory_quota: DEFAULT_TXN_MEMORY_QUOTA_CAPACITY,
         }
@@ -210,6 +218,7 @@ impl Config {
             );
         }
         self.io_rate_limit.validate()?;
+        self.max_ts.validate()?;
         if self.memory_quota < self.scheduler_pending_write_threshold {
             warn!(
                 "scheduler.memory-quota {:?} is smaller than scheduler.scheduler-pending-write-threshold, \
@@ -407,6 +416,43 @@ impl Default for IoRateLimitConfig {
     }
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, OnlineConfig)]
+#[serde(default)]
+#[serde(rename_all = "kebab-case")]
+pub struct MaxTsConfig {
+    /// Maximum max_ts deviation allowed from PD TSO.
+    pub max_drift: ReadableDuration,
+    /// How often to refresh the max_ts limit from PD.
+    #[online_config(skip)]
+    pub cache_sync_interval: ReadableDuration,
+    /// What TiKV does when it confirms an invalid max_ts update.
+    pub action_on_invalid_update: String,
+}
+
+impl Default for MaxTsConfig {
+    fn default() -> Self {
+        Self {
+            max_drift: ReadableDuration(DEFAULT_MAX_TS_DRIFT_ALLOWANCE),
+            cache_sync_interval: ReadableDuration(DEFAULT_MAX_TS_SYNC_INTERVAL),
+            action_on_invalid_update: DEFAULT_ACTION_ON_INVALID_MAX_TS_UPDATE.to_owned(),
+        }
+    }
+}
+
+impl MaxTsConfig {
+    fn validate(&mut self) -> Result<(), Box<dyn Error>> {
+        if self.max_drift <= self.cache_sync_interval {
+            return Err(format!(
+                "storage.max-ts.max-drift {:?} is smaller than or equal to storage.max-ts.cache-sync-interval {:?}",
+                self.max_drift, self.cache_sync_interval,
+            )
+            .into());
+        }
+        ActionOnInvalidMaxTs::try_from(self.action_on_invalid_update.as_str())?;
+        Ok(())
+    }
+}
+
 impl IoRateLimitConfig {
     pub fn build(&self, enable_statistics: bool) -> IoRateLimiter {
         let limiter = IoRateLimiter::new(self.mode, self.strict, enable_statistics);
@@ -477,6 +523,31 @@ mod tests {
         cfg.validate().unwrap_err();
 
         cfg.scheduler_worker_pool_size = max_pool_size + 1;
+        cfg.validate().unwrap_err();
+    }
+
+    #[test]
+    fn test_max_ts_config_defaults_to_error() {
+        let cfg = MaxTsConfig::default();
+        assert_eq!(cfg.action_on_invalid_update, "error");
+        assert_ne!(cfg.action_on_invalid_update, "panic");
+        assert!(ActionOnInvalidMaxTs::try_from(cfg.action_on_invalid_update.as_str()).is_ok());
+    }
+
+    #[test]
+    fn test_validate_max_ts_config() {
+        for action in ["error", "log", "panic"] {
+            let mut cfg = MaxTsConfig::default();
+            cfg.action_on_invalid_update = action.to_owned();
+            cfg.validate().unwrap();
+        }
+
+        let mut cfg = MaxTsConfig::default();
+        cfg.action_on_invalid_update = "invalid".to_owned();
+        cfg.validate().unwrap_err();
+
+        let mut cfg = MaxTsConfig::default();
+        cfg.max_drift = cfg.cache_sync_interval;
         cfg.validate().unwrap_err();
     }
 

--- a/src/storage/config_manager.rs
+++ b/src/storage/config_manager.rs
@@ -110,16 +110,69 @@ impl<EK: Engine, K: ConfigurableDb, L: LockManager> ConfigManager
                 }
             }
         }
-        if let Some(v) = change.remove("action_on_invalid_max_ts") {
+        dispatch_max_ts_config_change(&self.concurrency_manager, &mut change)?;
+        Ok(())
+    }
+}
+
+fn dispatch_max_ts_config_change(
+    concurrency_manager: &ConcurrencyManager,
+    change: &mut ConfigChange,
+) -> CfgResult<()> {
+    if let Some(ConfigValue::Module(mut max_ts)) = change.remove("max_ts") {
+        if let Some(v) = max_ts.remove("action_on_invalid_update") {
             let str_v: String = v.into();
             let action: concurrency_manager::ActionOnInvalidMaxTs = str_v.try_into()?;
-            self.concurrency_manager
-                .set_action_on_invalid_max_ts(action);
+            concurrency_manager.set_action_on_invalid_max_ts(action);
         }
-        if let Some(v) = change.remove("max_ts_drift_allowance") {
+        if let Some(v) = max_ts.remove("max_drift") {
             let dur_v: ReadableDuration = v.into();
-            self.concurrency_manager.set_max_ts_drift_allowance(dur_v.0);
+            concurrency_manager.set_max_ts_drift_allowance(dur_v.0);
         }
-        Ok(())
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use concurrency_manager::{ActionOnInvalidMaxTs, ConcurrencyManager};
+    use online_config::{ConfigChange, ConfigValue};
+    use txn_types::TimeStamp;
+
+    use super::dispatch_max_ts_config_change;
+
+    fn max_ts_action_change(action: &str) -> ConfigChange {
+        let mut max_ts = HashMap::new();
+        max_ts.insert(
+            "action_on_invalid_update".to_owned(),
+            ConfigValue::String(action.to_owned()),
+        );
+
+        let mut change = HashMap::new();
+        change.insert("max_ts".to_owned(), ConfigValue::Module(max_ts));
+        change
+    }
+
+    #[test]
+    fn test_dispatch_max_ts_action_on_invalid_update() {
+        let cm = ConcurrencyManager::new(TimeStamp::new(1));
+
+        let mut change = max_ts_action_change("error");
+        dispatch_max_ts_config_change(&cm, &mut change).unwrap();
+        assert_eq!(cm.action_on_invalid_max_ts(), ActionOnInvalidMaxTs::Error);
+
+        let mut change = max_ts_action_change("log");
+        dispatch_max_ts_config_change(&cm, &mut change).unwrap();
+        assert_eq!(cm.action_on_invalid_max_ts(), ActionOnInvalidMaxTs::Log);
+
+        let mut change = max_ts_action_change("panic");
+        dispatch_max_ts_config_change(&cm, &mut change).unwrap();
+        assert_eq!(cm.action_on_invalid_max_ts(), ActionOnInvalidMaxTs::Panic);
+
+        let mut change = max_ts_action_change("invalid");
+        dispatch_max_ts_config_change(&cm, &mut change).unwrap_err();
+        assert_eq!(cm.action_on_invalid_max_ts(), ActionOnInvalidMaxTs::Panic);
     }
 }

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -38,8 +38,8 @@ use tikv::{
         lock_manager::Config as PessimisticTxnConfig,
     },
     storage::config::{
-        BlockCacheConfig, Config as StorageConfig, EngineType, FlowControlConfig, IoRateLimitConfig,
-        MaxTsConfig,
+        BlockCacheConfig, Config as StorageConfig, EngineType, FlowControlConfig,
+        IoRateLimitConfig, MaxTsConfig,
     },
 };
 use tikv_util::config::{LogFormat, ReadableDuration, ReadableSchedule, ReadableSize};

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -39,6 +39,7 @@ use tikv::{
     },
     storage::config::{
         BlockCacheConfig, Config as StorageConfig, EngineType, FlowControlConfig, IoRateLimitConfig,
+        MaxTsConfig,
     },
 };
 use tikv_util::config::{LogFormat, ReadableDuration, ReadableSchedule, ReadableSize};
@@ -778,6 +779,7 @@ fn test_serde_custom_tikv_config() {
             export_priority: IoPriority::High,
             other_priority: IoPriority::Low,
         },
+        max_ts: MaxTsConfig::default(),
         background_error_recovery_window: ReadableDuration::hours(1),
         txn_status_cache_capacity: 1000,
         memory_quota: ReadableSize::kb(123),


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: Ref #19755

What's Changed:

```commit-message
storage: add max ts invalid update action config

Add TiKV storage.max-ts configuration for invalid max_ts update handling.
The new storage.max-ts.action-on-invalid-update option supports error, log,
and panic. The default is error so confirmed invalid max_ts updates are
rejected without panicking TiKV.

The server initialization path now reads max-ts settings from TiKV config
instead of hardcoding ActionOnInvalidMaxTs::Log. The storage online config
manager dispatches max-ts action changes to ConcurrencyManager.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [x] Need to cherry-pick to the release branch

### Check List

Tests

- [x] Unit test
- [x] Manual test (add detailed scripts or steps below)

Manual test commands:

```bash
cargo test -p tikv --lib test_max_ts_config_defaults_to_error -- --nocapture
cargo test -p tikv --lib test_validate_max_ts_config -- --nocapture
cargo test -p tikv --lib test_dispatch_max_ts_action_on_invalid_update -- --nocapture
cargo test -p tikv --lib test_to_config_change -- --nocapture
cargo test -p tikv --lib test_serde_to_online_config -- --nocapture
cargo check -p server
git diff --check
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [x] Breaking backward compatibility

The default handling changes from logging confirmed invalid max_ts updates to returning an error. Operators can set `storage.max-ts.action-on-invalid-update = "log"` to keep the previous behavior.

### Release note

```release-note
Add `storage.max-ts.action-on-invalid-update` to control TiKV behavior for confirmed invalid max_ts updates. The default is `error`, which rejects the invalid update without panicking TiKV. The option can be changed online to `log` or `panic`.
```

