### PR TITLE
support sum_int function (#19332)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8912,7 +8912,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "tipb"
 version = "0.0.1"
-source = "git+https://github.com/pingcap/tipb.git?branch=master#5f9928e91afe4ac82c770cc9cd5fb2c804a7555e"
+source = "git+https://github.com/pingcap/tipb.git#5f9928e91afe4ac82c770cc9cd5fb2c804a7555e"
 dependencies = [
  "futures 0.3.15",
  "grpcio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8912,7 +8912,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "tipb"
 version = "0.0.1"
-source = "git+https://github.com/pingcap/tipb.git#c84c57424fa7c7f1a51042991e6ec78d3f9fe5b3"
+source = "git+https://github.com/pingcap/tipb.git?branch=master#5f9928e91afe4ac82c770cc9cd5fb2c804a7555e"
 dependencies = [
  "futures 0.3.15",
  "grpcio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -380,7 +380,7 @@ grpcio = { version = "0.10.4", default-features = false, features = [
 grpcio-health = { version = "0.10.4", default-features = false, features = [
   "protobuf-codec",
 ] }
-tipb = { git = "https://github.com/pingcap/tipb.git" }
+tipb = { git = "https://github.com/pingcap/tipb.git", branch = "master" }
 kvproto = { git = "https://github.com/pingcap/kvproto.git" }
 yatp = { git = "https://github.com/tikv/yatp.git", branch = "master" }
 tokio-timer = { git = "https://github.com/tikv/tokio", branch = "tokio-timer-hotfix" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -380,7 +380,7 @@ grpcio = { version = "0.10.4", default-features = false, features = [
 grpcio-health = { version = "0.10.4", default-features = false, features = [
   "protobuf-codec",
 ] }
-tipb = { git = "https://github.com/pingcap/tipb.git", branch = "master" }
+tipb = { git = "https://github.com/pingcap/tipb.git" }
 kvproto = { git = "https://github.com/pingcap/kvproto.git" }
 yatp = { git = "https://github.com/tikv/yatp.git", branch = "master" }
 tokio-timer = { git = "https://github.com/tikv/tokio", branch = "tokio-timer-hotfix" }

--- a/components/tidb_query_aggr/src/impl_sum_int.rs
+++ b/components/tidb_query_aggr/src/impl_sum_int.rs
@@ -174,7 +174,7 @@ impl AggrFnStateSumIntUnsigned {
                     return Ok(());
                 }
                 self.sum = self.sum.checked_add(value).ok_or_else(|| {
-                    Error::overflow("BIGINT UNSIGNED", format!("({}, {})", self.sum, value))
+                    Error::overflow("BIGINT UNSIGNED", format!("({} + {})", self.sum, value))
                 })?;
                 Ok(())
             }
@@ -329,4 +329,76 @@ mod tests {
             .parse(expr, &mut ctx, &src_schema, &mut schema, &mut exp)
             .unwrap_err();
     }
+
+     #[test]
+     fn test_sum_int_signed_overflow() {
+         let expr = ExprDefBuilder::aggr_func(ExprType::SumInt, FieldTypeTp::LongLong)
+             .push_child(ExprDefBuilder::column_ref(0, FieldTypeTp::LongLong))
+             .build();
+         AggrFnDefinitionParserSumInt.check_supported(&expr).unwrap();
+         let src_schema = [FieldTypeTp::LongLong.into()];
+         let mut columns = LazyBatchColumnVec::from(vec![{
+             let mut col = LazyBatchColumn::decoded_with_capacity_and_tp(0, EvalType::Int);
+             col.mut_decoded().push_int(Some(i64::MAX));
+             col.mut_decoded().push_int(Some(1));
+             col
+         }]);
+         let logical_rows = vec![0, 1];
+         let mut schema = vec![];
+         let mut exp = vec![];
+         let mut ctx = EvalContext::default();
+         let aggr_fn = AggrFnDefinitionParserSumInt
+             .parse(expr, &mut ctx, &src_schema, &mut schema, &mut exp)
+             .unwrap();
+         let mut state = aggr_fn.create_state();
+         let exp_result = exp[0]
+             .eval(&mut ctx, &src_schema, &mut columns, &logical_rows, 2)
+             .unwrap();
+         let exp_result = exp_result.vector_value().unwrap();
+         let vec = exp_result.as_ref().to_int_vec();
+         let chunked_vec: ChunkedVecSized<Int> = vec.into();
+         assert!(update_vector!(state, &mut ctx, chunked_vec, exp_result.logical_rows()).is_err());
+     }
+
+     #[test]
+     fn test_sum_int_unsigned_overflow() {
+         let out_ft = FieldTypeBuilder::new()
+             .tp(FieldTypeTp::LongLong)
+             .flag(FieldTypeFlag::UNSIGNED)
+             .build();
+         let in_ft = FieldTypeBuilder::new()
+             .tp(FieldTypeTp::LongLong)
+             .flag(FieldTypeFlag::UNSIGNED)
+             .build();
+         let expr = ExprDefBuilder::aggr_func(ExprType::SumInt, out_ft)
+             .push_child(ExprDefBuilder::column_ref(0, in_ft))
+             .build();
+         AggrFnDefinitionParserSumInt.check_supported(&expr).unwrap();
+         let src_schema = [FieldTypeBuilder::new()
+             .tp(FieldTypeTp::LongLong)
+             .flag(FieldTypeFlag::UNSIGNED)
+             .build()];
+         let mut columns = LazyBatchColumnVec::from(vec![{
+             let mut col = LazyBatchColumn::decoded_with_capacity_and_tp(0, EvalType::Int);
+             // `u64::MAX` is carried as `-1_i64` in the TiDB/TiKV DAG int representation.
+             col.mut_decoded().push_int(Some(-1));
+             col.mut_decoded().push_int(Some(1));
+             col
+         }]);
+         let logical_rows = vec![0, 1];
+         let mut schema = vec![];
+         let mut exp = vec![];
+         let mut ctx = EvalContext::default();
+         let aggr_fn = AggrFnDefinitionParserSumInt
+             .parse(expr, &mut ctx, &src_schema, &mut schema, &mut exp)
+             .unwrap();
+         let mut state = aggr_fn.create_state();
+         let exp_result = exp[0]
+             .eval(&mut ctx, &src_schema, &mut columns, &logical_rows, 2)
+             .unwrap();
+         let exp_result = exp_result.vector_value().unwrap();
+         let vec = exp_result.as_ref().to_int_vec();
+         let chunked_vec: ChunkedVecSized<Int> = vec.into();
+         assert!(update_vector!(state, &mut ctx, chunked_vec, exp_result.logical_rows()).is_err());
+     }
 }

--- a/components/tidb_query_aggr/src/impl_sum_int.rs
+++ b/components/tidb_query_aggr/src/impl_sum_int.rs
@@ -115,7 +115,7 @@ impl AggrFnStateSumIntSigned {
                     return Ok(());
                 }
                 self.sum = self.sum.checked_add(value).ok_or_else(|| {
-                    Error::overflow("BIGINT", format!("({}, {})", self.sum, value))
+                    Error::overflow("BIGINT", format!("({} + {})", self.sum, value))
                 })?;
                 Ok(())
             }

--- a/components/tidb_query_aggr/src/impl_sum_int.rs
+++ b/components/tidb_query_aggr/src/impl_sum_int.rs
@@ -330,75 +330,75 @@ mod tests {
             .unwrap_err();
     }
 
-     #[test]
-     fn test_sum_int_signed_overflow() {
-         let expr = ExprDefBuilder::aggr_func(ExprType::SumInt, FieldTypeTp::LongLong)
-             .push_child(ExprDefBuilder::column_ref(0, FieldTypeTp::LongLong))
-             .build();
-         AggrFnDefinitionParserSumInt.check_supported(&expr).unwrap();
-         let src_schema = [FieldTypeTp::LongLong.into()];
-         let mut columns = LazyBatchColumnVec::from(vec![{
-             let mut col = LazyBatchColumn::decoded_with_capacity_and_tp(0, EvalType::Int);
-             col.mut_decoded().push_int(Some(i64::MAX));
-             col.mut_decoded().push_int(Some(1));
-             col
-         }]);
-         let logical_rows = vec![0, 1];
-         let mut schema = vec![];
-         let mut exp = vec![];
-         let mut ctx = EvalContext::default();
-         let aggr_fn = AggrFnDefinitionParserSumInt
-             .parse(expr, &mut ctx, &src_schema, &mut schema, &mut exp)
-             .unwrap();
-         let mut state = aggr_fn.create_state();
-         let exp_result = exp[0]
-             .eval(&mut ctx, &src_schema, &mut columns, &logical_rows, 2)
-             .unwrap();
-         let exp_result = exp_result.vector_value().unwrap();
-         let vec = exp_result.as_ref().to_int_vec();
-         let chunked_vec: ChunkedVecSized<Int> = vec.into();
-         assert!(update_vector!(state, &mut ctx, chunked_vec, exp_result.logical_rows()).is_err());
-     }
+    #[test]
+    fn test_sum_int_signed_overflow() {
+        let expr = ExprDefBuilder::aggr_func(ExprType::SumInt, FieldTypeTp::LongLong)
+            .push_child(ExprDefBuilder::column_ref(0, FieldTypeTp::LongLong))
+            .build();
+        AggrFnDefinitionParserSumInt.check_supported(&expr).unwrap();
+        let src_schema = [FieldTypeTp::LongLong.into()];
+        let mut columns = LazyBatchColumnVec::from(vec![{
+            let mut col = LazyBatchColumn::decoded_with_capacity_and_tp(0, EvalType::Int);
+            col.mut_decoded().push_int(Some(i64::MAX));
+            col.mut_decoded().push_int(Some(1));
+            col
+        }]);
+        let logical_rows = vec![0, 1];
+        let mut schema = vec![];
+        let mut exp = vec![];
+        let mut ctx = EvalContext::default();
+        let aggr_fn = AggrFnDefinitionParserSumInt
+            .parse(expr, &mut ctx, &src_schema, &mut schema, &mut exp)
+            .unwrap();
+        let mut state = aggr_fn.create_state();
+        let exp_result = exp[0]
+            .eval(&mut ctx, &src_schema, &mut columns, &logical_rows, 2)
+            .unwrap();
+        let exp_result = exp_result.vector_value().unwrap();
+        let vec = exp_result.as_ref().to_int_vec();
+        let chunked_vec: ChunkedVecSized<Int> = vec.into();
+        assert!(update_vector!(state, &mut ctx, chunked_vec, exp_result.logical_rows()).is_err());
+    }
 
-     #[test]
-     fn test_sum_int_unsigned_overflow() {
-         let out_ft = FieldTypeBuilder::new()
-             .tp(FieldTypeTp::LongLong)
-             .flag(FieldTypeFlag::UNSIGNED)
-             .build();
-         let in_ft = FieldTypeBuilder::new()
-             .tp(FieldTypeTp::LongLong)
-             .flag(FieldTypeFlag::UNSIGNED)
-             .build();
-         let expr = ExprDefBuilder::aggr_func(ExprType::SumInt, out_ft)
-             .push_child(ExprDefBuilder::column_ref(0, in_ft))
-             .build();
-         AggrFnDefinitionParserSumInt.check_supported(&expr).unwrap();
-         let src_schema = [FieldTypeBuilder::new()
-             .tp(FieldTypeTp::LongLong)
-             .flag(FieldTypeFlag::UNSIGNED)
-             .build()];
-         let mut columns = LazyBatchColumnVec::from(vec![{
-             let mut col = LazyBatchColumn::decoded_with_capacity_and_tp(0, EvalType::Int);
-             // `u64::MAX` is carried as `-1_i64` in the TiDB/TiKV DAG int representation.
-             col.mut_decoded().push_int(Some(-1));
-             col.mut_decoded().push_int(Some(1));
-             col
-         }]);
-         let logical_rows = vec![0, 1];
-         let mut schema = vec![];
-         let mut exp = vec![];
-         let mut ctx = EvalContext::default();
-         let aggr_fn = AggrFnDefinitionParserSumInt
-             .parse(expr, &mut ctx, &src_schema, &mut schema, &mut exp)
-             .unwrap();
-         let mut state = aggr_fn.create_state();
-         let exp_result = exp[0]
-             .eval(&mut ctx, &src_schema, &mut columns, &logical_rows, 2)
-             .unwrap();
-         let exp_result = exp_result.vector_value().unwrap();
-         let vec = exp_result.as_ref().to_int_vec();
-         let chunked_vec: ChunkedVecSized<Int> = vec.into();
-         assert!(update_vector!(state, &mut ctx, chunked_vec, exp_result.logical_rows()).is_err());
-     }
+    #[test]
+    fn test_sum_int_unsigned_overflow() {
+        let out_ft = FieldTypeBuilder::new()
+            .tp(FieldTypeTp::LongLong)
+            .flag(FieldTypeFlag::UNSIGNED)
+            .build();
+        let in_ft = FieldTypeBuilder::new()
+            .tp(FieldTypeTp::LongLong)
+            .flag(FieldTypeFlag::UNSIGNED)
+            .build();
+        let expr = ExprDefBuilder::aggr_func(ExprType::SumInt, out_ft)
+            .push_child(ExprDefBuilder::column_ref(0, in_ft))
+            .build();
+        AggrFnDefinitionParserSumInt.check_supported(&expr).unwrap();
+        let src_schema = [FieldTypeBuilder::new()
+            .tp(FieldTypeTp::LongLong)
+            .flag(FieldTypeFlag::UNSIGNED)
+            .build()];
+        let mut columns = LazyBatchColumnVec::from(vec![{
+            let mut col = LazyBatchColumn::decoded_with_capacity_and_tp(0, EvalType::Int);
+            // `u64::MAX` is carried as `-1_i64` in the TiDB/TiKV DAG int representation.
+            col.mut_decoded().push_int(Some(-1));
+            col.mut_decoded().push_int(Some(1));
+            col
+        }]);
+        let logical_rows = vec![0, 1];
+        let mut schema = vec![];
+        let mut exp = vec![];
+        let mut ctx = EvalContext::default();
+        let aggr_fn = AggrFnDefinitionParserSumInt
+            .parse(expr, &mut ctx, &src_schema, &mut schema, &mut exp)
+            .unwrap();
+        let mut state = aggr_fn.create_state();
+        let exp_result = exp[0]
+            .eval(&mut ctx, &src_schema, &mut columns, &logical_rows, 2)
+            .unwrap();
+        let exp_result = exp_result.vector_value().unwrap();
+        let vec = exp_result.as_ref().to_int_vec();
+        let chunked_vec: ChunkedVecSized<Int> = vec.into();
+        assert!(update_vector!(state, &mut ctx, chunked_vec, exp_result.logical_rows()).is_err());
+    }
 }

--- a/components/tidb_query_aggr/src/impl_sum_int.rs
+++ b/components/tidb_query_aggr/src/impl_sum_int.rs
@@ -1,0 +1,332 @@
+// Copyright 2026 TiKV Project Authors. Licensed under Apache-2.0.
+
+use tidb_query_codegen::AggrFunction;
+use tidb_query_common::Result;
+use tidb_query_datatype::{
+    EvalType, FieldTypeAccessor, FieldTypeTp,
+    codec::{Error, data_type::*},
+    expr::EvalContext,
+};
+use tidb_query_expr::RpnExpression;
+use tipb::{Expr, ExprType, FieldType};
+
+use super::*;
+
+/// The parser for SUM_INT aggregate function.
+pub struct AggrFnDefinitionParserSumInt;
+
+impl super::parser::AggrDefinitionParser for AggrFnDefinitionParserSumInt {
+    fn check_supported(&self, aggr_def: &Expr) -> Result<()> {
+        assert_eq!(aggr_def.get_tp(), ExprType::SumInt);
+        super::util::check_aggr_exp_supported_one_child(aggr_def)
+    }
+
+    #[inline]
+    fn parse_rpn(
+        &self,
+        mut root_expr: Expr,
+        exp: RpnExpression,
+        _ctx: &mut EvalContext,
+        src_schema: &[FieldType],
+        out_schema: &mut Vec<FieldType>,
+        out_exp: &mut Vec<RpnExpression>,
+    ) -> Result<Box<dyn AggrFunction>> {
+        assert_eq!(root_expr.get_tp(), ExprType::SumInt);
+
+        let out_ft = root_expr.take_field_type();
+        let out_tp = out_ft.as_accessor().tp();
+        let out_et = box_try!(EvalType::try_from(out_tp));
+        if out_et != EvalType::Int || out_tp != FieldTypeTp::LongLong {
+            return Err(other_err!(
+                "Unexpected return field type {} for SUM_INT",
+                out_tp
+            ));
+        }
+
+        let arg_ft = exp.ret_field_type(src_schema);
+        let arg_tp = arg_ft.as_accessor().tp();
+        match arg_tp {
+            FieldTypeTp::Tiny
+            | FieldTypeTp::Short
+            | FieldTypeTp::Int24
+            | FieldTypeTp::Long
+            | FieldTypeTp::LongLong => {}
+            _ => {
+                return Err(other_err!(
+                    "SUM_INT only accepts integer arguments, but got {}",
+                    arg_tp
+                ));
+            }
+        }
+
+        let out_is_unsigned = out_ft.as_accessor().is_unsigned();
+        let arg_is_unsigned = arg_ft.as_accessor().is_unsigned();
+        if out_is_unsigned != arg_is_unsigned {
+            return Err(other_err!(
+                "Unexpected unsigned flag for SUM_INT: return_is_unsigned={}, arg_is_unsigned={}",
+                out_is_unsigned,
+                arg_is_unsigned
+            ));
+        }
+
+        // SUM_INT outputs one column.
+        out_schema.push(out_ft);
+        out_exp.push(exp);
+
+        Ok(if out_is_unsigned {
+            Box::new(AggrFnSumIntUnsigned)
+        } else {
+            Box::new(AggrFnSumIntSigned)
+        })
+    }
+}
+
+/// The SUM_INT aggregate function for signed integer arguments.
+#[derive(Debug, AggrFunction)]
+#[aggr_function(state = AggrFnStateSumIntSigned::new())]
+pub struct AggrFnSumIntSigned;
+
+#[derive(Debug)]
+pub struct AggrFnStateSumIntSigned {
+    sum: i64,
+    has_value: bool,
+}
+
+impl AggrFnStateSumIntSigned {
+    pub fn new() -> Self {
+        Self {
+            sum: 0,
+            has_value: false,
+        }
+    }
+
+    #[inline]
+    fn update_concrete<'a, TT>(&mut self, _ctx: &mut EvalContext, value: Option<TT>) -> Result<()>
+    where
+        TT: EvaluableRef<'a, EvaluableType = Int>,
+    {
+        match value {
+            None => Ok(()),
+            Some(value) => {
+                let value = value.into_owned_value();
+                if !self.has_value {
+                    self.sum = value;
+                    self.has_value = true;
+                    return Ok(());
+                }
+                self.sum = self.sum.checked_add(value).ok_or_else(|| {
+                    Error::overflow("BIGINT", format!("({}, {})", self.sum, value))
+                })?;
+                Ok(())
+            }
+        }
+    }
+}
+
+impl super::ConcreteAggrFunctionState for AggrFnStateSumIntSigned {
+    type ParameterType = &'static Int;
+
+    impl_concrete_state! { Self::ParameterType }
+
+    #[inline]
+    fn push_result(&self, _ctx: &mut EvalContext, target: &mut [VectorValue]) -> Result<()> {
+        assert_eq!(target.len(), 1);
+        if !self.has_value {
+            target[0].push_int(None);
+        } else {
+            target[0].push_int(Some(self.sum));
+        }
+        Ok(())
+    }
+}
+
+/// The SUM_INT aggregate function for unsigned integer arguments.
+#[derive(Debug, AggrFunction)]
+#[aggr_function(state = AggrFnStateSumIntUnsigned::new())]
+pub struct AggrFnSumIntUnsigned;
+
+#[derive(Debug)]
+pub struct AggrFnStateSumIntUnsigned {
+    sum: u64,
+    has_value: bool,
+}
+
+impl AggrFnStateSumIntUnsigned {
+    pub fn new() -> Self {
+        Self {
+            sum: 0,
+            has_value: false,
+        }
+    }
+
+    #[inline]
+    fn update_concrete<'a, TT>(&mut self, _ctx: &mut EvalContext, value: Option<TT>) -> Result<()>
+    where
+        TT: EvaluableRef<'a, EvaluableType = Int>,
+    {
+        match value {
+            None => Ok(()),
+            Some(value) => {
+                let value = value.into_owned_value() as u64;
+                if !self.has_value {
+                    self.sum = value;
+                    self.has_value = true;
+                    return Ok(());
+                }
+                self.sum = self.sum.checked_add(value).ok_or_else(|| {
+                    Error::overflow("BIGINT UNSIGNED", format!("({}, {})", self.sum, value))
+                })?;
+                Ok(())
+            }
+        }
+    }
+}
+
+impl super::ConcreteAggrFunctionState for AggrFnStateSumIntUnsigned {
+    type ParameterType = &'static Int;
+
+    impl_concrete_state! { Self::ParameterType }
+
+    #[inline]
+    fn push_result(&self, _ctx: &mut EvalContext, target: &mut [VectorValue]) -> Result<()> {
+        assert_eq!(target.len(), 1);
+        if !self.has_value {
+            target[0].push_int(None);
+        } else {
+            // Note: Integer values are carried by `i64` in TiKV/TiDB DAG, and will be
+            // interpreted by the output field type's UNSIGNED flag in upper
+            // layer.
+            target[0].push_int(Some(self.sum as Int));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tidb_query_datatype::{
+        EvalType, FieldTypeFlag,
+        builder::FieldTypeBuilder,
+        codec::batch::{LazyBatchColumn, LazyBatchColumnVec},
+    };
+    use tipb_helper::ExprDefBuilder;
+
+    use super::*;
+    use crate::parser::AggrDefinitionParser;
+
+    #[test]
+    fn test_sum_int_signed_integration() {
+        let expr = ExprDefBuilder::aggr_func(ExprType::SumInt, FieldTypeTp::LongLong)
+            .push_child(ExprDefBuilder::column_ref(0, FieldTypeTp::Long))
+            .build();
+        AggrFnDefinitionParserSumInt.check_supported(&expr).unwrap();
+
+        let src_schema = [FieldTypeTp::Long.into()];
+        let mut columns = LazyBatchColumnVec::from(vec![{
+            let mut col = LazyBatchColumn::decoded_with_capacity_and_tp(0, EvalType::Int);
+            col.mut_decoded().push_int(Some(1));
+            col.mut_decoded().push_int(None);
+            col.mut_decoded().push_int(Some(5));
+            col.mut_decoded().push_int(Some(-2));
+            col
+        }]);
+        let logical_rows = vec![0, 1, 2, 3];
+
+        let mut schema = vec![];
+        let mut exp = vec![];
+        let mut ctx = EvalContext::default();
+
+        let aggr_fn = AggrFnDefinitionParserSumInt
+            .parse(expr, &mut ctx, &src_schema, &mut schema, &mut exp)
+            .unwrap();
+        assert_eq!(schema.len(), 1);
+        assert_eq!(schema[0].as_accessor().tp(), FieldTypeTp::LongLong);
+        assert!(!schema[0].as_accessor().is_unsigned());
+
+        let mut state = aggr_fn.create_state();
+
+        let exp_result = exp[0]
+            .eval(&mut ctx, &src_schema, &mut columns, &logical_rows, 4)
+            .unwrap();
+        let exp_result = exp_result.vector_value().unwrap();
+        let vec = exp_result.as_ref().to_int_vec();
+        let chunked_vec: ChunkedVecSized<Int> = vec.into();
+        update_vector!(state, &mut ctx, chunked_vec, exp_result.logical_rows()).unwrap();
+
+        let mut aggr_result = [VectorValue::with_capacity(0, EvalType::Int)];
+        state.push_result(&mut ctx, &mut aggr_result).unwrap();
+        assert_eq!(aggr_result[0].to_int_vec(), &[Some(4)]);
+    }
+
+    #[test]
+    fn test_sum_int_unsigned_integration() {
+        let out_ft = FieldTypeBuilder::new()
+            .tp(FieldTypeTp::LongLong)
+            .flag(FieldTypeFlag::UNSIGNED)
+            .build();
+        let in_ft = FieldTypeBuilder::new()
+            .tp(FieldTypeTp::LongLong)
+            .flag(FieldTypeFlag::UNSIGNED)
+            .build();
+
+        let expr = ExprDefBuilder::aggr_func(ExprType::SumInt, out_ft)
+            .push_child(ExprDefBuilder::column_ref(0, in_ft))
+            .build();
+        AggrFnDefinitionParserSumInt.check_supported(&expr).unwrap();
+
+        let src_schema = [FieldTypeBuilder::new()
+            .tp(FieldTypeTp::LongLong)
+            .flag(FieldTypeFlag::UNSIGNED)
+            .build()];
+
+        let mut columns = LazyBatchColumnVec::from(vec![{
+            let mut col = LazyBatchColumn::decoded_with_capacity_and_tp(0, EvalType::Int);
+            col.mut_decoded().push_int(Some(1));
+            col.mut_decoded().push_int(Some(2));
+            col.mut_decoded().push_int(None);
+            col.mut_decoded().push_int(Some(3));
+            col
+        }]);
+        let logical_rows = vec![0, 1, 2, 3];
+
+        let mut schema = vec![];
+        let mut exp = vec![];
+        let mut ctx = EvalContext::default();
+
+        let aggr_fn = AggrFnDefinitionParserSumInt
+            .parse(expr, &mut ctx, &src_schema, &mut schema, &mut exp)
+            .unwrap();
+        assert_eq!(schema.len(), 1);
+        assert!(schema[0].as_accessor().is_unsigned());
+
+        let mut state = aggr_fn.create_state();
+
+        let exp_result = exp[0]
+            .eval(&mut ctx, &src_schema, &mut columns, &logical_rows, 4)
+            .unwrap();
+        let exp_result = exp_result.vector_value().unwrap();
+        let vec = exp_result.as_ref().to_int_vec();
+        let chunked_vec: ChunkedVecSized<Int> = vec.into();
+        update_vector!(state, &mut ctx, chunked_vec, exp_result.logical_rows()).unwrap();
+
+        let mut aggr_result = [VectorValue::with_capacity(0, EvalType::Int)];
+        state.push_result(&mut ctx, &mut aggr_result).unwrap();
+        assert_eq!(aggr_result[0].to_int_vec(), &[Some(6)]);
+    }
+
+    #[test]
+    fn test_sum_int_illegal_request() {
+        let expr = ExprDefBuilder::aggr_func(ExprType::SumInt, FieldTypeTp::LongLong)
+            .push_child(ExprDefBuilder::column_ref(0, FieldTypeTp::VarString))
+            .build();
+        AggrFnDefinitionParserSumInt.check_supported(&expr).unwrap();
+
+        let src_schema = [FieldTypeTp::VarString.into()];
+        let mut schema = vec![];
+        let mut exp = vec![];
+        let mut ctx = EvalContext::default();
+        AggrFnDefinitionParserSumInt
+            .parse(expr, &mut ctx, &src_schema, &mut schema, &mut exp)
+            .unwrap_err();
+    }
+}

--- a/components/tidb_query_aggr/src/lib.rs
+++ b/components/tidb_query_aggr/src/lib.rs
@@ -20,6 +20,7 @@ mod impl_count;
 mod impl_first;
 mod impl_max_min;
 mod impl_sum;
+mod impl_sum_int;
 mod impl_variance;
 mod parser;
 mod summable;

--- a/components/tidb_query_aggr/src/parser.rs
+++ b/components/tidb_query_aggr/src/parser.rs
@@ -68,6 +68,7 @@ fn map_pb_sig_to_aggr_func_parser(value: ExprType) -> Result<Box<dyn AggrDefinit
     match value {
         ExprType::Count => Ok(Box::new(super::impl_count::AggrFnDefinitionParserCount)),
         ExprType::Sum => Ok(Box::new(super::impl_sum::AggrFnDefinitionParserSum)),
+        ExprType::SumInt => Ok(Box::new(super::impl_sum_int::AggrFnDefinitionParserSumInt)),
         ExprType::Avg => Ok(Box::new(super::impl_avg::AggrFnDefinitionParserAvg)),
         ExprType::First => Ok(Box::new(super::impl_first::AggrFnDefinitionParserFirst)),
         ExprType::AggBitAnd => Ok(Box::new(AggrFnDefinitionParserBitOp::<BitAnd>::new())),


### PR DESCRIPTION
(cherry picked from commit 97af2f1c9a14ba184aa4cb8fc0e5e8553e6d54c2)

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?

<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close tikv/tikv#19370

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:
This pr cherry-pick #19332 to master branch


### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
support `sum_int` 
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the `SUM_INT` aggregate, including correct signed vs unsigned behavior and a single-column output.
  * Wired `SUM_INT` mapping so the new aggregate is recognized in expressions.
* **Bug Fixes**
  * Returns `NULL` when all inputs are `NULL`.
  * Detects arithmetic overflow and raises an error instead of producing an incorrect total.
* **Tests**
  * Added end-to-end coverage for signed/unsigned aggregation with `NULL` inputs.
  * Added validation tests for non-integer arguments and overflow scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->