### PR TITLE
ime: recover watch after etcd gRPC compaction error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4170,6 +4170,7 @@ dependencies = [
  "engine_traits",
  "fail",
  "futures 0.3.15",
+ "grpcio",
  "hex 0.4.3",
  "keys",
  "kvproto",

--- a/components/in_memory_engine/Cargo.toml
+++ b/components/in_memory_engine/Cargo.toml
@@ -29,6 +29,7 @@ engine_rocks = { workspace = true }
 engine_traits = { workspace = true }
 fail = "0.5"
 futures = { version = "0.3", features = ["compat"] }
+grpcio = { workspace = true }
 hex = "0.4"
 keys = { workspace = true }
 kvproto = { workspace = true }

--- a/components/in_memory_engine/src/region_label.rs
+++ b/components/in_memory_engine/src/region_label.rs
@@ -505,14 +505,8 @@ pub mod tests {
                 .build()
                 .unwrap();
 
-        // Put a rule in etcd so reload_all_region_labels has something to load.
-        add_region_label_rule(
-            s.meta_client.clone(),
-            cluster_id,
-            &new_region_label_rule("cache/compaction-test", "a", "b"),
-        );
-
-        // Arm the flag — next Watch call will return the gRPC compaction error.
+        // Arm the flag before starting the watch so the very first Watch call
+        // fails with the gRPC compaction error.
         inject_flag.store(true, Ordering::Release);
 
         let background_worker = Builder::new("ime-compaction-test").thread_count(1).create();
@@ -521,8 +515,20 @@ pub mod tests {
             s_clone.watch_region_labels().await;
         });
 
-        // The service must detect the error, call reload_all_region_labels,
-        // and the rule must appear within 5 seconds.
+        // Give the watch time to hit the compaction error and call reload
+        // (which finds no labels yet).
+        std::thread::sleep(Duration::from_secs(1));
+
+        // Now disable injection and put the rule. The next reload (or the
+        // resumed watch) should pick it up.
+        inject_flag.store(false, Ordering::Release);
+        add_region_label_rule(
+            s.meta_client.clone(),
+            cluster_id,
+            &new_region_label_rule("cache/compaction-test", "a", "b"),
+        );
+
+        // The rule must appear within 5 seconds, proving the service recovered.
         let deadline = std::time::Instant::now() + Duration::from_secs(5);
         loop {
             if region_label_manager.region_labels().len() == 1 {
@@ -535,6 +541,8 @@ pub mod tests {
             std::thread::sleep(Duration::from_millis(10));
         }
 
+        server.stop();
+    }
         server.stop();
     }
 }

--- a/components/in_memory_engine/src/region_label.rs
+++ b/components/in_memory_engine/src/region_label.rs
@@ -244,6 +244,25 @@ impl RegionLabelService {
                         cancel.abort();
                         continue 'outer;
                     }
+                    // etcd can also send compaction as a raw gRPC error
+                    // instead of inside the ResponseHeader proto field.
+                    // That arrives as PdError::Grpc and was falling into
+                    // the generic handler below, retrying forever from the
+                    // same stale revision. Catch it here and recover the
+                    // same way as DataCompacted.
+                    Err(PdError::Grpc(grpcio::Error::RpcFailure(ref status)))
+                        if status
+                            .message()
+                            .contains("required revision has been compacted") =>
+                    {
+                        warn!(
+                            "ime required revision has been compacted (gRPC transport error)";
+                            "err" => ?status
+                        );
+                        self.reload_all_region_labels().await;
+                        cancel.abort();
+                        continue 'outer;
+                    }
                     Err(err) => {
                         error!("ime failed to watch region labels"; "err" => ?err);
                         let _ = GLOBAL_TIMER_HANDLE
@@ -462,6 +481,59 @@ pub mod tests {
         assert!(s.manager.get_region_label("cache/0").is_none());
         let label = s.manager.get_region_label("cache/1").unwrap();
         assert_eq!(label.data[0].start_key, "c".to_string());
+
+        server.stop();
+    }
+    #[test]
+    fn watch_grpc_compaction_error_recovers() {
+        use std::sync::atomic::Ordering;
+        use test_pd::util::new_client_with_update_interval;
+
+        // Build our own MetaStorage so we can control the injection flag.
+        let mocker = Arc::new(MetaStorage::default());
+        let inject_flag = mocker.inject_compaction_error.clone();
+
+        let mut server = MockServer::with_case(1, Arc::clone(&mocker));
+        let eps = server.bind_addrs();
+        let client = new_client_with_update_interval(eps, None, ReadableDuration::millis(100));
+
+        let region_label_manager = Arc::new(RegionLabelRulesManager::default());
+        let cluster_id = client.get_cluster_id().unwrap();
+
+        let mut s =
+            RegionLabelServiceBuilder::new(Arc::clone(&region_label_manager), Arc::new(client))
+                .build()
+                .unwrap();
+
+        // Put a rule in etcd so reload_all_region_labels has something to load.
+        add_region_label_rule(
+            s.meta_client.clone(),
+            cluster_id,
+            &new_region_label_rule("cache/compaction-test", "a", "b"),
+        );
+
+        // Arm the flag — next Watch call will return the gRPC compaction error.
+        inject_flag.store(true, Ordering::Release);
+
+        let background_worker = Builder::new("ime-compaction-test").thread_count(1).create();
+        let mut s_clone = s.clone();
+        background_worker.spawn_async_task(async move {
+            s_clone.watch_region_labels().await;
+        });
+
+        // The service must detect the error, call reload_all_region_labels,
+        // and the rule must appear within 5 seconds.
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            if region_label_manager.region_labels().len() == 1 {
+                break;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "timed out: service did not recover after gRPC compaction error"
+            );
+            std::thread::sleep(Duration::from_millis(10));
+        }
 
         server.stop();
     }

--- a/components/in_memory_engine/src/region_label.rs
+++ b/components/in_memory_engine/src/region_label.rs
@@ -251,10 +251,10 @@ impl RegionLabelService {
                     // same stale revision. Catch it here and recover the
                     // same way as DataCompacted.
                     Err(PdError::Grpc(grpcio::Error::RpcFailure(ref status)))
-                        if status
-                            .message()
-                            .contains("required revision has been compacted") =>
-                    {
+                        if status.code() == grpcio::RpcStatusCode::UNKNOWN
+                            && status
+                                .message()
+                                .contains("required revision has been compacted") => {
                         warn!(
                             "ime required revision has been compacted (gRPC transport error)";
                             "err" => ?status

--- a/components/in_memory_engine/src/region_label.rs
+++ b/components/in_memory_engine/src/region_label.rs
@@ -1,6 +1,6 @@
 // Copyright 2024 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::{sync::Arc, time::Duration};
+use std::{collections::HashSet, sync::Arc, time::Duration};
 
 use dashmap::DashMap;
 use engine_traits::CacheRegion;
@@ -99,6 +99,18 @@ impl RegionLabelRulesManager {
         }
     }
 
+    fn retain_region_labels(&self, valid_rule_ids: &HashSet<String>) {
+        let stale_rules = self
+            .region_labels
+            .iter()
+            .filter(|entry| !valid_rule_ids.contains(entry.key()))
+            .map(|entry| entry.value().clone())
+            .collect::<Vec<_>>();
+        for rule in stale_rules {
+            self.remove_region_label(&rule);
+        }
+    }
+
     #[cfg(test)]
     pub fn get_region_label(&self, label_rule_id: &str) -> Option<LabelRule> {
         self.region_labels
@@ -182,21 +194,20 @@ impl RegionLabelService {
         )
     }
 
-    fn on_label_rule_add(&mut self, label_rule: &LabelRule) {
-        let should_add_label = self
-            .rule_filter_fn
+    fn should_apply_label_rule(&self, label_rule: &LabelRule) -> bool {
+        self.rule_filter_fn
             .as_ref()
-            .map_or_else(|| true, |r_f_fn| r_f_fn(label_rule));
-        if should_add_label {
+            .map_or_else(|| true, |rule_filter_fn| rule_filter_fn(label_rule))
+    }
+
+    fn on_label_rule_add(&mut self, label_rule: &LabelRule) {
+        if self.should_apply_label_rule(label_rule) {
             self.manager.add_region_label(label_rule)
         }
     }
+
     fn on_label_rule_delete(&mut self, label_rule: &LabelRule) {
-        let should_remove_label = self
-            .rule_filter_fn
-            .as_ref()
-            .map_or_else(|| true, |r_f_fn| r_f_fn(label_rule));
-        if should_remove_label {
+        if self.should_apply_label_rule(label_rule) {
             self.manager.remove_region_label(label_rule)
         }
     }
@@ -254,7 +265,8 @@ impl RegionLabelService {
                         if status.code() == grpcio::RpcStatusCode::UNKNOWN
                             && status
                                 .message()
-                                .contains("required revision has been compacted") => {
+                                .contains("required revision has been compacted") =>
+                    {
                         warn!(
                             "ime required revision has been compacted (gRPC transport error)";
                             "err" => ?status
@@ -285,16 +297,28 @@ impl RegionLabelService {
                 .await
             {
                 Ok(mut resp) => {
+                    let revision = resp.get_header().get_revision();
                     let kvs = resp.take_kvs().into_iter().collect::<Vec<_>>();
+                    let mut valid_rule_ids = HashSet::with_capacity(kvs.len());
                     for g in kvs.iter() {
                         match serde_json::from_slice::<LabelRule>(g.get_value()) {
-                            Ok(label_rule) => self.on_label_rule_add(&label_rule),
+                            Ok(label_rule) => {
+                                if self.should_apply_label_rule(&label_rule) {
+                                    valid_rule_ids.insert(label_rule.id.clone());
+                                    self.manager.add_region_label(&label_rule);
+                                }
+                            }
 
                             Err(e) => {
                                 error!("ime parse label rule failed"; "name" => ?g.get_key(), "err" => ?e);
                             }
                         }
                     }
+                    // The GET response and its revision form one snapshot. Reconcile
+                    // removals before resuming the watch from that revision so events
+                    // missed due to compaction cannot leave stale rules behind.
+                    self.manager.retain_region_labels(&valid_rule_ids);
+                    self.revision = revision;
                     return;
                 }
                 Err(err) => {
@@ -419,6 +443,12 @@ pub mod tests {
         );
         block_on(s.reload_all_region_labels());
         assert_eq!(s.manager.region_labels().len(), 1);
+        assert_eq!(s.revision, 1);
+
+        delete_region_label_rule(s.meta_client.clone(), cluster_id, "cache/0");
+        block_on(s.reload_all_region_labels());
+        assert_eq!(s.manager.region_labels().len(), 0);
+        assert_eq!(s.revision, 2);
 
         server.stop();
     }
@@ -487,6 +517,7 @@ pub mod tests {
     #[test]
     fn watch_grpc_compaction_error_recovers() {
         use std::sync::atomic::Ordering;
+
         use test_pd::util::new_client_with_update_interval;
 
         // Build our own MetaStorage so we can control the injection flag.
@@ -500,13 +531,20 @@ pub mod tests {
         let region_label_manager = Arc::new(RegionLabelRulesManager::default());
         let cluster_id = client.get_cluster_id().unwrap();
 
-        let mut s =
-            RegionLabelServiceBuilder::new(Arc::clone(&region_label_manager), Arc::new(client))
-                .build()
-                .unwrap();
+        let s = RegionLabelServiceBuilder::new(Arc::clone(&region_label_manager), Arc::new(client))
+            .build()
+            .unwrap();
 
-        // Arm the flag before starting the watch so the very first Watch call
-        // fails with the gRPC compaction error.
+        // Establish a non-zero snapshot revision. Both the initial watch and
+        // the watch restarted after compaction must use this revision.
+        add_region_label_rule(
+            s.meta_client.clone(),
+            cluster_id,
+            &new_region_label_rule("cache/before-compaction", "a", "b"),
+        );
+
+        // Fail the first Watch call with the production gRPC compaction error.
+        // The mock injects it once and records every requested start revision.
         inject_flag.store(true, Ordering::Release);
 
         let background_worker = Builder::new("ime-compaction-test").thread_count(1).create();
@@ -515,34 +553,41 @@ pub mod tests {
             s_clone.watch_region_labels().await;
         });
 
-        // Give the watch time to hit the compaction error and call reload
-        // (which finds no labels yet).
-        std::thread::sleep(Duration::from_secs(1));
+        // Wait for the watch to restart, then verify the compaction arm did a
+        // second snapshot GET. The generic error path retries without reloading.
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        while mocker.watch_start_revisions.lock().unwrap().len() < 2 {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "compaction recovery did not restart the watch"
+            );
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert_eq!(mocker.get_call_count.load(Ordering::Relaxed), 2);
+        assert_eq!(
+            mocker.watch_start_revisions.lock().unwrap().as_slice(),
+            &[1, 1]
+        );
 
-        // Now disable injection and put the rule. The next reload (or the
-        // resumed watch) should pick it up.
-        inject_flag.store(false, Ordering::Release);
+        // A new event after recovery must arrive through the resumed watch.
         add_region_label_rule(
             s.meta_client.clone(),
             cluster_id,
-            &new_region_label_rule("cache/compaction-test", "a", "b"),
+            &new_region_label_rule("cache/after-compaction", "c", "d"),
         );
 
-        // The rule must appear within 5 seconds, proving the service recovered.
         let deadline = std::time::Instant::now() + Duration::from_secs(5);
         loop {
-            if region_label_manager.region_labels().len() == 1 {
+            if region_label_manager.region_labels().len() == 2 {
                 break;
             }
             assert!(
                 std::time::Instant::now() < deadline,
-                "timed out: service did not recover after gRPC compaction error"
+                "resumed watch did not receive an event after compaction recovery"
             );
             std::thread::sleep(Duration::from_millis(10));
         }
 
-        server.stop();
-    }
         server.stop();
     }
 }

--- a/components/test_pd/src/mocker/meta_storage.rs
+++ b/components/test_pd/src/mocker/meta_storage.rs
@@ -1,7 +1,9 @@
 // Copyright 2023 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::sync::{Arc, Mutex};
-
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicBool, Ordering},
+};
 use futures::{SinkExt, StreamExt, executor::block_on};
 use grpcio::{RpcStatus, RpcStatusCode};
 use kvproto::meta_storagepb as mpb;
@@ -12,6 +14,10 @@ use crate::PdMocker;
 #[derive(Default)]
 pub struct MetaStorage {
     store: Arc<Mutex<Etcd>>,
+    /// When true, the next Watch call will immediately fail with the
+    /// same gRPC error that etcd sends on compaction in production.
+    pub inject_compaction_error: Arc<AtomicBool>,
+
 }
 
 fn convert_kv(from: KeyValue) -> mpb::KeyValue {
@@ -90,6 +96,18 @@ impl PdMocker for MetaStorage {
                 sink.fail(RpcStatus::with_message(
                     RpcStatusCode::INVALID_ARGUMENT,
                     err,
+                ))
+                .await
+                .unwrap()
+            });
+            return true;
+        }
+        // Simulate etcd sending compaction as a gRPC transport error.
+        if self.inject_compaction_error.load(Ordering::Acquire) {
+            ctx.spawn(async move {
+                sink.fail(RpcStatus::with_message(
+                    RpcStatusCode::UNKNOWN,
+                    "etcdserver: mvcc: required revision has been compacted".to_owned(),
                 ))
                 .await
                 .unwrap()

--- a/components/test_pd/src/mocker/meta_storage.rs
+++ b/components/test_pd/src/mocker/meta_storage.rs
@@ -2,8 +2,9 @@
 
 use std::sync::{
     Arc, Mutex,
-    atomic::{AtomicBool, Ordering},
+    atomic::{AtomicBool, AtomicUsize, Ordering},
 };
+
 use futures::{SinkExt, StreamExt, executor::block_on};
 use grpcio::{RpcStatus, RpcStatusCode};
 use kvproto::meta_storagepb as mpb;
@@ -17,7 +18,10 @@ pub struct MetaStorage {
     /// When true, the next Watch call will immediately fail with the
     /// same gRPC error that etcd sends on compaction in production.
     pub inject_compaction_error: Arc<AtomicBool>,
-
+    /// Start revisions received by Watch calls.
+    pub watch_start_revisions: Arc<Mutex<Vec<i64>>>,
+    /// Number of Get calls received by meta storage.
+    pub get_call_count: Arc<AtomicUsize>,
 }
 
 fn convert_kv(from: KeyValue) -> mpb::KeyValue {
@@ -45,6 +49,7 @@ impl PdMocker for MetaStorage {
         if let Err(err) = check_header(req.get_header()) {
             return Some(Err(err));
         }
+        self.get_call_count.fetch_add(1, Ordering::Relaxed);
 
         let store = self.store.lock().unwrap();
         let key = if req.get_range_end().is_empty() {
@@ -102,8 +107,12 @@ impl PdMocker for MetaStorage {
             });
             return true;
         }
+        self.watch_start_revisions
+            .lock()
+            .unwrap()
+            .push(req.get_start_revision());
         // Simulate etcd sending compaction as a gRPC transport error.
-        if self.inject_compaction_error.load(Ordering::Acquire) {
+        if self.inject_compaction_error.swap(false, Ordering::AcqRel) {
             ctx.spawn(async move {
                 sink.fail(RpcStatus::with_message(
                     RpcStatusCode::UNKNOWN,

--- a/doc/maintenance-guides/components/in_memory_engine.md
+++ b/doc/maintenance-guides/components/in_memory_engine.md
@@ -60,6 +60,10 @@ eviction.
 - `memory_controller.rs` treats node overhead as an estimated component of total
   memory use. If write-path accounting or skiplist structure changes, revisit
   memory-pressure decisions and the eviction thresholds they drive.
+- `region_label.rs` maintains a PD meta-storage snapshot plus watch. A full
+  reload must reconcile both additions and removals, then resume watching from
+  the revision carried by that same GET response. Reusing an older revision
+  after etcd compaction can permanently stall the watcher.
 
 ## Start Here
 
@@ -155,6 +159,9 @@ eviction.
 - If config semantics change, review both bootstrap validation and online
   config dispatch. Silent threshold drift after a live config change is a real
   operational risk.
+- Treat region-label reload contents and the recorded watch revision as one
+  consistency boundary. Recovery tests should reject compacted revisions and
+  prove that events continue to arrive after the snapshot is reloaded.
 
 ## Change-Impact Matrix
 
@@ -163,6 +170,9 @@ eviction.
   `hybrid_engine`
 - Background load/GC/eviction changes:
   inspect `background.rs`, `memory_controller.rs`, metrics, and PD hint usage
+- Region-label watch or reload changes:
+  inspect `region_label.rs`, the PD meta-storage client, compaction recovery,
+  full-snapshot deletion reconciliation, and `test_pd` watch behavior
 - Memory-threshold or accounting changes:
   inspect `config.rs`, `memory_controller.rs`, write-batch paths, and operator
   metrics


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: Close #19792

When etcd compacts old history, the watch revision held by TiKV's
In-Memory Engine region label service becomes invalid. etcd sometimes
reports this condition as a raw gRPC UNKNOWN status with the message
"etcdserver: mvcc: required revision has been compacted" instead of
encoding it inside the ResponseHeader proto field.

The existing `PdError::DataCompacted` handler in `watch_region_labels`
only catches the proto variant. The gRPC variant fell into the generic
error handler which logged the error, waited 1 second, and retried
from the same stale revision — forever. The watch never recovered
unless the TiKV store was restarted.

Fix by adding a new match arm between `PdError::DataCompacted` and the
generic error arm that detects the gRPC compaction error by message
content and takes the same recovery action: call
`reload_all_region_labels` to fetch all rules fresh via Get (which
also updates `self.revision`), then restart the watch from the new
valid revision.

Also extend the `MetaStorage` test mocker with an
`inject_compaction_error: Arc<AtomicBool>` flag that causes
`meta_store_watch` to immediately fail with the exact gRPC UNKNOWN
status that etcd sends in production.

```commit-message
ime: recover watch after etcd gRPC compaction error

When etcd compacts and the watch revision is gone, it sometimes
sends the error as a raw gRPC UNKNOWN status instead of inside
the ResponseHeader proto. The existing DataCompacted handler only
catches the proto variant, so the gRPC variant fell into the
generic error handler and retried forever from the same stale
revision.

Fix by adding a new match arm that detects the gRPC compaction
error by message content and takes the same recovery action:
reload all region labels and restart the watch from a fresh
revision.

Also extend the MetaStorage test mocker with an
inject_compaction_error flag, and add a test that verifies
recovery after the gRPC variant of the error.

Fixes #19792
```

### Related changes
- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List
Tests <!-- At least one of them must be included. -->
- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note

```release-note
Fixed a bug in the In-Memory Engine region label watch client where
etcd compaction errors delivered as raw gRPC UNKNOWN status (instead
of inside the ResponseHeader) caused the watch to retry forever from
the same stale revision without recovering. The service now detects
this error variant and recovers automatically by reloading all region
labels and restarting the watch from a fresh revision.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved region-label watch recovery for targeted gRPC compaction transport failures by reloading all region-label rules, updating the effective revision from the latest snapshot, and resuming watching to prevent stalls.
  * Strengthened full reload reconciliation by removing only rules absent from the snapshot and applying only rules that pass the configured filter.
* **Tests**
  * Added a watch-recovery test that injects the compaction error and verifies label events appear after recovery.
  * Updated CRUD checks to assert expected revision values after reloads.
* **Documentation**
  * Expanded the in-memory engine maintenance guide with region-label reload/revision consistency and recovery expectations.
* **Chores**
  * Enhanced the test MetaStorage mock to inject watch failures and track watch/Get call behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->