### PR TITLE
raftstore: fix load-based split accounting and stale state

### DIFF
--- a/components/raftstore/src/store/worker/pd.rs
+++ b/components/raftstore/src/store/worker/pd.rs
@@ -843,15 +843,36 @@ where
     ) {
         let start_time = TiInstant::now();
         match auto_split_controller.refresh_and_check_cfg() {
-            SplitConfigChange::UpdateRegionCpuCollector(is_register) => {
-                // If it's a deregister task, just take and drop the original collector.
-                if !is_register {
+            SplitConfigChange::ResetStats {
+                update_region_cpu_collector,
+            } => {
+                // Request old-collector deregistration before draining to
+                // narrow the window for late old-configuration intervals.
+                if update_region_cpu_collector == Some(false) {
                     region_cpu_records_collector.take();
-                } else {
+                }
+                // This only clears statistics already visible to the stats
+                // monitor. Queued PD-worker tasks, in-progress resource-metering
+                // intervals, and long-lived TLS observations can arrive later,
+                // so this is not a generation fence.
+                auto_split_controller_ctx
+                    .discard_pending_stats(read_stats_receiver, cpu_stats_receiver);
+                // Prime the next thread-CPU interval after the reset boundary.
+                thread_stats.record();
+                // Register a newly enabled collector only after old records are
+                // drained, so its first interval is not discarded here.
+                if update_region_cpu_collector == Some(true) {
                     region_cpu_records_collector.get_or_insert(
                         collector_reg_handle.register(Box::new(reporter.clone()), false),
                     );
                 }
+                for rank in 0..TOP_N {
+                    READ_QPS_TOPN
+                        .with_label_values(&[&rank.to_string()])
+                        .set(0.0);
+                }
+                LOAD_BASE_SPLIT_DURATION_HISTOGRAM.observe(start_time.saturating_elapsed_secs());
+                return;
             }
             SplitConfigChange::Noop => {}
         }
@@ -3073,16 +3094,151 @@ fn get_read_query_num(stat: &pdpb::QueryStats) -> u64 {
 
 #[cfg(test)]
 mod tests {
-    use std::thread::sleep;
+    use std::{
+        sync::{
+            atomic::{AtomicUsize, Ordering as AtomicOrdering},
+            mpsc,
+        },
+        thread::sleep,
+    };
 
     use kvproto::{kvrpcpb, pdpb::QueryKind};
+    use online_config::{ConfigChange, ConfigManager, ConfigValue};
     use pd_client::{BucketMeta, new_bucket_stats};
-    use tikv_util::worker::LazyWorker;
+    use tikv_util::{config::VersionTrack, worker::LazyWorker};
 
     use super::*;
-    use crate::store::util::build_key_range;
+    use crate::store::{
+        util::build_key_range,
+        worker::{SplitConfig, SplitConfigManager},
+    };
 
     const DEFAULT_TEST_STORE_ID: u64 = 1;
+
+    #[derive(Clone, Default)]
+    struct TestStatsReporter {
+        auto_split_calls: Arc<AtomicUsize>,
+    }
+
+    impl Collector for TestStatsReporter {
+        fn collect(&self, _records: Arc<RawRecords>) {}
+    }
+
+    impl StoreStatsReporter for TestStatsReporter {
+        fn report_store_infos(
+            &self,
+            _cpu_usages: RecordPairVec,
+            _read_io_rates: RecordPairVec,
+            _write_io_rates: RecordPairVec,
+        ) {
+        }
+
+        fn report_min_resolved_ts(&self, _store_id: u64, _min_resolved_ts: u64) {}
+
+        fn auto_split(&self, _split_infos: Vec<SplitInfo>) {
+            self.auto_split_calls.fetch_add(1, AtomicOrdering::SeqCst);
+        }
+
+        fn update_latency_stats(&self, _timer_tick: u64, _factor: InspectFactor) {}
+    }
+
+    #[test]
+    fn test_load_base_split_reset_drains_queues_and_updates_collector_guard() {
+        let mut manager = SplitConfigManager(Arc::new(VersionTrack::new(SplitConfig::default())));
+        let mut controller = AutoSplitController::new(manager.clone(), 0, 0, None);
+        let mut context = AutoSplitControllerContext::new(8);
+        let mut thread_stats = ThreadInfoStatistics::default();
+        let split_validator = SplitValidator::new();
+        let (read_sender, read_receiver) = mpsc::sync_channel(8);
+        let (cpu_sender, cpu_receiver) = mpsc::sync_channel(8);
+        read_sender.send(ReadStats::with_sample_num(1)).unwrap();
+        cpu_sender.send(Arc::new(RawRecords::default())).unwrap();
+
+        let mut change = ConfigChange::new();
+        change.insert(String::from("sample_threshold"), ConfigValue::U64(101));
+        manager.dispatch(change).unwrap();
+
+        let reporter = TestStatsReporter::default();
+        let collector_reg_handle = CollectorRegHandle::new_for_test();
+        let mut collector = Some(collector_reg_handle.register(Box::new(reporter.clone()), false));
+        StatsMonitor::load_base_split(
+            &mut controller,
+            &mut context,
+            &read_receiver,
+            &cpu_receiver,
+            &mut thread_stats,
+            &reporter,
+            &collector_reg_handle,
+            &mut collector,
+            &split_validator,
+        );
+
+        assert_eq!(reporter.auto_split_calls.load(AtomicOrdering::SeqCst), 0);
+        assert!(matches!(
+            read_receiver.try_recv(),
+            Err(mpsc::TryRecvError::Empty)
+        ));
+        assert!(matches!(
+            cpu_receiver.try_recv(),
+            Err(mpsc::TryRecvError::Empty)
+        ));
+        assert!(collector.is_some());
+
+        // A normal tick reaches the reporter, proving the reset path returned
+        // before flush rather than the mock swallowing every call.
+        StatsMonitor::load_base_split(
+            &mut controller,
+            &mut context,
+            &read_receiver,
+            &cpu_receiver,
+            &mut thread_stats,
+            &reporter,
+            &collector_reg_handle,
+            &mut collector,
+            &split_validator,
+        );
+        assert_eq!(reporter.auto_split_calls.load(AtomicOrdering::SeqCst), 1);
+
+        let mut change = ConfigChange::new();
+        change.insert(
+            String::from("region_cpu_overload_threshold_ratio"),
+            ConfigValue::F64(0.0),
+        );
+        manager.dispatch(change).unwrap();
+        StatsMonitor::load_base_split(
+            &mut controller,
+            &mut context,
+            &read_receiver,
+            &cpu_receiver,
+            &mut thread_stats,
+            &reporter,
+            &collector_reg_handle,
+            &mut collector,
+            &split_validator,
+        );
+        assert!(collector.is_none());
+        assert_eq!(reporter.auto_split_calls.load(AtomicOrdering::SeqCst), 1);
+
+        let mut change = ConfigChange::new();
+        change.insert(
+            String::from("region_cpu_overload_threshold_ratio"),
+            ConfigValue::F64(0.1),
+        );
+        manager.dispatch(change).unwrap();
+        StatsMonitor::load_base_split(
+            &mut controller,
+            &mut context,
+            &read_receiver,
+            &cpu_receiver,
+            &mut thread_stats,
+            &reporter,
+            &collector_reg_handle,
+            &mut collector,
+            &split_validator,
+        );
+        assert!(collector.is_some());
+        assert_eq!(reporter.auto_split_calls.load(AtomicOrdering::SeqCst), 1);
+    }
 
     #[cfg(not(target_os = "macos"))]
     #[test]

--- a/components/raftstore/src/store/worker/split_controller.rs
+++ b/components/raftstore/src/store/worker/split_controller.rs
@@ -4,8 +4,12 @@ use std::{
     cmp::{Ordering, min},
     collections::{BinaryHeap, HashSet},
     slice::{Iter, IterMut},
-    sync::{Arc, mpsc::Receiver},
-    time::{Duration, SystemTime},
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering as AtomicOrdering},
+        mpsc::Receiver,
+    },
+    time::Duration,
 };
 
 use collections::HashMap;
@@ -271,7 +275,7 @@ pub struct Recorder {
     pub detect_times: usize,
     pub peer: Peer,
     pub key_ranges: Vec<Vec<KeyRange>>,
-    pub create_time: SystemTime,
+    pub create_time: Instant,
     pub cpu_usage: f64,
     pub hottest_key_range: Option<KeyRange>,
 }
@@ -282,7 +286,7 @@ impl Recorder {
             detect_times: detect_times as usize,
             peer: Peer::default(),
             key_ranges: vec![],
-            create_time: SystemTime::now(),
+            create_time: Instant::now_coarse(),
             cpu_usage: 0.0,
             hottest_key_range: None,
         }
@@ -562,7 +566,11 @@ impl SplitInfo {
 #[derive(PartialEq, Debug)]
 pub enum SplitConfigChange {
     Noop,
-    UpdateRegionCpuCollector(bool),
+    ResetStats {
+        /// `Some(true)` registers the CPU collector and `Some(false)` removes
+        /// it. `None` keeps the current registration unchanged.
+        update_region_cpu_collector: Option<bool>,
+    },
 }
 
 pub struct AutoSplitController {
@@ -573,7 +581,7 @@ pub struct AutoSplitController {
     // Thread-related info
     max_grpc_thread_count: usize,
     max_unified_read_pool_thread_count: usize,
-    unified_read_pool_scale_receiver: Option<Receiver<usize>>,
+    unified_read_pool_size: Option<Arc<AtomicUsize>>,
     grpc_thread_usage_vec: Vec<f64>,
 }
 
@@ -582,15 +590,20 @@ impl AutoSplitController {
         config_manager: SplitConfigManager,
         max_grpc_thread_count: usize,
         max_unified_read_pool_thread_count: usize,
-        unified_read_pool_scale_receiver: Option<Receiver<usize>>,
+        unified_read_pool_size: Option<Arc<AtomicUsize>>,
     ) -> AutoSplitController {
+        let max_unified_read_pool_thread_count = unified_read_pool_size
+            .as_ref()
+            .map_or(max_unified_read_pool_thread_count, |current_pool_size| {
+                current_pool_size.load(AtomicOrdering::Relaxed)
+            });
         AutoSplitController {
             recorders: HashMap::default(),
             cfg: config_manager.value().clone(),
             cfg_tracker: config_manager.0.clone().tracker("split_hub".to_owned()),
             max_grpc_thread_count,
             max_unified_read_pool_thread_count,
-            unified_read_pool_scale_receiver,
+            unified_read_pool_size,
             grpc_thread_usage_vec: vec![],
         }
     }
@@ -687,33 +700,36 @@ impl AutoSplitController {
     ) -> &'c HashMap<u64, (f64, Option<KeyRange>)> {
         // RegionID -> (CPU usage, Hottest Key Range), calculate the CPU usage and its
         // hottest key range.
-        if !self.should_check_region_cpu() {
-            return ctx.empty_region_cpu_map();
+        let should_check_region_cpu = self.should_check_region_cpu();
+        let (cpu_stats_vec, cpu_stats_cache) = ctx.batch_recv_cpu_stats(cpu_stats_receiver);
+        // Keep draining records after CPU-based split is disabled. Otherwise, records
+        // collected before the collector is deregistered can be reused after the mode
+        // is enabled again.
+        if !should_check_region_cpu {
+            cpu_stats_vec.clear();
+            return &cpu_stats_cache.region_cpu_map;
         }
 
-        let (
-            cpu_stats_vec,
-            CpuStatsCache {
-                region_cpu_map,
-                hottest_key_range_cpu_time_map,
-            },
-        ) = ctx.batch_recv_cpu_stats(cpu_stats_receiver);
+        let CpuStatsCache {
+            region_cpu_map,
+            hottest_key_range_cpu_time_map,
+        } = cpu_stats_cache;
         // Calculate the Region CPU usage.
         let mut collect_interval_ms = 0;
         let mut region_key_range_cpu_time_map = HashMap::default();
         cpu_stats_vec.iter().for_each(|cpu_stats| {
             cpu_stats.records.iter().for_each(|(tag, record)| {
-                // Calculate the Region ID -> CPU Time.
+                // Calculate the Region ID -> Unified Read CPU Time.
                 region_cpu_map
                     .entry(tag.region_id)
-                    .and_modify(|(cpu_time, _)| *cpu_time += record.cpu_time as f64)
-                    .or_insert_with(|| (record.cpu_time as f64, None));
-                // Calculate the (Region ID, Key Range) -> CPU Time.
+                    .and_modify(|(cpu_time, _)| *cpu_time += record.unified_read_cpu_time as f64)
+                    .or_insert_with(|| (record.unified_read_cpu_time as f64, None));
+                // Calculate the (Region ID, Key Range) -> Unified Read CPU Time.
                 tag.key_ranges.iter().for_each(|key_range| {
                     region_key_range_cpu_time_map
                         .entry((tag.region_id, key_range))
-                        .and_modify(|cpu_time| *cpu_time += record.cpu_time)
-                        .or_insert_with(|| record.cpu_time);
+                        .and_modify(|cpu_time| *cpu_time += record.unified_read_cpu_time)
+                        .or_insert_with(|| record.unified_read_cpu_time);
                 })
             });
             collect_interval_ms += cpu_stats.duration.as_millis();
@@ -802,6 +818,8 @@ impl AutoSplitController {
         let region_qps_histogram = LOAD_BASE_SPLIT_REGION_LOAD_VEC.with_label_values(&["qps"]);
         let region_bytes_histogram =
             LOAD_BASE_SPLIT_REGION_LOAD_VEC.with_label_values(&["bytes_kib"]);
+        self.recorders
+            .retain(|region_id, _| !split_validator.is_disabled(*region_id));
         for (region_id, region_infos) in region_infos_map {
             if split_validator.is_disabled(region_id) {
                 continue;
@@ -954,34 +972,49 @@ impl AutoSplitController {
     pub fn clear(&mut self) {
         let interval = Duration::from_secs(self.cfg.detect_times * 2);
         self.recorders
-            .retain(|_, recorder| match recorder.create_time.elapsed() {
-                Ok(life_time) => life_time < interval,
-                Err(_) => true,
-            });
+            .retain(|_, recorder| recorder.create_time.saturating_elapsed() < interval);
+    }
+
+    fn reset_stats(&mut self) {
+        self.recorders.clear();
+        self.grpc_thread_usage_vec.clear();
     }
 
     pub fn refresh_and_check_cfg(&mut self) -> SplitConfigChange {
-        let mut cfg_change = SplitConfigChange::Noop;
+        let mut reset_stats = false;
+        let mut update_region_cpu_collector = None;
         if let Some(incoming) = self.cfg_tracker.any_new() {
             if self.cfg.region_cpu_overload_threshold_ratio() <= 0.0
                 && incoming.region_cpu_overload_threshold_ratio() > 0.0
             {
-                cfg_change = SplitConfigChange::UpdateRegionCpuCollector(true);
+                update_region_cpu_collector = Some(true);
             }
             if self.cfg.region_cpu_overload_threshold_ratio() > 0.0
                 && incoming.region_cpu_overload_threshold_ratio() <= 0.0
             {
-                cfg_change = SplitConfigChange::UpdateRegionCpuCollector(false);
+                update_region_cpu_collector = Some(false);
             }
             self.cfg = incoming.clone();
+            // Producers can observe an intermediate version even when multiple
+            // updates return to the previous value before this tick.
+            reset_stats = true;
         }
-        // Adjust with the size change of the Unified Read Pool.
-        if let Some(rx) = &self.unified_read_pool_scale_receiver {
-            if let Ok(max_thread_count) = rx.try_recv() {
-                self.max_unified_read_pool_thread_count = max_thread_count;
+        // Each flush re-evaluates the busy gate with the current pool capacity
+        // while preserving normal QPS and byte detection history. Intermediate
+        // resize values are irrelevant; only the capacity currently in effect is
+        // needed.
+        if let Some(current_pool_size) = &self.unified_read_pool_size {
+            self.max_unified_read_pool_thread_count =
+                current_pool_size.load(AtomicOrdering::Relaxed);
+        }
+        if reset_stats {
+            self.reset_stats();
+            SplitConfigChange::ResetStats {
+                update_region_cpu_collector,
             }
+        } else {
+            SplitConfigChange::Noop
         }
-        cfg_change
     }
 }
 
@@ -1015,6 +1048,24 @@ impl AutoSplitControllerContext {
         }
     }
 
+    /// Clears statistics retained by or already queued to the stats monitor.
+    ///
+    /// Queued PD-worker tasks, in-progress resource-metering intervals, and
+    /// long-lived TLS observations can publish older statistics after this
+    /// returns, so this is not a generation fence.
+    pub fn discard_pending_stats(
+        &mut self,
+        read_stats_receiver: &Receiver<ReadStats>,
+        cpu_stats_receiver: &Receiver<Arc<RawRecords>>,
+    ) {
+        self.read_stats_vec.clear();
+        self.cpu_stats_vec.clear();
+        self.cpu_stats_cache.region_cpu_map.clear();
+        self.cpu_stats_cache.hottest_key_range_cpu_time_map.clear();
+        while read_stats_receiver.try_recv().is_ok() {}
+        while cpu_stats_receiver.try_recv().is_ok() {}
+    }
+
     pub fn batch_recv_read_stats(
         &mut self,
         read_stats_receiver: &Receiver<ReadStats>,
@@ -1045,11 +1096,6 @@ impl AutoSplitControllerContext {
             }
         }
         (&mut self.cpu_stats_vec, &mut self.cpu_stats_cache)
-    }
-
-    pub fn empty_region_cpu_map(&mut self) -> &HashMap<u64, (f64, Option<KeyRange>)> {
-        self.cpu_stats_cache.region_cpu_map.clear();
-        &self.cpu_stats_cache.region_cpu_map
     }
 
     pub fn maybe_gc(&mut self) {
@@ -1179,6 +1225,22 @@ mod tests {
         assert!(recorder.is_ready());
         let key = recorder.collect(&config);
         assert_eq!(key, b"b");
+    }
+
+    #[test]
+    fn test_clear_removes_stale_recorders() {
+        let mut hub = AutoSplitController::default();
+        hub.cfg.detect_times = 1;
+
+        let mut stale = Recorder::new(hub.cfg.detect_times);
+        stale.create_time = Instant::now_coarse() - Duration::from_secs(3);
+        hub.recorders.insert(1, stale);
+        hub.recorders.insert(2, Recorder::new(hub.cfg.detect_times));
+
+        hub.clear();
+
+        assert!(!hub.recorders.contains_key(&1));
+        assert!(hub.recorders.contains_key(&2));
     }
 
     #[test]
@@ -1442,6 +1504,7 @@ mod tests {
                 key_range_tag.clone(),
                 RawRecord {
                     cpu_time: cpu_times[idx],
+                    unified_read_cpu_time: cpu_times[idx],
                     read_keys: 0,
                     write_keys: 0,
                     network_in_bytes: 0,
@@ -1817,7 +1880,9 @@ mod tests {
         );
         assert_eq!(
             auto_split_controller.refresh_and_check_cfg(),
-            SplitConfigChange::UpdateRegionCpuCollector(false),
+            SplitConfigChange::ResetStats {
+                update_region_cpu_collector: Some(false),
+            },
         );
         assert_eq!(
             auto_split_controller
@@ -1837,7 +1902,9 @@ mod tests {
         );
         assert_eq!(
             auto_split_controller.refresh_and_check_cfg(),
-            SplitConfigChange::UpdateRegionCpuCollector(true),
+            SplitConfigChange::ResetStats {
+                update_region_cpu_collector: Some(true),
+            },
         );
         assert_eq!(
             auto_split_controller
@@ -1849,6 +1916,127 @@ mod tests {
             auto_split_controller.refresh_and_check_cfg(),
             SplitConfigChange::Noop,
         );
+
+        // A round trip still invalidates samples produced between versions.
+        dispatch_split_cfg_change(
+            &mut split_cfg_manager,
+            "region_cpu_overload_threshold_ratio",
+            ConfigValue::F64(0.2),
+        );
+        dispatch_split_cfg_change(
+            &mut split_cfg_manager,
+            "region_cpu_overload_threshold_ratio",
+            ConfigValue::F64(0.1),
+        );
+        assert_eq!(
+            auto_split_controller.refresh_and_check_cfg(),
+            SplitConfigChange::ResetStats {
+                update_region_cpu_collector: None,
+            },
+        );
+        assert_eq!(
+            auto_split_controller.refresh_and_check_cfg(),
+            SplitConfigChange::Noop,
+        );
+    }
+
+    #[test]
+    fn test_refresh_config_clears_controller_history() {
+        let split_config = SplitConfig::default();
+        let mut split_cfg_manager =
+            SplitConfigManager::new(Arc::new(VersionTrack::new(split_config)));
+        let mut auto_split_controller =
+            AutoSplitController::new(split_cfg_manager.clone(), 0, 0, None);
+        auto_split_controller
+            .recorders
+            .insert(1, Recorder::new(auto_split_controller.cfg.detect_times));
+        auto_split_controller.update_grpc_thread_usage(1.0);
+
+        dispatch_split_cfg_change(
+            &mut split_cfg_manager,
+            "sample_threshold",
+            ConfigValue::U64(auto_split_controller.cfg.sample_threshold + 1),
+        );
+
+        assert_eq!(
+            auto_split_controller.refresh_and_check_cfg(),
+            SplitConfigChange::ResetStats {
+                update_region_cpu_collector: None,
+            },
+        );
+        assert!(auto_split_controller.recorders.is_empty());
+        assert!(auto_split_controller.grpc_thread_usage_vec.is_empty());
+    }
+
+    #[test]
+    fn test_read_pool_resize_preserves_controller_history() {
+        let current_pool_size = Arc::new(AtomicUsize::new(1));
+        let mut auto_split_controller = AutoSplitController::new(
+            SplitConfigManager::default(),
+            0,
+            1,
+            Some(current_pool_size.clone()),
+        );
+        auto_split_controller
+            .recorders
+            .insert(1, Recorder::new(auto_split_controller.cfg.detect_times));
+        auto_split_controller.update_grpc_thread_usage(1.0);
+
+        current_pool_size.store(2, AtomicOrdering::Relaxed);
+        current_pool_size.store(3, AtomicOrdering::Relaxed);
+        current_pool_size.store(4, AtomicOrdering::Relaxed);
+        assert_eq!(
+            auto_split_controller.refresh_and_check_cfg(),
+            SplitConfigChange::Noop,
+        );
+        assert_eq!(auto_split_controller.max_unified_read_pool_thread_count, 4);
+        assert_eq!(auto_split_controller.recorders.len(), 1);
+        assert!(auto_split_controller.recorders.contains_key(&1));
+        assert_eq!(auto_split_controller.grpc_thread_usage_vec, vec![1.0]);
+
+        auto_split_controller
+            .recorders
+            .insert(2, Recorder::new(auto_split_controller.cfg.detect_times));
+        auto_split_controller.update_grpc_thread_usage(2.0);
+        // Returning from A to B and back to A before a tick still observes the
+        // current capacity without resetting detection history.
+        current_pool_size.store(3, AtomicOrdering::Relaxed);
+        current_pool_size.store(4, AtomicOrdering::Relaxed);
+        assert_eq!(
+            auto_split_controller.refresh_and_check_cfg(),
+            SplitConfigChange::Noop,
+        );
+        assert_eq!(auto_split_controller.max_unified_read_pool_thread_count, 4);
+        assert_eq!(auto_split_controller.recorders.len(), 2);
+        assert!(auto_split_controller.recorders.contains_key(&1));
+        assert!(auto_split_controller.recorders.contains_key(&2));
+        assert_eq!(auto_split_controller.grpc_thread_usage_vec, vec![1.0, 2.0]);
+    }
+
+    #[test]
+    fn test_flush_removes_recorders_for_disabled_regions() {
+        let mut auto_split_controller = AutoSplitController::default();
+        auto_split_controller
+            .recorders
+            .insert(1, Recorder::new(auto_split_controller.cfg.detect_times));
+        auto_split_controller
+            .recorders
+            .insert(2, Recorder::new(auto_split_controller.cfg.detect_times));
+        let split_validator = SplitValidator::new();
+        split_validator.disable(1);
+        let (mut ctx, read_stats_receiver, cpu_stats_receiver) =
+            new_auto_split_controller_ctx(vec![], vec![]);
+
+        auto_split_controller.flush(
+            &mut ctx,
+            &read_stats_receiver,
+            &cpu_stats_receiver,
+            &mut ThreadInfoStatistics::default(),
+            &split_validator,
+        );
+
+        assert!(!auto_split_controller.recorders.contains_key(&1));
+        assert!(auto_split_controller.recorders.contains_key(&2));
     }
 
     fn dispatch_split_cfg_change(
@@ -1859,6 +2047,15 @@ mod tests {
         let mut config_change = ConfigChange::new();
         config_change.insert(String::from(cfg_name), cfg_value);
         split_cfg_manager.dispatch(config_change).unwrap();
+    }
+
+    fn inverse_total_cpu_time(unified_read_cpu_time: u32) -> u32 {
+        const TEST_CPU_TIME_BUDGET: u32 = 1_000;
+        let total_cpu_time = TEST_CPU_TIME_BUDGET
+            .checked_sub(unified_read_cpu_time)
+            .expect("test unified-read CPU time must fit the test budget");
+        assert!(total_cpu_time >= unified_read_cpu_time);
+        total_cpu_time
     }
 
     #[test]
@@ -1918,11 +2115,12 @@ mod tests {
         for (i, test_case) in test_cases.iter().enumerate() {
             let mut raw_records = RawRecords::default();
             raw_records.duration = Duration::from_millis(100);
-            // ["a", "b"] with (test_case.0)ms CPU time.
+            // ["a", "b"] with (test_case.0)ms unified-read CPU time.
             raw_records.records.insert(
                 ab_key_range_tag.clone(),
                 RawRecord {
-                    cpu_time: test_case.0,
+                    cpu_time: inverse_total_cpu_time(test_case.0),
+                    unified_read_cpu_time: test_case.0,
                     read_keys: 0,
                     write_keys: 0,
                     network_in_bytes: 0,
@@ -1932,11 +2130,12 @@ mod tests {
                     ..Default::default()
                 },
             );
-            // ["c", "d"] with (test_case.1)ms CPU time.
+            // ["c", "d"] with (test_case.1)ms unified-read CPU time.
             raw_records.records.insert(
                 cd_key_range_tag.clone(),
                 RawRecord {
-                    cpu_time: test_case.1,
+                    cpu_time: inverse_total_cpu_time(test_case.1),
+                    unified_read_cpu_time: test_case.1,
                     read_keys: 0,
                     write_keys: 0,
                     network_in_bytes: 0,
@@ -1946,11 +2145,12 @@ mod tests {
                     ..Default::default()
                 },
             );
-            // Multiple key ranges with (test_case.2)ms CPU time.
+            // Multiple key ranges with (test_case.2)ms unified-read CPU time.
             raw_records.records.insert(
                 multiple_key_ranges_tag.clone(),
                 RawRecord {
-                    cpu_time: test_case.2,
+                    cpu_time: inverse_total_cpu_time(test_case.2),
+                    unified_read_cpu_time: test_case.2,
                     read_keys: 0,
                     write_keys: 0,
                     network_in_bytes: 0,
@@ -1960,11 +2160,12 @@ mod tests {
                     ..Default::default()
                 },
             );
-            // Empty key range with (test_case.3)ms CPU time.
+            // Empty key range with (test_case.3)ms unified-read CPU time.
             raw_records.records.insert(
                 empty_key_range_tag.clone(),
                 RawRecord {
-                    cpu_time: test_case.3,
+                    cpu_time: inverse_total_cpu_time(test_case.3),
+                    unified_read_cpu_time: test_case.3,
                     read_keys: 0,
                     write_keys: 0,
                     network_in_bytes: 0,
@@ -1998,6 +2199,26 @@ mod tests {
                 i
             );
         }
+    }
+
+    #[test]
+    fn test_collect_cpu_stats_drains_channel_when_cpu_split_disabled() {
+        let mut auto_split_controller = AutoSplitController::default();
+        auto_split_controller
+            .cfg
+            .region_cpu_overload_threshold_ratio = Some(0.0);
+        let cpu_stats = gen_cpu_stats(1, vec![build_key_range(b"a", b"b", false)], vec![100]);
+        let (mut ctx, _, cpu_stats_receiver) =
+            new_auto_split_controller_ctx(vec![], vec![cpu_stats]);
+
+        let region_cpu_map = auto_split_controller.collect_cpu_stats(&mut ctx, &cpu_stats_receiver);
+
+        assert!(region_cpu_map.is_empty());
+        assert!(ctx.cpu_stats_vec.is_empty());
+        assert!(matches!(
+            cpu_stats_receiver.try_recv(),
+            Err(TryRecvError::Disconnected)
+        ));
     }
 
     #[test]
@@ -2190,13 +2411,6 @@ mod tests {
                 TryRecvError::Empty
             );
         }
-    }
-
-    #[test]
-    fn test_auto_split_controller_empty_region_cpu_map() {
-        let mut ctx = AutoSplitControllerContext::new(1);
-        ctx.cpu_stats_cache.region_cpu_map.insert(1, (0.0, None));
-        assert!(ctx.empty_region_cpu_map().is_empty());
     }
 
     #[test]

--- a/components/raftstore/src/store/worker/split_controller.rs
+++ b/components/raftstore/src/store/worker/split_controller.rs
@@ -800,15 +800,13 @@ impl AutoSplitController {
         } = cpu_stats_cache;
         // Calculate the Region CPU usage.
         let mut collect_interval_ms = 0;
-        let mut region_key_range_cpu_time_map = HashMap::default();
+        let mut region_key_range_cpu_time_map: HashMap<(u64, _), u32> = HashMap::default();
         cpu_stats_vec.iter().for_each(|cpu_stats| {
             cpu_stats.records.iter().for_each(|(tag, record)| {
                 // Calculate the Region ID -> Unified Read CPU Time.
                 region_cpu_map
                     .entry(tag.region_id)
-                    .and_modify(|(cpu_time, _)| {
-                        *cpu_time += record.unified_read_cpu_time as f64
-                    })
+                    .and_modify(|(cpu_time, _)| *cpu_time += record.unified_read_cpu_time as f64)
                     .or_insert_with(|| (record.unified_read_cpu_time as f64, None));
                 // Calculate the (Region ID, Key Range) -> Unified Read CPU Time.
                 tag.key_ranges.iter().for_each(|key_range| {
@@ -1189,10 +1187,7 @@ impl AutoSplitControllerContext {
     }
 
     /// Discards all CPU records currently queued by resource metering.
-    pub fn discard_pending_cpu_stats(
-        &mut self,
-        cpu_stats_receiver: &Receiver<Arc<RawRecords>>,
-    ) {
+    pub fn discard_pending_cpu_stats(&mut self, cpu_stats_receiver: &Receiver<Arc<RawRecords>>) {
         self.cpu_stats_vec.clear();
         self.cpu_stats_cache.region_cpu_map.clear();
         self.cpu_stats_cache.hottest_key_range_cpu_time_map.clear();
@@ -2432,8 +2427,7 @@ mod tests {
         let batch_limit = 2;
         let (cpu_stats_sender, cpu_stats_receiver) = mpsc::sync_channel(4);
         for _ in 0..4 {
-            let cpu_stats =
-                gen_cpu_stats(1, vec![build_key_range(b"a", b"b", false)], vec![100]);
+            let cpu_stats = gen_cpu_stats(1, vec![build_key_range(b"a", b"b", false)], vec![100]);
             cpu_stats_sender.try_send(cpu_stats).unwrap();
         }
         drop(cpu_stats_sender);

--- a/components/raftstore/src/store/worker/split_controller.rs
+++ b/components/raftstore/src/store/worker/split_controller.rs
@@ -784,14 +784,15 @@ impl AutoSplitController {
         // RegionID -> (CPU usage, Hottest Key Range), calculate the CPU usage and its
         // hottest key range.
         let should_check_region_cpu = self.should_check_region_cpu();
-        let (cpu_stats_vec, cpu_stats_cache) = ctx.batch_recv_cpu_stats(cpu_stats_receiver);
-        // Keep draining records after CPU-based split is disabled. Otherwise, records
-        // collected before the collector is deregistered can be reused after the mode
-        // is enabled again.
         if !should_check_region_cpu {
-            cpu_stats_vec.clear();
-            return &cpu_stats_cache.region_cpu_map;
+            // A bounded batch is appropriate while collecting CPU load, but it
+            // is insufficient when the collector is disabled: records left in
+            // the channel could be consumed after CPU splitting is enabled
+            // again and attributed to a newer interval.
+            ctx.discard_pending_cpu_stats(cpu_stats_receiver);
+            return &ctx.cpu_stats_cache.region_cpu_map;
         }
+        let (cpu_stats_vec, cpu_stats_cache) = ctx.batch_recv_cpu_stats(cpu_stats_receiver);
 
         let CpuStatsCache {
             region_cpu_map,
@@ -805,13 +806,17 @@ impl AutoSplitController {
                 // Calculate the Region ID -> Unified Read CPU Time.
                 region_cpu_map
                     .entry(tag.region_id)
-                    .and_modify(|(cpu_time, _)| *cpu_time += record.unified_read_cpu_time as f64)
+                    .and_modify(|(cpu_time, _)| {
+                        *cpu_time += record.unified_read_cpu_time as f64
+                    })
                     .or_insert_with(|| (record.unified_read_cpu_time as f64, None));
                 // Calculate the (Region ID, Key Range) -> Unified Read CPU Time.
                 tag.key_ranges.iter().for_each(|key_range| {
                     region_key_range_cpu_time_map
                         .entry((tag.region_id, key_range))
-                        .and_modify(|cpu_time| *cpu_time += record.unified_read_cpu_time)
+                        .and_modify(|cpu_time| {
+                            *cpu_time = cpu_time.saturating_add(record.unified_read_cpu_time)
+                        })
                         .or_insert_with(|| record.unified_read_cpu_time);
                 })
             });
@@ -1179,10 +1184,18 @@ impl AutoSplitControllerContext {
         cpu_stats_receiver: &Receiver<Arc<RawRecords>>,
     ) {
         self.read_stats_vec.clear();
+        while read_stats_receiver.try_recv().is_ok() {}
+        self.discard_pending_cpu_stats(cpu_stats_receiver);
+    }
+
+    /// Discards all CPU records currently queued by resource metering.
+    pub fn discard_pending_cpu_stats(
+        &mut self,
+        cpu_stats_receiver: &Receiver<Arc<RawRecords>>,
+    ) {
         self.cpu_stats_vec.clear();
         self.cpu_stats_cache.region_cpu_map.clear();
         self.cpu_stats_cache.hottest_key_range_cpu_time_map.clear();
-        while read_stats_receiver.try_recv().is_ok() {}
         while cpu_stats_receiver.try_recv().is_ok() {}
     }
 
@@ -2416,9 +2429,15 @@ mod tests {
         auto_split_controller
             .cfg
             .region_cpu_overload_threshold_ratio = Some(0.0);
-        let cpu_stats = gen_cpu_stats(1, vec![build_key_range(b"a", b"b", false)], vec![100]);
-        let (mut ctx, _, cpu_stats_receiver) =
-            new_auto_split_controller_ctx(vec![], vec![cpu_stats]);
+        let batch_limit = 2;
+        let (cpu_stats_sender, cpu_stats_receiver) = mpsc::sync_channel(4);
+        for _ in 0..4 {
+            let cpu_stats =
+                gen_cpu_stats(1, vec![build_key_range(b"a", b"b", false)], vec![100]);
+            cpu_stats_sender.try_send(cpu_stats).unwrap();
+        }
+        drop(cpu_stats_sender);
+        let mut ctx = AutoSplitControllerContext::new(batch_limit);
 
         let region_cpu_map = auto_split_controller.collect_cpu_stats(&mut ctx, &cpu_stats_receiver);
 

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -18,8 +18,7 @@ use std::{
     str::FromStr,
     sync::{
         Arc, Mutex,
-        atomic::{AtomicU32, AtomicU64},
-        mpsc,
+        atomic::{AtomicU32, AtomicU64, AtomicUsize},
     },
     time::Duration,
 };
@@ -815,14 +814,16 @@ where
             cop_read_pools.handle()
         };
 
-        let mut unified_read_pool_scale_receiver = None;
+        let mut unified_read_pool_size = None;
         if self.core.config.readpool.is_unified_pool_enabled() {
-            let (unified_read_pool_scale_notifier, rx) = mpsc::sync_channel(10);
+            let current_pool_size = Arc::new(AtomicUsize::new(
+                self.core.config.readpool.unified.max_thread_count,
+            ));
             cfg_controller.register(
                 tikv::config::Module::Readpool,
                 Box::new(ReadPoolConfigManager::new(
                     unified_read_pool.as_ref().unwrap().handle(),
-                    unified_read_pool_scale_notifier,
+                    current_pool_size.clone(),
                     &self.core.background_worker,
                     self.core.config.readpool.unified.min_thread_count,
                     self.core.config.readpool.unified.max_thread_count,
@@ -830,7 +831,7 @@ where
                     self.core.config.readpool.unified.cpu_threshold,
                 )),
             );
-            unified_read_pool_scale_receiver = Some(rx);
+            unified_read_pool_size = Some(current_pool_size);
         }
 
         // Register cdc.
@@ -1081,7 +1082,7 @@ where
             split_config_manager,
             self.core.config.server.grpc_concurrency,
             self.core.config.readpool.unified.max_thread_count,
-            unified_read_pool_scale_receiver,
+            unified_read_pool_size,
         );
 
         // `ConsistencyCheckObserver` must be registered before

--- a/components/server/src/server2.rs
+++ b/components/server/src/server2.rs
@@ -18,8 +18,8 @@ use std::{
     str::FromStr,
     sync::{
         Arc,
-        atomic::{AtomicU32, AtomicU64},
-        mpsc::{self, sync_channel},
+        atomic::{AtomicU32, AtomicU64, AtomicUsize},
+        mpsc::sync_channel,
     },
     time::Duration,
 };
@@ -668,14 +668,16 @@ where
             cop_read_pools.handle()
         };
 
-        let mut unified_read_pool_scale_receiver = None;
+        let mut unified_read_pool_size = None;
         if self.core.config.readpool.is_unified_pool_enabled() {
-            let (unified_read_pool_scale_notifier, rx) = mpsc::sync_channel(10);
+            let current_pool_size = Arc::new(AtomicUsize::new(
+                self.core.config.readpool.unified.max_thread_count,
+            ));
             cfg_controller.register(
                 tikv::config::Module::Readpool,
                 Box::new(ReadPoolConfigManager::new(
                     unified_read_pool.as_ref().unwrap().handle(),
-                    unified_read_pool_scale_notifier,
+                    current_pool_size.clone(),
                     &self.core.background_worker,
                     self.core.config.readpool.unified.min_thread_count,
                     self.core.config.readpool.unified.max_thread_count,
@@ -683,7 +685,7 @@ where
                     self.core.config.readpool.unified.cpu_threshold,
                 )),
             );
-            unified_read_pool_scale_receiver = Some(rx);
+            unified_read_pool_size = Some(current_pool_size);
         }
 
         // Run check leader in a dedicate thread, because it is time sensitive
@@ -927,7 +929,7 @@ where
             split_config_manager,
             self.core.config.server.grpc_concurrency,
             self.core.config.readpool.unified.max_thread_count,
-            unified_read_pool_scale_receiver,
+            unified_read_pool_size,
         );
 
         // `ConsistencyCheckObserver` must be registered before `Node::start`.

--- a/doc/maintenance-guides/components/raftstore.md
+++ b/doc/maintenance-guides/components/raftstore.md
@@ -129,6 +129,25 @@ High-risk contracts:
 - `store/worker/read.rs`: local reader and read delegates
 - `store/worker/refresh_config.rs`: runtime config propagation
 
+Load-based split accounting and state:
+
+- Region CPU load is compared with unified-read-pool utilization, so both the
+  region numerator and hottest-range ranking must use unified-read CPU time.
+- Disabling CPU-based detection still drains queued resource-metering records.
+  Split-config changes and per-region split-validator disables discard prior
+  controller detection history.
+- Unified-read-pool capacity is published after each applied resize and shared
+  as authoritative current state rather than queued resize events. The current
+  busy gate reloads that state without interrupting normal QPS and byte
+  detection history.
+- A split-config version change drains observations already visible to the
+  stats monitor, primes a new thread-CPU baseline, and skips that detection
+  tick. Queued PD-worker tasks, in-progress resource-metering intervals, and
+  long-lived TLS observations can still arrive after the drain; the boundary
+  remains best effort until producers carry a configuration generation.
+- Recorder expiration uses monotonic elapsed time so wall-clock adjustments
+  cannot retain stale detection history.
+
 ### Coprocessor hooks
 
 - `coprocessor/dispatcher.rs` hosts raftstore observers.

--- a/doc/maintenance-guides/components/raftstore.md
+++ b/doc/maintenance-guides/components/raftstore.md
@@ -67,6 +67,9 @@ High-risk contracts:
   with their read statistics; execution must re-enter the current peer FSM and
   build the split request from its current Region and peer; a local follower
   rejects the candidate rather than forwarding it to the current leader
+- the load-based split CPU gate reads the unified read pool capacity already
+  applied by the read-pool runner; pool resizing must publish that current
+  capacity without resetting normal QPS or byte detection history
 - persisted apply/raft state alignment in `peer_storage.rs`
 - callback/result semantics in `store/msg.rs` and `store/fsm/apply.rs`
 

--- a/src/read_pool.rs
+++ b/src/read_pool.rs
@@ -5,8 +5,7 @@ use std::{
     future::Future,
     sync::{
         Arc, Mutex,
-        atomic::{AtomicU64, Ordering},
-        mpsc::SyncSender,
+        atomic::{AtomicU64, AtomicUsize, Ordering},
     },
     time::Duration,
 };
@@ -777,7 +776,10 @@ impl ReadPoolCpuTimeTracker {
 }
 struct ReadPoolConfigRunner {
     interval: Duration,
-    sender: SyncSender<usize>,
+    // The value reflects the capacity already applied to the pool. Resize
+    // transitions do not need to be queued because consumers only need the
+    // current capacity.
+    current_pool_size: Arc<AtomicUsize>,
     handle: ReadPoolHandle,
     cpu_time_tracker: ReadPoolCpuTimeTracker,
     process_stats: ProcessStat,
@@ -800,10 +802,8 @@ impl Runnable for ReadPoolConfigRunner {
         match task {
             Task::PoolSize(s) => {
                 if s != self.core_thread_count {
-                    self.handle.scale_pool_size(s);
+                    self.scale_pool_size(s);
                     self.core_thread_count = s;
-                    self.cur_thread_count = s;
-                    self.notify_pool_size_change(s);
                 }
             }
             Task::AutoAdjust(s) => {
@@ -962,9 +962,7 @@ impl ReadPoolConfigRunner {
     /// Resizes the pool, no-op if it is already at `new_thread_count`.
     fn set_thread_count(&mut self, new_thread_count: usize) {
         if new_thread_count != self.cur_thread_count {
-            self.handle.scale_pool_size(new_thread_count);
-            self.notify_pool_size_change(new_thread_count);
-            self.cur_thread_count = new_thread_count;
+            self.scale_pool_size(new_thread_count);
         }
     }
 
@@ -974,11 +972,14 @@ impl ReadPoolConfigRunner {
         self.set_thread_count(self.core_thread_count);
     }
 
-    fn notify_pool_size_change(&self, new_thread_count: usize) {
-        // it's unlikely to send failed.
-        if let Err(e) = self.sender.try_send(new_thread_count) {
-            warn!("notify read pool thread count change failed"; "err" => ?e);
-        }
+    fn scale_pool_size(&mut self, new_thread_count: usize) {
+        self.handle.scale_pool_size(new_thread_count);
+        // Publish after the handle reflects the new capacity. A single atomic
+        // value cannot lose the final state when several resizes happen before
+        // the split controller refreshes.
+        self.current_pool_size
+            .store(new_thread_count, Ordering::Relaxed);
+        self.cur_thread_count = new_thread_count;
     }
 }
 
@@ -1007,7 +1008,7 @@ pub struct ReadPoolConfigManager {
 impl ReadPoolConfigManager {
     pub fn new(
         handle: ReadPoolHandle,
-        sender: SyncSender<usize>,
+        current_pool_size: Arc<AtomicUsize>,
         worker: &Worker,
         min_thread_count: usize,
         max_thread_count: usize,
@@ -1016,7 +1017,7 @@ impl ReadPoolConfigManager {
     ) -> Self {
         let runner = ReadPoolConfigRunner {
             interval: READ_POOL_THREAD_CHECK_DURATION,
-            sender,
+            current_pool_size,
             handle,
             cpu_time_tracker: ReadPoolCpuTimeTracker::new(&get_unified_read_pool_name()),
             process_stats: ProcessStat::cur_proc_stat().unwrap(),
@@ -1496,7 +1497,7 @@ mod tests {
         // Create ReadPoolConfigRunner with a real CPU tracker first
         let mut runner = ReadPoolConfigRunner {
             interval: Duration::from_secs(10),
-            sender: std::sync::mpsc::sync_channel(10).0,
+            current_pool_size: Arc::new(AtomicUsize::new(config.min_thread_count)),
             handle: handle.clone(),
             cpu_time_tracker: ReadPoolCpuTimeTracker::new("test-pool"),
             process_stats: ProcessStat::cur_proc_stat().unwrap(),
@@ -1580,7 +1581,7 @@ mod tests {
         let worker = Worker::new("test-worker");
         let mut runner = ReadPoolConfigRunner {
             interval: Duration::from_secs(10),
-            sender: std::sync::mpsc::sync_channel(10).0,
+            current_pool_size: Arc::new(AtomicUsize::new(config.max_thread_count)),
             handle: handle.clone(),
             cpu_time_tracker: ReadPoolCpuTimeTracker::new("test-pool"),
             process_stats: ProcessStat::cur_proc_stat().unwrap(),
@@ -1663,7 +1664,7 @@ mod tests {
         let worker = Worker::new("test-worker");
         let mut runner = ReadPoolConfigRunner {
             interval: Duration::from_secs(10),
-            sender: std::sync::mpsc::sync_channel(10).0,
+            current_pool_size: Arc::new(AtomicUsize::new(2)),
             handle: handle.clone(),
             cpu_time_tracker: ReadPoolCpuTimeTracker::new("test-pool"),
             process_stats: ProcessStat::cur_proc_stat().unwrap(),
@@ -1736,7 +1737,7 @@ mod tests {
         let worker = Worker::new("test-worker");
         let runner = ReadPoolConfigRunner {
             interval: Duration::from_secs(10),
-            sender: std::sync::mpsc::sync_channel(10).0,
+            current_pool_size: Arc::new(AtomicUsize::new(config.max_thread_count)),
             handle,
             cpu_time_tracker: ReadPoolCpuTimeTracker::new("test-pool"),
             process_stats: ProcessStat::cur_proc_stat().unwrap(),
@@ -2218,9 +2219,7 @@ mod tests {
     }
 
     #[test]
-    fn test_auto_adjust_disable_notifies_pool_size_change() {
-        use std::sync::mpsc::sync_channel;
-
+    fn test_auto_adjust_disable_updates_pool_size() {
         let config = UnifiedReadPoolConfig {
             min_thread_count: 2,
             max_thread_count: 8,
@@ -2240,8 +2239,6 @@ mod tests {
         );
         let handle = pool.handle();
 
-        let (tx, rx) = sync_channel(10);
-
         let core_thread_count = config.max_thread_count;
         let max_thread_count = config.max_thread_count;
         let process_stats = match tikv_util::sys::cpu_time::ProcessStat::cur_proc_stat() {
@@ -2251,7 +2248,7 @@ mod tests {
 
         let mut runner = ReadPoolConfigRunner {
             interval: READ_POOL_THREAD_CHECK_DURATION,
-            sender: tx,
+            current_pool_size: Arc::new(AtomicUsize::new(5)),
             handle,
             cpu_time_tracker: ReadPoolCpuTimeTracker::new("test"),
             process_stats,
@@ -2266,25 +2263,20 @@ mod tests {
         runner.cur_thread_count = 5;
         runner.run(Task::AutoAdjust(false));
 
-        // The config change only records the flag now; sizing the pool belongs
-        // to adjust_pool_size.
+        // The config task only changes the gate. The timer owns pool sizing.
         assert_eq!(runner.cur_thread_count, 5);
-        assert!(
-            rx.try_recv().is_err(),
-            "disabling auto-adjust should not resize the pool by itself"
+        assert_eq!(
+            runner.current_pool_size.load(Ordering::Relaxed),
+            5
         );
 
-        // With no resource manager this takes the early-return path, which
-        // restores the configured size.
+        // The next timer tick restores the configured size and publishes it to
+        // the split controller.
         runner.adjust_pool_size();
-
-        match rx.recv_timeout(Duration::from_millis(100)) {
-            Ok(size) => assert_eq!(size, core_thread_count),
-            Err(_) => {
-                panic!("No pool size change notification received when auto-adjust was disabled.")
-            }
-        }
-
         assert_eq!(runner.cur_thread_count, core_thread_count);
+        assert_eq!(
+            runner.current_pool_size.load(Ordering::Relaxed),
+            core_thread_count
+        );
     }
 }


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: Close #19812

Changes:

```commit-message
Use unified-read CPU time for Region overload calculation and hottest-range
selection so the accounting basis matches unified-read-pool utilization.

Drain queued resource-metering records while CPU-based splitting is disabled.
Treat every observed split-config version as a reset boundary, including
updates that return to the previous value. Clear controller history, drain
observations already visible to StatsMonitor, prime a new thread-CPU baseline,
and skip that reset tick.

Publish the unified-read-pool capacity after each applied resize through a
shared atomic value. The split controller reads the capacity currently in
effect on every refresh, so rapid resizes cannot lose the final value. Pool
resizing does not clear normal QPS/byte detection history.

Order Region CPU collector deregistration and registration around the reset
drain. Remove recorders for Regions disabled by SplitValidator, and use
monotonic elapsed time for recorder expiration.
```

The reset boundary is intentionally best effort. Queued PD-worker tasks,
in-progress resource-metering intervals, and long-lived TLS observations can
publish an older observation after the drain. A strict generation protocol
would require changes across every producer and task boundary; that expansion
is not justified for one boundary-overlapping input to a split heuristic and is
intentionally outside this PR. This does not affect Raft or data correctness.

This shape matches what already runs in production in the cloud-engine fork,
keeping the two codebases aligned: the split controller reads the current
applied capacity from the shared atomic value. Resize transitions do not reset
normal QPS/byte detection history; only split-config changes reset controller
observations.

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`
- [ ] Need to cherry-pick to the release branch

### Check List

Tests

- [x] Unit test coverage added

Relevant test commands:

- `cargo test -p raftstore --lib -- test_refresh test_read_pool_resize test_collect_cpu split_controller::tests::test_flush`

### Release note

```release-note
None
```
