### PR TITLE
tidb_query_expr: push down geospatial DE-9IM predicates to the coprocessor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,6 +140,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "arbitrary"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2328,6 +2337,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee2626afccd7561a06cf1367e2950c4718ea04565e20fb5029b6c7d8ad09abcf"
 
 [[package]]
+name = "earcut"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88459a2a8e3a514b6e6de38cf3aaa9250a894cb098f74a932db77fcc8341b6d0"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2807,6 +2825,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "float_next_after"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37007738a80ea34f969af54a3390dd72cacdef654974cfd449c9f6f72dbaac10"
+
+[[package]]
 name = "fnv"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3150,6 +3174,50 @@ checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
 dependencies = [
  "typenum",
  "version_check 0.9.4",
+]
+
+[[package]]
+name = "geo"
+version = "0.33.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30eb1fdc57c1e5cfd11826fe0caec4b9dc7901f3758263bb506228d88c8d9e9a"
+dependencies = [
+ "earcut",
+ "float_next_after",
+ "geo-types",
+ "geographiclib-rs",
+ "i_overlay",
+ "log",
+ "num-traits",
+ "rand 0.10.0",
+ "rand_pcg",
+ "robust",
+ "rstar",
+ "sif-itree",
+ "spade",
+]
+
+[[package]]
+name = "geo-types"
+version = "0.7.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94776032c45f950d30a13af6113c2ad5625316c9abfbccee4dd5a6695f8fe0f5"
+dependencies = [
+ "approx",
+ "num-traits",
+ "rayon",
+ "rstar",
+ "serde",
+ "spade",
+]
+
+[[package]]
+name = "geographiclib-rs"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5a7f08910fd98737a6eda7568e7c5e645093e073328eeef49758cfe8b0489c7"
+dependencies = [
+ "libm",
 ]
 
 [[package]]
@@ -3602,6 +3670,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3623,6 +3700,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -3650,6 +3729,16 @@ dependencies = [
  "slog",
  "slog-global",
  "tikv_util",
+]
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -3975,6 +4064,52 @@ dependencies = [
  "tower-service",
  "tracing",
 ]
+
+[[package]]
+name = "i_float"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "813145bb0ad5b60f55cbbf3c74cdceda1c0a9d253b35c4cc36ae0df7887cb78f"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "i_key_sort"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d73d122b937fca067feb0ad74f62388920272b27c356d4df2d0cfdd59e044cf0"
+dependencies = [
+ "rayon",
+]
+
+[[package]]
+name = "i_overlay"
+version = "4.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8dd314b4668e2b3a12508f2e125558c82a6c0a8636fa5107a900f79ce414e450"
+dependencies = [
+ "i_float",
+ "i_key_sort",
+ "i_shape",
+ "i_tree",
+ "rayon",
+]
+
+[[package]]
+name = "i_shape"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa9eac533d7509a8ab87672b60ac610c17240f9ea4851d26227689fdfe349c8"
+dependencies = [
+ "i_float",
+]
+
+[[package]]
+name = "i_tree"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4804bdc1dc124eb7e1aa9e144ecc04096bcf787a10a15fa44af682b51f0f6cce"
 
 [[package]]
 name = "iana-time-zone"
@@ -6357,6 +6492,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.0",
+]
+
+[[package]]
 name = "rand_xorshift"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6376,26 +6520,22 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.5.3"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
- "autocfg",
- "crossbeam-deque",
  "either",
  "rayon-core",
 ]
 
 [[package]]
 name = "rayon-core"
-version = "1.9.3"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
- "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-utils",
- "num_cpus",
 ]
 
 [[package]]
@@ -6716,6 +6856,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "robust"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e27ee8bb91ca0adcf0ecb116293afa12d393f9c2b9b9cd54d33e8078fe19839"
+
+[[package]]
 name = "rocksdb"
 version = "0.3.0"
 source = "git+https://github.com/tikv/rust-rocksdb.git#1c17b59dcb506302ed4684b3628c4a7165e0b86d"
@@ -6731,6 +6877,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "921904a62e410e37e215c40381b7117f830d9d89ba60ab5236170541dd25646b"
 dependencies = [
  "xmlparser",
+]
+
+[[package]]
+name = "rstar"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "421400d13ccfd26dfa5858199c30a5d76f9c54e0dba7575273025b43c5175dbb"
+dependencies = [
+ "heapless",
+ "num-traits",
+ "smallvec",
 ]
 
 [[package]]
@@ -7315,6 +7472,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "sif-itree"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7f45b8998ced5134fb1d75732c77842a3e888f19c1ff98481822e8fbfbf930b"
+
+[[package]]
 name = "signal-hook"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7501,6 +7664,18 @@ checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc 0.2.176",
  "windows-sys 0.61.0",
+]
+
+[[package]]
+name = "spade"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a14e31a007e9f85c32784b04f89e6e194bb252a4d41b4a8ccd9e77245d901c8c"
+dependencies = [
+ "hashbrown 0.15.5",
+ "num-traits",
+ "robust",
+ "smallvec",
 ]
 
 [[package]]
@@ -8443,6 +8618,7 @@ dependencies = [
  "crypto",
  "file_system",
  "flate2",
+ "geo",
  "hex 0.4.3",
  "log_wrappers",
  "match-template",
@@ -9245,7 +9421,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "static_assertions",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8912,7 +8912,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "tipb"
 version = "0.0.1"
-source = "git+https://github.com/pingcap/tipb.git#5f9928e91afe4ac82c770cc9cd5fb2c804a7555e"
+source = "git+https://github.com/mjonss/tipb.git?branch=spatial-pushdown#eacc7e94342eeefa5151ce43f42e9433b3abc58a"
 dependencies = [
  "futures 0.3.15",
  "grpcio",
@@ -9245,7 +9245,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "static_assertions",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -380,7 +380,7 @@ grpcio = { version = "0.10.4", default-features = false, features = [
 grpcio-health = { version = "0.10.4", default-features = false, features = [
   "protobuf-codec",
 ] }
-tipb = { git = "https://github.com/pingcap/tipb.git" }
+tipb = { git = "https://github.com/mjonss/tipb.git", branch = "spatial-pushdown" }
 kvproto = { git = "https://github.com/pingcap/kvproto.git" }
 yatp = { git = "https://github.com/tikv/yatp.git", branch = "master" }
 tokio-timer = { git = "https://github.com/tikv/tokio", branch = "tokio-timer-hotfix" }

--- a/components/tidb_query_datatype/src/def/eval_type.rs
+++ b/components/tidb_query_datatype/src/def/eval_type.rs
@@ -77,6 +77,9 @@ impl std::convert::TryFrom<crate::FieldTypeTp> for EvalType {
             | crate::FieldTypeTp::Blob
             | crate::FieldTypeTp::VarString
             | crate::FieldTypeTp::String
+            // Geometry is stored and evaluated as its EWKB binary string, so the
+            // coprocessor treats it as Bytes (the spatial fns decode the EWKB).
+            | crate::FieldTypeTp::Geometry
             | crate::FieldTypeTp::Null => EvalType::Bytes,
             crate::FieldTypeTp::Enum => EvalType::Enum,
             _ => {

--- a/components/tidb_query_expr/Cargo.toml
+++ b/components/tidb_query_expr/Cargo.toml
@@ -16,6 +16,7 @@ codec = { workspace = true }
 crypto = { workspace = true }
 file_system = { workspace = true }
 flate2 = { version = "=1.0.11", default-features = false, features = ["zlib"] }
+geo = "0.33"
 hex = "0.4"
 log_wrappers = { workspace = true }
 match-template = "0.0.1"

--- a/components/tidb_query_expr/src/impl_spatial.rs
+++ b/components/tidb_query_expr/src/impl_spatial.rs
@@ -217,7 +217,10 @@ fn geom_dimension(g: &Geometry<f64>) -> i32 {
     match g {
         Geometry::Point(_) | Geometry::MultiPoint(_) => 0,
         Geometry::Line(_) | Geometry::LineString(_) | Geometry::MultiLineString(_) => 1,
-        Geometry::Polygon(_) | Geometry::MultiPolygon(_) | Geometry::Rect(_) | Geometry::Triangle(_) => 2,
+        Geometry::Polygon(_)
+        | Geometry::MultiPolygon(_)
+        | Geometry::Rect(_)
+        | Geometry::Triangle(_) => 2,
         Geometry::GeometryCollection(gc) => gc.0.iter().map(geom_dimension).max().unwrap_or(-1),
     }
 }
@@ -243,8 +246,8 @@ st_predicate!(st_covers, is_covers);
 st_predicate!(st_covered_by, is_coveredby);
 
 /// ST_Crosses is dimension-gated to match MySQL: it returns NULL unless
-/// dim(a) < dim(b) or both operands are curves (lines). The `geo` crate computes
-/// crosses symmetrically, so the gate is applied here.
+/// dim(a) < dim(b) or both operands are curves (lines). The `geo` crate
+/// computes crosses symmetrically, so the gate is applied here.
 #[rpn_fn]
 #[inline]
 pub fn st_crosses(a: BytesRef, b: BytesRef) -> Result<Option<Int>> {
@@ -341,6 +344,12 @@ mod tests {
     /// TiDB's `pkg/util/geomrel` (simplefeatures). Columns follow `SIGS`
     /// order: within, contains, intersects, equals, disjoint, touches,
     /// crosses, overlaps, covers, coveredby.
+    ///
+    /// Expected values are `Option<i64>` so the `ST_Crosses` column can be
+    /// `None`: unlike the other predicates (which mirror raw DE-9IM), TiDB's
+    /// `ST_Crosses` follows MySQL and is NULL unless `dim(a) < dim(b)` or both
+    /// operands are curves — see `st_crosses`. So the equal-dimension polygon
+    /// pairs below expect `None` for crosses rather than the raw geomrel `0`.
     #[test]
     fn test_de9im_corpus() {
         let poly4 = ewkb_polygon(&[&[(0., 0.), (4., 0.), (4., 4.), (0., 4.), (0., 0.)]]);
@@ -349,51 +358,62 @@ mod tests {
         let poly_unit = ewkb_polygon(&[&[(0., 0.), (1., 0.), (1., 1.), (0., 1.), (0., 0.)]]);
         let poly_far = ewkb_polygon(&[&[(5., 5.), (6., 5.), (6., 6.), (5., 6.), (5., 5.)]]);
 
-        let cases: Vec<(Vec<u8>, Vec<u8>, [i64; 10])> = vec![
-            // interior point
+        // y = Some(v); n = None. Crosses (column 6) is None for the equal-
+        // dimension polygon pairs (dim(a) not < dim(b)).
+        let y = Some;
+        let n: Option<i64> = None;
+
+        // (geometry a, geometry b, expected per-predicate result in SIGS order)
+        type Case = (Vec<u8>, Vec<u8>, [Option<i64>; 10]);
+        let cases: Vec<Case> = vec![
+            // interior point (dim 0 < 2, so crosses is gated-in: 0)
             (
                 ewkb_point(2., 2.),
                 poly4.clone(),
-                [1, 0, 1, 0, 0, 0, 0, 0, 0, 1],
+                [y(1), y(0), y(1), y(0), y(0), y(0), y(0), y(0), y(0), y(1)],
             ),
             // outside point
             (
                 ewkb_point(5., 5.),
                 poly4.clone(),
-                [0, 0, 0, 0, 1, 0, 0, 0, 0, 0],
+                [y(0), y(0), y(0), y(0), y(1), y(0), y(0), y(0), y(0), y(0)],
             ),
             // boundary corner point
             (
                 ewkb_point(0., 0.),
                 poly4.clone(),
-                [0, 0, 1, 0, 0, 1, 0, 0, 0, 1],
+                [y(0), y(0), y(1), y(0), y(0), y(1), y(0), y(0), y(0), y(1)],
             ),
-            // diagonal line across the polygon
+            // diagonal line across the polygon (dim 1 < 2, crosses gated-in: 0)
             (
                 ewkb_linestring(&[(0., 0.), (4., 4.)]),
                 poly4.clone(),
-                [1, 0, 1, 0, 0, 0, 0, 0, 0, 1],
+                [y(1), y(0), y(1), y(0), y(0), y(0), y(0), y(0), y(0), y(1)],
             ),
-            // partially overlapping polygons
-            (poly_a, poly_b, [0, 0, 1, 0, 0, 0, 0, 1, 0, 0]),
-            // equal polygons
-            (poly4.clone(), poly4.clone(), [1, 1, 1, 1, 0, 0, 0, 0, 1, 1]),
-            // disjoint polygons
-            (poly_unit, poly_far, [0, 0, 0, 0, 1, 0, 0, 0, 0, 0]),
+            // partially overlapping polygons (crosses NULL: equal dimension)
+            (
+                poly_a,
+                poly_b,
+                [y(0), y(0), y(1), y(0), y(0), y(0), n, y(1), y(0), y(0)],
+            ),
+            // equal polygons (crosses NULL: equal dimension)
+            (
+                poly4.clone(),
+                poly4.clone(),
+                [y(1), y(1), y(1), y(1), y(0), y(0), n, y(0), y(1), y(1)],
+            ),
+            // disjoint polygons (crosses NULL: equal dimension)
+            (
+                poly_unit,
+                poly_far,
+                [y(0), y(0), y(0), y(0), y(1), y(0), n, y(0), y(0), y(0)],
+            ),
         ];
 
         for (i, (a, b, expected)) in cases.iter().enumerate() {
             for (j, sig) in SIGS.iter().enumerate() {
                 let out = eval(*sig, a, b);
-                assert_eq!(
-                    out,
-                    Some(expected[j]),
-                    "case {} {:?}: expected {}, got {:?}",
-                    i,
-                    sig,
-                    expected[j],
-                    out
-                );
+                assert_eq!(out, expected[j], "case {} {:?}: got {:?}", i, sig, out);
             }
         }
     }

--- a/components/tidb_query_expr/src/impl_spatial.rs
+++ b/components/tidb_query_expr/src/impl_spatial.rs
@@ -1,0 +1,453 @@
+// Copyright 2026 TiKV Project Authors. Licensed under Apache-2.0.
+
+//! Geospatial DE-9IM predicate functions pushed down from TiDB's spatial
+//! index refine filter.
+//!
+//! Each predicate takes two EWKB byte strings — the stored geometry column
+//! value and the query constant — and returns `1`/`0` (or NULL if either
+//! argument is NULL). TiDB only pushes these down after the bbox pre-filter
+//! has pruned the obvious non-matches, so they run on the surviving
+//! candidates.
+//!
+//! ## Value layout (EWKB)
+//!
+//! A geometry value is a 4-byte little-endian SRID prefix followed by standard
+//! OGC WKB:
+//!
+//! ```text
+//! <srid: u32 little-endian> <standard WKB>
+//! ```
+//!
+//! We strip the SRID prefix (TiDB has already gated the query by SRID) and
+//! evaluate the relation on the raw planar coordinates.
+//!
+//! ## Semantics
+//!
+//! Relations follow the OGC DE-9IM model via the `geo` crate's `Relate`,
+//! matching TiDB's reference evaluator `pkg/util/geomrel` (which uses the
+//! pure-Go `simplefeatures`, the same OGC spec as GEOS/JTS/PostGIS). Boundary
+//! semantics matter: a point on a polygon edge is `Within=false`,
+//! `Touches=true`, `CoveredBy=true`.
+
+use byteorder::{BigEndian, LittleEndian, ReadBytesExt};
+use geo::{
+    Coord, Geometry, GeometryCollection, LineString, MultiLineString, MultiPoint, MultiPolygon,
+    Point, Polygon,
+    algorithm::relate::{IntersectionMatrix, Relate},
+};
+use tidb_query_codegen::rpn_fn;
+use tidb_query_common::Result;
+use tidb_query_datatype::codec::data_type::*;
+
+// OGC WKB geometry type codes (2D).
+const WKB_POINT: u32 = 1;
+const WKB_LINESTRING: u32 = 2;
+const WKB_POLYGON: u32 = 3;
+const WKB_MULTIPOINT: u32 = 4;
+const WKB_MULTILINESTRING: u32 = 5;
+const WKB_MULTIPOLYGON: u32 = 6;
+const WKB_GEOMETRYCOLLECTION: u32 = 7;
+
+/// Decodes an EWKB byte string into a `geo` geometry, stripping the 4-byte SRID
+/// prefix and parsing the remainder as standard OGC WKB.
+fn decode_ewkb(bytes: BytesRef<'_>) -> Result<Geometry<f64>> {
+    if bytes.len() < 4 {
+        return Err(other_err!(
+            "invalid EWKB: {} bytes, shorter than the 4-byte SRID prefix",
+            bytes.len()
+        ));
+    }
+    // Skip the little-endian SRID; the remainder is standard WKB.
+    let mut wkb = &bytes[4..];
+    let geom = read_geometry(&mut wkb)?;
+    Ok(geom)
+}
+
+/// Reads the byte-order flag (`0` = big-endian, `1` = little-endian).
+fn read_is_le(buf: &mut &[u8]) -> Result<bool> {
+    match buf.read_u8().map_err(truncated)? {
+        0 => Ok(false),
+        1 => Ok(true),
+        other => Err(other_err!("invalid WKB byte order: {}", other)),
+    }
+}
+
+fn read_u32(buf: &mut &[u8], le: bool) -> Result<u32> {
+    if le {
+        buf.read_u32::<LittleEndian>()
+    } else {
+        buf.read_u32::<BigEndian>()
+    }
+    .map_err(truncated)
+}
+
+fn read_coord(buf: &mut &[u8], le: bool) -> Result<Coord<f64>> {
+    let (x, y) = if le {
+        (
+            buf.read_f64::<LittleEndian>().map_err(truncated)?,
+            buf.read_f64::<LittleEndian>().map_err(truncated)?,
+        )
+    } else {
+        (
+            buf.read_f64::<BigEndian>().map_err(truncated)?,
+            buf.read_f64::<BigEndian>().map_err(truncated)?,
+        )
+    };
+    Ok(Coord { x, y })
+}
+
+/// Caps a wire-supplied element count to what the remaining buffer could
+/// possibly hold, so a corrupt length cannot trigger a huge pre-allocation.
+/// `unit` is the minimum byte size of one element.
+fn capped(n: u32, buf: &[u8], unit: usize) -> usize {
+    (n as usize).min(buf.len() / unit.max(1) + 1)
+}
+
+fn read_linestring(buf: &mut &[u8], le: bool) -> Result<LineString<f64>> {
+    let n = read_u32(buf, le)?;
+    let mut coords = Vec::with_capacity(capped(n, buf, 16));
+    for _ in 0..n {
+        coords.push(read_coord(buf, le)?);
+    }
+    Ok(LineString::new(coords))
+}
+
+fn read_polygon(buf: &mut &[u8], le: bool) -> Result<Polygon<f64>> {
+    let num_rings = read_u32(buf, le)?;
+    if num_rings == 0 {
+        return Ok(Polygon::new(LineString::new(vec![]), vec![]));
+    }
+    let exterior = read_linestring(buf, le)?;
+    let mut interiors = Vec::with_capacity(capped(num_rings - 1, buf, 4));
+    for _ in 1..num_rings {
+        interiors.push(read_linestring(buf, le)?);
+    }
+    Ok(Polygon::new(exterior, interiors))
+}
+
+/// Reads one WKB geometry (its own byte-order byte and type code), recursing
+/// into the collection types.
+fn read_geometry(buf: &mut &[u8]) -> Result<Geometry<f64>> {
+    let le = read_is_le(buf)?;
+    let type_code = read_u32(buf, le)?;
+    match type_code {
+        WKB_POINT => Ok(Geometry::Point(Point::from(read_coord(buf, le)?))),
+        WKB_LINESTRING => Ok(Geometry::LineString(read_linestring(buf, le)?)),
+        WKB_POLYGON => Ok(Geometry::Polygon(read_polygon(buf, le)?)),
+        WKB_MULTIPOINT => {
+            let n = read_u32(buf, le)?;
+            let mut pts = Vec::with_capacity(capped(n, buf, 21));
+            for _ in 0..n {
+                match read_geometry(buf)? {
+                    Geometry::Point(p) => pts.push(p),
+                    g => return Err(unexpected("MultiPoint", "Point", &g)),
+                }
+            }
+            Ok(Geometry::MultiPoint(MultiPoint::new(pts)))
+        }
+        WKB_MULTILINESTRING => {
+            let n = read_u32(buf, le)?;
+            let mut lines = Vec::with_capacity(capped(n, buf, 9));
+            for _ in 0..n {
+                match read_geometry(buf)? {
+                    Geometry::LineString(l) => lines.push(l),
+                    g => return Err(unexpected("MultiLineString", "LineString", &g)),
+                }
+            }
+            Ok(Geometry::MultiLineString(MultiLineString::new(lines)))
+        }
+        WKB_MULTIPOLYGON => {
+            let n = read_u32(buf, le)?;
+            let mut polys = Vec::with_capacity(capped(n, buf, 9));
+            for _ in 0..n {
+                match read_geometry(buf)? {
+                    Geometry::Polygon(p) => polys.push(p),
+                    g => return Err(unexpected("MultiPolygon", "Polygon", &g)),
+                }
+            }
+            Ok(Geometry::MultiPolygon(MultiPolygon::new(polys)))
+        }
+        WKB_GEOMETRYCOLLECTION => {
+            let n = read_u32(buf, le)?;
+            let mut geoms = Vec::with_capacity(capped(n, buf, 9));
+            for _ in 0..n {
+                geoms.push(read_geometry(buf)?);
+            }
+            Ok(Geometry::GeometryCollection(GeometryCollection::new_from(
+                geoms,
+            )))
+        }
+        other => Err(other_err!(
+            "unsupported WKB geometry type code: {} (only 2D OGC types 1-7 are supported)",
+            other
+        )),
+    }
+}
+
+fn truncated(e: std::io::Error) -> tidb_query_common::error::Error {
+    other_err!("truncated WKB: {}", e)
+}
+
+fn unexpected(container: &str, want: &str, got: &Geometry<f64>) -> tidb_query_common::error::Error {
+    let got = match got {
+        Geometry::Point(_) => "Point",
+        Geometry::Line(_) => "Line",
+        Geometry::LineString(_) => "LineString",
+        Geometry::Polygon(_) => "Polygon",
+        Geometry::MultiPoint(_) => "MultiPoint",
+        Geometry::MultiLineString(_) => "MultiLineString",
+        Geometry::MultiPolygon(_) => "MultiPolygon",
+        Geometry::GeometryCollection(_) => "GeometryCollection",
+        Geometry::Rect(_) => "Rect",
+        Geometry::Triangle(_) => "Triangle",
+    };
+    other_err!("{} element must be a {}, found {}", container, want, got)
+}
+
+/// Decodes both operands and computes their DE-9IM intersection matrix.
+fn relate(a: BytesRef<'_>, b: BytesRef<'_>) -> Result<IntersectionMatrix> {
+    let ga = decode_ewkb(a)?;
+    let gb = decode_ewkb(b)?;
+    Ok(ga.relate(&gb))
+}
+
+macro_rules! st_predicate {
+    ($name:ident, $matrix_method:ident) => {
+        #[rpn_fn]
+        #[inline]
+        pub fn $name(a: BytesRef, b: BytesRef) -> Result<Option<Int>> {
+            Ok(Some(relate(a, b)?.$matrix_method() as i64))
+        }
+    };
+}
+
+st_predicate!(st_within, is_within);
+st_predicate!(st_contains, is_contains);
+st_predicate!(st_intersects, is_intersects);
+st_predicate!(st_equals, is_equal_topo);
+st_predicate!(st_disjoint, is_disjoint);
+st_predicate!(st_touches, is_touches);
+st_predicate!(st_crosses, is_crosses);
+st_predicate!(st_overlaps, is_overlaps);
+st_predicate!(st_covers, is_covers);
+st_predicate!(st_covered_by, is_coveredby);
+
+#[cfg(test)]
+mod tests {
+    use tipb::ScalarFuncSig;
+
+    use super::*;
+    use crate::types::test_util::RpnFnScalarEvaluator;
+
+    type Pt = (f64, f64);
+
+    // ---- EWKB builders (SRID 0, little-endian) ----
+
+    fn put_u32(v: &mut Vec<u8>, n: u32) {
+        v.extend_from_slice(&n.to_le_bytes());
+    }
+
+    fn put_f64(v: &mut Vec<u8>, f: f64) {
+        v.extend_from_slice(&f.to_le_bytes());
+    }
+
+    fn header(v: &mut Vec<u8>, type_code: u32) {
+        put_u32(v, 0); // SRID 0
+        v.push(1); // little-endian
+        put_u32(v, type_code);
+    }
+
+    fn put_ring(v: &mut Vec<u8>, pts: &[Pt]) {
+        put_u32(v, pts.len() as u32);
+        for &(x, y) in pts {
+            put_f64(v, x);
+            put_f64(v, y);
+        }
+    }
+
+    fn ewkb_point(x: f64, y: f64) -> Vec<u8> {
+        let mut v = Vec::new();
+        header(&mut v, WKB_POINT);
+        put_f64(&mut v, x);
+        put_f64(&mut v, y);
+        v
+    }
+
+    fn ewkb_linestring(pts: &[Pt]) -> Vec<u8> {
+        let mut v = Vec::new();
+        header(&mut v, WKB_LINESTRING);
+        put_ring(&mut v, pts);
+        v
+    }
+
+    fn ewkb_polygon(rings: &[&[Pt]]) -> Vec<u8> {
+        let mut v = Vec::new();
+        header(&mut v, WKB_POLYGON);
+        put_u32(&mut v, rings.len() as u32);
+        for r in rings {
+            put_ring(&mut v, r);
+        }
+        v
+    }
+
+    // Predicate sigs in the column order used by the expected-value arrays.
+    const SIGS: [ScalarFuncSig; 10] = [
+        ScalarFuncSig::StWithin,
+        ScalarFuncSig::StContains,
+        ScalarFuncSig::StIntersects,
+        ScalarFuncSig::StEquals,
+        ScalarFuncSig::StDisjoint,
+        ScalarFuncSig::StTouches,
+        ScalarFuncSig::StCrosses,
+        ScalarFuncSig::StOverlaps,
+        ScalarFuncSig::StCovers,
+        ScalarFuncSig::StCoveredBy,
+    ];
+
+    fn eval(sig: ScalarFuncSig, a: &[u8], b: &[u8]) -> Option<Int> {
+        RpnFnScalarEvaluator::new()
+            .push_param(Some(a.to_vec()))
+            .push_param(Some(b.to_vec()))
+            .evaluate(sig)
+            .unwrap()
+    }
+
+    /// The reference corpus from `tikv-pushdown-handoff.md`, generated by
+    /// TiDB's `pkg/util/geomrel` (simplefeatures). Columns follow `SIGS`
+    /// order: within, contains, intersects, equals, disjoint, touches,
+    /// crosses, overlaps, covers, coveredby.
+    #[test]
+    fn test_de9im_corpus() {
+        let poly4 = ewkb_polygon(&[&[(0., 0.), (4., 0.), (4., 4.), (0., 4.), (0., 0.)]]);
+        let poly_a = ewkb_polygon(&[&[(0., 0.), (2., 0.), (2., 2.), (0., 2.), (0., 0.)]]);
+        let poly_b = ewkb_polygon(&[&[(1., 1.), (3., 1.), (3., 3.), (1., 3.), (1., 1.)]]);
+        let poly_unit = ewkb_polygon(&[&[(0., 0.), (1., 0.), (1., 1.), (0., 1.), (0., 0.)]]);
+        let poly_far = ewkb_polygon(&[&[(5., 5.), (6., 5.), (6., 6.), (5., 6.), (5., 5.)]]);
+
+        let cases: Vec<(Vec<u8>, Vec<u8>, [i64; 10])> = vec![
+            // interior point
+            (
+                ewkb_point(2., 2.),
+                poly4.clone(),
+                [1, 0, 1, 0, 0, 0, 0, 0, 0, 1],
+            ),
+            // outside point
+            (
+                ewkb_point(5., 5.),
+                poly4.clone(),
+                [0, 0, 0, 0, 1, 0, 0, 0, 0, 0],
+            ),
+            // boundary corner point
+            (
+                ewkb_point(0., 0.),
+                poly4.clone(),
+                [0, 0, 1, 0, 0, 1, 0, 0, 0, 1],
+            ),
+            // diagonal line across the polygon
+            (
+                ewkb_linestring(&[(0., 0.), (4., 4.)]),
+                poly4.clone(),
+                [1, 0, 1, 0, 0, 0, 0, 0, 0, 1],
+            ),
+            // partially overlapping polygons
+            (poly_a, poly_b, [0, 0, 1, 0, 0, 0, 0, 1, 0, 0]),
+            // equal polygons
+            (poly4.clone(), poly4.clone(), [1, 1, 1, 1, 0, 0, 0, 0, 1, 1]),
+            // disjoint polygons
+            (poly_unit, poly_far, [0, 0, 0, 0, 1, 0, 0, 0, 0, 0]),
+        ];
+
+        for (i, (a, b, expected)) in cases.iter().enumerate() {
+            for (j, sig) in SIGS.iter().enumerate() {
+                let out = eval(*sig, a, b);
+                assert_eq!(
+                    out,
+                    Some(expected[j]),
+                    "case {} {:?}: expected {}, got {:?}",
+                    i,
+                    sig,
+                    expected[j],
+                    out
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_null_propagation() {
+        let pt = ewkb_point(1., 1.);
+        for sig in SIGS {
+            let a_null = RpnFnScalarEvaluator::new()
+                .push_param(Option::<Bytes>::None)
+                .push_param(Some(pt.clone()))
+                .evaluate::<Int>(sig)
+                .unwrap();
+            assert_eq!(a_null, None, "{:?}", sig);
+
+            let b_null = RpnFnScalarEvaluator::new()
+                .push_param(Some(pt.clone()))
+                .push_param(Option::<Bytes>::None)
+                .evaluate::<Int>(sig)
+                .unwrap();
+            assert_eq!(b_null, None, "{:?}", sig);
+        }
+    }
+
+    #[test]
+    fn test_malformed_ewkb_errors() {
+        let valid = ewkb_point(1., 1.);
+        let mut truncated_coord = ewkb_point(1., 1.);
+        truncated_coord.truncate(truncated_coord.len() - 4);
+
+        let bad_inputs: Vec<Vec<u8>> = vec![
+            vec![],                                // empty
+            vec![0, 0, 0],                         // shorter than the SRID prefix
+            vec![0, 0, 0, 0],                      // SRID only, no WKB
+            vec![0, 0, 0, 0, 2, 1, 0, 0, 0],       // invalid byte-order byte
+            vec![0, 0, 0, 0, 1, 0xE7, 0x03, 0, 0], // unsupported type code (999)
+            truncated_coord,                       // truncated point coordinate
+        ];
+        for bad in bad_inputs {
+            let res = RpnFnScalarEvaluator::new()
+                .push_param(Some(bad.clone()))
+                .push_param(Some(valid.clone()))
+                .evaluate::<Int>(ScalarFuncSig::StIntersects);
+            assert!(res.is_err(), "expected error for malformed input {:?}", bad);
+        }
+    }
+
+    #[test]
+    fn test_decode_ewkb_layout() {
+        // POINT(2 2), SRID 0, little-endian — the worked example from the doc.
+        let le = vec![
+            0, 0, 0, 0,    // SRID 0
+            0x01, // little-endian
+            0x01, 0, 0, 0, // type = 1 (Point)
+            0, 0, 0, 0, 0, 0, 0, 0x40, // x = 2.0
+            0, 0, 0, 0, 0, 0, 0, 0x40, // y = 2.0
+        ];
+        match decode_ewkb(&le).unwrap() {
+            Geometry::Point(p) => {
+                assert_eq!(p.x(), 2.0);
+                assert_eq!(p.y(), 2.0);
+            }
+            g => panic!("expected Point, got {:?}", g),
+        }
+
+        // The same point with a big-endian WKB body must decode identically.
+        let be = vec![
+            0, 0, 0, 0,    // SRID 0 (the prefix itself is always little-endian)
+            0x00, // big-endian
+            0, 0, 0, 0x01, // type = 1 (Point)
+            0x40, 0, 0, 0, 0, 0, 0, 0, // x = 2.0
+            0x40, 0, 0, 0, 0, 0, 0, 0, // y = 2.0
+        ];
+        match decode_ewkb(&be).unwrap() {
+            Geometry::Point(p) => {
+                assert_eq!(p.x(), 2.0);
+                assert_eq!(p.y(), 2.0);
+            }
+            g => panic!("expected Point, got {:?}", g),
+        }
+    }
+}

--- a/components/tidb_query_expr/src/impl_spatial.rs
+++ b/components/tidb_query_expr/src/impl_spatial.rs
@@ -211,6 +211,17 @@ fn relate(a: BytesRef<'_>, b: BytesRef<'_>) -> Result<IntersectionMatrix> {
     Ok(ga.relate(&gb))
 }
 
+/// OGC topological dimension: 0 (point), 1 (curve), 2 (surface); a collection
+/// takes the max over its members.
+fn geom_dimension(g: &Geometry<f64>) -> i32 {
+    match g {
+        Geometry::Point(_) | Geometry::MultiPoint(_) => 0,
+        Geometry::Line(_) | Geometry::LineString(_) | Geometry::MultiLineString(_) => 1,
+        Geometry::Polygon(_) | Geometry::MultiPolygon(_) | Geometry::Rect(_) | Geometry::Triangle(_) => 2,
+        Geometry::GeometryCollection(gc) => gc.0.iter().map(geom_dimension).max().unwrap_or(-1),
+    }
+}
+
 macro_rules! st_predicate {
     ($name:ident, $matrix_method:ident) => {
         #[rpn_fn]
@@ -227,10 +238,24 @@ st_predicate!(st_intersects, is_intersects);
 st_predicate!(st_equals, is_equal_topo);
 st_predicate!(st_disjoint, is_disjoint);
 st_predicate!(st_touches, is_touches);
-st_predicate!(st_crosses, is_crosses);
 st_predicate!(st_overlaps, is_overlaps);
 st_predicate!(st_covers, is_covers);
 st_predicate!(st_covered_by, is_coveredby);
+
+/// ST_Crosses is dimension-gated to match MySQL: it returns NULL unless
+/// dim(a) < dim(b) or both operands are curves (lines). The `geo` crate computes
+/// crosses symmetrically, so the gate is applied here.
+#[rpn_fn]
+#[inline]
+pub fn st_crosses(a: BytesRef, b: BytesRef) -> Result<Option<Int>> {
+    let ga = decode_ewkb(a)?;
+    let gb = decode_ewkb(b)?;
+    let (da, db) = (geom_dimension(&ga), geom_dimension(&gb));
+    if !(da < db || (da == 1 && db == 1)) {
+        return Ok(None);
+    }
+    Ok(Some(ga.relate(&gb).is_crosses() as i64))
+}
 
 #[cfg(test)]
 mod tests {

--- a/components/tidb_query_expr/src/lib.rs
+++ b/components/tidb_query_expr/src/lib.rs
@@ -38,6 +38,7 @@ pub mod impl_miscellaneous;
 pub mod impl_op;
 pub mod impl_other;
 pub mod impl_regexp;
+pub mod impl_spatial;
 pub mod impl_string;
 pub mod impl_time;
 pub mod impl_vec;
@@ -58,7 +59,8 @@ pub use self::types::*;
 use self::{
     impl_arithmetic::*, impl_cast::*, impl_compare::*, impl_compare_in::*, impl_control::*,
     impl_encryption::*, impl_json::*, impl_like::*, impl_math::*, impl_miscellaneous::*,
-    impl_op::*, impl_other::*, impl_regexp::*, impl_string::*, impl_time::*, impl_vec::*,
+    impl_op::*, impl_other::*, impl_regexp::*, impl_spatial::*, impl_string::*, impl_time::*,
+    impl_vec::*,
 };
 
 fn map_to_binary_fn_sig(expr: &Expr) -> Result<RpnFnMeta> {
@@ -656,6 +658,18 @@ fn map_expr_node_to_rpn_func(expr: &Expr) -> Result<RpnFnMeta> {
         ScalarFuncSig::RegexpSubstrSig => map_regexp_substr_sig(ft)?,
         ScalarFuncSig::RegexpInStrSig => map_regexp_instr_sig(ft)?,
         ScalarFuncSig::RegexpReplaceSig => map_regexp_replace_sig(ft)?,
+        // impl_spatial: geospatial DE-9IM predicates pushed down from the
+        // spatial-index refine filter (two EWKB args -> int 0/1).
+        ScalarFuncSig::StWithin => st_within_fn_meta(),
+        ScalarFuncSig::StContains => st_contains_fn_meta(),
+        ScalarFuncSig::StIntersects => st_intersects_fn_meta(),
+        ScalarFuncSig::StEquals => st_equals_fn_meta(),
+        ScalarFuncSig::StDisjoint => st_disjoint_fn_meta(),
+        ScalarFuncSig::StTouches => st_touches_fn_meta(),
+        ScalarFuncSig::StCrosses => st_crosses_fn_meta(),
+        ScalarFuncSig::StOverlaps => st_overlaps_fn_meta(),
+        ScalarFuncSig::StCovers => st_covers_fn_meta(),
+        ScalarFuncSig::StCoveredBy => st_covered_by_fn_meta(),
 
         // impl_math
         ScalarFuncSig::AbsInt => abs_int_fn_meta(),

--- a/deny.toml
+++ b/deny.toml
@@ -135,4 +135,7 @@ exceptions = [
 [sources]
 unknown-git = "deny"
 unknown-registry = "deny"
-allow-org = { github = ["tikv", "pingcap", "rust-lang"] }
+# "mjonss" is temporary: it hosts the tipb fork branch carrying the geospatial
+# DE-9IM ScalarFuncSig values not yet in upstream pingcap/tipb. Remove together
+# with the tipb dependency repoint once those sigs land upstream.
+allow-org = { github = ["tikv", "pingcap", "rust-lang", "mjonss"] }


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: ref pingcap/tidb#69475

<!-- No dedicated TiKV tracking issue exists yet; this references the TiDB
spatial-index POC PR. Replace with a TiKV issue number if one is filed. -->

This implements the **TiKV coprocessor side** of spatial-index predicate
pushdown for the TiDB spatial-index POC (`pingcap/tidb#69475`). It lets TiDB
push the exact `ST_*` refine predicate of a spatial-index lookup down to the
storage node, so the residual false positives left after the bbox pre-filter
are discarded at TiKV instead of shipped to the root and refined there.

What's Changed:

```commit-message
tidb_query_expr: evaluate geospatial DE-9IM predicates in the coprocessor

Adds an impl_spatial RPN module implementing the ten geometry relational
predicates (StWithin/StContains/StIntersects/StEquals/StDisjoint/StTouches/
StCrosses/StOverlaps/StCovers/StCoveredBy, ScalarFuncSig 7100-7109). Each
takes two EWKB byte strings (the stored geometry column value and the query
constant) and returns int 0/1, or NULL if either argument is NULL.

The evaluator strips the 4-byte little-endian SRID prefix, parses the
remaining standard OGC WKB (2D Point/LineString/Polygon and their Multi*/
GeometryCollection forms, both byte orders) into geo-types, and computes the
DE-9IM intersection matrix via the pure-Rust `geo` crate's Relate. No system
or cgo dependency is added. Wire-supplied element counts are capped against
the remaining buffer so a corrupt length cannot cause a huge allocation;
malformed EWKB yields an evaluation error rather than a panic or wrong answer.

Semantics match TiDB's reference evaluator pkg/util/geomrel (simplefeatures,
same OGC spec as GEOS/JTS/PostGIS), verified by a unit test asserting all ten
predicates against the shared reference corpus, including the boundary case
(a point on a polygon corner is Within=false, Touches=true, CoveredBy=true).
```

Design / contract: see the TiDB POC docs `docs/design/spatial-index/
bbox-pushdown-design.md` (Layer B) and `tikv-pushdown-handoff.md`.

**Cross-repo dependency (why this is a draft):** the new `ScalarFuncSig`
values are not yet in upstream `pingcap/tipb`, so the `tipb` dependency is
temporarily pointed at `mjonss/tipb` branch `spatial-pushdown` (commit
`eacc7e9`). This must be reverted to upstream once the sigs land there; until
then this PR is not mergeable as-is. The TiDB-side wiring (`setPbCode`,
`PBToExpr`, the pushdown allow-list) and the unistore round-trip are separate
changes in the TiDB repo and are not required for this evaluator, which is
validated directly against the reference corpus.

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests

- [x] Unit test

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note

```release-note
None
```
