### PR TITLE
*: expand maintenance guides for backup, CDC, import, resolved-ts, and GC worker

### DIFF
--- a/doc/maintenance-guides/README.md
+++ b/doc/maintenance-guides/README.md
@@ -68,6 +68,10 @@ short, but they should still be present.
   `components/raftstore-v2`
 - Generic FSM batching framework used heavily by raftstore:
   `components/batch-system`
+- Shared region progress tracking for CDC, backup-stream, and stale-read-style
+  consumers: `components/resolved_ts`
+- MVCC GC, safe-point enforcement, and compaction-filter helpers:
+  `src/server/gc_worker`
 - Resource groups, fairness, admission control, quota adjustment:
   `components/resource_control`
 - Hybrid disk + region-cache engine glue: `components/hybrid_engine`
@@ -83,6 +87,10 @@ short, but they should still be present.
 
 ### `components/`
 
+- [backup](./components/backup.md)
+- [backup-stream](./components/backup-stream.md)
+- [cdc](./components/cdc.md)
+- [resolved_ts](./components/resolved_ts.md)
 - [raftstore](./components/raftstore.md)
 - [raftstore-v2](./components/raftstore-v2.md)
 - [resource_control](./components/resource_control.md)
@@ -91,11 +99,14 @@ short, but they should still be present.
 - [batch-system](./components/batch-system.md)
 - [server](./components/server.md)
 - [service](./components/service.md)
+- [sst_importer](./components/sst_importer.md)
 
 ### `src/`
 
 - [coprocessor](./src/coprocessor.md)
 - [coprocessor_v2](./src/coprocessor_v2.md)
+- [gc_worker](./src/gc_worker.md)
+- [import](./src/import.md)
 - [server](./src/server.md)
 - [storage](./src/storage.md)
 
@@ -128,6 +139,10 @@ short, but they should still be present.
 
 - The guide set currently includes:
   - `repo-overview.md`
+  - `components/backup.md`
+  - `components/backup-stream.md`
+  - `components/cdc.md`
+  - `components/resolved_ts.md`
   - `components/raftstore.md`
   - `components/raftstore-v2.md`
   - `components/resource_control.md`
@@ -136,23 +151,20 @@ short, but they should still be present.
   - `components/batch-system.md`
   - `components/server.md`
   - `components/service.md`
+  - `components/sst_importer.md`
   - `src/coprocessor.md`
   - `src/coprocessor_v2.md`
+  - `src/gc_worker.md`
+  - `src/import.md`
   - `src/server.md`
   - `src/storage.md`
 - The guide set now covers both the classic `raftstore` path and the
   `RaftKv2` / `raftstore-v2` path at maintainer-map granularity.
 - The guides focus on maintenance and review, not on external deployment or SQL
   semantics.
-- The repository overview discusses additional subsystems for cross-component
-  reasoning, but these do not yet have dedicated subsystem guides:
-  - `components/cdc`
-  - `components/backup`
-  - `components/backup-stream`
-  - `components/engine_rocks`
-  - `components/pd_client`
-  - `components/sst_importer`
-  - `src/import`
+- Additional cross-component subsystems such as `components/engine_rocks` and
+  `components/pd_client` are still described primarily through
+  `repo-overview.md` and the guides that depend on them.
 
 ## External Reference Links
 
@@ -164,3 +176,7 @@ These upstream docs are useful orientation material and were used together with
 - TiDB / TiKV overview: `https://docs.pingcap.com/tidb/stable/tikv-overview`
 - TiDB resource control and resource groups:
   `https://docs.pingcap.com/tidb/stable/tidb-resource-control-overview`
+- TiDB BR backup and restore overview:
+  `https://docs.pingcap.com/tidb/stable/backup-and-restore-overview/`
+- TiCDC overview:
+  `https://docs.pingcap.com/tidb/stable/ticdc-overview/`

--- a/doc/maintenance-guides/components/backup-stream.md
+++ b/doc/maintenance-guides/components/backup-stream.md
@@ -1,0 +1,275 @@
+# `components/backup-stream` Maintenance Guide
+
+## Purpose And Scope
+
+`components/backup-stream` owns TiKV's log-backup / PITR capture path. It
+covers:
+
+- task watch and task lifecycle for log-backup jobs
+- leader-side observation of Raft apply events
+- initial scans for newly observed regions
+- temporary-file buffering, flush, and upload
+- per-region, per-store, and global checkpoint tracking
+- gRPC endpoints for force flush and checkpoint inspection
+
+It is closely related to `resolved_ts`, `raftstore` observers, and the BR/TiDB
+control plane, but the data-plane logic lives here.
+
+## Architectural Views
+
+### Data-plane view
+
+1. A task is created in metadata under `/tidb/br-stream/...`.
+2. `Endpoint` watches metadata and installs the task into the in-memory router.
+3. `BackupStreamObserver` subscribes leader regions whose ranges overlap a task.
+4. `router.rs` converts `CmdBatch` apply events into per-task event streams and
+   tracks lock/resolved-ts state.
+5. Temp files accumulate encoded events until flush.
+6. Flush uploads data files and backup metadata, then updates task
+   checkpoints.
+
+### Control-plane view
+
+- `metadata/client.rs` abstracts the metadata store and task status keys.
+- `checkpoint_manager.rs` tracks resolved, frozen, and durable checkpoints.
+- `service.rs` exposes force-flush and checkpoint-query RPCs.
+- Fatal task errors pause the task and publish a service safe point in PD so GC
+  does not outrun the last safe checkpoint.
+
+## Process Lifecycle And Startup Sequencing
+
+- The subsystem starts only when `log_backup.enable` is true.
+- Startup wiring is in:
+  - `components/server/src/server.rs` for classic `RaftKv`
+  - `components/server/src/server2.rs` for `RaftKv2`
+- Startup order matters:
+  1. register `BackupStreamObserver` on the coprocessor host
+  2. register `BackupStreamConfigManager`
+  3. construct `Endpoint`
+  4. start the worker that owns `Endpoint`
+  5. register the gRPC `LogBackup` service
+- `Endpoint::new` immediately spawns background loops on its Tokio runtime:
+  - flush ticker
+  - metadata task watcher
+  - region subscription manager
+  - checkpoint subscription manager
+  - min-ts worker
+
+Shutdown rule:
+
+- The endpoint runtime owns task watching, region operations, and checkpoint
+  callbacks. Do not drop it before the worker is stopped or checkpoint/task
+  state can be left half-updated.
+
+## Data Model And Metadata Contracts
+
+`metadata/keys.rs` is the best place to start. The core metadata contracts are:
+
+- task info:
+  `/tidb/br-stream/info/<task>`
+- task ranges:
+  `/tidb/br-stream/ranges/<task>/<start_key>`
+- region/store checkpoints:
+  `/tidb/br-stream/checkpoint/<task>/...`
+- storage checkpoint:
+  `/tidb/br-stream/storage-checkpoint/<task>/<store_id>`
+- pause and last-error state:
+  `/tidb/br-stream/pause/<task>` and `/last-error/...`
+
+Important in-memory state holders:
+
+- `StreamTask`: task info plus paused state
+- `Task`: endpoint message enum
+- `ObserveOp`: region-observation state transitions
+- `TaskSelector`: task matching by name, key, range, or all tasks
+- `CheckpointManager`: resolved, frozen, and durable checkpoint maps
+- `ResolvedRegions`: batch result of region checkpoint resolution
+
+Checkpoint contract:
+
+- `resolved_ts` is still advancing with incoming mutations.
+- `freeze()` snapshots that progress for the next flush wave.
+- `flush_and_notify()` moves frozen progress into durable checkpoint state and
+  informs subscribers.
+- global checkpoint updates must be monotonic and conservative; they are
+  consumed by the outer control plane and by safe-point management.
+
+## Start Here
+
+- `components/backup-stream/src/lib.rs`
+- `components/backup-stream/src/endpoint.rs`
+- `components/backup-stream/src/router.rs`
+- `components/backup-stream/src/observer.rs`
+- `components/backup-stream/src/subscription_manager.rs`
+- `components/backup-stream/src/checkpoint_manager.rs`
+- `components/backup-stream/src/metadata/keys.rs`
+- `components/backup-stream/src/metadata/client.rs`
+- `components/backup-stream/src/service.rs`
+- `components/backup-stream/src/metrics.rs`
+
+## Must-Read File Order
+
+1. `components/backup-stream/src/endpoint.rs`
+2. `components/backup-stream/src/router.rs`
+3. `components/backup-stream/src/observer.rs`
+4. `components/backup-stream/src/subscription_manager.rs`
+5. `components/backup-stream/src/checkpoint_manager.rs`
+6. `components/backup-stream/src/metadata/keys.rs`
+7. `components/backup-stream/src/metadata/client.rs`
+8. `components/backup-stream/src/service.rs`
+9. `components/backup-stream/src/metrics.rs`
+
+## Core Concepts
+
+- `StreamTask`: one log-backup task definition from metadata
+- `Router`: per-task event routing, temp-file ownership, and flush handling
+- `ObserveOp`: explicit state transitions for region observation
+- `SubscriptionTracer`: region subscription registry and resolver ownership
+- `CheckpointManager`: region/store/global checkpoint bookkeeping
+- `InitialDataLoader`: initial scan engine for new regions
+
+## Why It Matters
+
+This crate is one of the easiest places to create silent RPO regressions. A
+bug can leave a task apparently healthy while dropping mutations, advancing a
+checkpoint too far, or pausing a task too late to keep GC safe.
+
+## Critical Invariants
+
+- Only leader-owned regions should emit apply events for a task.
+- Initial scan output must be ordered with subsequent delta events; the barrier
+  and observe-handle logic in `subscription_manager.rs` and `router.rs` are
+  part of the correctness boundary.
+- Locks tracked in the router must stay consistent with resolved-ts advancement
+  or checkpoints can move ahead of unflushed data.
+- Checkpoint advancement must be monotonic and must not publish data that has
+  not been durably flushed.
+- Fatal task errors must pause the task and publish a conservative service safe
+  point.
+- Range matching must stay stable across split/merge/leader changes.
+- Metadata key layout is a compatibility surface. Renaming keys or changing
+  interpretation without migration is unsafe.
+
+## Observability And Operational Signals
+
+Open `components/backup-stream/src/metrics.rs` first. The most useful signals
+are:
+
+- `tikv_log_backup_internal_actor_acting_duration_sec`
+- `tikv_log_backup_event_handle_duration_sec`
+- `tikv_log_backup_flush_duration_sec`
+- `tikv_log_backup_store_checkpoint_ts`
+- `tikv_log_backup_store_last_checkpoint_ts`
+- `tikv_log_backup_store_last_checkpoint_region_id`
+- `tikv_log_backup_errors`
+- `tikv_log_backup_fatal_errors`
+- `tikv_log_backup_pending_initial_scan`
+- `tikv_log_backup_active_subscription_number`
+- `tikv_log_backup_temp_file_memory_usage`
+- `tikv_log_backup_temp_file_count`
+- `tikv_log_backup_task_status`
+
+Operationally useful logs tend to appear around:
+
+- skipped or retried observation
+- fatal upload/checkpoint errors
+- global checkpoint updates
+- failover marking
+- high-memory warnings during observation
+
+## Change Management Guidance
+
+- Any change to metadata paths, pause semantics, or checkpoint semantics must
+  update this guide in the same change.
+- If a patch changes how apply events are decoded or which locks are tracked,
+  audit `resolved_ts`, `cdc`, and the affected transaction metadata format.
+- If a patch changes flush or temp-file behavior, audit global checkpoint and
+  safepoint side effects, not only file upload code.
+- If a patch changes observation retry logic, review split/merge and leader
+  transfer cases explicitly.
+
+## Change-Impact Matrix
+
+- Task lifecycle or metadata watch changes:
+  inspect `endpoint.rs` and `metadata/client.rs`
+- Apply-event decoding or filtering changes:
+  inspect `router.rs`, observer wiring, and transaction metadata readers
+- Initial scan changes:
+  inspect `subscription_manager.rs`, `event_loader.rs`, and resolver ordering
+- Checkpoint semantics changes:
+  inspect `checkpoint_manager.rs`, global checkpoint updates, and PD safe-point
+  calls
+- Temp-file or upload changes:
+  inspect `router.rs`, `tempfiles.rs`, and metadata file emission
+
+## Review Checklist
+
+- Does the patch change when a region starts or stops being observed?
+- Does it change barrier ordering between initial scan and delta events?
+- Does it change checkpoint freeze/flush/global-update sequencing?
+- Does it change metadata key naming or persistence format?
+- Does it change pause/error behavior or service-safe-point updates?
+- Does it change memory/backpressure handling in temp-file or routing code?
+
+## Observability And Tests
+
+- Integration tests live in `components/backup-stream/tests/integration/mod.rs`.
+- Failpoint coverage lives in `components/backup-stream/tests/failpoints/mod.rs`.
+- Unit coverage is spread across `router.rs`, `checkpoint_manager.rs`,
+  `metadata/test.rs`, `observer.rs`, and `subscription_manager.rs`.
+- Many production regressions require cluster tests because leadership and
+  region topology changes are part of the steady-state design.
+
+## Common Failure Modes
+
+- repeated observe retries on stale leadership or epoch drift
+- checkpoint advancing ahead of flushed data
+- task pause state not matching actual fatal error state
+- failover stores publishing checkpoints too aggressively
+- temp-file memory growth or swap behavior causing backpressure
+- metadata drift between task ranges and in-memory router state
+
+## Reading Map And Companion Docs
+
+Suggested reading order:
+
+1. `endpoint.rs`
+2. `router.rs`
+3. `subscription_manager.rs`
+4. `checkpoint_manager.rs`
+5. `metadata/client.rs`
+
+Companion docs:
+
+- `repo-overview.md`
+- `components/cdc.md`
+- `components/resolved_ts.md`
+- `src/gc_worker.md`
+- `components/raftstore.md`
+- `components/raftstore-v2.md`
+- BR overview:
+  `https://docs.pingcap.com/tidb/stable/backup-and-restore-overview/`
+
+## Glossary
+
+- Initial scan:
+  the catch-up scan from last checkpoint when a region first becomes observed
+- Resolved-ts:
+  the in-flight per-region progress bound used to determine which mutations are
+  safe to flush into the next checkpoint wave
+- Frozen checkpoint:
+  the snapshot of resolved progress associated with the current flush wave
+- Storage checkpoint:
+  the durable checkpoint uploaded by one store for one task
+- Global checkpoint:
+  the conservative lower bound used by the outer control plane
+
+## Related Components
+
+- `components/raftstore`
+- `components/raftstore-v2`
+- `components/resolved_ts`
+- `src/gc_worker`
+- `components/external_storage`
+- `components/encryption`
+- `components/cdc`

--- a/doc/maintenance-guides/components/backup-stream.md
+++ b/doc/maintenance-guides/components/backup-stream.md
@@ -269,7 +269,7 @@ Companion docs:
 - `components/raftstore`
 - `components/raftstore-v2`
 - `components/resolved_ts`
-- `src/gc_worker`
+- `src/server/gc_worker`
 - `components/external_storage`
 - `components/encryption`
 - `components/cdc`

--- a/doc/maintenance-guides/components/backup.md
+++ b/doc/maintenance-guides/components/backup.md
@@ -1,0 +1,259 @@
+# `components/backup` Maintenance Guide
+
+## Purpose And Scope
+
+`components/backup` owns TiKV's BR-facing backup service. It covers:
+
+- transactional range backup
+- raw KV backup
+- streaming RPC orchestration for `Backup`
+- disk-snapshot backup preparation RPCs used by newer BR flows
+- backup-side concurrency tuning, SST building, encryption, and external
+  storage upload
+
+This crate does not own restore or ingest. Those live in `src/import` and
+`components/sst_importer`.
+
+## Architectural Views
+
+### Request execution view
+
+1. `service.rs` accepts `Backup` or `PrepareSnapshotBackup` RPCs.
+2. `Task::new` in `endpoint.rs` validates the request and captures the backup
+   parameters, lock-bypass lists, rate limiting, and cancel handle.
+3. `Endpoint::run` turns the request range into region-scoped `BackupRange`
+   units through `Progress`.
+4. `BackupRange::backup` or `BackupRange::backup_raw_kv_to_file` takes a
+   snapshot, scans the region fragment, and builds in-memory SST files.
+5. `save_backup_file_worker` uploads the built SSTs to external storage and
+   emits `BackupResponse` records.
+
+### Snapshot-backup control view
+
+- `service.rs::prepare_snapshot_backup` owns the long-lived duplex stream used
+  for disk snapshot orchestration.
+- `disk_snap.rs` mediates lease updates, wait-apply fanout, and abort/error
+  mapping around `raftstore::store::snapshot_backup`.
+- On classic `RaftKv`, `PrepareDiskSnapObserver` in raftstore is the
+  cluster-local guard that controls whether snapshot backup can proceed.
+- On `RaftKv2`, the `Backup` gRPC service still exists, but the snapshot-backup
+  handle is currently unimplemented, so disk snapshot backup is not available
+  there yet.
+
+## Process Lifecycle And Startup Sequencing
+
+- Classic `RaftKv` wiring lives in `components/server/src/server.rs`.
+- `RaftKv2` wiring lives in `components/server/src/server2.rs`.
+- Both paths register the gRPC `Backup` service before starting the backup
+  endpoint worker.
+- The endpoint owns:
+  - a worker scheduler for `Task`
+  - a separate Tokio IO runtime for file upload
+  - a `SoftLimitKeeper` background task for adaptive concurrency
+  - a config manager registered under `tikv::config::Module::Backup`
+- The snapshot-backup stream additionally requires, on classic `RaftKv`:
+  - a `PrepareDiskSnapObserver` already registered to the coprocessor host
+  - a `SnapshotBrHandle` from the raftstore/router side
+  - an async runtime handle for stream-side fanout
+- On `RaftKv2`, do not assume the same disk-snapshot flow exists yet; the
+  stream-side handle is intentionally unimplemented today.
+
+Shutdown rule:
+
+- Stop new RPC admission first, then let the endpoint worker and its upload
+  runtime drain. Do not reorder this casually; the response stream and cancel
+  handling assume the worker outlives in-flight upload tasks.
+
+## Data Model And Metadata Contracts
+
+- `Task.request` is the request contract. The fields that tend to matter during
+  maintenance are:
+  - key range and optional sub-ranges
+  - `start_ts` / `end_ts`
+  - raw vs transactional mode
+  - destination API version and CF
+  - replica-read intent
+  - resolved/committed lock bypass lists
+  - resource-group and request-origin metadata
+- `Progress` slices the user request into region-aligned `BackupRange` work
+  items. Reviewers should treat region slicing as a correctness boundary.
+- `BackupRange` binds:
+  - concrete region and peer
+  - effective `[start_key, end_key)` inside that region
+  - codec rules for API-version conversion
+  - whether the range is served by leader or follower
+- Output file metadata is `kvproto::brpb::File`. The file name, key range,
+  versions, checksum, SHA-256, CF name, and encryption IV must stay aligned
+  with the uploaded bytes.
+- Disk snapshot preparation maintains a lease-like state in
+  `PrepareDiskSnapObserver`; the stream protocol in `disk_snap.rs` assumes the
+  lease transitions and wait-apply responses stay coherent across retries.
+
+## Start Here
+
+- `components/backup/src/lib.rs`
+- `components/backup/src/service.rs`
+- `components/backup/src/endpoint.rs`
+- `components/backup/src/writer.rs`
+- `components/backup/src/disk_snap.rs`
+- `components/backup/src/softlimit.rs`
+- `components/backup/src/errors.rs`
+- `components/backup/src/metrics.rs`
+
+## Must-Read File Order
+
+1. `components/backup/src/endpoint.rs`
+2. `components/backup/src/service.rs`
+3. `components/backup/src/writer.rs`
+4. `components/backup/src/disk_snap.rs`
+5. `components/backup/src/softlimit.rs`
+6. `components/backup/src/errors.rs`
+7. `components/backup/src/metrics.rs`
+
+## Core Concepts
+
+- `Task`: one backup RPC request plus its cancel handle and response stream
+- `Progress`: the region-walking state machine for a request
+- `BackupRange`: one region-scoped backup fragment
+- `BackupWriter` / `BackupRawKvWriter`: SST builders for transactional and raw
+  backup
+- `SoftLimitKeeper`: backup-specific adaptive concurrency controller
+- `Env` / `StreamHandleLoop`: disk-snapshot backup stream coordination
+
+## Why It Matters
+
+Backup is a correctness-sensitive export path. Regressions here can silently
+produce incomplete data, stale snapshots, wrong key encoding, or files that are
+well-formed but semantically unusable by restore.
+
+## Critical Invariants
+
+- Transactional backup must read from a snapshot consistent with `end_ts` and
+  the intended lock-bypass rules.
+- Replica-read backup still has to perform request-origin-aware max-ts
+  validation before taking the snapshot.
+- Region slicing must preserve the exact request range without gaps or overlap.
+- The response stream may report partial region results; error paths must not
+  hide already-sent success records.
+- File metadata must describe the uploaded encrypted/compressed SST accurately.
+- Cancellation must be observed both before scheduling and inside long-running
+  scan loops.
+- Disk snapshot backup must not treat expired leases or aborted wait-apply
+  results as success.
+
+## Observability And Operational Signals
+
+Open `components/backup/src/metrics.rs` first. The main signals are:
+
+- `tikv_backup_range_duration_seconds`
+- `tikv_backup_range_size_bytes`
+- `tikv_backup_thread_pool_size`
+- `tikv_backup_error_counter`
+- `tikv_backup_softlimit`
+- `tikv_backup_scan_wait_for_writer_seconds`
+- `tikv_backup_scan_kv_count`
+- `tikv_backup_scan_kv_size_bytes`
+- `tikv_backup_raw_expired_count`
+
+Operationally useful logs live mostly in `endpoint.rs` and `disk_snap.rs`,
+especially around:
+
+- long-running scans
+- region seek failures
+- upload failures
+- snapshot wait/apply aborts
+- client-side cancellation
+
+## Change Management Guidance
+
+- Treat snapshot-taking, lock-checking, key codec conversion, and file-metadata
+  changes as correctness changes, not just performance changes.
+- If a patch changes the snapshot-backup stream protocol or lease semantics,
+  audit `raftstore::store::snapshot_backup` and the server bootstrap path in
+  the same review.
+- If a patch changes request context handling, review resource-control and
+  request-origin behavior together with `src/server/service/kv.rs`.
+- If backup output format or encryption handling changes, audit restore/import
+  consumers and update this guide.
+
+## Change-Impact Matrix
+
+- Range splitting or region iteration changes:
+  inspect `Progress`, `BackupRange`, and `RegionInfoProvider` call sites
+- Snapshot or lock-check behavior changes:
+  inspect `BackupRange::backup`, `ConcurrencyManager`, and storage snapshot
+  APIs
+- Output SST format or checksum changes:
+  inspect `writer.rs`, `brpb::File`, and restore/import consumers
+- Disk snapshot protocol changes:
+  inspect `service.rs`, `disk_snap.rs`, and raftstore snapshot-backup code
+- Concurrency or auto-tuning changes:
+  inspect `softlimit.rs`, endpoint scheduling, and upload runtime usage
+
+## Review Checklist
+
+- Does the patch change which peer or role can serve backup?
+- Does it change how region boundaries are converted into backup ranges?
+- Does it change `BackupResponse` partial-success or error behavior?
+- Does it change snapshot lifetime or lock-check semantics?
+- Does it change SST metadata, encryption, checksum, or upload ordering?
+- Does it change disk snapshot lease/update/wait-apply sequencing?
+
+## Observability And Tests
+
+- Unit-heavy coverage lives in `components/backup/src/endpoint.rs`,
+  `service.rs`, and `disk_snap.rs`.
+- Integration-style helpers live in `components/test_backup/src/lib.rs` and
+  `components/test_backup/src/disk_snap.rs`.
+- Regressions often require cluster-level validation because the failure modes
+  are usually tied to leadership, region movement, or snapshot timing.
+
+## Common Failure Modes
+
+- not-leader / epoch-not-match loops while walking regions
+- stale or missing lock handling around backup ts
+- canceled clients leaving long-running scans alive
+- mismatched API-version conversion for raw or transactional keys
+- output file metadata not matching uploaded bytes
+- disk snapshot wait-apply aborts caused by leadership or epoch changes
+
+## Reading Map And Companion Docs
+
+Suggested reading order:
+
+1. `endpoint.rs`
+2. `writer.rs`
+3. `service.rs`
+4. `disk_snap.rs`
+5. `softlimit.rs`
+
+Companion docs:
+
+- `repo-overview.md`
+- `src/storage.md`
+- `src/gc_worker.md`
+- `components/server.md`
+- `src/import.md`
+- BR overview:
+  `https://docs.pingcap.com/tidb/stable/backup-and-restore-overview/`
+
+## Glossary
+
+- Backup ts:
+  the snapshot timestamp exported by transactional backup
+- Sub-range:
+  a caller-provided sub-interval inside the top-level backup range
+- Replica read backup:
+  backup served by a follower after the required snapshot checks
+- Wait-apply:
+  the snapshot-backup step that waits for leaders to apply to the target point
+
+## Related Components
+
+- `src/storage`
+- `src/gc_worker`
+- `components/raftstore`
+- `components/raftstore-v2`
+- `components/external_storage`
+- `components/encryption`
+- `src/import`

--- a/doc/maintenance-guides/components/backup.md
+++ b/doc/maintenance-guides/components/backup.md
@@ -251,7 +251,7 @@ Companion docs:
 ## Related Components
 
 - `src/storage`
-- `src/gc_worker`
+- `src/server/gc_worker`
 - `components/raftstore`
 - `components/raftstore-v2`
 - `components/external_storage`

--- a/doc/maintenance-guides/components/cdc.md
+++ b/doc/maintenance-guides/components/cdc.md
@@ -1,0 +1,264 @@
+# `components/cdc` Maintenance Guide
+
+## Purpose And Scope
+
+`components/cdc` owns TiKV's change data capture service for TiCDC. It covers:
+
+- gRPC event-feed connection handling
+- region capture registration and deregistration
+- apply-event observation from raftstore
+- incremental scan initialization for new downstreams
+- old-value lookup and cache management
+- resolved-ts advancement coordination for captured regions
+- connection watchdog and sink-memory backpressure behavior
+
+`components/resolved_ts` is a companion subsystem, but CDC owns the
+changefeed-facing state machine and delivery semantics.
+
+## Architectural Views
+
+### Event-feed view
+
+1. `service.rs` accepts `ChangeData` event-feed streams and opens a `Conn`.
+2. `Endpoint` owns region capture state, downstream registration, and
+   background scan/tso runtimes.
+3. `CdcObserver` registers on raftstore and forwards applied command batches
+   plus role/region changes into the endpoint task queue.
+4. `Initializer` acquires an incremental snapshot and installs the downstream
+   into steady-state event delivery.
+5. `Delegate` per region fans events and resolved-ts updates to downstreams.
+
+### State-ownership view
+
+- `Conn`: one gRPC connection and its request-to-downstream map
+- `Delegate`: one captured region and its observed downstreams
+- `Downstream`: one request's consumer state machine
+- `ObserveId` / `DownstreamId`: ABA guards for region observation and sink
+  ownership
+
+## Process Lifecycle And Startup Sequencing
+
+- Bootstrap wiring is in:
+  - `components/server/src/server.rs` for classic `RaftKv`
+  - `components/server/src/server2.rs` for `RaftKv2`
+- Required startup order:
+  1. create CDC worker and scheduler
+  2. install `CdcTxnExtraScheduler` into the storage engine
+  3. register `CdcObserver` on the coprocessor host
+  4. register `CdcConfigManager`
+  5. create and start `Endpoint`
+  6. register the gRPC `ChangeData` service
+- `Endpoint::new` creates:
+  - a worker runtime for incremental scans
+  - a TSO runtime for min-ts work
+  - scan concurrency semaphore and speed limiters
+  - old-value cache
+  - leader resolver bootstrap for min-ts events
+
+Shutdown rule:
+
+- The event-feed service should stop accepting new connections before the
+  endpoint and scan runtimes are torn down. Otherwise incremental-scan or sink
+  tasks can race shutdown and produce misleading downstream errors.
+
+## Data Model And Metadata Contracts
+
+- `Task` in `endpoint.rs` is the central endpoint message contract.
+- `Conn`, `RequestId`, and `ConnId` in `service.rs` define connection-side
+  routing.
+- `Downstream`, `DownstreamState`, and `DownstreamId` in `delegate.rs` define
+  sink ownership and event-delivery readiness.
+- `ObserveId` from raftstore is the region-observation identity. CDC depends on
+  it to avoid ABA bugs when leadership or region ownership changes quickly.
+- `OldValueCache` is a best-effort cache, but its size, miss behavior, and
+  value encoding expectations are part of the maintenance surface.
+- `TxnSource` bits in `txn_source.rs` are part of a cross-component contract.
+  CDC deliberately treats Lightning physical-import writes specially; import
+  changes that touch txn-source bits must be reviewed together with CDC.
+
+## Start Here
+
+- `components/cdc/src/lib.rs`
+- `components/cdc/src/service.rs`
+- `components/cdc/src/endpoint.rs`
+- `components/cdc/src/delegate.rs`
+- `components/cdc/src/initializer.rs`
+- `components/cdc/src/observer.rs`
+- `components/cdc/src/old_value.rs`
+- `components/cdc/src/watchdog.rs`
+- `components/cdc/src/txn_source.rs`
+- `components/cdc/src/metrics.rs`
+
+## Must-Read File Order
+
+1. `components/cdc/src/service.rs`
+2. `components/cdc/src/endpoint.rs`
+3. `components/cdc/src/delegate.rs`
+4. `components/cdc/src/initializer.rs`
+5. `components/cdc/src/observer.rs`
+6. `components/cdc/src/old_value.rs`
+7. `components/cdc/src/watchdog.rs`
+8. `components/cdc/src/txn_source.rs`
+9. `components/cdc/src/metrics.rs`
+
+## Core Concepts
+
+- `Conn`: one event-feed stream from a client
+- `Delegate`: one captured region's fanout and resolver state
+- `Downstream`: one request on one connection
+- Incremental scan:
+  the snapshot catch-up phase before steady-state delta event delivery
+- Old value:
+  previous committed value lookup for TiCDC row-change semantics
+- Watchdog:
+  per-connection abort logic for idle or quota-stressed streams
+
+## Why It Matters
+
+CDC is easy to break with changes that appear local to storage, apply order, or
+import. Failures here often show up as lag, duplicate events, missing old
+values, or downstream termination rather than obvious local crashes.
+
+## Critical Invariants
+
+- Observer scheduling must stay FIFO enough to preserve event ordering
+  expectations documented in `CdcObserver`.
+- Incremental scan results must not overtake earlier delta events. The barrier
+  flow in `Initializer::initialize` is a correctness boundary.
+- `DownstreamState` transitions must stay monotonic:
+  `Uninitialized -> Initializing -> Normal -> Stopped`.
+- No more change events or resolved-ts updates may be sent after an error event
+  has been emitted for a downstream.
+- `ObserveId` and `DownstreamId` checks must stay in place to prevent stale
+  deregistration from removing new owners.
+- Old-value reads must observe a snapshot that is valid for the corresponding
+  command batch.
+- Sink memory quota and congestion handling are correctness-relevant because
+  they drive explicit downstream errors and retry behavior.
+
+## Observability And Operational Signals
+
+Open `components/cdc/src/metrics.rs` first. The most useful signals are:
+
+- `tikv_cdc_endpoint_pending_tasks`
+- `tikv_cdc_grpc_connection_count`
+- `tikv_cdc_scan_tasks`
+- `tikv_cdc_scan_duration_seconds`
+- `tikv_cdc_scan_bytes_total`
+- `tikv_cdc_pending_bytes`
+- `tikv_cdc_captured_region_total`
+- `tikv_cdc_min_resolved_ts`
+- `tikv_cdc_min_resolved_ts_lag`
+- `tikv_cdc_old_value_cache_bytes`
+- `tikv_cdc_old_value_duration`
+- `tikv_cdc_sink_memory_bytes`
+- `tikv_cdc_aborted_connections`
+
+Useful logs are usually around:
+
+- duplicate or invalid registration
+- observer deregistration after leader/split/merge changes
+- slow or canceled incremental scans
+- sink congestion and memory-quota aborts
+- watchdog-triggered connection aborts
+
+## Change Management Guidance
+
+- If a patch changes write-path ordering, old-value encoding, or txn-source
+  bits, review CDC even if the patch is nominally in storage or import.
+- If a patch changes scan concurrency or sink-memory behavior, audit both
+  liveness and downstream-visible error semantics.
+- If a patch changes region lifecycle or observe-handle behavior, audit split,
+  merge, leader transfer, and not-leader cleanup paths.
+- If a patch changes feature negotiation or request validation, review both old
+  and new TiCDC client behavior.
+
+## Change-Impact Matrix
+
+- Connection or request-protocol changes:
+  inspect `service.rs`, `Conn`, and feature-gate logic
+- Region capture lifecycle changes:
+  inspect `endpoint.rs`, `delegate.rs`, and `observer.rs`
+- Incremental scan changes:
+  inspect `initializer.rs`, scan concurrency, and barrier logic
+- Old-value changes:
+  inspect `old_value.rs`, MVCC readers, and apply-batch callbacks
+- Import / txn-source changes:
+  inspect `txn_source.rs` and `src/import/sst_service.rs`
+
+## Review Checklist
+
+- Does the patch change event ordering between incremental scan and delta flow?
+- Does it change observe-handle registration or deregistration conditions?
+- Does it change old-value lookup or cache semantics?
+- Does it change how sink congestion or memory pressure is surfaced?
+- Does it change txn-source handling for imported or replicated writes?
+- Does it change resolved-ts advancement inputs or delegate lock tracking?
+
+## Observability And Tests
+
+- Integration tests live in `components/cdc/tests/integrations/`.
+- Benchmarks live in `components/cdc/benches/cdc_event.rs`.
+- Unit coverage is spread through `endpoint.rs`, `observer.rs`, `service.rs`,
+  `delegate.rs`, `old_value.rs`, and `watchdog.rs`.
+- CDC regressions often need multi-region or leadership-changing tests. Pure
+  unit coverage is not enough for most ordering fixes.
+
+## Common Failure Modes
+
+- stale deregistration after fast leader changes or region replacement
+- missing or duplicated events due to barrier/order regressions
+- old-value lookup regressions under cache miss or GC-fence edge cases
+- too many pending incremental scans causing immediate downstream failure
+- sink congestion causing repeated aborted or stuck connections
+- imported Lightning writes unexpectedly showing up in CDC streams
+
+## Reading Map And Companion Docs
+
+Suggested reading order:
+
+1. `service.rs`
+2. `endpoint.rs`
+3. `delegate.rs`
+4. `initializer.rs`
+5. `observer.rs`
+
+Companion docs:
+
+- `repo-overview.md`
+- `src/storage.md`
+- `src/gc_worker.md`
+- `components/raftstore.md`
+- `components/raftstore-v2.md`
+- `components/resolved_ts.md`
+- `src/import.md`
+- TiCDC overview:
+  `https://docs.pingcap.com/tidb/stable/ticdc-overview/`
+
+## Glossary
+
+- Event feed:
+  the long-lived gRPC stream used by TiCDC
+- Delegate:
+  the per-region CDC owner in TiKV
+- Downstream:
+  the per-request consumer attached to a delegate
+- Changefeed checkpoint:
+  the durable lower bound a TiCDC changefeed has fully replicated to its sink;
+  it must lag or equal every region-level progress signal that still protects
+  correctness
+- Changefeed resolved-ts:
+  the in-flight upper bound that says all commits below this timestamp are
+  known and ordered for the captured span, but may not yet be durably flushed
+  by the downstream sink
+- Old value:
+  the previously committed value used to construct row changes
+
+## Related Components
+
+- `components/resolved_ts`
+- `src/gc_worker`
+- `components/raftstore`
+- `components/raftstore-v2`
+- `src/storage`
+- `src/import`

--- a/doc/maintenance-guides/components/cdc.md
+++ b/doc/maintenance-guides/components/cdc.md
@@ -227,7 +227,7 @@ Companion docs:
 
 - `repo-overview.md`
 - `src/storage.md`
-- `src/gc_worker.md`
+- `src/server/gc_worker.md`
 - `components/raftstore.md`
 - `components/raftstore-v2.md`
 - `components/resolved_ts.md`
@@ -257,7 +257,7 @@ Companion docs:
 ## Related Components
 
 - `components/resolved_ts`
-- `src/gc_worker`
+- `src/server/gc_worker`
 - `components/raftstore`
 - `components/raftstore-v2`
 - `src/storage`

--- a/doc/maintenance-guides/components/resolved_ts.md
+++ b/doc/maintenance-guides/components/resolved_ts.md
@@ -1,0 +1,292 @@
+# `components/resolved_ts` Maintenance Guide
+
+## Purpose And Scope
+
+`components/resolved_ts` owns TiKV's shared resolved-ts engine. It provides the
+leader-side machinery used to compute a conservative progress timestamp for
+observed regions so that CDC, backup-stream, stale read, and related features
+can reason about which commits are definitely visible.
+
+Its maintenance surface covers:
+
+- lock-only apply-event observation from raftstore
+- initial lock scan when a region starts being observed
+- per-region resolver state and lock heap tracking
+- periodic min-ts advancement driven by PD TSO and concurrency-manager locks
+- leadership confirmation before publishing progress
+- memory quota, re-registration, and diagnosis surfaces for observed regions
+
+This crate does not own TiCDC or log backup task semantics. It owns the shared
+timestamp computation and observation pipeline those subsystems depend on.
+
+## Architectural Views
+
+### Progress-computation view
+
+1. `Observer` subscribes to lock-relevant applied command batches plus
+   role/region changes from raftstore.
+2. `Endpoint` owns the observed-region map and per-region `Resolver`.
+3. `ScannerPool` acquires an incremental snapshot and scans existing locks for
+   a newly observed region.
+4. `Resolver` tracks pending and steady-state locks, tracked apply index, and
+   the region's current resolved-ts.
+5. `AdvanceTsWorker` obtains a fresh lower bound from PD and the concurrency
+   manager, then `LeadershipResolver` confirms leadership before the endpoint
+   publishes the advanced timestamp.
+
+### State-ownership view
+
+- `ObserveRegion`: one observed region plus observe handle, metadata, and
+  resolver state
+- `ResolverStatus::Pending`:
+  initialization state while lock scan and buffered change logs are still being
+  merged
+- `Resolver`:
+  steady-state lock heap, tracked index, min-ts, and diagnosis state
+- `TsSource`:
+  the explanation for why progress advanced or stalled
+
+## Process Lifecycle And Startup Sequencing
+
+- Classic `RaftKv` startup wiring lives in `components/server/src/server.rs`.
+- `RaftKv2` startup wiring lives in `components/server/src/server2.rs`.
+- `resolved_ts` starts only when `resolved_ts.enable` is true.
+- Required startup order:
+  1. create the worker and scheduler
+  2. register `Observer` on the coprocessor host
+  3. register `ResolvedTsConfigManager`
+  4. construct `Endpoint`
+  5. start the worker that owns the endpoint
+  6. keep the scheduler available for subsystems that explicitly schedule
+     resolved-ts tasks, such as debug-service diagnosis
+- Relationship note:
+  - CDC and backup-stream are closely related consumers of resolved-ts
+    semantics, config, and invariants
+  - they do not consume the resolved-ts worker scheduler directly during
+    bootstrap; each owns its own min-ts / leadership-resolution path
+- `Endpoint::new` also creates:
+  - the lock-scan runtime and concurrency semaphore
+  - the advance-ts worker
+  - memory quota tracking for pending locks and steady-state lock heaps
+  - the leadership resolver used to validate leader quorum before publishing
+    progress
+
+Shutdown rule:
+
+- Stop dependent publishers and diagnostics before tearing down the endpoint and
+  scan runtimes. Otherwise in-flight re-register, advance-ts, or diagnosis
+  tasks can observe partially dismantled state and report misleading errors.
+
+## Data Model And Metadata Contracts
+
+- `Task` in `endpoint.rs` is the main internal protocol:
+  `RegisterRegion`, `ScanLocks`, `ResolvedTsAdvanced`, `RegionUpdated`,
+  `RegionDestroyed`, `ReRegisterRegion`, and diagnosis tasks all route through
+  it.
+- `ObserveHandle` / `ObserveId` are ABA guards. They must stay attached to
+  scan, re-register, and applied-change processing.
+- `ObserveRegion` binds region metadata, one observe handle, one resolver, and
+  one initialization state machine.
+- `Resolver` tracks:
+  - `locks_by_key`
+  - `lock_ts_heap`
+  - large-transaction representatives
+  - `tracked_index`
+  - `resolved_ts`
+  - `min_ts`
+  - `last_attempt`
+- `TsSource` is a diagnosis and contract surface. It distinguishes whether
+  progress was limited by a lock, a memory lock in concurrency manager, PD TSO,
+  CDC, or backup-stream.
+- `RegionReadProgress` integration is part of the contract because stale-read
+  users consume the published safe progress.
+
+## Start Here
+
+- `components/resolved_ts/src/lib.rs`
+- `components/resolved_ts/src/observer.rs`
+- `components/resolved_ts/src/endpoint.rs`
+- `components/resolved_ts/src/resolver.rs`
+- `components/resolved_ts/src/scanner.rs`
+- `components/resolved_ts/src/advance.rs`
+- `components/resolved_ts/src/cmd.rs`
+- `components/resolved_ts/src/metrics.rs`
+
+## Must-Read File Order
+
+1. `components/resolved_ts/src/lib.rs`
+2. `components/resolved_ts/src/observer.rs`
+3. `components/resolved_ts/src/endpoint.rs`
+4. `components/resolved_ts/src/resolver.rs`
+5. `components/resolved_ts/src/scanner.rs`
+6. `components/resolved_ts/src/advance.rs`
+7. `components/resolved_ts/src/cmd.rs`
+8. `components/resolved_ts/src/metrics.rs`
+
+## Core Concepts
+
+- Resolved-ts:
+  a conservative timestamp such that no future commit below it should still
+  appear for the observed region
+- Initial scan:
+  the snapshot-based lock scan that seeds the resolver before steady-state
+  apply-event tracking begins
+- Tracked index:
+  the apply index boundary proving how far the resolver has consumed region
+  history
+- Leadership resolution:
+  quorum confirmation via `CheckLeader` RPC before a leader publishes advanced
+  progress
+- `TsSource`:
+  the reason progress advanced or stalled
+
+## Why It Matters
+
+This crate is a cross-component correctness hinge. Bugs here can make CDC or
+backup-stream look healthy while silently advancing progress too far, or they
+can stall whole downstream systems behind a conservative but incorrect zero or
+stale resolved-ts.
+
+## Critical Invariants
+
+- Resolved-ts may advance only after the leader has applied on its own term.
+- Only lock-relevant change logs should be fed into the resolver. Expanding or
+  shrinking that filter changes both correctness and memory pressure.
+- Initial scan results must merge with buffered change logs without losing the
+  tracked-index ordering boundary.
+- `ObserveId` checks must guard all long-lived async work to prevent stale scan
+  results or re-registers from mutating a new owner.
+- Resolver tracked index must be monotonic.
+- Published resolved-ts must be no greater than the minimum of:
+  - the current lower-bound timestamp
+  - the oldest tracked lock
+  - the concurrency manager's global in-memory min lock
+- Leadership must be confirmed before publishing advanced progress; local
+  leader state alone is not sufficient.
+- Memory quota accounting for pending locks and lock heaps must stay balanced on
+  error, cancellation, and drop paths.
+
+## Observability And Operational Signals
+
+Open `components/resolved_ts/src/metrics.rs` first. The most useful signals
+are:
+
+- `tikv_resolved_ts_min_resolved_ts`
+- `tikv_resolved_ts_min_resolved_ts_gap_millis`
+- `tikv_resolved_ts_min_leader_resolved_ts`
+- `tikv_resolved_ts_min_leader_resolved_ts_gap_millis`
+- `tikv_resolved_ts_min_follower_resolved_ts`
+- `tikv_resolved_ts_min_follower_resolved_ts_gap_millis`
+- `tikv_resolved_ts_zero_resolved_ts`
+- `tikv_resolved_ts_scan_tasks`
+- `tikv_resolved_ts_scan_duration_seconds`
+- `tikv_resolved_ts_initial_scan_backoff_duration_seconds`
+- `tikv_resolved_ts_fail_advance_count`
+- `tikv_resolved_ts_lock_heap_bytes`
+- `tikv_resolved_ts_memory_quota_in_use_bytes`
+- `tikv_check_leader_request_pending_count`
+- `tikv_resolved_ts_region_resolve_status`
+- `tikv_concurrency_manager_min_lock_ts`
+
+Operationally useful logs cluster around:
+
+- repeated re-register after scan or epoch errors
+- check-leader timeouts or failures
+- memory quota exhaustion for pending locks
+- regions stuck at zero resolved-ts
+- long gaps between now and the minimum leader/follower resolved-ts
+
+## Change Management Guidance
+
+- If a patch changes lock observation, tracked apply-index behavior, or
+  scan/re-register flow, review CDC and backup-stream in the same change.
+- If a patch changes `TsSource`, diagnosis output, or read-progress integration,
+  review stale-read and debug-service consumers too.
+- If a patch changes memory quota, lock tracking strategy, or large-txn
+  handling, audit both steady-state latency and failure cleanup paths.
+- If a patch changes leadership validation or PD/concurrency-manager min-ts
+  handling, review it as a correctness change, not a performance tweak.
+
+## Change-Impact Matrix
+
+- Observer or applied-change filtering changes:
+  inspect `observer.rs`, `cmd.rs`, and resolver lock tracking
+- Initial scan changes:
+  inspect `scanner.rs`, `endpoint.rs`, and re-register behavior
+- Resolver logic changes:
+  inspect `resolver.rs`, lock heap accounting, and read-progress updates
+- Min-ts advancement changes:
+  inspect `advance.rs`, concurrency manager interaction, and leader checks
+- Diagnosis or debug-service changes:
+  inspect endpoint diagnosis tasks and `src/server/service/debug.rs`
+
+## Review Checklist
+
+- Does the patch preserve the apply-on-current-term requirement?
+- Does it change the set of applied commands that resolved-ts observes?
+- Does it change scan/barrier ordering between initial locks and delta events?
+- Does it change `ObserveId` or tracked-index guards on async work?
+- Does it change how concurrency-manager min locks cap progress?
+- Does it change leader-check quorum logic, retry cadence, or timeout behavior?
+- Does it change memory quota accounting for pending or steady-state locks?
+
+## Observability And Tests
+
+- Unit-heavy coverage lives in `observer.rs`, `resolver.rs`, `scanner.rs`, and
+  `endpoint.rs`.
+- Production regressions often require leadership change, split/merge, or
+  long-running lock scenarios; pure unit tests are often insufficient.
+- The debug service in `src/server/service/debug.rs` is a useful maintainer
+  entry point when triaging stuck progress on live nodes.
+
+## Common Failure Modes
+
+- region stuck at zero resolved-ts after failed initial scan or missed
+  re-register
+- progress advancing too far because a lock source was missed
+- progress lag caused by stale in-memory min-lock state or failed max-ts update
+- stale async scan result mutating a newly re-observed region
+- memory pressure from large lock heaps or pending-lock buildup
+- check-leader RPC failures causing long progress stalls
+
+## Reading Map And Companion Docs
+
+Suggested reading order:
+
+1. `lib.rs`
+2. `observer.rs`
+3. `endpoint.rs`
+4. `resolver.rs`
+5. `scanner.rs`
+6. `advance.rs`
+
+Companion docs:
+
+- `repo-overview.md`
+- `src/server.md`
+- `components/cdc.md`
+- `components/backup-stream.md`
+- `src/storage.md`
+- `src/gc_worker.md`
+
+## Glossary
+
+- Resolved-ts:
+  the conservative timestamp below which no new commit should still appear for
+  the observed region
+- Change log:
+  the filtered apply-event payload used to track locks and commits
+- Initial scan:
+  the bootstrap lock scan over a region snapshot
+- Tracked index:
+  the highest apply index the resolver has incorporated
+- Check-leader:
+  the quorum confirmation RPC used before publishing progress
+
+## Related Components
+
+- `components/cdc`
+- `components/backup-stream`
+- `components/raftstore`
+- `components/raftstore-v2`
+- `src/storage`

--- a/doc/maintenance-guides/components/sst_importer.md
+++ b/doc/maintenance-guides/components/sst_importer.md
@@ -1,0 +1,232 @@
+# `components/sst_importer` Maintenance Guide
+
+## Purpose And Scope
+
+`components/sst_importer` is the shared library behind TiKV's SST import and
+restore flows. It owns:
+
+- import-directory layout and file lifecycle
+- upload target creation and validation
+- download from external storage
+- rewrite / merge / prepare-for-ingest helpers
+- importer-side caching and memory quota
+- import-mode switching for classic and partitioned-raft-kv engines
+
+The RPC-facing import service lives in `src/import`. This crate is the storage
+and file-management backend used by that service.
+
+## Architectural Views
+
+### File lifecycle view
+
+1. `ImportDir` defines the root, `.temp`, and `.clone` directories.
+2. `ImportFile` writes to a temporary file, validates CRC32, and renames it
+   into the durable import directory.
+3. `SstImporter` manages already-uploaded files plus externally downloaded
+   files and in-memory buffers.
+4. Import service or raftstore ingest code later asks for preparation,
+   verification, or ingest-specific clones.
+
+### Import-mode view
+
+- `import_mode.rs` is the classic single-RocksDB switcher. Import mode is
+  global for the shared KV engine and modifies RocksDB options.
+- `import_mode2.rs` is the `RaftKv2` / partitioned-raft-kv switcher. Import
+  mode is range-scoped and does not rewrite RocksDB options globally.
+
+## Process Lifecycle And Startup Sequencing
+
+- `SstImporter` instances are created during server bootstrap in:
+  - `components/server/src/server.rs`
+  - `components/server/src/server2.rs`
+- Creation initializes:
+  - import directory structure
+  - download/runtime infrastructure
+  - cache GC loop
+  - memory quota derived from `import.memory_use_ratio`
+- `src/import::ImportSstService` later calls
+  `start_switch_mode_check(...)` and periodically refreshes dynamic settings.
+
+Shutdown rule:
+
+- The importer's background runtime must outlive in-flight downloads and cache
+  cleanup work. Avoid extracting ad hoc download helpers that bypass the
+  importer's owned runtime.
+
+## Data Model And Metadata Contracts
+
+- `ImportDir` path layout is part of the maintenance surface:
+  - `<root>/`
+  - `<root>/.temp/`
+  - `<root>/.clone/`
+- `ImportPath` tracks three paths for one SST:
+  - `temp`: upload in progress
+  - `save`: durable imported file
+  - `clone`: ingest-side clone or prepared path
+- `ImportFile` validates CRC32 against `SstMeta` before finalizing the file.
+- `SstImporter` couples:
+  - `BackendConfig`
+  - encryption key manager / master keys
+  - API version expectations
+  - cache entries and file-lock state
+- `CacheKvFile` has multiple states, including deduplicated in-progress
+  download state. That state machine is correctness-sensitive, not just a
+  cache optimization.
+
+## Start Here
+
+- `components/sst_importer/src/lib.rs`
+- `components/sst_importer/src/sst_importer.rs`
+- `components/sst_importer/src/import_file.rs`
+- `components/sst_importer/src/import_mode.rs`
+- `components/sst_importer/src/import_mode2.rs`
+- `components/sst_importer/src/sst_writer.rs`
+- `components/sst_importer/src/metrics.rs`
+- `components/sst_importer/src/config.rs`
+- `components/sst_importer/src/errors.rs`
+
+## Must-Read File Order
+
+1. `components/sst_importer/src/sst_importer.rs`
+2. `components/sst_importer/src/import_file.rs`
+3. `components/sst_importer/src/import_mode.rs`
+4. `components/sst_importer/src/import_mode2.rs`
+5. `components/sst_importer/src/sst_writer.rs`
+6. `components/sst_importer/src/config.rs`
+7. `components/sst_importer/src/errors.rs`
+8. `components/sst_importer/src/metrics.rs`
+
+## Core Concepts
+
+- `SstImporter`: the main owner of import files, downloads, cache, and mode
+  switching
+- `ImportDir`: the on-disk directory contract
+- `ImportModeSwitcher` / `ImportModeSwitcherV2`: classic vs range-scoped import
+  mode
+- `CacheKvFile`: importer-side cache entry and in-flight dedup state
+- `DownloadedSstFile`: disk-backed or memory-backed downloaded SST
+
+## Why It Matters
+
+This crate sits on the boundary between external restore data and TiKV local
+storage. Bugs here commonly surface as file corruption, stale downloads, wrong
+API-version handling, or import-mode behavior that silently distorts ingest
+performance.
+
+## Critical Invariants
+
+- `ImportFile::finish` must validate CRC32 before rename.
+- Temporary-file cleanup must not delete successfully finalized files or leave
+  stale encryption metadata behind.
+- Classic import mode must restore RocksDB options after timeout.
+- Range-scoped import mode must only report overlap for the intended ranges.
+- Downloaded SST readers must verify checksum before use.
+- Cache state transitions must prevent duplicate downloads without turning
+  transient failures into permanent stuck state.
+- `import.memory_use_ratio` is intentionally bounded; callers should not bypass
+  that control with ad hoc large in-memory allocations.
+
+## Observability And Operational Signals
+
+Open `components/sst_importer/src/metrics.rs` first. The main signals are:
+
+- `tikv_import_download_duration`
+- `tikv_import_download_bytes`
+- `tikv_import_apply_bytes`
+- `tikv_import_ingest_duration`
+- `tikv_import_ingest_bytes`
+- `tikv_import_error_counter`
+- `tikv_import_storage_cache`
+- `tikv_import_apply_cached_bytes`
+- `tikv_import_apply_cache_event`
+- `tikv_import_applier_event`
+- `tikv_import_engine_request`
+
+The error taxonomy in `errors.rs::error_inc` is also part of the operational
+surface; patches that introduce new failure classes should decide whether a new
+metric label is needed.
+
+## Change Management Guidance
+
+- If a patch changes path layout, rename behavior, or checksum rules, update
+  this guide and review restore/import callers together.
+- If a patch changes import mode semantics, audit both classic `RaftKv` and
+  `RaftKv2` behavior explicitly; the two modes are intentionally different.
+- If a patch changes download caching or encryption handling, review both local
+  and external-storage code paths.
+- If a patch changes API-version checks, review `src/import` RPC validation and
+  restore tooling assumptions together.
+
+## Change-Impact Matrix
+
+- File lifecycle changes:
+  inspect `import_file.rs`, cleanup-on-drop, and encryption metadata handling
+- Download/cache changes:
+  inspect `sst_importer.rs`, `caching/*`, and external-storage wrappers
+- Import-mode changes:
+  inspect `import_mode.rs`, `import_mode2.rs`, and server bootstrap/service
+  callers
+- API-version or key rewrite changes:
+  inspect `sst_writer.rs`, `sst_importer.rs`, and `src/import`
+
+## Review Checklist
+
+- Does the patch change temp/save/clone path semantics?
+- Does it change checksum or integrity verification before ingest?
+- Does it change classic import-mode option restoration?
+- Does it change range-overlap behavior for `RaftKv2` import mode?
+- Does it change download deduplication, cache expiry, or encryption wrapping?
+- Does it change API-version compatibility or key-prefix rewriting?
+
+## Observability And Tests
+
+- Test helpers live in `components/test_sst_importer/src/lib.rs`.
+- `components/sst_importer/src/sst_importer.rs` contains extensive unit coverage.
+- Many regressions are easiest to reproduce through `src/import` service tests
+  or higher-level restore flows because RPC chunking and engine interaction are
+  outside this crate.
+
+## Common Failure Modes
+
+- CRC mismatch or malformed imported file
+- leaked temp files or orphaned encryption metadata
+- import mode not reverting after timeout
+- range-scoped import mode overlapping too much or too little
+- stale in-progress cache entries suppressing retries
+- incompatible API-version data entering the ingest path
+
+## Reading Map And Companion Docs
+
+Suggested reading order:
+
+1. `sst_importer.rs`
+2. `import_file.rs`
+3. `import_mode.rs`
+4. `import_mode2.rs`
+5. `errors.rs`
+
+Companion docs:
+
+- `repo-overview.md`
+- `src/import.md`
+- `components/backup.md`
+- BR overview:
+  `https://docs.pingcap.com/tidb/stable/backup-and-restore-overview/`
+
+## Glossary
+
+- Import dir:
+  the local directory tree used to stage imported SSTs
+- Import mode:
+  a temporary mode optimized for ingest-heavy workloads
+- Clone path:
+  a prepared file path used for ingest-specific handling
+- Download state:
+  importer cache entry representing an in-progress external download
+
+## Related Components
+
+- `src/import`
+- `components/external_storage`
+- `components/encryption`
+- `components/engine_rocks`

--- a/doc/maintenance-guides/repo-overview.md
+++ b/doc/maintenance-guides/repo-overview.md
@@ -105,7 +105,11 @@ work:
 - `components/backup` and `components/backup-stream` own backup and log-backup
   surfaces.
 - `components/cdc` owns changefeed capture and delivery.
+- `components/resolved_ts` owns the shared progress engine used by CDC,
+  backup-stream, and stale-read-style consumers.
 - `src/import` and `components/sst_importer` own SST import and ingest flows.
+- `src/server/gc_worker` owns MVCC GC, GC auto-scheduling, compaction-filter
+  integration, and related safe-point enforcement.
 
 Repository boundary rule:
 

--- a/doc/maintenance-guides/src/gc_worker.md
+++ b/doc/maintenance-guides/src/gc_worker.md
@@ -1,0 +1,267 @@
+# `src/server/gc_worker` Maintenance Guide
+
+## Purpose And Scope
+
+`src/server/gc_worker` owns TiKV's MVCC garbage-collection worker subsystem at
+the actual repo ownership boundary. It covers:
+
+- MVCC GC for leader-owned regions
+- raw KV GC for raw keys
+- unsafe destroy-range execution
+- orphan-version cleanup delegated from compaction filters
+- auto-GC scheduling based on PD safe point
+- GC-related compaction-filter and auto-compaction integration
+- dynamic config and runtime scaling for GC worker threads
+
+This is the subsystem both BR- and CDC-adjacent maintainers need to read when a
+change touches safe point, GC pace, or MVCC retention behavior.
+
+## Architectural Views
+
+### Task-execution view
+
+1. `GcWorker` owns the worker scheduler, runner pool, and current safe point.
+2. `GcManager` polls PD for the latest GC safe point and scans leader regions
+   on this store.
+3. Region work becomes `GcTask` items such as `Gc`, `GcKeys`, `RawGcKeys`,
+   `UnsafeDestroyRange`, or `OrphanVersions`.
+4. `GcRunner` performs MVCC reads, deletes obsolete versions, and writes the
+   cleanup results back through the engine.
+5. Compaction-filter and auto-compaction helpers either delete obsolete
+   versions inline or bounce fallback work back into the GC worker.
+
+### Control-plane view
+
+- `GcSafePointProvider` abstracts PD safe-point reads.
+- `GcWorkerConfigManager` applies dynamic config changes.
+- `CompactionRunner` evaluates region candidates for automatic compaction.
+- `WriteCompactionFilterFactory` and raw-KV compaction filters reuse the same
+  safe point and config state.
+
+## Process Lifecycle And Startup Sequencing
+
+- Classic startup wiring lives in `components/server/src/server.rs`.
+- `RaftKv2` startup wiring lives in `components/server/src/server2.rs`.
+- Shared startup order:
+  1. create `GcWorker`
+  2. register `GcWorkerConfigManager`
+  3. wire the worker into storage/server services that submit GC tasks
+  4. after the node/store id is known, call `gc_worker.start(...)`
+  5. call `start_auto_gc(...)`, which also initializes compaction-filter
+     context for the disk engine before starting `GcManager`
+- Path-specific note:
+  - classic `RaftKv` currently starts auto-compaction after `start_auto_gc(...)`
+  - `RaftKv2` currently does not start the auto-compaction runner in bootstrap
+- `GcWorker::new` owns:
+  - the safe-point cache
+  - the runner pool and write limiter
+  - scheduler capacity and task backpressure behavior
+  - dynamic config tracker
+
+Shutdown rule:
+
+- Stop auto-GC and, if it was started on this path, auto-compaction before
+  dropping the worker scheduler or compaction-filter context. Otherwise
+  background threads can keep enqueueing work into a partially dismantled
+  worker.
+
+## Data Model And Metadata Contracts
+
+- `GcTask` in `gc_worker.rs` is the main execution contract:
+  `Gc`, `GcKeys`, `RawGcKeys`, `UnsafeDestroyRange`, and `OrphanVersions`.
+- PD GC safe point is a correctness contract, not a hint. GC must never delete
+  MVCC history newer than the effective safe point.
+- `check_need_gc` in `mod.rs` is an optimization boundary based on MVCC table
+  properties. It may produce false positives, but false negatives or a
+  semantic change affect liveness and cleanup cost.
+- `GcConfig` and `AutoCompactionConfig` are live operational contracts for:
+  - batch size
+  - write throttling
+  - compaction-filter enablement
+  - thread count
+  - automatic compaction thresholds
+- `RegionInfoProvider` is part of the subsystem contract because auto-GC and
+  range tasks depend on current leader-owned region layout.
+
+## Start Here
+
+- `src/server/gc_worker/mod.rs`
+- `src/server/gc_worker/gc_worker.rs`
+- `src/server/gc_worker/gc_manager.rs`
+- `src/server/gc_worker/config.rs`
+- `src/server/gc_worker/compaction_filter.rs`
+- `src/server/gc_worker/rawkv_compaction_filter.rs`
+- `src/server/gc_worker/compaction_runner.rs`
+
+## Must-Read File Order
+
+1. `src/server/gc_worker/mod.rs`
+2. `src/server/gc_worker/gc_worker.rs`
+3. `src/server/gc_worker/gc_manager.rs`
+4. `src/server/gc_worker/config.rs`
+5. `src/server/gc_worker/compaction_filter.rs`
+6. `src/server/gc_worker/rawkv_compaction_filter.rs`
+7. `src/server/gc_worker/compaction_runner.rs`
+
+## Core Concepts
+
+- Safe point:
+  the global lower bound below which obsolete MVCC history may be removed
+- Auto-GC:
+  the loop that polls PD and schedules per-region GC on leader-owned regions
+- Orphan versions:
+  default-CF versions left for GC worker cleanup when compaction filter cannot
+  finish the delete path inline
+- Compaction filter:
+  RocksDB-time GC of old MVCC versions, guarded by cluster-version and runtime
+  safety checks
+- Auto compaction:
+  background region candidate selection based on tombstones, redundant rows, and
+  optionally MVCC-read pressure
+
+## Why It Matters
+
+This subsystem enforces retention and cleanup safety for TiKV MVCC state. Bugs
+here can corrupt snapshot visibility, leak large amounts of obsolete data, or
+let safe-point-sensitive subsystems such as CDC and BR observe history that was
+deleted too early.
+
+## Critical Invariants
+
+- Safe point must be treated as a hard upper bound on what GC may delete.
+- Auto-GC should only schedule region GC for regions whose leader is on this
+  store.
+- `GcTask` ordering and backpressure must not silently drop cleanup work.
+- `UnsafeDestroyRange` remains a destructive administrative path and must keep
+  strict region/context validation.
+- Compaction filter must not run before safe point is initialized and must
+  honor version-gate restrictions unless explicitly overridden.
+- Fallback work from compaction filter must preserve correctness when the DB is
+  stalled or inline cleanup cannot proceed.
+- Dynamic config changes, especially thread count and write throttling, must
+  take effect without leaving the worker in a half-updated state.
+
+## Observability And Operational Signals
+
+Start with:
+
+- `src/server/metrics.rs`
+- metrics registered in `compaction_filter.rs`
+- metrics registered in `compaction_runner.rs`
+
+The most useful signals are:
+
+- auto-GC status gauges
+- GC task latency and backlog metrics
+- write-throttle and batch behavior metrics
+- `tikv_gc_compaction_filtered`
+- `tikv_gc_compaction_failure`
+- `tikv_gc_compaction_filter_skip`
+- `tikv_gc_compaction_filter_perform`
+- `tikv_gc_compaction_filter_orphan_versions`
+- `tikv_gc_compaction_filter_mvcc_deletion_met`
+- `tikv_gc_compaction_filter_mvcc_deletion_handled`
+- `tikv_gc_compaction_filter_mvcc_deletion_wasted`
+- `tikv_auto_compaction_duration_seconds`
+- `tikv_auto_compaction_regions_meet_threshold`
+- `tikv_auto_compaction_pending_candidates`
+- `tikv_auto_compaction_score`
+
+Operationally useful logs appear around:
+
+- safe-point polling failures
+- repeated region scan/retry loops in auto-GC
+- compaction-filter version-gate or stalled-DB skips
+- worker saturation or schedule failures
+- long-running GC tasks and destroy-range paths
+
+## Change Management Guidance
+
+- If a patch changes safe-point semantics, update this guide and review CDC,
+  backup-stream, and storage snapshot readers in the same change.
+- If a patch changes compaction-filter behavior, audit fallback orphan-version
+  cleanup and downgrade/version-gate safety.
+- If a patch changes region selection or auto-GC cadence, review split/merge
+  and leader-transfer behavior explicitly.
+- If a patch changes auto-compaction scoring, thresholds, or MVCC-read-aware
+  prioritization, review operational impact as well as correctness.
+
+## Change-Impact Matrix
+
+- Safe-point or task semantics changes:
+  inspect `gc_worker.rs`, `gc_manager.rs`, and storage MVCC GC helpers
+- Dynamic config changes:
+  inspect `config.rs`, pool scaling, and limiter behavior
+- Compaction-filter changes:
+  inspect `compaction_filter.rs`, `rawkv_compaction_filter.rs`, and fallback
+  `OrphanVersions` task flow
+- Auto-compaction changes:
+  inspect `compaction_runner.rs`, region candidate scoring, and thresholds
+- Destroy-range or raw-GC changes:
+  inspect `GcTask` variants and region/provider validation
+
+## Review Checklist
+
+- Does the patch preserve safe-point correctness under retries and failures?
+- Does it change which regions auto-GC schedules on a store?
+- Does it change batch sizing, limiter behavior, or task backlog semantics?
+- Does it change compaction-filter gating, fallback, or downgrade safety?
+- Does it change orphan-version cleanup or raw-KV GC behavior?
+- Does it change auto-compaction scoring or candidate eligibility?
+
+## Observability And Tests
+
+- Inline tests exist across `gc_worker.rs`, `mod.rs`, compaction-filter code,
+  and auto-compaction helpers.
+- Failpoint and cluster-style validation are important for compaction-filter,
+  leadership, and safe-point race conditions.
+- This guide complements `src/server.md`; use the dedicated guide when the
+  change is truly about GC semantics rather than general server wiring.
+
+## Common Failure Modes
+
+- safe-point drift causing GC to run too conservatively or too aggressively
+- GC worker backlog causing long retention lag
+- auto-GC scanning stale region ownership and skipping needed cleanup
+- compaction filter disabled unexpectedly due to version gate or DB stall
+- orphan versions accumulating after fallback cleanup fails
+- auto-compaction picking poor candidates and amplifying write pressure
+
+## Reading Map And Companion Docs
+
+Suggested reading order:
+
+1. `mod.rs`
+2. `gc_worker.rs`
+3. `gc_manager.rs`
+4. `config.rs`
+5. `compaction_filter.rs`
+6. `compaction_runner.rs`
+
+Companion docs:
+
+- `repo-overview.md`
+- `src/server.md`
+- `src/storage.md`
+- `components/cdc.md`
+- `components/backup-stream.md`
+- `components/resolved_ts.md`
+
+## Glossary
+
+- GC safe point:
+  the PD-published timestamp below which obsolete MVCC history may be deleted
+- Auto-GC round:
+  one pass that scans current leader-owned regions and schedules GC tasks
+- Orphan versions:
+  default-CF remnants left for worker-side cleanup after compaction-filter work
+- Destroy range:
+  the administrative path that forcefully removes a key range
+
+## Related Components
+
+- `src/storage`
+- `src/server`
+- `components/cdc`
+- `components/backup-stream`
+- `components/resolved_ts`

--- a/doc/maintenance-guides/src/import.md
+++ b/doc/maintenance-guides/src/import.md
@@ -1,0 +1,247 @@
+# `src/import` Maintenance Guide
+
+## Purpose And Scope
+
+`src/import` owns TiKV's RPC-facing import and ingest service. It exposes the
+APIs used by Lightning and restore workflows to:
+
+- upload SSTs to a TiKV node
+- download and rewrite remote SST/KV files
+- apply KV data through raft writes
+- ingest prepared SST files into region engines
+- detect duplicates for conflict checks
+- suspend or gate import traffic
+- switch import mode and manage force-partition ranges
+
+This module is the service layer above `components/sst_importer`.
+
+## Architectural Views
+
+### Service-layer view
+
+`ImportSstService` in `sst_service.rs` is the main entry point. It owns RPC
+handlers for:
+
+- `upload`
+- `download`
+- `batch_download`
+- `batch_download_latest_mvcc`
+- `apply`
+- `ingest`
+- `multi_ingest`
+- `write` / `raw_write`
+- `duplicate_detect`
+- `switch_mode`
+- `suspend_import_rpc`
+- force-partition-range management
+
+### Apply / ingest split
+
+- `apply` rewrites downloaded KV data into regular raft writes. It is heavy on
+  request batching, TLS-engine apply workers, and txn-source tagging.
+- `ingest` / `multi_ingest` ingest already prepared SSTs into the target region
+  after region and snapshot checks.
+
+## Process Lifecycle And Startup Sequencing
+
+- Service bootstrap is in:
+  - `components/server/src/server.rs`
+  - `components/server/src/server2.rs`
+- It starts after the shared `SstImporter` exists and after the main storage
+  engine/tablet registry is ready.
+- `ImportSstService::new` creates:
+  - a resizable Tokio runtime whose worker threads install the TLS engine
+  - a `ConfigManager` that can resize the runtime dynamically
+  - a background ticker that refreshes importer memory settings and cache
+    shrink behavior
+  - a `ThrottledTlsEngineWriter` GC loop
+
+Shutdown rule:
+
+- The runtime worker threads own the TLS engine registration used by
+  `raft_writer.rs`. Do not move apply work onto threads that have not installed
+  the expected engine type.
+
+## Data Model And Metadata Contracts
+
+- `RequestCollector` in `sst_service.rs` is the main apply-path batching
+  contract.
+  - It de-duplicates write-CF keys.
+  - It batches requests conservatively against raft-entry size.
+  - It emits `WriteData` units consumed by `raft_writer.rs`.
+- `prepare_write` sets the Lightning physical-import txn-source bit. CDC relies
+  on that bit to suppress imported traffic from normal TiCDC semantics.
+- `IngestLatch` in `ingest.rs` prevents duplicate ingest of the same SST path
+  within one CF.
+- `SuspendDeadline` is the service-wide temporary admission gate for import
+  requests.
+- `duplicate_detect.rs` scans `CF_WRITE` and, when needed, `CF_DEFAULT` to
+  report conflicting historical versions after a given `min_commit_ts`.
+- Region freshness checks compare the request epoch with local region info
+  before heavy work begins.
+
+## Start Here
+
+- `src/import/mod.rs`
+- `src/import/sst_service.rs`
+- `src/import/ingest.rs`
+- `src/import/raft_writer.rs`
+- `src/import/duplicate_detect.rs`
+
+## Must-Read File Order
+
+1. `src/import/sst_service.rs`
+2. `src/import/ingest.rs`
+3. `src/import/raft_writer.rs`
+4. `src/import/duplicate_detect.rs`
+5. `components/sst_importer/src/sst_importer.rs`
+6. `components/sst_importer/src/import_mode.rs`
+7. `components/sst_importer/src/import_mode2.rs`
+
+## Core Concepts
+
+- `ImportSstService`: the RPC facade
+- `RequestCollector`: apply-path batcher and deduplicator
+- `ThrottledTlsEngineWriter`: per-region apply throttling over TLS engine state
+- `IngestLatch`: duplicate-ingest guard
+- `SuspendDeadline`: temporary request rejection gate
+- `DuplicateDetector`: conflict scanner over MVCC history
+
+## Why It Matters
+
+This module is where remote restore/import traffic becomes real local writes or
+ingest operations. Small mistakes here can create Raft-entry blowups, duplicate
+apply, stalled regions, unexpected CDC side effects, or subtle restore
+corruption.
+
+## Critical Invariants
+
+- Write-CF apply batching must not send duplicate keys in one request. The
+  resolved-ts and apply path assume this.
+- Lightning physical import writes must preserve the txn-source bit masking
+  expected by CDC.
+- Ingest must acquire a fresh snapshot before checking file existence and
+  submitting ingest writes, so the leader is current-term and the region view is
+  coherent.
+- Region epoch checks must happen before expensive upload/download/apply work.
+- Resource checks for memory and disk are part of admission control, not just
+  best-effort warnings.
+- `RaftKv2` import mode requires explicit ranges; do not silently fall back to
+  classic global import-mode assumptions.
+- TLS-engine apply workers must run only on threads where the matching engine
+  type was installed.
+
+## Observability And Operational Signals
+
+Most metrics live in `components/sst_importer/src/metrics.rs`. For this module,
+the most useful ones are:
+
+- `tikv_import_rpc_duration`
+- `tikv_import_rpc_count`
+- `tikv_import_upload_chunk_bytes`
+- `tikv_import_upload_chunk_duration`
+- `tikv_import_download_duration`
+- `tikv_import_ingest_duration`
+- `tikv_import_apply_duration`
+- `tikv_import_error_counter`
+- `tikv_import_applier_event`
+- `tikv_import_engine_request`
+
+Operationally useful logs are concentrated around:
+
+- region-staleness checks
+- apply batching and request-size behavior
+- resource rejection
+- ingest slowdowns / `server_is_busy`
+- import suspension and resume
+
+## Change Management Guidance
+
+- If a patch changes batching, deduplication, or txn-source tagging, review CDC
+  and resolved-ts interactions together with import logic.
+- If a patch changes ingest stalling or import-mode behavior, review both
+  classic and `RaftKv2` paths explicitly.
+- If a patch changes admission control, keep the user-visible retry semantics in
+  `Error::ResourceNotEnough`, `Error::Suspended`, and epoch-staleness errors
+  coherent.
+- If a patch changes force-partition-range or region-info access, audit split
+  and region-movement scenarios.
+
+## Change-Impact Matrix
+
+- Upload/download RPC changes:
+  inspect `sst_service.rs` plus `components/sst_importer`
+- Apply batching or throttling changes:
+  inspect `RequestCollector`, `raft_writer.rs`, and raft-entry sizing
+- Ingest correctness changes:
+  inspect `ingest.rs`, snapshot acquisition, and importer file state
+- Duplicate detection changes:
+  inspect `duplicate_detect.rs` and MVCC/value lookup rules
+- Import mode or suspension changes:
+  inspect `switch_mode`, `SuspendDeadline`, and server bootstrap/config wiring
+
+## Review Checklist
+
+- Does the patch change write-CF deduplication or batch splitting?
+- Does it change how the Lightning physical-import txn-source bit is set?
+- Does it change region epoch freshness checks?
+- Does it change ingest ordering around snapshot acquisition and file existence?
+- Does it change import-mode assumptions for `RaftKv2`?
+- Does it change resource rejection or suspension behavior seen by clients?
+
+## Observability And Tests
+
+- `src/import/sst_service.rs`, `raft_writer.rs`, and `duplicate_detect.rs` all
+  carry significant unit coverage.
+- `components/test_sst_importer` provides engine-side helpers.
+- Cluster-level import/restore behavior is also exercised indirectly through BR
+  and Lightning test suites outside this module.
+
+## Common Failure Modes
+
+- duplicate write-CF keys causing downstream panic or rejected apply
+- oversized raft requests due to incorrect batch accounting
+- stale region epoch errors after region movement
+- ingest conflict or missing file after retries
+- import service rejecting traffic because memory or disk thresholds are crossed
+- imported writes surfacing incorrectly in CDC because txn-source tagging broke
+
+## Reading Map And Companion Docs
+
+Suggested reading order:
+
+1. `sst_service.rs`
+2. `ingest.rs`
+3. `raft_writer.rs`
+4. `duplicate_detect.rs`
+5. `components/sst_importer/src/sst_importer.rs`
+
+Companion docs:
+
+- `repo-overview.md`
+- `components/sst_importer.md`
+- `components/cdc.md`
+- `components/resolved_ts.md`
+- `src/gc_worker.md`
+- `components/backup.md`
+- BR overview:
+  `https://docs.pingcap.com/tidb/stable/backup-and-restore-overview/`
+
+## Glossary
+
+- Apply:
+  rewrite remote KV records into normal raft writes
+- Ingest:
+  install prepared SST files through the engine ingest path
+- TLS engine:
+  the thread-local storage engine handle used by async apply workers
+- Physical import bit:
+  the txn-source bit marking Lightning physical import writes
+
+## Related Components
+
+- `components/sst_importer`
+- `components/cdc`
+- `components/raftstore`
+- `components/raftstore-v2`
+- `src/storage`

--- a/doc/maintenance-guides/src/server.md
+++ b/doc/maintenance-guides/src/server.md
@@ -122,6 +122,8 @@ High-risk service contracts:
 ### GC and lock manager
 
 - `gc_worker/*` implements MVCC garbage collection and compaction filter logic.
+- `src/gc_worker.md` is the dedicated maintenance map for GC-specific
+  correctness, safe-point, and compaction behavior.
 - `lock_manager/*` owns the live waiter-manager workers, deadlock detector, and
   RPC-facing lock-manager runtime.
 - This module sits on top of the storage-side wait-queue contracts in
@@ -217,6 +219,7 @@ Companion docs:
 
 - `repo-overview.md`
 - `components/server.md`
+- `src/gc_worker.md`
 - `src/storage.md`
 
 ## Glossary


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: ref https://github.com/tikv/tikv/issues/19757

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

- Add dedicated maintenance guides for `components/backup`, `components/backup-stream`,
  `components/cdc`, `components/resolved_ts`, `components/sst_importer`,
  `src/import`, and `src/server/gc_worker`.
- Update `doc/maintenance-guides/README.md`, `repo-overview.md`, and
  `src/server.md` so the new guides are part of the repository maintenance
  surface and reachable from the maintainer entrypoints.
- Expand the CDC glossary with explicit `Changefeed checkpoint` and
  `Changefeed resolved-ts` definitions.
- Add cross-component guidance around GC safe point, resolved-ts, CDC, BR, and
  import interactions.
- Fix review-found documentation inaccuracies in GC startup sequencing,
  `RaftKv2` snapshot-backup support, and the resolved-ts bootstrap relationship
  to CDC and backup-stream.

```commit-message
Add maintainer-oriented guides for BR backup, log backup, CDC, SST import,
resolved-ts, and GC worker related subsystems.

This change expands the maintenance-guide set under
`doc/maintenance-guides/` so reviewers and developers can find the real
ownership boundaries, startup anchors, invariants, observability signals, and
must-read files for these data-movement and progress-tracking paths.

It also adds missing cross-references from the guide index and repository
overview, documents CDC glossary terms for changefeed checkpoint and
changefeed resolved-ts, and corrects doc-level inaccuracies found during
deep review:
- GC worker startup sequencing now matches the actual bootstrap path
- `RaftKv2` snapshot backup is documented as unsupported today
- resolved-ts guide now distinguishes semantic coupling from direct scheduler
  consumption
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!--
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```