### PR TITLE
resolved_ts: add more logs to detect why stuck after the change peer

### DIFF
--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -5112,7 +5112,8 @@ where
         assert_eq!(prev, Some(prev_region));
         drop(meta);
 
-        self.fsm.peer.read_progress.update_leader_info(
+        self.fsm.peer.read_progress.update_leader_info_with_source(
+            "peer_fsm_on_ready_persist_snapshot",
             self.fsm.peer.leader_id(),
             self.fsm.peer.term(),
             &region,

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -1564,8 +1564,12 @@ where
         self.maybe_update_read_progress(reader, progress);
 
         // Update leader info
-        self.read_progress
-            .update_leader_info(self.leader_id(), self.term(), self.region());
+        self.read_progress.update_leader_info_with_source(
+            "peer_set_region",
+            self.leader_id(),
+            self.term(),
+            self.region(),
+        );
 
         {
             let mut pessimistic_locks = self.txn_ext.pessimistic_locks.write();
@@ -2307,8 +2311,12 @@ where
             "peer_id" => self.peer_id(),
         );
 
-        self.read_progress
-            .update_leader_info(leader_id, term, self.region());
+        self.read_progress.update_leader_info_with_source(
+            "peer_on_leader_changed",
+            leader_id,
+            term,
+            self.region(),
+        );
     }
 
     #[inline]

--- a/components/raftstore/src/store/util.rs
+++ b/components/raftstore/src/store/util.rs
@@ -51,84 +51,61 @@ use crate::{
 
 const INVALID_TIMESTAMP: u64 = u64::MAX;
 const CHECK_LEADER_LOG_REGION_LIMIT: usize = 3;
-const CHECK_LEADER_REGISTRY_MUTATION_LIMIT: usize = 128;
+const CHECK_LEADER_REGISTRY_MUTATION_LIMIT: usize = 10;
 
-#[derive(Clone, Copy)]
+#[derive(Debug)]
 enum CheckLeaderUnreturnedReason {
-    RegistryMiss,
-    LeaderInfoMismatch,
+    RegistryMiss {
+        registry_recent_mutations: Vec<CheckLeaderRegistryMutation>,
+    },
+    LeaderInfoMismatch {
+        leader_info_mismatch: CheckLeaderLeaderInfoMismatch,
+    },
 }
 
-impl CheckLeaderUnreturnedReason {
-    fn as_str(&self) -> &'static str {
-        match self {
-            CheckLeaderUnreturnedReason::RegistryMiss => "registry_miss",
-            CheckLeaderUnreturnedReason::LeaderInfoMismatch => "leader_info_mismatch",
-        }
-    }
-}
-
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 struct CheckLeaderRegistryMutation {
-    /// Monotonic counter of registry mutations in this store.
-    mutation_count: u64,
     /// Registry mutation kind.
     kind: &'static str,
-    /// Region id touched by the registry mutation.
-    region_id: u64,
     /// Whether this operation saw an existing entry for the region before it
     /// ran.
     had_previous_entry: bool,
 }
 
-impl fmt::Debug for CheckLeaderRegistryMutation {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("CheckLeaderRegistryMutation")
-            .field("mutation_count", &self.mutation_count)
-            .field("kind", &self.kind)
-            .field("region_id", &self.region_id)
-            .field("had_previous_entry", &self.had_previous_entry)
-            .finish()
-    }
-}
-
 struct CheckLeaderRegistryDiagnostics {
-    mutation_count: u64,
-    recent_mutations: VecDeque<CheckLeaderRegistryMutation>,
+    recent_mutations_by_region: HashMap<u64, VecDeque<CheckLeaderRegistryMutation>>,
 }
 
 impl CheckLeaderRegistryDiagnostics {
     fn new() -> Self {
         CheckLeaderRegistryDiagnostics {
-            mutation_count: 0,
-            recent_mutations: VecDeque::with_capacity(CHECK_LEADER_REGISTRY_MUTATION_LIMIT),
+            recent_mutations_by_region: HashMap::default(),
         }
     }
 
     fn record(&mut self, kind: &'static str, region_id: u64, had_previous_entry: bool) {
-        self.mutation_count += 1;
-        if self.recent_mutations.len() >= CHECK_LEADER_REGISTRY_MUTATION_LIMIT {
-            self.recent_mutations.pop_front();
+        let recent_mutations = self
+            .recent_mutations_by_region
+            .entry(region_id)
+            .or_insert_with(|| VecDeque::with_capacity(CHECK_LEADER_REGISTRY_MUTATION_LIMIT));
+        if recent_mutations.len() >= CHECK_LEADER_REGISTRY_MUTATION_LIMIT {
+            recent_mutations.pop_front();
         }
-        self.recent_mutations
-            .push_back(CheckLeaderRegistryMutation {
-                mutation_count: self.mutation_count,
-                kind,
-                region_id,
-                had_previous_entry,
-            });
+        recent_mutations.push_back(CheckLeaderRegistryMutation {
+            kind,
+            had_previous_entry,
+        });
     }
 
-    fn last_mutation(&self, region_id: u64) -> Option<CheckLeaderRegistryMutation> {
-        self.recent_mutations
-            .iter()
-            .rev()
-            .find(|mutation| mutation.region_id == region_id)
-            .copied()
+    fn recent_mutations(&self, region_id: u64) -> Vec<CheckLeaderRegistryMutation> {
+        self.recent_mutations_by_region
+            .get(&region_id)
+            .map(|mutations| mutations.iter().copied().collect())
+            .unwrap_or_default()
     }
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Debug, Clone, Copy)]
 struct CheckLeaderLeaderInfoSnapshot {
     /// Leader peer id recorded in local `RegionReadProgress`.
     leader_id: u64,
@@ -157,7 +134,7 @@ impl CheckLeaderLeaderInfoSnapshot {
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 struct CheckLeaderLeaderInfoUpdate {
     /// Code path that performed the last in-memory leader info update.
     source: &'static str,
@@ -169,28 +146,17 @@ struct CheckLeaderLeaderInfoUpdate {
     after: CheckLeaderLeaderInfoSnapshot,
 }
 
-impl fmt::Debug for CheckLeaderLeaderInfoUpdate {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("CheckLeaderLeaderInfoUpdate")
-            .field("source", &self.source)
-            .field("update_count", &self.update_count)
-            .field("before", &self.before)
-            .field("after", &self.after)
-            .finish()
-    }
-}
-
-#[derive(Clone, Copy, Debug)]
-struct CheckLeaderLocalLeaderInfo {
+#[derive(Debug, Clone, Copy)]
+struct CheckLeaderLeaderInfoMismatch {
     /// Current local leader info when check-leader detects a mismatch.
     current: CheckLeaderLeaderInfoSnapshot,
     /// Last in-memory update that wrote current local leader info.
     last_update: Option<CheckLeaderLeaderInfoUpdate>,
 }
 
-impl CheckLeaderLocalLeaderInfo {
+impl CheckLeaderLeaderInfoMismatch {
     fn from_core(core: &RegionReadProgressCore) -> Self {
-        CheckLeaderLocalLeaderInfo {
+        CheckLeaderLeaderInfoMismatch {
             current: CheckLeaderLeaderInfoSnapshot::from_local_info(&core.leader_info),
             last_update: core.last_leader_info_update,
         }
@@ -198,6 +164,7 @@ impl CheckLeaderLocalLeaderInfo {
 }
 
 /// Sample of a region requested by check-leader but not returned by this store.
+#[derive(Debug)]
 struct CheckLeaderUnreturnedRegion {
     /// Region id from the leader-side check-leader request.
     region_id: u64,
@@ -211,32 +178,10 @@ struct CheckLeaderUnreturnedRegion {
     request_epoch_conf_ver: u64,
     /// Region epoch version carried by the check-leader request.
     request_epoch_version: u64,
-    /// Local leader id in this store's `RegionReadProgress`.
-    local_leader_id: Option<u64>,
-    /// Local leader term in this store's `RegionReadProgress`.
-    local_leader_term: Option<u64>,
-    /// Local region epoch conf_ver in this store's `RegionReadProgress`.
-    local_epoch_conf_ver: Option<u64>,
-    /// Local region epoch version in this store's `RegionReadProgress`.
-    local_epoch_version: Option<u64>,
-    /// Local leader store id in this store's `RegionReadProgress`.
-    local_leader_store_id: Option<u64>,
-    /// Number of peers in this store's local `RegionReadProgress`.
-    local_peer_count: Option<usize>,
-    /// Last in-memory update that wrote local leader info before this mismatch.
-    local_last_update: Option<CheckLeaderLeaderInfoUpdate>,
-    /// Recent registry mutation for this region, if it is still in the bounded
-    /// ring buffer.
-    registry_last_mutation: Option<CheckLeaderRegistryMutation>,
 }
 
 impl CheckLeaderUnreturnedRegion {
-    fn new(
-        leader_info: &LeaderInfo,
-        reason: CheckLeaderUnreturnedReason,
-        local_leader_info: Option<CheckLeaderLocalLeaderInfo>,
-        registry_last_mutation: Option<CheckLeaderRegistryMutation>,
-    ) -> Self {
+    fn new(leader_info: &LeaderInfo, reason: CheckLeaderUnreturnedReason) -> Self {
         let region_epoch = leader_info.get_region_epoch();
         CheckLeaderUnreturnedRegion {
             region_id: leader_info.get_region_id(),
@@ -245,36 +190,7 @@ impl CheckLeaderUnreturnedRegion {
             request_term: leader_info.term,
             request_epoch_conf_ver: region_epoch.get_conf_ver(),
             request_epoch_version: region_epoch.get_version(),
-            local_leader_id: local_leader_info.map(|info| info.current.leader_id),
-            local_leader_term: local_leader_info.map(|info| info.current.leader_term),
-            local_epoch_conf_ver: local_leader_info.map(|info| info.current.epoch_conf_ver),
-            local_epoch_version: local_leader_info.map(|info| info.current.epoch_version),
-            local_leader_store_id: local_leader_info.and_then(|info| info.current.leader_store_id),
-            local_peer_count: local_leader_info.map(|info| info.current.peer_count),
-            local_last_update: local_leader_info.and_then(|info| info.last_update),
-            registry_last_mutation,
         }
-    }
-}
-
-impl fmt::Debug for CheckLeaderUnreturnedRegion {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("CheckLeaderUnreturnedRegion")
-            .field("region_id", &self.region_id)
-            .field("reason", &self.reason.as_str())
-            .field("request_peer_id", &self.request_peer_id)
-            .field("request_term", &self.request_term)
-            .field("request_epoch_conf_ver", &self.request_epoch_conf_ver)
-            .field("request_epoch_version", &self.request_epoch_version)
-            .field("local_leader_id", &self.local_leader_id)
-            .field("local_leader_term", &self.local_leader_term)
-            .field("local_epoch_conf_ver", &self.local_epoch_conf_ver)
-            .field("local_epoch_version", &self.local_epoch_version)
-            .field("local_leader_store_id", &self.local_leader_store_id)
-            .field("local_peer_count", &self.local_peer_count)
-            .field("local_last_update", &self.local_last_update)
-            .field("registry_last_mutation", &self.registry_last_mutation)
-            .finish()
     }
 }
 
@@ -1518,8 +1434,8 @@ impl RegionReadProgressRegistry {
             .record(kind, region_id, had_previous_entry);
     }
 
-    fn last_registry_mutation(&self, region_id: u64) -> Option<CheckLeaderRegistryMutation> {
-        self.diagnostics.lock().unwrap().last_mutation(region_id)
+    fn recent_registry_mutations(&self, region_id: u64) -> Vec<CheckLeaderRegistryMutation> {
+        self.diagnostics.lock().unwrap().recent_mutations(region_id)
     }
 
     pub fn get(&self, region_id: &u64) -> Option<Arc<RegionReadProgress>> {
@@ -1583,35 +1499,33 @@ impl RegionReadProgressRegistry {
             let now = Some(Instant::now_coarse());
             for leader_info in &leaders {
                 let region_id = leader_info.get_region_id();
-                let mut local_leader_info = None;
-                let reason = if let Some(rp) = registry.get(&region_id) {
+                if let Some(rp) = registry.get(&region_id) {
                     if let Some(mismatch_info) =
                         rp.consume_leader_info_and_get_mismatch(leader_info, coprocessor, now)
                     {
                         leader_info_mismatch_count += 1;
-                        local_leader_info = Some(mismatch_info);
-                        Some(CheckLeaderUnreturnedReason::LeaderInfoMismatch)
+                        if unreturned_regions.len() < CHECK_LEADER_LOG_REGION_LIMIT {
+                            unreturned_regions.push(CheckLeaderUnreturnedRegion::new(
+                                leader_info,
+                                CheckLeaderUnreturnedReason::LeaderInfoMismatch {
+                                    leader_info_mismatch: mismatch_info,
+                                },
+                            ));
+                        } else {
+                            unreturned_regions_truncated = true;
+                        }
                     } else {
                         regions.push(region_id);
-                        None
                     }
                 } else {
                     registry_miss_count += 1;
-                    Some(CheckLeaderUnreturnedReason::RegistryMiss)
-                };
-                if let Some(reason) = reason {
                     if unreturned_regions.len() < CHECK_LEADER_LOG_REGION_LIMIT {
-                        let registry_last_mutation =
-                            if matches!(reason, CheckLeaderUnreturnedReason::RegistryMiss) {
-                                self.last_registry_mutation(region_id)
-                            } else {
-                                None
-                            };
                         unreturned_regions.push(CheckLeaderUnreturnedRegion::new(
                             leader_info,
-                            reason,
-                            local_leader_info,
-                            registry_last_mutation,
+                            CheckLeaderUnreturnedReason::RegistryMiss {
+                                registry_recent_mutations: self
+                                    .recent_registry_mutations(region_id),
+                            },
                         ));
                     } else {
                         unreturned_regions_truncated = true;
@@ -1784,7 +1698,7 @@ impl RegionReadProgress {
         leader_info: &LeaderInfo,
         coprocessor: &CoprocessorHost<E>,
         now: Option<Instant>,
-    ) -> Option<CheckLeaderLocalLeaderInfo> {
+    ) -> Option<CheckLeaderLeaderInfoMismatch> {
         let mut core = self.core.lock().unwrap();
         if matches!((core.last_instant_of_consume_leader, now), (None, Some(_)))
             || matches!((core.last_instant_of_consume_leader, now), (Some(l), Some(r)) if l < r)
@@ -1812,7 +1726,7 @@ impl RegionReadProgress {
         {
             None
         } else {
-            Some(CheckLeaderLocalLeaderInfo::from_core(&core))
+            Some(CheckLeaderLeaderInfoMismatch::from_core(&core))
         }
     }
 

--- a/components/raftstore/src/store/util.rs
+++ b/components/raftstore/src/store/util.rs
@@ -51,7 +51,9 @@ use crate::{
 
 const INVALID_TIMESTAMP: u64 = u64::MAX;
 const CHECK_LEADER_LOG_REGION_LIMIT: usize = 3;
+const CHECK_LEADER_REGISTRY_MUTATION_LIMIT: usize = 128;
 
+#[derive(Clone, Copy)]
 enum CheckLeaderUnreturnedReason {
     RegistryMiss,
     LeaderInfoMismatch,
@@ -67,20 +69,130 @@ impl CheckLeaderUnreturnedReason {
 }
 
 #[derive(Clone, Copy)]
-struct CheckLeaderLocalLeaderInfo {
+struct CheckLeaderRegistryMutation {
+    /// Monotonic counter of registry mutations in this store.
+    mutation_count: u64,
+    /// Registry mutation kind.
+    kind: &'static str,
+    /// Region id touched by the registry mutation.
+    region_id: u64,
+    /// Whether this operation saw an existing entry for the region before it
+    /// ran.
+    had_previous_entry: bool,
+}
+
+impl fmt::Debug for CheckLeaderRegistryMutation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CheckLeaderRegistryMutation")
+            .field("mutation_count", &self.mutation_count)
+            .field("kind", &self.kind)
+            .field("region_id", &self.region_id)
+            .field("had_previous_entry", &self.had_previous_entry)
+            .finish()
+    }
+}
+
+struct CheckLeaderRegistryDiagnostics {
+    mutation_count: u64,
+    recent_mutations: VecDeque<CheckLeaderRegistryMutation>,
+}
+
+impl CheckLeaderRegistryDiagnostics {
+    fn new() -> Self {
+        CheckLeaderRegistryDiagnostics {
+            mutation_count: 0,
+            recent_mutations: VecDeque::with_capacity(CHECK_LEADER_REGISTRY_MUTATION_LIMIT),
+        }
+    }
+
+    fn record(&mut self, kind: &'static str, region_id: u64, had_previous_entry: bool) {
+        self.mutation_count += 1;
+        if self.recent_mutations.len() >= CHECK_LEADER_REGISTRY_MUTATION_LIMIT {
+            self.recent_mutations.pop_front();
+        }
+        self.recent_mutations
+            .push_back(CheckLeaderRegistryMutation {
+                mutation_count: self.mutation_count,
+                kind,
+                region_id,
+                had_previous_entry,
+            });
+    }
+
+    fn last_mutation(&self, region_id: u64) -> Option<CheckLeaderRegistryMutation> {
+        self.recent_mutations
+            .iter()
+            .rev()
+            .find(|mutation| mutation.region_id == region_id)
+            .copied()
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct CheckLeaderLeaderInfoSnapshot {
+    /// Leader peer id recorded in local `RegionReadProgress`.
     leader_id: u64,
+    /// Leader term recorded in local `RegionReadProgress`.
     leader_term: u64,
+    /// Region epoch conf_ver recorded in local `RegionReadProgress`.
     epoch_conf_ver: u64,
+    /// Region epoch version recorded in local `RegionReadProgress`.
     epoch_version: u64,
+    /// Store id resolved from the local peer list and local leader id.
+    leader_store_id: Option<u64>,
+    /// Number of peers in the local peer list.
+    peer_count: usize,
+}
+
+impl CheckLeaderLeaderInfoSnapshot {
+    fn from_local_info(local_info: &LocalLeaderInfo) -> Self {
+        CheckLeaderLeaderInfoSnapshot {
+            leader_id: local_info.leader_id,
+            leader_term: local_info.leader_term,
+            epoch_conf_ver: local_info.epoch.get_conf_ver(),
+            epoch_version: local_info.epoch.get_version(),
+            leader_store_id: local_info.leader_store_id,
+            peer_count: local_info.peers.len(),
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct CheckLeaderLeaderInfoUpdate {
+    /// Code path that performed the last in-memory leader info update.
+    source: &'static str,
+    /// Monotonic counter of in-memory leader info updates for this region.
+    update_count: u64,
+    /// Local leader info before the last update.
+    before: CheckLeaderLeaderInfoSnapshot,
+    /// Local leader info after the last update.
+    after: CheckLeaderLeaderInfoSnapshot,
+}
+
+impl fmt::Debug for CheckLeaderLeaderInfoUpdate {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CheckLeaderLeaderInfoUpdate")
+            .field("source", &self.source)
+            .field("update_count", &self.update_count)
+            .field("before", &self.before)
+            .field("after", &self.after)
+            .finish()
+    }
+}
+
+#[derive(Clone, Copy)]
+struct CheckLeaderLocalLeaderInfo {
+    /// Current local leader info when check-leader detects a mismatch.
+    current: CheckLeaderLeaderInfoSnapshot,
+    /// Last in-memory update that wrote current local leader info.
+    last_update: Option<CheckLeaderLeaderInfoUpdate>,
 }
 
 impl CheckLeaderLocalLeaderInfo {
     fn from_core(core: &RegionReadProgressCore) -> Self {
         CheckLeaderLocalLeaderInfo {
-            leader_id: core.leader_info.leader_id,
-            leader_term: core.leader_info.leader_term,
-            epoch_conf_ver: core.leader_info.epoch.get_conf_ver(),
-            epoch_version: core.leader_info.epoch.get_version(),
+            current: CheckLeaderLeaderInfoSnapshot::from_local_info(&core.leader_info),
+            last_update: core.last_leader_info_update,
         }
     }
 }
@@ -107,6 +219,15 @@ struct CheckLeaderUnreturnedRegion {
     local_epoch_conf_ver: Option<u64>,
     /// Local region epoch version in this store's `RegionReadProgress`.
     local_epoch_version: Option<u64>,
+    /// Local leader store id in this store's `RegionReadProgress`.
+    local_leader_store_id: Option<u64>,
+    /// Number of peers in this store's local `RegionReadProgress`.
+    local_peer_count: Option<usize>,
+    /// Last in-memory update that wrote local leader info before this mismatch.
+    local_last_update: Option<CheckLeaderLeaderInfoUpdate>,
+    /// Recent registry mutation for this region, if it is still in the bounded
+    /// ring buffer.
+    registry_last_mutation: Option<CheckLeaderRegistryMutation>,
 }
 
 impl CheckLeaderUnreturnedRegion {
@@ -114,6 +235,7 @@ impl CheckLeaderUnreturnedRegion {
         leader_info: &LeaderInfo,
         reason: CheckLeaderUnreturnedReason,
         local_leader_info: Option<CheckLeaderLocalLeaderInfo>,
+        registry_last_mutation: Option<CheckLeaderRegistryMutation>,
     ) -> Self {
         let region_epoch = leader_info.get_region_epoch();
         CheckLeaderUnreturnedRegion {
@@ -123,10 +245,14 @@ impl CheckLeaderUnreturnedRegion {
             request_term: leader_info.term,
             request_epoch_conf_ver: region_epoch.get_conf_ver(),
             request_epoch_version: region_epoch.get_version(),
-            local_leader_id: local_leader_info.map(|info| info.leader_id),
-            local_leader_term: local_leader_info.map(|info| info.leader_term),
-            local_epoch_conf_ver: local_leader_info.map(|info| info.epoch_conf_ver),
-            local_epoch_version: local_leader_info.map(|info| info.epoch_version),
+            local_leader_id: local_leader_info.map(|info| info.current.leader_id),
+            local_leader_term: local_leader_info.map(|info| info.current.leader_term),
+            local_epoch_conf_ver: local_leader_info.map(|info| info.current.epoch_conf_ver),
+            local_epoch_version: local_leader_info.map(|info| info.current.epoch_version),
+            local_leader_store_id: local_leader_info.and_then(|info| info.current.leader_store_id),
+            local_peer_count: local_leader_info.map(|info| info.current.peer_count),
+            local_last_update: local_leader_info.and_then(|info| info.last_update),
+            registry_last_mutation,
         }
     }
 }
@@ -144,6 +270,10 @@ impl fmt::Debug for CheckLeaderUnreturnedRegion {
             .field("local_leader_term", &self.local_leader_term)
             .field("local_epoch_conf_ver", &self.local_epoch_conf_ver)
             .field("local_epoch_version", &self.local_epoch_version)
+            .field("local_leader_store_id", &self.local_leader_store_id)
+            .field("local_peer_count", &self.local_peer_count)
+            .field("local_last_update", &self.local_last_update)
+            .field("registry_last_mutation", &self.registry_last_mutation)
             .finish()
     }
 }
@@ -1345,12 +1475,14 @@ impl Display for MsgType<'_> {
 #[derive(Clone)]
 pub struct RegionReadProgressRegistry {
     registry: Arc<Mutex<HashMap<u64, Arc<RegionReadProgress>>>>,
+    diagnostics: Arc<Mutex<CheckLeaderRegistryDiagnostics>>,
 }
 
 impl RegionReadProgressRegistry {
     pub fn new() -> RegionReadProgressRegistry {
         RegionReadProgressRegistry {
             registry: Arc::new(Mutex::new(HashMap::new())),
+            diagnostics: Arc::new(Mutex::new(CheckLeaderRegistryDiagnostics::new())),
         }
     }
 
@@ -1359,14 +1491,35 @@ impl RegionReadProgressRegistry {
         region_id: u64,
         read_progress: Arc<RegionReadProgress>,
     ) -> Option<Arc<RegionReadProgress>> {
-        self.registry
+        let previous = self
+            .registry
             .lock()
             .unwrap()
-            .insert(region_id, read_progress)
+            .insert(region_id, read_progress);
+        self.record_registry_mutation("insert", region_id, previous.is_some());
+        previous
     }
 
     pub fn remove(&self, region_id: &u64) -> Option<Arc<RegionReadProgress>> {
-        self.registry.lock().unwrap().remove(region_id)
+        let previous = self.registry.lock().unwrap().remove(region_id);
+        self.record_registry_mutation("remove", *region_id, previous.is_some());
+        previous
+    }
+
+    fn record_registry_mutation(
+        &self,
+        kind: &'static str,
+        region_id: u64,
+        had_previous_entry: bool,
+    ) {
+        self.diagnostics
+            .lock()
+            .unwrap()
+            .record(kind, region_id, had_previous_entry);
+    }
+
+    fn last_registry_mutation(&self, region_id: u64) -> Option<CheckLeaderRegistryMutation> {
+        self.diagnostics.lock().unwrap().last_mutation(region_id)
     }
 
     pub fn get(&self, region_id: &u64) -> Option<Arc<RegionReadProgress>> {
@@ -1430,31 +1583,36 @@ impl RegionReadProgressRegistry {
             let now = Some(Instant::now_coarse());
             for leader_info in &leaders {
                 let region_id = leader_info.get_region_id();
-                let unreturned_region = if let Some(rp) = registry.get(&region_id) {
-                    if let Some(local_leader_info) =
+                let mut local_leader_info = None;
+                let reason = if let Some(rp) = registry.get(&region_id) {
+                    if let Some(mismatch_info) =
                         rp.consume_leader_info_and_get_mismatch(leader_info, coprocessor, now)
                     {
                         leader_info_mismatch_count += 1;
-                        Some(CheckLeaderUnreturnedRegion::new(
-                            leader_info,
-                            CheckLeaderUnreturnedReason::LeaderInfoMismatch,
-                            Some(local_leader_info),
-                        ))
+                        local_leader_info = Some(mismatch_info);
+                        Some(CheckLeaderUnreturnedReason::LeaderInfoMismatch)
                     } else {
                         regions.push(region_id);
                         None
                     }
                 } else {
                     registry_miss_count += 1;
-                    Some(CheckLeaderUnreturnedRegion::new(
-                        leader_info,
-                        CheckLeaderUnreturnedReason::RegistryMiss,
-                        None,
-                    ))
+                    Some(CheckLeaderUnreturnedReason::RegistryMiss)
                 };
-                if let Some(unreturned_region) = unreturned_region {
+                if let Some(reason) = reason {
                     if unreturned_regions.len() < CHECK_LEADER_LOG_REGION_LIMIT {
-                        unreturned_regions.push(unreturned_region);
+                        let registry_last_mutation =
+                            if matches!(reason, CheckLeaderUnreturnedReason::RegistryMiss) {
+                                self.last_registry_mutation(region_id)
+                            } else {
+                                None
+                            };
+                        unreturned_regions.push(CheckLeaderUnreturnedRegion::new(
+                            leader_info,
+                            reason,
+                            local_leader_info,
+                            registry_last_mutation,
+                        ));
                     } else {
                         unreturned_regions_truncated = true;
                     }
@@ -1668,7 +1826,18 @@ impl RegionReadProgress {
     }
 
     pub fn update_leader_info(&self, peer_id: u64, term: u64, region: &Region) {
+        self.update_leader_info_with_source("update_leader_info", peer_id, term, region)
+    }
+
+    pub(crate) fn update_leader_info_with_source(
+        &self,
+        source: &'static str,
+        peer_id: u64,
+        term: u64,
+        region: &Region,
+    ) {
         let mut core = self.core.lock().unwrap();
+        let before = CheckLeaderLeaderInfoSnapshot::from_local_info(&core.leader_info);
         core.leader_info.leader_id = peer_id;
         core.leader_info.leader_term = term;
         if !is_region_epoch_equal(region.get_region_epoch(), &core.leader_info.epoch) {
@@ -1680,7 +1849,14 @@ impl RegionReadProgress {
             core.leader_info.peers = region.get_peers().to_vec();
         }
         core.leader_info.leader_store_id =
-            find_store_id(&core.leader_info.peers, core.leader_info.leader_id)
+            find_store_id(&core.leader_info.peers, core.leader_info.leader_id);
+        core.leader_info_update_count += 1;
+        core.last_leader_info_update = Some(CheckLeaderLeaderInfoUpdate {
+            source,
+            update_count: core.leader_info_update_count,
+            before,
+            after: CheckLeaderLeaderInfoSnapshot::from_local_info(&core.leader_info),
+        });
     }
 
     /// Reset `safe_ts` to 0 and stop updating it
@@ -1732,6 +1908,10 @@ pub struct RegionReadProgressCore {
     read_state: ReadState,
     // The local peer's acknowledge about the leader
     leader_info: LocalLeaderInfo,
+    // Number of in-memory updates to `leader_info`, used only for anomaly diagnosis.
+    leader_info_update_count: u64,
+    // Last in-memory update to `leader_info`, printed only by check-leader anomaly logs.
+    last_leader_info_update: Option<CheckLeaderLeaderInfoUpdate>,
     // `pending_items` is a *sorted* list of `(apply_index, safe_ts)` item
     pending_items: VecDeque<ReadState>,
     // After the region commit merged, the region's key range is extended and the region's
@@ -1817,6 +1997,8 @@ impl RegionReadProgressCore {
             applied_index,
             read_state: ReadState::default(),
             leader_info: LocalLeaderInfo::new(region),
+            leader_info_update_count: 0,
+            last_leader_info_update: None,
             pending_items: VecDeque::with_capacity(cap),
             last_merge_index: 0,
             pause: is_witness,

--- a/components/raftstore/src/store/util.rs
+++ b/components/raftstore/src/store/util.rs
@@ -180,7 +180,7 @@ impl fmt::Debug for CheckLeaderLeaderInfoUpdate {
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 struct CheckLeaderLocalLeaderInfo {
     /// Current local leader info when check-leader detects a mismatch.
     current: CheckLeaderLeaderInfoSnapshot,

--- a/components/raftstore/src/store/util.rs
+++ b/components/raftstore/src/store/util.rs
@@ -53,6 +53,7 @@ const INVALID_TIMESTAMP: u64 = u64::MAX;
 const CHECK_LEADER_LOG_REGION_LIMIT: usize = 3;
 const CHECK_LEADER_REGISTRY_MUTATION_LIMIT: usize = 10;
 
+#[allow(dead_code)]
 #[derive(Debug)]
 enum CheckLeaderUnreturnedReason {
     RegistryMiss {
@@ -63,6 +64,7 @@ enum CheckLeaderUnreturnedReason {
     },
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Clone, Copy)]
 struct CheckLeaderRegistryMutation {
     /// Registry mutation kind.
@@ -105,6 +107,7 @@ impl CheckLeaderRegistryDiagnostics {
     }
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Clone, Copy)]
 struct CheckLeaderLeaderInfoSnapshot {
     /// Leader peer id recorded in local `RegionReadProgress`.
@@ -134,6 +137,7 @@ impl CheckLeaderLeaderInfoSnapshot {
     }
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Clone, Copy)]
 struct CheckLeaderLeaderInfoUpdate {
     /// Code path that performed the last in-memory leader info update.
@@ -146,6 +150,7 @@ struct CheckLeaderLeaderInfoUpdate {
     after: CheckLeaderLeaderInfoSnapshot,
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Clone, Copy)]
 struct CheckLeaderLeaderInfoMismatch {
     /// Current local leader info when check-leader detects a mismatch.
@@ -164,6 +169,7 @@ impl CheckLeaderLeaderInfoMismatch {
 }
 
 /// Sample of a region requested by check-leader but not returned by this store.
+#[allow(dead_code)]
 #[derive(Debug)]
 struct CheckLeaderUnreturnedRegion {
     /// Region id from the leader-side check-leader request.

--- a/components/raftstore/src/store/util.rs
+++ b/components/raftstore/src/store/util.rs
@@ -36,7 +36,7 @@ use tikv_util::{
     debug, info,
     store::{find_peer_by_id, region},
     time::{monotonic_raw_now, Instant},
-    Either,
+    warn, Either,
 };
 use time::{Duration, Timespec};
 use tokio::sync::Notify;
@@ -50,6 +50,103 @@ use crate::{
 };
 
 const INVALID_TIMESTAMP: u64 = u64::MAX;
+const CHECK_LEADER_LOG_REGION_LIMIT: usize = 3;
+
+enum CheckLeaderUnreturnedReason {
+    RegistryMiss,
+    LeaderInfoMismatch,
+}
+
+impl CheckLeaderUnreturnedReason {
+    fn as_str(&self) -> &'static str {
+        match self {
+            CheckLeaderUnreturnedReason::RegistryMiss => "registry_miss",
+            CheckLeaderUnreturnedReason::LeaderInfoMismatch => "leader_info_mismatch",
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct CheckLeaderLocalLeaderInfo {
+    leader_id: u64,
+    leader_term: u64,
+    epoch_conf_ver: u64,
+    epoch_version: u64,
+}
+
+impl CheckLeaderLocalLeaderInfo {
+    fn from_core(core: &RegionReadProgressCore) -> Self {
+        CheckLeaderLocalLeaderInfo {
+            leader_id: core.leader_info.leader_id,
+            leader_term: core.leader_info.leader_term,
+            epoch_conf_ver: core.leader_info.epoch.get_conf_ver(),
+            epoch_version: core.leader_info.epoch.get_version(),
+        }
+    }
+}
+
+/// Sample of a region requested by check-leader but not returned by this store.
+struct CheckLeaderUnreturnedRegion {
+    /// Region id from the leader-side check-leader request.
+    region_id: u64,
+    /// First-level reason why this region was not returned.
+    reason: CheckLeaderUnreturnedReason,
+    /// Leader peer id carried by the check-leader request.
+    request_peer_id: u64,
+    /// Leader term carried by the check-leader request.
+    request_term: u64,
+    /// Region epoch conf_ver carried by the check-leader request.
+    request_epoch_conf_ver: u64,
+    /// Region epoch version carried by the check-leader request.
+    request_epoch_version: u64,
+    /// Local leader id in this store's `RegionReadProgress`.
+    local_leader_id: Option<u64>,
+    /// Local leader term in this store's `RegionReadProgress`.
+    local_leader_term: Option<u64>,
+    /// Local region epoch conf_ver in this store's `RegionReadProgress`.
+    local_epoch_conf_ver: Option<u64>,
+    /// Local region epoch version in this store's `RegionReadProgress`.
+    local_epoch_version: Option<u64>,
+}
+
+impl CheckLeaderUnreturnedRegion {
+    fn new(
+        leader_info: &LeaderInfo,
+        reason: CheckLeaderUnreturnedReason,
+        local_leader_info: Option<CheckLeaderLocalLeaderInfo>,
+    ) -> Self {
+        let region_epoch = leader_info.get_region_epoch();
+        CheckLeaderUnreturnedRegion {
+            region_id: leader_info.get_region_id(),
+            reason,
+            request_peer_id: leader_info.peer_id,
+            request_term: leader_info.term,
+            request_epoch_conf_ver: region_epoch.get_conf_ver(),
+            request_epoch_version: region_epoch.get_version(),
+            local_leader_id: local_leader_info.map(|info| info.leader_id),
+            local_leader_term: local_leader_info.map(|info| info.leader_term),
+            local_epoch_conf_ver: local_leader_info.map(|info| info.epoch_conf_ver),
+            local_epoch_version: local_leader_info.map(|info| info.epoch_version),
+        }
+    }
+}
+
+impl fmt::Debug for CheckLeaderUnreturnedRegion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CheckLeaderUnreturnedRegion")
+            .field("region_id", &self.region_id)
+            .field("reason", &self.reason.as_str())
+            .field("request_peer_id", &self.request_peer_id)
+            .field("request_term", &self.request_term)
+            .field("request_epoch_conf_ver", &self.request_epoch_conf_ver)
+            .field("request_epoch_version", &self.request_epoch_version)
+            .field("local_leader_id", &self.local_leader_id)
+            .field("local_leader_term", &self.local_leader_term)
+            .field("local_epoch_conf_ver", &self.local_epoch_conf_ver)
+            .field("local_epoch_version", &self.local_epoch_version)
+            .finish()
+    }
+}
 
 /// Check if key in region range (`start_key`, `end_key`).
 pub fn check_key_in_region_exclusive(key: &[u8], region: &metapb::Region) -> Result<()> {
@@ -1322,16 +1419,58 @@ impl RegionReadProgressRegistry {
         leaders: Vec<LeaderInfo>,
         coprocessor: &CoprocessorHost<E>,
     ) -> Vec<u64> {
+        let request_count = leaders.len();
         let mut regions = Vec::with_capacity(leaders.len());
-        let registry = self.registry.lock().unwrap();
-        let now = Some(Instant::now_coarse());
-        for leader_info in &leaders {
-            let region_id = leader_info.get_region_id();
-            if let Some(rp) = registry.get(&region_id) {
-                if rp.consume_leader_info(leader_info, coprocessor, now) {
-                    regions.push(region_id);
+        let mut registry_miss_count = 0;
+        let mut leader_info_mismatch_count = 0;
+        let mut unreturned_regions = Vec::new();
+        let mut unreturned_regions_truncated = false;
+        {
+            let registry = self.registry.lock().unwrap();
+            let now = Some(Instant::now_coarse());
+            for leader_info in &leaders {
+                let region_id = leader_info.get_region_id();
+                let unreturned_region = if let Some(rp) = registry.get(&region_id) {
+                    if let Some(local_leader_info) =
+                        rp.consume_leader_info_and_get_mismatch(leader_info, coprocessor, now)
+                    {
+                        leader_info_mismatch_count += 1;
+                        Some(CheckLeaderUnreturnedRegion::new(
+                            leader_info,
+                            CheckLeaderUnreturnedReason::LeaderInfoMismatch,
+                            Some(local_leader_info),
+                        ))
+                    } else {
+                        regions.push(region_id);
+                        None
+                    }
+                } else {
+                    registry_miss_count += 1;
+                    Some(CheckLeaderUnreturnedRegion::new(
+                        leader_info,
+                        CheckLeaderUnreturnedReason::RegistryMiss,
+                        None,
+                    ))
+                };
+                if let Some(unreturned_region) = unreturned_region {
+                    if unreturned_regions.len() < CHECK_LEADER_LOG_REGION_LIMIT {
+                        unreturned_regions.push(unreturned_region);
+                    } else {
+                        unreturned_regions_truncated = true;
+                    }
                 }
             }
+        }
+        if regions.len() < request_count {
+            warn!(
+                "[resolved-ts-stuck] check leader task returned partial regions";
+                "request_count" => request_count,
+                "response_count" => regions.len(),
+                "registry_miss_count" => registry_miss_count,
+                "leader_info_mismatch_count" => leader_info_mismatch_count,
+                "unreturned_regions" => ?unreturned_regions,
+                "unreturned_regions_truncated" => unreturned_regions_truncated,
+            );
         }
         regions
     }
@@ -1478,6 +1617,16 @@ impl RegionReadProgress {
         coprocessor: &CoprocessorHost<E>,
         now: Option<Instant>,
     ) -> bool {
+        self.consume_leader_info_and_get_mismatch(leader_info, coprocessor, now)
+            .is_none()
+    }
+
+    fn consume_leader_info_and_get_mismatch<E: KvEngine>(
+        &self,
+        leader_info: &LeaderInfo,
+        coprocessor: &CoprocessorHost<E>,
+        now: Option<Instant>,
+    ) -> Option<CheckLeaderLocalLeaderInfo> {
         let mut core = self.core.lock().unwrap();
         if matches!((core.last_instant_of_consume_leader, now), (None, Some(_)))
             || matches!((core.last_instant_of_consume_leader, now), (Some(l), Some(r)) if l < r)
@@ -1499,9 +1648,14 @@ impl RegionReadProgress {
             coprocessor.on_update_safe_ts(leader_info.region_id, self.safe_ts(), rs.get_safe_ts())
         }
         // whether the provided `LeaderInfo` is same as ours
-        core.leader_info.leader_term == leader_info.term
+        if core.leader_info.leader_term == leader_info.term
             && core.leader_info.leader_id == leader_info.peer_id
             && is_region_epoch_equal(&core.leader_info.epoch, leader_info.get_region_epoch())
+        {
+            None
+        } else {
+            Some(CheckLeaderLocalLeaderInfo::from_core(&core))
+        }
     }
 
     // Dump the `LeaderInfo` and the peer list

--- a/components/raftstore/src/store/util.rs
+++ b/components/raftstore/src/store/util.rs
@@ -87,7 +87,7 @@ impl CheckLeaderRegistryDiagnostics {
         let recent_mutations = self
             .recent_mutations_by_region
             .entry(region_id)
-            .or_insert_with(|| VecDeque::with_capacity(CHECK_LEADER_REGISTRY_MUTATION_LIMIT));
+            .or_default();
         if recent_mutations.len() >= CHECK_LEADER_REGISTRY_MUTATION_LIMIT {
             recent_mutations.pop_front();
         }

--- a/components/resolved_ts/src/advance.rs
+++ b/components/resolved_ts/src/advance.rs
@@ -3,6 +3,7 @@
 use std::{
     cmp,
     ffi::CString,
+    fmt,
     sync::{
         atomic::{AtomicI32, Ordering},
         Arc,
@@ -48,6 +49,45 @@ use crate::{endpoint::Task, metrics::*, TsSource};
 pub(crate) const DEFAULT_CHECK_LEADER_TIMEOUT_DURATION: Duration = Duration::from_secs(5); // 5s
 const DEFAULT_GRPC_GZIP_COMPRESSION_LEVEL: usize = 2;
 const DEFAULT_GRPC_MIN_MESSAGE_SIZE_TO_COMPRESS: usize = 4096;
+const CHECK_LEADER_LOG_REGION_LIMIT: usize = 3;
+
+/// Per target-store status in the check-leader unresolved summary log.
+///
+/// This is printed only when some checked regions cannot pass quorum, so every
+/// field is aimed at answering which requested stores did not return the
+/// unresolved regions.
+struct CheckLeaderStoreStatus {
+    /// Store that received a check-leader request from this leader.
+    to_store_id: u64,
+    /// Number of regions included in the request sent to this store.
+    requested_count: usize,
+    /// Number of regions returned in this store's check-leader response.
+    returned_count: usize,
+    /// Sample of unresolved regions requested from this store but not returned
+    /// by it.
+    unreturned_regions: Vec<u64>,
+    /// Whether `unreturned_regions` was cut at `CHECK_LEADER_LOG_REGION_LIMIT`.
+    unreturned_regions_truncated: bool,
+    /// RPC error from this target store when the request failed before a
+    /// response.
+    rpc_error: Option<String>,
+}
+
+impl fmt::Debug for CheckLeaderStoreStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CheckLeaderStoreStatus")
+            .field("to_store_id", &self.to_store_id)
+            .field("requested_count", &self.requested_count)
+            .field("returned_count", &self.returned_count)
+            .field("unreturned_regions", &self.unreturned_regions)
+            .field(
+                "unreturned_regions_truncated",
+                &self.unreturned_regions_truncated,
+            )
+            .field("rpc_error", &self.rpc_error)
+            .finish()
+    }
+}
 
 pub struct AdvanceTsWorker {
     pd_client: Arc<dyn PdClient>,
@@ -309,6 +349,8 @@ impl LeadershipResolver {
             .find(|req| !req.regions.is_empty())
             .map_or(0, |req| req.regions[0].compute_size());
         let mut check_leader_rpcs = Vec::with_capacity(store_req_map.len());
+        let mut requested_regions_by_store = HashMap::default();
+
         for (store_id, req) in store_req_map {
             if req.regions.is_empty() {
                 continue;
@@ -316,6 +358,13 @@ impl LeadershipResolver {
             let env = env.clone();
             let to_store = *store_id;
             let region_num = req.regions.len() as u32;
+            requested_regions_by_store.insert(
+                to_store,
+                req.regions
+                    .iter()
+                    .map(|leader_info| leader_info.get_region_id())
+                    .collect::<Vec<_>>(),
+            );
             CHECK_LEADER_REQ_SIZE_HISTOGRAM.observe((leader_info_size * region_num) as f64);
             CHECK_LEADER_REQ_ITEM_COUNT_HISTOGRAM.observe(region_num as f64);
 
@@ -375,6 +424,8 @@ impl LeadershipResolver {
         });
 
         let rpc_count = check_leader_rpcs.len();
+        let mut returned_regions_by_store = HashMap::default();
+        let mut check_leader_errors = HashMap::default();
         for _ in 0..rpc_count {
             // Use `select_all` to avoid the process getting blocked when some
             // TiKVs were down.
@@ -382,6 +433,7 @@ impl LeadershipResolver {
             check_leader_rpcs = remains;
             match res {
                 Ok((to_store, resp)) => {
+                    returned_regions_by_store.insert(to_store, resp.get_regions().to_vec());
                     for region_id in resp.regions {
                         if let Some(prog) = progresses.get_mut(&region_id) {
                             if prog.resolved {
@@ -397,6 +449,7 @@ impl LeadershipResolver {
                 }
                 Err((to_store, reconnect, err)) => {
                     info!("check leader failed"; "error" => ?err, "to_store" => to_store);
+                    check_leader_errors.insert(to_store, err);
                     if reconnect {
                         self.tikv_clients.lock().await.remove(&to_store);
                     }
@@ -408,10 +461,28 @@ impl LeadershipResolver {
         }
         let res: Vec<u64> = self.valid_regions.drain().collect();
         if res.len() != checking_regions.len() {
+            let valid_region_set = res.iter().copied().collect::<HashSet<_>>();
+            let unresolved_region_set = checking_regions
+                .iter()
+                .filter(|region_id| !valid_region_set.contains(region_id))
+                .copied()
+                .collect::<HashSet<_>>();
+            let (unresolved_regions, unresolved_regions_truncated) =
+                limited_region_list(unresolved_region_set.iter().copied());
+            let target_store_status = build_check_leader_store_status(
+                &requested_regions_by_store,
+                &returned_regions_by_store,
+                &check_leader_errors,
+                &unresolved_region_set,
+            );
             warn!(
-                "check leader returns valid regions different from checking regions";
+                "[resolved-ts-stuck] check leader unresolved regions";
+                "store_id" => self.store_id,
                 "valid_regions" => res.len(),
                 "checking_regions" => checking_regions.len(),
+                "unresolved_regions" => ?unresolved_regions,
+                "unresolved_regions_truncated" => unresolved_regions_truncated,
+                "target_store_status" => ?target_store_status,
             );
         }
         res
@@ -449,6 +520,54 @@ where
 
     let resps = futures::future::join_all(reqs).await;
     resps.into_iter().flatten().collect::<Vec<u64>>()
+}
+
+fn limited_region_list<I>(regions: I) -> (Vec<u64>, bool)
+where
+    I: IntoIterator<Item = u64>,
+{
+    let mut limited = Vec::with_capacity(CHECK_LEADER_LOG_REGION_LIMIT);
+    let mut truncated = false;
+    for region_id in regions {
+        if limited.len() == CHECK_LEADER_LOG_REGION_LIMIT {
+            truncated = true;
+            break;
+        }
+        limited.push(region_id);
+    }
+    (limited, truncated)
+}
+
+fn build_check_leader_store_status(
+    requested_regions_by_store: &HashMap<u64, Vec<u64>>,
+    returned_regions_by_store: &HashMap<u64, Vec<u64>>,
+    check_leader_errors: &HashMap<u64, String>,
+    unresolved_region_set: &HashSet<u64>,
+) -> Vec<CheckLeaderStoreStatus> {
+    let mut target_store_status = Vec::with_capacity(requested_regions_by_store.len());
+    for (to_store_id, requested_regions) in requested_regions_by_store {
+        let returned_regions = returned_regions_by_store.get(to_store_id);
+        let returned_region_set = returned_regions
+            .map(|regions| regions.iter().copied().collect::<HashSet<_>>())
+            .unwrap_or_default();
+        let (unreturned_regions, unreturned_regions_truncated) = limited_region_list(
+            requested_regions
+                .iter()
+                .filter(|region_id| unresolved_region_set.contains(region_id))
+                .filter(|region_id| !returned_region_set.contains(region_id))
+                .copied(),
+        );
+        target_store_status.push(CheckLeaderStoreStatus {
+            to_store_id: *to_store_id,
+            requested_count: requested_regions.len(),
+            returned_count: returned_regions.map_or(0, Vec::len),
+            unreturned_regions,
+            unreturned_regions_truncated,
+            rpc_error: check_leader_errors.get(to_store_id).cloned(),
+        });
+    }
+    target_store_status.sort_by_key(|status| status.to_store_id);
+    target_store_status
 }
 
 fn region_has_quorum(peers: &[Peer], stores: &[u64]) -> bool {

--- a/components/resolved_ts/src/advance.rs
+++ b/components/resolved_ts/src/advance.rs
@@ -51,6 +51,7 @@ const DEFAULT_GRPC_MIN_MESSAGE_SIZE_TO_COMPRESS: usize = 4096;
 const CHECK_LEADER_LOG_REGION_LIMIT: usize = 3;
 
 /// CheckLeaderStoreStatus record each store's leadership details.
+#[allow(dead_code)]
 #[derive(Debug)]
 struct CheckLeaderStoreStatus {
     /// Store that received a check-leader request from this leader.

--- a/components/resolved_ts/src/advance.rs
+++ b/components/resolved_ts/src/advance.rs
@@ -51,11 +51,7 @@ const DEFAULT_GRPC_GZIP_COMPRESSION_LEVEL: usize = 2;
 const DEFAULT_GRPC_MIN_MESSAGE_SIZE_TO_COMPRESS: usize = 4096;
 const CHECK_LEADER_LOG_REGION_LIMIT: usize = 3;
 
-/// Per target-store status in the check-leader unresolved summary log.
-///
-/// This is printed only when some checked regions cannot pass quorum, so every
-/// field is aimed at answering which requested stores did not return the
-/// unresolved regions.
+/// CheckLeaderStoreStatus record each store's leadership details.
 struct CheckLeaderStoreStatus {
     /// Store that received a check-leader request from this leader.
     to_store_id: u64,
@@ -467,7 +463,7 @@ impl LeadershipResolver {
                 .filter(|region_id| !valid_region_set.contains(region_id))
                 .copied()
                 .collect::<HashSet<_>>();
-            let (unresolved_regions, unresolved_regions_truncated) =
+            let (unresolved_regions, _) =
                 limited_region_list(unresolved_region_set.iter().copied());
             let target_store_status = build_check_leader_store_status(
                 &requested_regions_by_store,
@@ -481,7 +477,6 @@ impl LeadershipResolver {
                 "valid_region_count" => res.len(),
                 "checking_region_count" => checking_regions.len(),
                 "unresolved_regions" => ?unresolved_regions,
-                "unresolved_regions_truncated" => unresolved_regions_truncated,
                 "target_store_status" => ?target_store_status,
             );
         }

--- a/components/resolved_ts/src/advance.rs
+++ b/components/resolved_ts/src/advance.rs
@@ -477,9 +477,9 @@ impl LeadershipResolver {
             );
             warn!(
                 "[resolved-ts-stuck] check leader unresolved regions";
-                "store_id" => self.store_id,
-                "valid_regions" => res.len(),
-                "checking_regions" => checking_regions.len(),
+                "local_store_id" => self.store_id,
+                "valid_region_count" => res.len(),
+                "checking_region_count" => checking_regions.len(),
                 "unresolved_regions" => ?unresolved_regions,
                 "unresolved_regions_truncated" => unresolved_regions_truncated,
                 "target_store_status" => ?target_store_status,

--- a/components/resolved_ts/src/advance.rs
+++ b/components/resolved_ts/src/advance.rs
@@ -3,7 +3,6 @@
 use std::{
     cmp,
     ffi::CString,
-    fmt,
     sync::{
         atomic::{AtomicI32, Ordering},
         Arc,
@@ -52,6 +51,7 @@ const DEFAULT_GRPC_MIN_MESSAGE_SIZE_TO_COMPRESS: usize = 4096;
 const CHECK_LEADER_LOG_REGION_LIMIT: usize = 3;
 
 /// CheckLeaderStoreStatus record each store's leadership details.
+#[derive(Debug)]
 struct CheckLeaderStoreStatus {
     /// Store that received a check-leader request from this leader.
     to_store_id: u64,
@@ -67,22 +67,6 @@ struct CheckLeaderStoreStatus {
     /// RPC error from this target store when the request failed before a
     /// response.
     rpc_error: Option<String>,
-}
-
-impl fmt::Debug for CheckLeaderStoreStatus {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("CheckLeaderStoreStatus")
-            .field("to_store_id", &self.to_store_id)
-            .field("requested_count", &self.requested_count)
-            .field("returned_count", &self.returned_count)
-            .field("unreturned_regions", &self.unreturned_regions)
-            .field(
-                "unreturned_regions_truncated",
-                &self.unreturned_regions_truncated,
-            )
-            .field("rpc_error", &self.rpc_error)
-            .finish()
-    }
 }
 
 pub struct AdvanceTsWorker {
@@ -542,14 +526,13 @@ fn build_check_leader_store_status(
     let mut target_store_status = Vec::with_capacity(requested_regions_by_store.len());
     for (to_store_id, requested_regions) in requested_regions_by_store {
         let returned_regions = returned_regions_by_store.get(to_store_id);
-        let returned_region_set = returned_regions
-            .map(|regions| regions.iter().copied().collect::<HashSet<_>>())
-            .unwrap_or_default();
         let (unreturned_regions, unreturned_regions_truncated) = limited_region_list(
             requested_regions
                 .iter()
                 .filter(|region_id| unresolved_region_set.contains(region_id))
-                .filter(|region_id| !returned_region_set.contains(region_id))
+                .filter(|region_id| {
+                    !returned_regions.map_or(false, |regions| regions.contains(*region_id))
+                })
                 .copied(),
         );
         target_store_status.push(CheckLeaderStoreStatus {


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: ref #19768

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
add logs to the resolved ts advancer and raft log update leader info to detect why the leadership not confirmed when change peer happens
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
none
```
