### PR TITLE
[cherry-pick] fix pushdown cast to datetime from float (#19532)

### DIFF
--- a/components/tidb_query_datatype/src/codec/mysql/time/mod.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/time/mod.rs
@@ -689,6 +689,13 @@ mod parser {
             1 | 2 => {
                 let result: i64 = components[0].convert(ctx).ok()?;
                 let whole_time = parse_from_i64(ctx, result, time_type, fsp)?;
+                if whole_time.is_zero() {
+                    // Should handle zero properly to match TiDB behaviors.
+                    return match handle_zero_date(ctx, TimeArgs::zero(fsp as i8, time_type)) {
+                        Ok(Some(args)) => Time::new(ctx, args).ok(),
+                        _ => None,
+                    };
+                }
                 let mut whole = [
                     whole_time.get_year(),
                     whole_time.get_month(),
@@ -2305,6 +2312,8 @@ mod tests {
     #[test]
     fn test_parse_from_real() -> Result<()> {
         let cases = vec![
+            ("0000-00-00 00:00:00", "0", 0),
+            ("0000-00-00 00:00:00.0", "0.0", 1),
             ("2000-03-05 00:00:00", "305", 0),
             ("2000-12-03 00:00:00", "1203", 0),
             ("2003-12-05 00:00:00.0", "31205", 1),
@@ -2337,6 +2346,38 @@ mod tests {
             Time::parse_from_real(&mut ctx, &case, TimeType::DateTime, 0, true).unwrap_err();
         }
         Ok(())
+    }
+
+    #[test]
+    fn test_parse_from_real_zero_date() {
+        let mut ctx = EvalContext::default();
+        for input in ["0", "0.0", "0.000"] {
+            let actual = parser::parse_from_float_string(
+                &mut ctx,
+                input.to_string(),
+                TimeType::DateTime,
+                0,
+                true,
+            );
+            assert!(actual.is_some());
+            assert_eq!(actual.unwrap().to_string(), "0000-00-00 00:00:00");
+        }
+
+        let mut ctx = EvalContext::from(TimeEnv {
+            no_zero_date: true,
+            strict_mode: true,
+            ..TimeEnv::default()
+        });
+        for input in ["0", "0.0", "0.000"] {
+            let actual = parser::parse_from_float_string(
+                &mut ctx,
+                input.to_string(),
+                TimeType::DateTime,
+                0,
+                true,
+            );
+            assert!(actual.is_none());
+        }
     }
 
     #[test]


### PR DESCRIPTION
Issue Number: ref #19534
### What is changed and how it works?

What's Changed:

This backport is also related to pingcap/tidb#67853.

```commit-message
properly handle zero date when casting 0.xx float/decimal values to date/datetime

When casting float/decimal values like 0.xx to DATE/DATETIME in TiKV
coprocessor, the parser previously parsed the integer part as 0 and returned
zero date/datetime. This is inconsistent with TiDB/MySQL semantics under
NO_ZERO_DATE and may cause pushed-down predicates to produce different results
from TiDB root execution.

This PR backports tikv/tikv#19532 to release-8.5 and makes the float/decimal
time parser handle zero date through the same zero-date path as TiDB.

(cherry picked from commit aa13e7a1adfb58324480817780256a68627a203d)
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests

- [x] Unit test
- [ ] Integration test
- [ ] Manual test
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note

```release-note
Fix inconsistent results between TiDB and TiKV when casting 0.xx float/decimal values to DATE/DATETIME in pushed-down expressions.
```