### PR TITLE
backup: clean saved files on response disconnect

### DIFF
--- a/components/backup/src/endpoint.rs
+++ b/components/backup/src/endpoint.rs
@@ -246,9 +246,14 @@ async fn save_backup_file_worker<EK: KvEngine>(
     rx: async_channel::Receiver<InMemBackupFiles<EK>>,
     tx: UnboundedSender<BackupResponse>,
     storage: Arc<dyn ExternalStorage>,
+    cancel: Arc<AtomicBool>,
     codec: KeyValueCodec,
 ) {
     while let Ok(msg) = rx.recv().await {
+        if cancel.load(Ordering::SeqCst) {
+            warn!("backup task has been canceled before saving files"; "region" => ?msg.region);
+            return;
+        }
         let files = if msg.files.need_flush_keys() {
             match with_resource_limiter(
                 msg.files.save(&storage),
@@ -295,6 +300,10 @@ async fn save_backup_file_worker<EK: KvEngine>(
             Ok(vec![])
         };
         let mut response = BackupResponse::default();
+        let saved_files = match &files {
+            Ok(files) => files.clone(),
+            Err(_) => vec![],
+        };
         match files {
             Err(e) => {
                 error_unknown!(?e; "backup region failed";
@@ -316,8 +325,21 @@ async fn save_backup_file_worker<EK: KvEngine>(
             "start_key" => &log_wrappers::Value::key(&msg.start_key),
             "end_key" => &log_wrappers::Value::key(&msg.end_key),);
             if e.is_disconnected() {
+                cleanup_saved_backup_files(&storage, saved_files);
                 return;
             }
+        }
+    }
+}
+
+fn cleanup_saved_backup_files(storage: &dyn ExternalStorage, files: Vec<File>) {
+    for file in files {
+        let file_name = file.get_name().to_owned();
+        let result =
+            tokio::task::block_in_place(|| Handle::current().block_on(storage.delete(&file_name)));
+        if let Err(err) = result {
+            error_unknown!(?err; "backup failed to clean saved file after response disconnect";
+                "file" => file_name,);
         }
     }
 }
@@ -1222,6 +1244,7 @@ impl<E: Engine, R: RegionInfoProvider + Clone + 'static> Endpoint<E, R> {
                 rx.clone(),
                 resp.clone(),
                 backend.clone(),
+                request.cancel.clone(),
                 codec,
             ));
         }
@@ -1394,14 +1417,17 @@ pub mod tests {
         storage::{
             RocksEngine, TestEngineBuilder,
             kv::LocalTablets,
-            txn::tests::{must_commit, must_prewrite_put},
+            txn::{
+                TxnEntry,
+                tests::{must_commit, must_prewrite_put},
+            },
         },
     };
     use tikv_util::{
         config::ReadableSize, info, store::new_peer, thread_name_prefix::BACKUP_WORKER_THREAD,
     };
     use tokio::time;
-    use txn_types::SHORT_VALUE_MAX_LEN;
+    use txn_types::{OldValue, SHORT_VALUE_MAX_LEN};
 
     use super::*;
 
@@ -1560,6 +1586,91 @@ pub mod tests {
         let unique = path.join(tmp_suffix);
         fs::create_dir_all(&unique).unwrap();
         unique
+    }
+
+    #[test]
+    fn test_save_worker_removes_files_when_response_channel_is_disconnected() {
+        let (tmp, endpoint) = new_endpoint();
+        let storage_dir = make_unique_dir(tmp.path());
+        let backend = make_local_backend(&storage_dir);
+        let storage = external_storage::create_storage(&backend, Default::default()).unwrap();
+        let storage = Arc::<dyn ExternalStorage>::from(storage);
+
+        let mut cipher = CipherInfo::default();
+        cipher.set_cipher_type(EncryptionMethod::Plaintext);
+        let mut writer = BackupWriter::new(
+            endpoint.engine.get_rocksdb(),
+            "disconnected-response",
+            None,
+            0,
+            Limiter::new(f64::INFINITY),
+            144 * 1024 * 1024,
+            cipher,
+        )
+        .unwrap();
+        let raw_key = b"cleanup-key";
+        let raw_value = b"cleanup-value";
+        let start_ts = TimeStamp::new(10);
+        let commit_ts = TimeStamp::new(20);
+        writer
+            .write(
+                vec![TxnEntry::Commit {
+                    default: (vec![], vec![]),
+                    write: (
+                        Key::from_raw(raw_key).append_ts(commit_ts).into_encoded(),
+                        txn_types::Write::new(
+                            txn_types::WriteType::Put,
+                            start_ts,
+                            Some(raw_value.to_vec()),
+                        )
+                        .as_ref()
+                        .to_bytes(),
+                    ),
+                    old_value: OldValue::None,
+                }]
+                .into_iter(),
+                true,
+            )
+            .unwrap();
+
+        let mut region = metapb::Region::default();
+        region.set_id(42);
+        region.mut_peers().push(new_peer(1, 1));
+        let queued_file = InMemBackupFiles {
+            files: KvWriter::Txn(writer),
+            start_key: raw_key.to_vec(),
+            end_key: b"cleanup-key\x00".to_vec(),
+            start_version: TimeStamp::zero(),
+            end_version: TimeStamp::new(100),
+            region,
+            resource_limiter: None,
+        };
+
+        let (save_tx, save_rx) = async_channel::bounded(1);
+        save_tx.try_send(queued_file).unwrap();
+        drop(save_tx);
+
+        let (resp_tx, resp_rx) = unbounded();
+        drop(resp_rx);
+
+        endpoint.io_pool.block_on(save_backup_file_worker(
+            save_rx,
+            resp_tx,
+            storage,
+            Arc::new(AtomicBool::new(false)),
+            KeyValueCodec::new(false, ApiVersion::V1, ApiVersion::V1),
+        ));
+
+        let ssts = fs::read_dir(&storage_dir)
+            .unwrap()
+            .map(|entry| entry.unwrap().path())
+            .filter(|path| path.extension().and_then(|ext| ext.to_str()) == Some("sst"))
+            .collect::<Vec<_>>();
+        assert!(
+            ssts.is_empty(),
+            "save worker must not leave files whose metadata cannot be delivered: {:?}",
+            ssts
+        );
     }
 
     #[test]


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #19775

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
backup: clean saved files on response disconnect

The backup save worker writes SST files to external storage before the
corresponding File metadata is sent back through BackupResponse.files. If the
response channel is already disconnected when the worker sends the response,
the worker returns and the just-written SST can be left outside the returned
backup metadata set.

Pass the request cancellation flag into the save worker and stop before saving
queued backup files after cancellation. Also keep the saved File descriptors
after a successful save, and best-effort delete those just-written files when
sending the response fails because the response channel is disconnected.
```

This PR fixes a backup cancellation/disconnect path in `save_backup_file_worker`.
The save worker can process an `InMemBackupFiles` item that was queued before
the request response stream was closed. Before this change, the worker could
save the queued writer to external storage, build a `BackupResponse`, fail to
send that response because the receiver was disconnected, and then return
without cleaning up the external SST files whose metadata was not delivered.

The updated worker now:

- receives the request cancellation flag and checks it before writing queued
  backup files;
- preserves the `File` descriptors returned by a successful save until response
  delivery is known to have succeeded;
- best-effort deletes the just-written files when `unbounded_send` fails with a
  disconnected response channel;
- keeps the existing error-response behavior for save failures.

A regression test covers the response-disconnect case by queueing a real
transaction backup writer, dropping the `BackupResponse` receiver before the
save worker runs, and asserting that no SST file remains in local external
storage after the worker returns.

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Test commands and results:

```bash
cargo fmt --all
cargo test -p backup --lib -- --nocapture
```

Result:

```text
running 26 tests
test endpoint::tests::test_backup_file_name ... ok
test endpoint::tests::test_transmute_locks ... ok
test utils::tests::test_is_valid_raw_value ... ok
test utils::tests::test_key_value_codec ... ok
test softlimit::softlimit_test::test_cpu_limit ... ok
test softlimit::softlimit_test::test_cpu_limit_remain ... ok
test softlimit::softlimit_test::test_current_idle ... ok
test softlimit::softlimit_test::test_limit ... ok
test endpoint::tests::test_backup_replica_read ... ok
test endpoint::tests::test_cancel ... ok
test endpoint::tests::test_seek_range ... ok
test endpoint::tests::test_save_worker_removes_files_when_response_channel_is_disconnected ... ok
test endpoint::tests::test_gcp_v2_enable_online_config ... ok
test endpoint::tests::test_seek_ranges ... ok
test endpoint::tests::test_backup_raw_apiv2_causal_ts ... ok
test endpoint::tests::test_scan_error ... ok
test endpoint::tests::test_s3_config ... ok
test endpoint::tests::test_seek_ranges_2 ... ok
test endpoint::tests::test_adjust_thread_pool_size ... ok
test endpoint::tests::test_control_thread_pool_adjust_keep_tasks ... ok
test writer::tests::test_writer ... ok
test endpoint::tests::test_handle_backup_task_bypass_locks ... ok
test endpoint::tests::test_handle_backup_task ... ok
test service::tests::test_client_stop ... ok
test endpoint::tests::test_handle_backup_raw ... ok
test endpoint::tests::test_busy ... ok

test result: ok. 26 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 6.14s
```

Focused regression and related tests were also run:

```bash
cargo test -p backup test_save_worker_removes_files_when_response_channel_is_disconnected -- --nocapture
cargo test -p backup test_cancel -- --nocapture
cargo test -p backup test_handle_backup -- --nocapture
```

Results:

```text
test_save_worker_removes_files_when_response_channel_is_disconnected: 1 passed; 0 failed
test_cancel: 1 passed; 0 failed
test_handle_backup: 3 passed; 0 failed
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!--
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Fix a backup cancellation path that could leave SST files without returned metadata.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved backup saving so active saves stop promptly when a request is canceled.
  * Prevented partially generated backup artifacts from being left behind when the backup response can’t be delivered.
  * Added handling to clean up already-saved backup files after an interrupted/inaccessible response.
* **Tests**
  * Added a regression test covering cleanup behavior when the response receiver disconnects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->