### PR TITLE
compact-log-backup: drain Ctrl-C safely

### DIFF
--- a/components/compact-log-backup/src/execute/mod.rs
+++ b/components/compact-log-backup/src/execute/mod.rs
@@ -4,7 +4,7 @@ pub mod hooking;
 #[cfg(test)]
 mod test;
 
-use std::{borrow::Cow, cell::Cell, path::Path, pin::Pin, str::FromStr, sync::Arc};
+use std::{borrow::Cow, cell::Cell, future::Future, path::Path, pin::Pin, str::FromStr, sync::Arc};
 
 use chrono::Utc;
 use engine_rocks::RocksEngine;
@@ -23,7 +23,7 @@ use tokio::{
 };
 use tokio_stream::Stream;
 use tracing::trace_span;
-use tracing_active_tree::{frame, root};
+use tracing_active_tree::root;
 
 use self::hooking::AbortedCtx;
 use super::{
@@ -226,6 +226,8 @@ impl slog::KV for ExecutionConfig {
 type FinishedCompaction = Result<(SubcompactionResult, CId)>;
 type CompactJoin = tokio::task::JoinHandle<FinishedCompaction>;
 
+const USER_CANCELED_BY_CTRL_C: &str = "User canceled by Ctrl-C";
+
 trait TakeLoadMetaStatistic {
     fn take_load_meta_statistic(&mut self) -> LoadMetaStatistic;
 }
@@ -338,6 +340,14 @@ struct ExecuteCtx<'a, H: ExecHooks> {
 }
 
 impl Execution {
+    fn user_canceled_error() -> crate::Error {
+        ErrorKind::Other(USER_CANCELED_BY_CTRL_C.to_owned()).into()
+    }
+
+    fn is_user_canceled(err: &crate::Error) -> bool {
+        matches!(&err.kind, ErrorKind::Other(msg) if msg == USER_CANCELED_BY_CTRL_C)
+    }
+
     async fn abort_and_drain<T>(pending: &mut Vec<JoinHandle<T>>) {
         for join in pending.iter() {
             join.abort();
@@ -354,6 +364,32 @@ impl Execution {
                 Err(ErrorKind::Other(format!("subcompaction task join error: {join_err}")).into())
             }
         }
+    }
+
+    async fn finish_compaction_join(
+        &self,
+        join_res: std::result::Result<FinishedCompaction, JoinError>,
+        storage: &dyn ExternalStorage,
+        hooks: &mut impl ExecHooks,
+    ) -> Result<()> {
+        let (cres, cid) = Self::unpack_compaction_join(join_res)?;
+        self.on_compaction_finish(cid, &cres, storage, hooks)
+            .await?;
+        Ok(())
+    }
+
+    async fn drain_compactions_after_cancel(
+        &self,
+        pending: &mut Vec<CompactJoin>,
+        storage: &dyn ExternalStorage,
+        hooks: &mut impl ExecHooks,
+    ) -> Result<()> {
+        while !pending.is_empty() {
+            let join_res = util::select_vec(pending).await;
+            self.finish_compaction_join(join_res, storage, hooks)
+                .await?;
+        }
+        Ok(())
     }
 
     pub fn gen_name(&self) -> String {
@@ -376,11 +412,27 @@ impl Execution {
         pending: &mut Vec<CompactJoin>,
         storage: &dyn ExternalStorage,
         hooks: &mut impl ExecHooks,
+        mut cancel: Pin<&mut impl Future<Output = ()>>,
     ) -> Result<()> {
-        while let Some(join) = pending.pop() {
-            let (cres, cid) = Self::unpack_compaction_join(frame!("final_wait"; join).await)?;
-            self.on_compaction_finish(cid, &cres, storage, hooks)
-                .await?;
+        let mut canceled = false;
+        while !pending.is_empty() {
+            if canceled {
+                let join_res = util::select_vec(pending).await;
+                self.finish_compaction_join(join_res, storage, hooks)
+                    .await?;
+                continue;
+            }
+            let res = self
+                .wait_one_compaction(pending, storage, hooks, cancel.as_mut())
+                .await;
+            match res {
+                Ok(()) => {}
+                Err(err) if Self::is_user_canceled(&err) => canceled = true,
+                Err(err) => return Err(err),
+            }
+        }
+        if canceled {
+            return Err(Self::user_canceled_error());
         }
         Ok(())
     }
@@ -423,10 +475,13 @@ impl Execution {
         pending: &mut Vec<CompactJoin>,
         storage: &dyn ExternalStorage,
         hooks: &mut impl ExecHooks,
+        mut cancel: Pin<&mut impl Future<Output = ()>>,
     ) -> Result<()> {
-        let join = util::select_vec(pending);
-        let (cres, cid) = Self::unpack_compaction_join(frame!("wait_for_compaction"; join).await)?;
-        self.on_compaction_finish(cid, &cres, storage, hooks)
+        let join_res = tokio::select! {
+            join_res = util::select_vec(pending) => join_res,
+            _ = cancel.as_mut() => return Err(Self::user_canceled_error()),
+        };
+        self.finish_compaction_join(join_res, storage, hooks)
             .await?;
         Ok(())
     }
@@ -439,11 +494,12 @@ impl Execution {
         c: Subcompaction,
         cid: CId,
         physical_file_cache: Option<Arc<PhysicalFileCache>>,
+        cancel: Pin<&mut impl Future<Output = ()>>,
     ) -> Result<()> {
         let join = self.spawn_subcompaction(storage, c, cid, physical_file_cache);
         pending.push(join);
         if pending.len() >= self.max_concurrent_subcompaction as _ {
-            self.wait_one_compaction(pending, storage.as_ref(), hooks)
+            self.wait_one_compaction(pending, storage.as_ref(), hooks, cancel)
                 .await?;
         }
         Ok(())
@@ -485,12 +541,20 @@ impl Execution {
         storage: &Arc<dyn ExternalStorage>,
         hooks: &mut impl ExecHooks,
         pending: &mut Vec<CompactJoin>,
+        mut cancel: Pin<&mut impl Future<Output = ()>>,
     ) -> Result<()>
     where
         S: Stream<Item = Result<Subcompaction>> + TakeStreamingSubcompactionStatistic + Unpin,
     {
         let mut id = 0;
-        while let Some(c) = compact_stream.next().await {
+        loop {
+            let c = tokio::select! {
+                c = compact_stream.next() => c,
+                _ = cancel.as_mut() => return Err(Self::user_canceled_error()),
+            };
+            let Some(c) = c else {
+                break;
+            };
             let cstat = compact_stream.take_collect_statistic();
             let lstat = compact_stream.take_load_meta_statistic();
             let c = c?;
@@ -512,6 +576,7 @@ impl Execution {
                     c,
                     cid,
                     physical_file_cache.clone(),
+                    cancel.as_mut(),
                 )
                 .await?;
             }
@@ -519,7 +584,11 @@ impl Execution {
         Ok(())
     }
 
-    async fn run_prepared(&mut self, cx: &mut ExecuteCtx<'_, impl ExecHooks>) -> Result<()> {
+    async fn run_prepared(
+        &mut self,
+        cx: &mut ExecuteCtx<'_, impl ExecHooks>,
+        mut cancel: Pin<&mut impl Future<Output = ()>>,
+    ) -> Result<()> {
         let mut ext = LoadFromExt::default();
         ext.prefetch_running_count = self.cfg.prefetch_running_count as usize;
         ext.prefetch_buffer_count = self.cfg.prefetch_buffer_count as usize;
@@ -586,6 +655,7 @@ impl Execution {
                 &storage,
                 *hooks,
                 &mut pending,
+                cancel.as_mut(),
             )
             .await
         } else {
@@ -600,17 +670,31 @@ impl Execution {
                 &storage,
                 *hooks,
                 &mut pending,
+                cancel.as_mut(),
             )
             .await
         };
 
         if let Err(err) = schedule_res {
-            Self::abort_and_drain(&mut pending).await;
+            if Self::is_user_canceled(&err) {
+                self.drain_compactions_after_cancel(&mut pending, &storage, *hooks)
+                    .await?;
+            } else {
+                Self::abort_and_drain(&mut pending).await;
+            }
             return Err(err);
         }
 
-        if let Err(err) = self.drain_compactions(&mut pending, &storage, *hooks).await {
-            Self::abort_and_drain(&mut pending).await;
+        if let Err(err) = self
+            .drain_compactions(&mut pending, &storage, *hooks, cancel.as_mut())
+            .await
+        {
+            if Self::is_user_canceled(&err) {
+                self.drain_compactions_after_cancel(&mut pending, &storage, *hooks)
+                    .await?;
+            } else {
+                Self::abort_and_drain(&mut pending).await;
+            }
             return Err(err);
         }
 
@@ -637,9 +721,21 @@ impl Execution {
     }
 
     pub async fn run_with_storage_async(
+        self,
+        storage: Arc<dyn ExternalStorage>,
+        hooks: impl ExecHooks,
+    ) -> Result<()> {
+        self.run_with_storage_async_with_cancel(storage, hooks, async {
+            let _ = tokio::signal::ctrl_c().await;
+        })
+        .await
+    }
+
+    async fn run_with_storage_async_with_cancel(
         mut self,
         storage: Arc<dyn ExternalStorage>,
         mut hooks: impl ExecHooks,
+        cancel: impl Future<Output = ()>,
     ) -> Result<()> {
         let mut cx = ExecuteCtx {
             storage: &storage,
@@ -647,11 +743,8 @@ impl Execution {
         };
 
         let guarded = async {
-            let all_works = self.run_prepared(&mut cx);
-            let res = tokio::select! {
-                res = all_works => res,
-                _ = tokio::signal::ctrl_c() => Err(ErrorKind::Other("User canceled by Ctrl-C".to_owned()).into())
-            };
+            tokio::pin!(cancel);
+            let res = self.run_prepared(&mut cx, cancel.as_mut()).await;
 
             if let Err(ref err) = res {
                 cx.hooks

--- a/components/compact-log-backup/src/execute/mod.rs
+++ b/components/compact-log-backup/src/execute/mod.rs
@@ -384,10 +384,17 @@ impl Execution {
         storage: &dyn ExternalStorage,
         hooks: &mut impl ExecHooks,
     ) -> Result<()> {
+        let mut first_err = None;
         while !pending.is_empty() {
             let join_res = util::select_vec(pending).await;
-            self.finish_compaction_join(join_res, storage, hooks)
-                .await?;
+            if let Err(err) = self.finish_compaction_join(join_res, storage, hooks).await {
+                if first_err.is_none() {
+                    first_err = Some(err);
+                }
+            }
+        }
+        if let Some(err) = first_err {
+            return Err(err);
         }
         Ok(())
     }
@@ -414,25 +421,19 @@ impl Execution {
         hooks: &mut impl ExecHooks,
         mut cancel: Pin<&mut impl Future<Output = ()>>,
     ) -> Result<()> {
-        let mut canceled = false;
         while !pending.is_empty() {
-            if canceled {
-                let join_res = util::select_vec(pending).await;
-                self.finish_compaction_join(join_res, storage, hooks)
-                    .await?;
-                continue;
-            }
             let res = self
                 .wait_one_compaction(pending, storage, hooks, cancel.as_mut())
                 .await;
             match res {
                 Ok(()) => {}
-                Err(err) if Self::is_user_canceled(&err) => canceled = true,
+                Err(err) if Self::is_user_canceled(&err) => {
+                    self.drain_compactions_after_cancel(pending, storage, hooks)
+                        .await?;
+                    return Err(err);
+                }
                 Err(err) => return Err(err),
             }
-        }
-        if canceled {
-            return Err(Self::user_canceled_error());
         }
         Ok(())
     }
@@ -598,15 +599,17 @@ impl Execution {
             ref mut hooks,
             ..
         } = cx;
-        let metadata_scan = StreamMetaStorage::count_objects(
-            storage.as_ref(),
-            CountObjectsExt {
-                calculate_shift_ts: self.cfg.calculate_shift_ts,
-                from_ts: self.cfg.from_ts,
-                until_ts: self.cfg.until_ts,
-            },
-        )
-        .await?;
+        let metadata_scan = tokio::select! {
+            res = StreamMetaStorage::count_objects(
+                storage.as_ref(),
+                CountObjectsExt {
+                    calculate_shift_ts: self.cfg.calculate_shift_ts,
+                    from_ts: self.cfg.from_ts,
+                    until_ts: self.cfg.until_ts,
+                },
+            ) => res?,
+            _ = cancel.as_mut() => return Err(Self::user_canceled_error()),
+        };
         self.cfg.shift_ts = metadata_scan.shift_ts;
 
         let cx = BeforeStartCtx {
@@ -615,7 +618,10 @@ impl Execution {
             this: self,
             meta_count: metadata_scan.count,
         };
-        hooks.before_execution_started(cx).await?;
+        tokio::select! {
+            res = hooks.before_execution_started(cx) => res?,
+            _ = cancel.as_mut() => return Err(Self::user_canceled_error()),
+        };
 
         // Avoid setting an explicit parent here: this span may be dropped while
         // the parent span is not currently entered (e.g. early-abort paths),
@@ -624,7 +630,10 @@ impl Execution {
         ext.shard = self.cfg.shard;
 
         let storage = Arc::clone(storage);
-        let meta = StreamMetaStorage::load_from_ext(&storage, ext).await?;
+        let meta = tokio::select! {
+            res = StreamMetaStorage::load_from_ext(&storage, ext) => res?,
+            _ = cancel.as_mut() => return Err(Self::user_canceled_error()),
+        };
         let collect_cfg = CollectSubcompactionConfig {
             compact_shift_from_ts: self.cfg.shift_ts,
             compact_from_ts: self.cfg.from_ts,
@@ -689,10 +698,7 @@ impl Execution {
             .drain_compactions(&mut pending, &storage, *hooks, cancel.as_mut())
             .await
         {
-            if Self::is_user_canceled(&err) {
-                self.drain_compactions_after_cancel(&mut pending, &storage, *hooks)
-                    .await?;
-            } else {
+            if !Self::is_user_canceled(&err) {
                 Self::abort_and_drain(&mut pending).await;
             }
             return Err(err);

--- a/components/compact-log-backup/src/execute/test.rs
+++ b/components/compact-log-backup/src/execute/test.rs
@@ -32,6 +32,8 @@ use crate::{
     test_util::{CompactInMem, KvGen, LogFileBuilder, TmpStorage, gen_step},
 };
 
+const FINISH_FAILED: &str = "finish failed";
+
 #[derive(Clone)]
 struct CompactionSpy(Sender<SubcompactionResult>);
 
@@ -58,6 +60,26 @@ impl ExecHooks for FinishCounter {
         _res: SubcompactionFinishCtx<'_>,
     ) -> crate::Result<()> {
         self.0.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+struct FailOneFinish {
+    finished: Arc<AtomicU64>,
+    fail_cid: CId,
+}
+
+impl ExecHooks for FailOneFinish {
+    async fn after_a_subcompaction_end(
+        &mut self,
+        cid: CId,
+        _res: SubcompactionFinishCtx<'_>,
+    ) -> crate::Result<()> {
+        if cid == self.fail_cid {
+            return Err(ErrorKind::Other(FINISH_FAILED.to_owned()).into());
+        }
+        self.finished.fetch_add(1, Ordering::SeqCst);
         Ok(())
     }
 }
@@ -658,6 +680,53 @@ async fn test_cancel_drain_processes_finished_compactions() {
 }
 
 #[tokio::test]
+async fn test_cancel_drain_continues_after_finish_error() {
+    let st = TmpStorage::create();
+    let exec = create_compaction(st.backend());
+    let finished = Arc::new(AtomicU64::new(0));
+    let mut hooks = FailOneFinish {
+        finished: Arc::clone(&finished),
+        fail_cid: CId(10),
+    };
+    let (fail_tx, fail_rx) = tokio::sync::oneshot::channel::<()>();
+    let (release_tx, release_rx) = tokio::sync::oneshot::channel::<()>();
+    let first = tokio::spawn(async move {
+        fail_rx.await.unwrap();
+        let result: super::FinishedCompaction = Ok((empty_subcompaction_result(45), CId(10)));
+        result
+    });
+    fail_tx.send(()).unwrap();
+    while !first.is_finished() {
+        tokio::task::yield_now().await;
+    }
+    let second = tokio::spawn(async move {
+        release_rx.await.unwrap();
+        let result: super::FinishedCompaction = Ok((empty_subcompaction_result(46), CId(11)));
+        result
+    });
+    let mut pending = vec![first, second];
+
+    let err = {
+        let drain =
+            exec.drain_compactions_after_cancel(&mut pending, st.storage().as_ref(), &mut hooks);
+        tokio::pin!(drain);
+        tokio::select! {
+            _ = drain.as_mut() => panic!("drain returned before the remaining compaction finished"),
+            _ = tokio::task::yield_now() => {}
+        }
+
+        release_tx.send(()).unwrap();
+        drain.await.unwrap_err()
+    };
+    assert!(matches!(
+        &err.kind,
+        ErrorKind::Other(msg) if msg == FINISH_FAILED
+    ));
+    assert!(pending.is_empty());
+    assert_eq!(finished.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
 async fn test_canceled_drain_returns_after_safe_point() {
     let st = TmpStorage::create();
     let exec = create_compaction(st.backend());
@@ -690,7 +759,7 @@ async fn test_canceled_drain_returns_after_safe_point() {
     };
     assert!(matches!(
         &err.kind,
-        ErrorKind::Other(msg) if msg == "User canceled by Ctrl-C"
+        ErrorKind::Other(msg) if msg == super::USER_CANCELED_BY_CTRL_C
     ));
     assert!(pending.is_empty());
     assert_eq!(finished.load(Ordering::SeqCst), 1);

--- a/components/compact-log-backup/src/execute/test.rs
+++ b/components/compact-log-backup/src/execute/test.rs
@@ -10,17 +10,18 @@ use std::{
     },
 };
 
+use bytes::Bytes;
 use engine_rocks::RocksEngine;
 use external_storage::{BackendConfig, ExternalStorage};
 use futures::{future::FutureExt, io::AsyncReadExt, stream::TryStreamExt};
-use kvproto::brpb::StorageBackend;
+use kvproto::brpb::{FileType, StorageBackend};
 use protobuf::Message;
 use tokio::sync::mpsc::Sender;
 
 use super::{Execution, ExecutionConfig, ShardConfig};
 use crate::{
     ErrorKind,
-    compaction::{META_OUT_REL, SubcompactionResult},
+    compaction::{META_OUT_REL, Subcompaction, SubcompactionCollectKey, SubcompactionResult},
     errors::OtherErrExt,
     exec_hooks::{
         checkpoint::Checkpoint, consistency::StorageConsistencyGuard, save_meta::SaveMeta,
@@ -45,6 +46,41 @@ impl ExecHooks for CompactionSpy {
             .map(|res| res.adapt_err())
             .await
     }
+}
+
+#[derive(Clone)]
+struct FinishCounter(Arc<AtomicU64>);
+
+impl ExecHooks for FinishCounter {
+    async fn after_a_subcompaction_end(
+        &mut self,
+        _cid: CId,
+        _res: SubcompactionFinishCtx<'_>,
+    ) -> crate::Result<()> {
+        self.0.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+}
+
+fn empty_subcompaction_result(region_id: u64) -> SubcompactionResult {
+    SubcompactionResult::of(Subcompaction {
+        inputs: Vec::new(),
+        size: 0,
+        subc_key: SubcompactionCollectKey {
+            cf: engine_traits::CF_DEFAULT,
+            region_id,
+            ty: FileType::Put,
+            is_meta: false,
+            table_id: 0,
+        },
+        input_max_ts: 0,
+        input_min_ts: 0,
+        compact_from_ts: 0,
+        compact_to_ts: u64::MAX,
+        min_key: Bytes::new(),
+        max_key: Bytes::new(),
+        epoch_hints: Vec::new(),
+    })
 }
 
 fn gen_builder(cm: &mut HashMap<usize, CompactInMem>, batch: i64, num: i64) -> Vec<LogFileBuilder> {
@@ -599,6 +635,97 @@ async fn test_abort_unlocking() {
         .unwrap_err();
     let l = load_locks(st.storage().as_ref()).await;
     assert_eq!(l.len(), 0, "it is {:?}", l);
+}
+
+#[tokio::test]
+async fn test_cancel_drain_processes_finished_compactions() {
+    let st = TmpStorage::create();
+    let exec = create_compaction(st.backend());
+    let finished = Arc::new(AtomicU64::new(0));
+    let mut hooks = FinishCounter(Arc::clone(&finished));
+    let result = empty_subcompaction_result(42);
+    let mut pending = vec![tokio::spawn(async move {
+        let result: super::FinishedCompaction = Ok((result, CId(7)));
+        result
+    })];
+
+    exec.drain_compactions_after_cancel(&mut pending, st.storage().as_ref(), &mut hooks)
+        .await
+        .unwrap();
+
+    assert!(pending.is_empty());
+    assert_eq!(finished.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn test_canceled_drain_returns_after_safe_point() {
+    let st = TmpStorage::create();
+    let exec = create_compaction(st.backend());
+    let finished = Arc::new(AtomicU64::new(0));
+    let mut hooks = FinishCounter(Arc::clone(&finished));
+    let (release_tx, release_rx) = tokio::sync::oneshot::channel::<()>();
+    let mut pending = vec![tokio::spawn(async move {
+        release_rx.await.unwrap();
+        let result: super::FinishedCompaction = Ok((empty_subcompaction_result(44), CId(9)));
+        result
+    })];
+    let cancel = futures::future::ready(());
+    tokio::pin!(cancel);
+
+    let err = {
+        let drain = exec.drain_compactions(
+            &mut pending,
+            st.storage().as_ref(),
+            &mut hooks,
+            cancel.as_mut(),
+        );
+        tokio::pin!(drain);
+        tokio::select! {
+            _ = drain.as_mut() => panic!("drain returned before the pending compaction finished"),
+            _ = tokio::task::yield_now() => {}
+        }
+
+        release_tx.send(()).unwrap();
+        drain.await.unwrap_err()
+    };
+    assert!(matches!(
+        &err.kind,
+        ErrorKind::Other(msg) if msg == "User canceled by Ctrl-C"
+    ));
+    assert!(pending.is_empty());
+    assert_eq!(finished.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn test_cancel_drain_awaits_unfinished_compactions() {
+    let st = TmpStorage::create();
+    let exec = create_compaction(st.backend());
+    let completed = Arc::new(AtomicU64::new(0));
+    let completed_on_task = Arc::clone(&completed);
+    let (release_tx, release_rx) = tokio::sync::oneshot::channel::<()>();
+    let mut pending = vec![tokio::spawn(async move {
+        release_rx.await.unwrap();
+        completed_on_task.fetch_add(1, Ordering::SeqCst);
+        let result: super::FinishedCompaction = Ok((empty_subcompaction_result(43), CId(8)));
+        result
+    })];
+
+    let mut hooks = super::hooking::NoHooks;
+    {
+        let drain =
+            exec.drain_compactions_after_cancel(&mut pending, st.storage().as_ref(), &mut hooks);
+        tokio::pin!(drain);
+        tokio::select! {
+            _ = drain.as_mut() => panic!("drain returned before the pending compaction finished"),
+            _ = tokio::task::yield_now() => {}
+        }
+        assert_eq!(completed.load(Ordering::SeqCst), 0);
+        release_tx.send(()).unwrap();
+        drain.await.unwrap();
+    }
+
+    assert!(pending.is_empty());
+    assert_eq!(completed.load(Ordering::SeqCst), 1);
 }
 
 #[tokio::test]


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Fix #19767

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

This PR fixes the Ctrl-C cancellation path in compact-log-backup.

- Pass the cancellation signal into the execution path that owns pending
  subcompaction join handles.
- Stop scheduling new subcompactions once cancellation is observed.
- Drain already-started subcompactions to a safe point and run the normal
  subcompaction finish hook for completed outputs, so `.cmeta` metadata is
  recorded for outputs that already became visible.
- Keep final migration publication only on fully successful completion,
  preserving canceled-run semantics.
- Add unit coverage for finished joins, pending joins, and cancellation during
  the drain path.

```commit-message
Ctrl-C previously raced against the whole compact-log-backup execution
future. If the signal branch won, `run_prepared` was dropped while it
owned pending subcompaction join handles. Dropping those handles can lose
the returned subcompaction metadata, even though the spawned task may have
already written external SST output.

Pass the cancellation signal into the execution path instead. Once
cancellation is observed, stop scheduling new subcompactions, drain
already-started work, and run the normal subcompaction finish hook for
completed outputs before returning the cancellation error.

This keeps partial outputs recoverable through the existing `.cmeta`
checkpoint path without writing the final migration for a canceled run.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Verified locally:

```bash
cargo fmt --all
git diff --check
./scripts/test test_cancel_drain_processes_finished_compactions -- --nocapture
./scripts/test test_canceled_drain_returns_after_safe_point -- --nocapture
./scripts/test test_cancel_drain_awaits_unfinished_compactions -- --nocapture
./scripts/test test_abort_unlocking -- --nocapture
./scripts/test test_checkpointing_reuses_only_committed_batches -- --nocapture
./scripts/test compact_log_backup -- --nocapture
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!--
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Fix compact-log-backup Ctrl-C handling to drain already-started subcompactions before returning cancellation.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cancellation handling during compaction backup is now more consistent and responsive to Ctrl-C, with standardized “user canceled” behavior.
* **Bug Fixes**
  * Improved shutdown flow: compactions are drained safely and deterministically, ensuring already-finished work is handled correctly while pending work is cleaned up appropriately.
  * Cancellation now exits at safer points to avoid abrupt termination.
* **Tests**
  * Added and expanded cancellation/drain test coverage for finished and unfinished compaction scenarios, including hook failure and error expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->