### PR TITLE
cloud/aws: abort on multipart complete error

### DIFF
--- a/components/cloud/aws/src/s3.rs
+++ b/components/cloud/aws/src/s3.rs
@@ -522,12 +522,19 @@ impl<'client> S3Uploader<'client> {
             })
             .await;
 
-            if upload_res.is_ok() {
-                retry_and_count(|| self.complete(), "complete_upload").await?;
-            } else {
-                let _ = retry_and_count(|| self.abort(), "abort_upload").await;
+            match upload_res {
+                Ok(()) => match retry_and_count(|| self.complete(), "complete_upload").await {
+                    Ok(()) => Ok(()),
+                    Err(err) => {
+                        let _ = retry_and_count(|| self.abort(), "abort_upload").await;
+                        Err(err)
+                    }
+                },
+                Err(err) => {
+                    let _ = retry_and_count(|| self.abort(), "abort_upload").await;
+                    Err(err)
+                }
             }
-            upload_res
         }
     }
 
@@ -1029,6 +1036,114 @@ mod tests {
             // length of magic_contents
             (magic_contents.len() / multi_part_size) as u64,
         );
+    }
+
+    #[tokio::test]
+    async fn test_s3_storage_multi_part_abort_after_complete_error() {
+        let _guard = MULTI_PART_TEST_LOCK.lock().await;
+        let magic_contents = "567890";
+
+        let bucket_name = StringNonEmpty::required("mybucket".to_string()).unwrap();
+        let mut bucket = BucketConf::default(bucket_name);
+        bucket.region = Some(StringNonEmpty::required("cn-north-1".to_string()).unwrap());
+
+        let mut config = Config::default(bucket);
+        let multi_part_size = 2;
+        // set multi_part_size to use upload_part function
+        config.multi_part_size = multi_part_size;
+        config.force_path_style = true;
+
+        // split magic_contents into 3 parts, so we mock 6 requests here(1 begin + 3
+        // part + 1 complete + 1 abort)
+        let client = StaticReplayClient::new(vec![
+            ReplayEvent::new(
+                http::Request::builder()
+                    .header("content-length", "0")
+                    .uri(Uri::from_static(
+                        "https://s3.cn-north-1.amazonaws.com.cn/mybucket/mykey?uploads"
+                    ))
+                    .body(SdkBody::from(""))
+                    .unwrap(),
+                http::Response::builder()
+                    .status(200)
+                    .body(SdkBody::from(
+                        r#"<?xml version="1.0" encoding="UTF-8"?>
+                            <InitiateMultipartUploadResult>
+                                <Bucket>mybucket</Bucket>
+                                <Key>mykey</Key>
+                                <UploadId>1</UploadId>
+                            </InitiateMultipartUploadResult>"#
+                    )).unwrap()
+            ),
+            ReplayEvent::new(
+                http::Request::builder()
+                    .header("content-length", "2")
+                    .uri(Uri::from_static(
+                        "https://s3.cn-north-1.amazonaws.com.cn/mybucket/mykey?x-id=UploadPart&partNumber=1&uploadId=1"
+                    ))
+                    .body(SdkBody::from("56"))
+                    .unwrap(),
+                http::Response::builder().status(200).body(SdkBody::from("")).unwrap()
+            ),
+            ReplayEvent::new(
+                http::Request::builder()
+                    .header("content-length", "2")
+                    .uri(Uri::from_static(
+                        "https://s3.cn-north-1.amazonaws.com.cn/mybucket/mykey?x-id=UploadPart&partNumber=2&uploadId=1"
+                    ))
+                    .body(SdkBody::from("78"))
+                    .unwrap(),
+                http::Response::builder().status(200).body(SdkBody::from("")).unwrap()
+            ),
+            ReplayEvent::new(
+                http::Request::builder()
+                    .header("content-length", "2")
+                    .uri(Uri::from_static(
+                        "https://s3.cn-north-1.amazonaws.com.cn/mybucket/mykey?x-id=UploadPart&partNumber=3&uploadId=1"
+                    ))
+                    .body(SdkBody::from("90"))
+                    .unwrap(),
+                http::Response::builder().status(200).body(SdkBody::from("")).unwrap()
+            ),
+            ReplayEvent::new(
+                http::Request::builder()
+                    .header("content-length", "216")
+                    .uri(Uri::from_static(
+                        "https://s3.cn-north-1.amazonaws.com.cn/mybucket/mykey?uploadId=1"
+                    ))
+                    .body(SdkBody::from(
+                        r#"<CompleteMultipartUpload xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Part><PartNumber>1</PartNumber></Part><Part><PartNumber>2</PartNumber></Part><Part><PartNumber>3</PartNumber></Part></CompleteMultipartUpload>"#
+                    ))
+                    .unwrap(),
+                http::Response::builder().status(404).body(SdkBody::from("Not Found")).unwrap()
+            ),
+            ReplayEvent::new(
+                http::Request::builder()
+                    .uri(Uri::from_static(
+                        "https://s3.cn-north-1.amazonaws.com.cn/mybucket/mykey?x-id=AbortMultipartUpload&uploadId=1"
+                    ))
+                    .body(SdkBody::from(""))
+                    .unwrap(),
+                http::Response::builder()
+                    .status(200)
+                    .body(SdkBody::from("")).unwrap()
+            ),
+        ]);
+
+        let creds = Credentials::from_keys("abc".to_string(), "xyz".to_string(), None);
+
+        let s = S3Storage::new_with_creds_client(config.clone(), client.clone(), creds).unwrap();
+        let err = s
+            .put(
+                "mykey",
+                PutResource(Box::new(magic_contents.as_bytes())),
+                magic_contents.len() as u64,
+            )
+            .await
+            .unwrap_err();
+
+        assert_str_contains!(err.to_string(), "Not Found");
+        client.assert_requests_match(&[]);
     }
 
     #[tokio::test]


### PR DESCRIPTION
<!-- Suggested PR title: cloud/aws: abort on multipart complete error -->

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: close #19780

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

This PR fixes the S3 multipart upload cleanup path when the final
`CompleteMultipartUpload` request fails.

- Preserve the existing successful multipart upload flow.
- Keep the existing best-effort abort behavior when uploading an individual
  part fails.
- Add the same best-effort abort behavior when all parts were uploaded but
  `CompleteMultipartUpload` returns an error.
- Preserve the original completion error as the result returned to the caller,
  so an abort failure does not mask the upload failure.
- Add unit coverage that verifies `AbortMultipartUpload` is issued after a
  failed `CompleteMultipartUpload`.

```commit-message
S3 multipart uploads already abort uploaded parts when the part upload
phase fails. However, if all parts are uploaded and the final
CompleteMultipartUpload request fails, the error path returned before
aborting the multipart upload.

This change makes the multipart uploader issue a best-effort abort when
CompleteMultipartUpload returns an error, while preserving the original
complete error as the result returned to the caller.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Verified locally:

```bash
cargo test -p aws test_s3_storage_multi_part -- --nocapture
# 3 passed; 0 failed

cargo test -p aws test_s3_storage_multi_part_abort -- --nocapture
# 2 passed; 0 failed

cargo test -p aws test_s3_storage_multi_part_abort_after_complete_error -- --nocapture
# 1 passed; 0 failed

make format
# exited 0

cargo fmt --all -- --check
# exited 0

git diff --check
# no output
```

Also run:

```bash
make clippy
```

This failed in the repository-level `cargo-deny` advisory check because the
current lockfile contains `anyhow v1.0.75`, which is reported under
`RUSTSEC-2026-0190`. This appears unrelated to this PR's S3 multipart upload
change.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!--
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Fix S3 external storage multipart uploads to abort uploaded parts when multipart completion fails.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multipart upload handling so failed finalization now properly aborts the upload and returns the error.
  * This prevents incomplete uploads from being left behind when the last step fails.
* **Tests**
  * Added coverage for the case where multipart upload completion fails, ensuring the abort path is exercised.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->