### PR TITLE
resolved-ts: keep leader info during region changes

### DIFF
--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -5314,11 +5314,7 @@ where
         assert_eq!(prev, Some(prev_region));
         drop(meta);
 
-        self.fsm.peer.read_progress.update_leader_info(
-            self.fsm.peer.leader_id(),
-            self.fsm.peer.term(),
-            &region,
-        );
+        self.fsm.peer.read_progress.update_region(&region);
 
         for r in &persist_res.destroy_regions {
             if let Err(e) = self.ctx.router.force_send(

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -1601,9 +1601,9 @@ where
         // follower becoming a leader.
         self.maybe_update_read_progress(reader, progress);
 
-        // Update leader info
-        self.read_progress
-            .update_leader_info(self.leader_id(), self.term(), self.region());
+        // Keep the resolved-ts region metadata fresh without overwriting the
+        // leader id/term with a follower's possibly stale raft view.
+        self.read_progress.update_region(self.region());
 
         {
             let mut pessimistic_locks = self.txn_ext.pessimistic_locks.write();

--- a/components/raftstore/src/store/util.rs
+++ b/components/raftstore/src/store/util.rs
@@ -2636,6 +2636,51 @@ mod tests {
     }
 
     #[test]
+    fn test_check_leader_rejects_stale_leader_after_peer_change() {
+        let coprocessor_host = CoprocessorHost::<KvTestEngine>::default();
+
+        let mut changed_region = metapb::Region::default();
+        changed_region.set_id(1);
+        changed_region.mut_region_epoch().set_version(10);
+        changed_region.mut_region_epoch().set_conf_ver(11);
+        changed_region.set_peers(vec![new_peer(1, 1), new_peer(2, 2), new_peer(3, 3)].into());
+
+        let leader_progress = RegionReadProgress::new(&changed_region, 10, 10, 1);
+        leader_progress.update_leader_info(1, 6, &changed_region);
+        let leader_info = leader_progress.core.lock().unwrap().get_leader_info();
+
+        let follower_progress = Arc::new(RegionReadProgress::new(&changed_region, 10, 10, 3));
+        let registry = RegionReadProgressRegistry::new();
+        registry.insert(1, follower_progress.clone());
+
+        // A peer can already have the new region epoch/peer list while its raft
+        // leader id has not caught up yet. In that window, check_leader rejects
+        // the region even though the peer metadata itself is current.
+        follower_progress.update_leader_info(raft::INVALID_ID, 6, &changed_region);
+        assert!(
+            registry
+                .handle_check_leaders(vec![leader_info.clone()], &coprocessor_host)
+                .is_empty()
+        );
+
+        // A matching leader id with an old term is rejected for the same reason.
+        follower_progress.update_leader_info(1, 5, &changed_region);
+        assert!(
+            registry
+                .handle_check_leaders(vec![leader_info.clone()], &coprocessor_host)
+                .is_empty()
+        );
+
+        // Once a later leader-state refresh writes the same leader id and term,
+        // the same region is acknowledged.
+        follower_progress.update_leader_info(1, 6, &changed_region);
+        assert_eq!(
+            registry.handle_check_leaders(vec![leader_info], &coprocessor_host),
+            vec![1]
+        );
+    }
+
+    #[test]
     fn test_peer_id_mismatch() {
         use kvproto::errorpb::{Error, MismatchPeerId};
         let mut header = RaftRequestHeader::default();

--- a/components/raftstore/src/store/util.rs
+++ b/components/raftstore/src/store/util.rs
@@ -1977,7 +1977,7 @@ pub fn validate_split_region(
 
 #[cfg(test)]
 mod tests {
-    use std::thread;
+    use std::{sync::Arc, thread};
 
     use engine_test::kv::KvTestEngine;
     use kvproto::{
@@ -2592,6 +2592,46 @@ mod tests {
         assert_eq!(
             rrp.core.lock().unwrap().get_local_leader_info().peers,
             *region.get_peers(),
+        );
+    }
+
+    #[test]
+    fn test_check_leader_rejects_stale_epoch_after_peer_change() {
+        let coprocessor_host = CoprocessorHost::<KvTestEngine>::default();
+
+        let mut old_region = metapb::Region::default();
+        old_region.set_id(1);
+        old_region.mut_region_epoch().set_version(10);
+        old_region.mut_region_epoch().set_conf_ver(10);
+        old_region.set_peers(vec![new_peer(1, 1), new_peer(2, 2)].into());
+
+        let mut changed_region = old_region.clone();
+        changed_region.mut_region_epoch().set_conf_ver(11);
+        changed_region.mut_peers().push(new_peer(3, 3));
+
+        let leader_progress = RegionReadProgress::new(&changed_region, 10, 10, 1);
+        leader_progress.update_leader_info(1, 5, &changed_region);
+        let leader_info = leader_progress.core.lock().unwrap().get_leader_info();
+
+        let follower_progress = Arc::new(RegionReadProgress::new(&old_region, 10, 10, 2));
+        follower_progress.update_leader_info(1, 5, &old_region);
+
+        let registry = RegionReadProgressRegistry::new();
+        registry.insert(1, follower_progress.clone());
+
+        // A peer change increments conf_ver. Before the follower has refreshed
+        // its RegionReadProgress epoch, check_leader does not acknowledge the
+        // leader's new epoch.
+        assert!(
+            registry
+                .handle_check_leaders(vec![leader_info.clone()], &coprocessor_host)
+                .is_empty()
+        );
+
+        follower_progress.update_leader_info(1, 5, &changed_region);
+        assert_eq!(
+            registry.handle_check_leaders(vec![leader_info], &coprocessor_host),
+            vec![1]
         );
     }
 

--- a/components/raftstore/src/store/util.rs
+++ b/components/raftstore/src/store/util.rs
@@ -1517,16 +1517,12 @@ impl RegionReadProgress {
         let mut core = self.core.lock().unwrap();
         core.leader_info.leader_id = peer_id;
         core.leader_info.leader_term = term;
-        if !is_region_epoch_equal(region.get_region_epoch(), &core.leader_info.epoch) {
-            core.leader_info.epoch = region.get_region_epoch().clone();
-        }
-        if core.leader_info.peers != region.get_peers() {
-            // In v2, we check peers and region epoch independently, because
-            // peers are incomplete but epoch is set correctly during split.
-            core.leader_info.peers = region.get_peers().to_vec();
-        }
-        core.leader_info.leader_store_id =
-            find_store_id(&core.leader_info.peers, core.leader_info.leader_id)
+        core.update_region(region);
+    }
+
+    pub fn update_region(&self, region: &Region) {
+        let mut core = self.core.lock().unwrap();
+        core.update_region(region);
     }
 
     /// Reset `safe_ts` to 0 and stop updating it
@@ -1649,6 +1645,19 @@ fn find_store_id(peer_list: &[Peer], peer_id: u64) -> Option<u64> {
 }
 
 impl RegionReadProgressCore {
+    fn update_region(&mut self, region: &Region) {
+        if !is_region_epoch_equal(region.get_region_epoch(), &self.leader_info.epoch) {
+            self.leader_info.epoch = region.get_region_epoch().clone();
+        }
+        if self.leader_info.peers != region.get_peers() {
+            // In v2, we check peers and region epoch independently, because
+            // peers are incomplete but epoch is set correctly during split.
+            self.leader_info.peers = region.get_peers().to_vec();
+        }
+        self.leader_info.leader_store_id =
+            find_store_id(&self.leader_info.peers, self.leader_info.leader_id)
+    }
+
     fn new(
         region: &Region,
         applied_index: u64,
@@ -2674,6 +2683,37 @@ mod tests {
         // Once a later leader-state refresh writes the same leader id and term,
         // the same region is acknowledged.
         follower_progress.update_leader_info(1, 6, &changed_region);
+        assert_eq!(
+            registry.handle_check_leaders(vec![leader_info], &coprocessor_host),
+            vec![1]
+        );
+    }
+
+    #[test]
+    fn test_region_update_keeps_resolved_ts_leader_after_peer_change() {
+        let coprocessor_host = CoprocessorHost::<KvTestEngine>::default();
+
+        let mut old_region = metapb::Region::default();
+        old_region.set_id(1);
+        old_region.mut_region_epoch().set_version(10);
+        old_region.mut_region_epoch().set_conf_ver(10);
+        old_region.set_peers(vec![new_peer(1, 1), new_peer(2, 2)].into());
+
+        let mut changed_region = old_region.clone();
+        changed_region.mut_region_epoch().set_conf_ver(11);
+        changed_region.mut_peers().push(new_peer(3, 3));
+
+        let leader_progress = RegionReadProgress::new(&changed_region, 10, 10, 1);
+        leader_progress.update_leader_info(1, 6, &changed_region);
+        let leader_info = leader_progress.core.lock().unwrap().get_leader_info();
+
+        let follower_progress = Arc::new(RegionReadProgress::new(&old_region, 10, 10, 2));
+        follower_progress.update_leader_info(1, 6, &old_region);
+        follower_progress.update_region(&changed_region);
+
+        let registry = RegionReadProgressRegistry::new();
+        registry.insert(1, follower_progress);
+
         assert_eq!(
             registry.handle_check_leaders(vec![leader_info], &coprocessor_host),
             vec![1]

--- a/components/resolved_ts/src/advance.rs
+++ b/components/resolved_ts/src/advance.rs
@@ -607,6 +607,7 @@ mod tests {
     #[derive(Clone)]
     struct MockTikv {
         req_tx: Sender<CheckLeaderRequest>,
+        resp_regions: Vec<u64>,
     }
 
     impl Tikv for MockTikv {
@@ -617,8 +618,10 @@ mod tests {
             sink: ::grpcio::UnarySink<CheckLeaderResponse>,
         ) {
             self.req_tx.send(req).unwrap();
+            let mut resp = CheckLeaderResponse::default();
+            resp.regions = self.resp_regions.clone();
             ctx.spawn(async {
-                sink.success(CheckLeaderResponse::default()).await.unwrap();
+                sink.success(resp).await.unwrap();
             })
         }
     }
@@ -626,9 +629,15 @@ mod tests {
     struct MockPdClient {}
     impl PdClient for MockPdClient {}
 
-    fn new_rpc_suite(env: Arc<Environment>) -> (Server, TikvClient, Receiver<CheckLeaderRequest>) {
+    fn new_rpc_suite(
+        env: Arc<Environment>,
+        resp_regions: Vec<u64>,
+    ) -> (Server, TikvClient, Receiver<CheckLeaderRequest>) {
         let (tx, rx) = channel();
-        let tikv_service = MockTikv { req_tx: tx };
+        let tikv_service = MockTikv {
+            req_tx: tx,
+            resp_regions,
+        };
         let builder = ServerBuilder::new(env.clone()).register_service(create_tikv(tikv_service));
         let mut server = builder.bind("127.0.0.1", 0).build().unwrap();
         server.start();
@@ -642,7 +651,7 @@ mod tests {
     #[tokio::test]
     async fn test_resolve_leader_request_size() {
         let env = Arc::new(EnvBuilder::new().build());
-        let (mut server, tikv_client, rx) = new_rpc_suite(env.clone());
+        let (mut server, tikv_client, rx) = new_rpc_suite(env.clone(), vec![]);
 
         let mut region1 = Region::default();
         region1.id = 1;
@@ -698,6 +707,64 @@ mod tests {
         rx.recv_timeout(Duration::from_secs(1)).unwrap_err();
 
         let _ = server.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn test_resolve_filters_region_after_peer_change_without_quorum_confirmation() {
+        let env = Arc::new(EnvBuilder::new().build());
+        let (mut server2, tikv_client2, _rx2) = new_rpc_suite(env.clone(), vec![2]);
+        let (mut server3, tikv_client3, _rx3) = new_rpc_suite(env.clone(), vec![]);
+
+        let mut changed_region = Region::default();
+        changed_region.id = 1;
+        changed_region.mut_region_epoch().set_version(10);
+        changed_region.mut_region_epoch().set_conf_ver(11);
+        changed_region.peers.push(new_peer(1, 1));
+        changed_region.peers.push(new_peer(2, 2));
+        changed_region.peers.push(new_peer(3, 3));
+        let changed_progress = RegionReadProgress::new(&changed_region, 1, 1, 1);
+        changed_progress.update_leader_info(1, 5, &changed_region);
+
+        let mut stable_region = Region::default();
+        stable_region.id = 2;
+        stable_region.mut_region_epoch().set_version(10);
+        stable_region.mut_region_epoch().set_conf_ver(10);
+        stable_region.peers.push(new_peer(1, 1));
+        stable_region.peers.push(new_peer(2, 2));
+        let stable_progress = RegionReadProgress::new(&stable_region, 1, 1, 1);
+        stable_progress.update_leader_info(1, 5, &stable_region);
+
+        let mut leader_resolver = LeadershipResolver::new(
+            1, // store id
+            Arc::new(MockPdClient {}),
+            env.clone(),
+            Arc::new(SecurityManager::default()),
+            RegionReadProgressRegistry::new(),
+            Duration::from_secs(1),
+        );
+        {
+            let mut tikv_clients = leader_resolver.tikv_clients.lock().await;
+            tikv_clients.insert(2 /* store id */, tikv_client2);
+            tikv_clients.insert(3 /* store id */, tikv_client3);
+        }
+        leader_resolver
+            .region_read_progress
+            .insert(1, Arc::new(changed_progress));
+        leader_resolver
+            .region_read_progress
+            .insert(2, Arc::new(stable_progress));
+
+        // Region 1 models a region whose peer change bumped conf_ver, but
+        // remote peers do not acknowledge the new leader info yet. Region 2
+        // models unaffected regions still advancing normally.
+        let mut resolved = leader_resolver
+            .resolve(vec![1, 2], TimeStamp::new(1), None)
+            .await;
+        resolved.sort_unstable();
+        assert_eq!(resolved, vec![2]);
+
+        let _ = server2.shutdown().await;
+        let _ = server3.shutdown().await;
     }
 
     #[test]


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #19768

Problem Summary:

A v7.5.1 case showed TiCDC resolved-ts stuck on a single initialized slow region after a peer change. TiKV logged `check leader returns valid regions different from checking regions` immediately after the peer change, and evicting the affected region leader recovered progress.

`RegionReadProgress::consume_leader_info` only acknowledges leader info when leader term, leader peer id, and region epoch match. The raftstore-v1 region update paths refreshed epoch/peers by calling `update_leader_info(self.leader_id(), self.term(), region)`. During a peer/conf change, a follower or newly restored peer can already have the new region metadata while its local raft leader view is still unknown or stale. Writing that transient leader id/term into `RegionReadProgress` can make resolved-ts `check_leader` filter the region out before CDC schedules `Task::MinTs`.

### What is changed and how does it work?

This PR separates resolved-ts leader state from region metadata refresh:

- keep `update_leader_info(peer_id, term, region)` for actual leader-state changes;
- add `RegionReadProgress::update_region(region)` to refresh only epoch/peers and recompute `leader_store_id`;
- make `Peer::set_region` and the persisted-region metadata update path call `update_region` so peer changes do not overwrite leader id/term with a follower's transient raft view.

It also keeps the reproduction coverage added for the suspected mechanism and adds a regression test that proves a peer change can refresh epoch/peers without losing valid resolved-ts leader info.

### Check List

Tests:

- Unit test

```bash
CFLAGS="-UTARGET_OS_MAC" CXXFLAGS="-Wno-error=vla-cxx-extension" cargo test -q -p raftstore test_region_update_keeps_resolved_ts_leader_after_peer_change
CFLAGS="-UTARGET_OS_MAC" CXXFLAGS="-Wno-error=vla-cxx-extension" cargo test -q -p raftstore test_check_leader_rejects_stale_leader_after_peer_change
CFLAGS="-UTARGET_OS_MAC" CXXFLAGS="-Wno-error=vla-cxx-extension" cargo test -q -p raftstore test_check_leader_rejects_stale_epoch_after_peer_change
CFLAGS="-UTARGET_OS_MAC" CXXFLAGS="-Wno-error=vla-cxx-extension" cargo test -q -p resolved_ts --features test-engine-kv-rocksdb,test-engine-raft-raft-engine test_resolve_filters_region_after_peer_change_without_quorum_confirmation
CFLAGS="-UTARGET_OS_MAC" CXXFLAGS="-Wno-error=vla-cxx-extension" cargo test -q -p raftstore test_region_read_progress
cargo fmt --all --check
git diff --check
```

### Release note

```release-note
Fix a resolved-ts stuck issue after region peer changes.
```