### PR TITLE
copr: handle malformed UTF-8 in LIKE

### DIFF
--- a/components/tidb_query_datatype/src/codec/collation/charset.rs
+++ b/components/tidb_query_datatype/src/codec/collation/charset.rs
@@ -41,15 +41,22 @@ impl Charset for CharsetUtf8mb4 {
 
     #[inline]
     fn decode_one(data: &[u8]) -> Option<(Self::Char, usize)> {
-        let mut it = data.iter();
-        let start = it.as_slice().as_ptr();
-        unsafe {
-            core::str::next_code_point(&mut it).map(|c| {
-                (
-                    std::char::from_u32_unchecked(c),
-                    it.as_slice().as_ptr().offset_from(start) as usize,
-                )
-            })
+        // Match Go's utf8.DecodeRune behavior used by TiDB: malformed UTF-8
+        // produces the replacement character and consumes one byte.
+        let width = match *data.first()? {
+            0x00..=0x7F => 1,
+            0xC2..=0xDF => 2,
+            0xE0..=0xEF => 3,
+            0xF0..=0xF4 => 4,
+            _ => return Some((char::REPLACEMENT_CHARACTER, 1)),
+        };
+        match data
+            .get(..width)
+            .and_then(|bytes| str::from_utf8(bytes).ok())
+            .and_then(|s| s.chars().next())
+        {
+            Some(ch) => Some((ch, width)),
+            None => Some((char::REPLACEMENT_CHARACTER, 1)),
         }
     }
 
@@ -63,3 +70,36 @@ pub type CharsetGbk = CharsetUtf8mb4;
 
 // gb18030 character data actually stored with utf8mb4 character encoding.
 pub type CharsetGb18030 = CharsetUtf8mb4;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_utf8mb4_decode_one() {
+        for (input, expected) in [
+            ("a", ('a', 1)),
+            ("é", ('é', 2)),
+            ("你", ('你', 3)),
+            ("🐶", ('🐶', 4)),
+        ] {
+            assert_eq!(CharsetUtf8mb4::decode_one(input.as_bytes()), Some(expected));
+        }
+        assert_eq!(CharsetUtf8mb4::decode_one(b""), None);
+
+        // Like Go's utf8.DecodeRune, malformed encodings consume one byte and
+        // produce the replacement character.
+        for input in [
+            &[0xE4][..],
+            &[0xAA][..],
+            &[0xC3, 0x28][..],
+            &[0xED, 0xA0, 0x80][..],
+            &[0xF5, 0x80, 0x80, 0x80][..],
+        ] {
+            assert_eq!(
+                CharsetUtf8mb4::decode_one(input),
+                Some((char::REPLACEMENT_CHARACTER, 1))
+            );
+        }
+    }
+}

--- a/components/tidb_query_datatype/src/codec/collation/charset.rs
+++ b/components/tidb_query_datatype/src/codec/collation/charset.rs
@@ -43,8 +43,11 @@ impl Charset for CharsetUtf8mb4 {
     fn decode_one(data: &[u8]) -> Option<(Self::Char, usize)> {
         // Match Go's utf8.DecodeRune behavior used by TiDB: malformed UTF-8
         // produces the replacement character and consumes one byte.
-        let width = match *data.first()? {
-            0x00..=0x7F => 1,
+        let first = *data.first()?;
+        if first < 0x80 {
+            return Some((first as char, 1));
+        }
+        let width = match first {
             0xC2..=0xDF => 2,
             0xE0..=0xEF => 3,
             0xF0..=0xF4 => 4,

--- a/components/tidb_query_datatype/src/codec/collation/collator/binary.rs
+++ b/components/tidb_query_datatype/src/codec/collation/collator/binary.rs
@@ -11,6 +11,7 @@ impl Collator for CollatorBinary {
     type Weight = u8;
 
     const IS_CASE_INSENSITIVE: bool = false;
+    const LIKE_LITERAL_MATCHES_BYTES: bool = true;
 
     #[inline]
     fn char_weight(ch: u8) -> Self::Weight {

--- a/components/tidb_query_datatype/src/codec/collation/collator/gb18030_collation.rs
+++ b/components/tidb_query_datatype/src/codec/collation/collator/gb18030_collation.rs
@@ -10,6 +10,7 @@ impl Collator for CollatorGb18030Bin {
     type Charset = CharsetGb18030;
     type Weight = u32;
     const IS_CASE_INSENSITIVE: bool = false;
+    const LIKE_LITERAL_MATCHES_BYTES: bool = true;
 
     #[inline]
     fn char_weight(ch: char) -> u32 {

--- a/components/tidb_query_datatype/src/codec/collation/mod.rs
+++ b/components/tidb_query_datatype/src/codec/collation/mod.rs
@@ -108,6 +108,10 @@ pub trait Collator: 'static + std::marker::Send + std::marker::Sync + std::fmt::
 
     const IS_CASE_INSENSITIVE: bool;
 
+    /// Whether LIKE literal matching uses the original bytes instead of the
+    /// collation sort order.
+    const LIKE_LITERAL_MATCHES_BYTES: bool = false;
+
     /// Returns the weight of a given char. The chars that have equal
     /// weight are considered as the same char with this collation.
     /// See more on <http://www.unicode.org/reports/tr10/#Weight_Level_Defn>.

--- a/components/tidb_query_expr/src/impl_like.rs
+++ b/components/tidb_query_expr/src/impl_like.rs
@@ -7,21 +7,17 @@ use tidb_query_datatype::codec::{collation::*, data_type::*};
 const UTF8_REPLACEMENT_CHARACTER: &[u8] = b"\xEF\xBF\xBD";
 
 // TiDB decodes malformed UTF-8 as U+FFFD when matching with a character
-// collation. Canonicalize only that case; binary collations must continue to
-// compare the original bytes.
+// collation. Canonicalize only that case; collators using byte-wise LIKE
+// literal matching must continue to compare the original bytes.
 #[inline]
-fn char_bytes_for_compare<C: Collator, CS: Charset>(
-    data: &[u8],
-    ch: CS::Char,
-    width: usize,
-) -> &[u8] {
+fn char_bytes_for_compare<C: Collator, CS: Charset>(data: &[u8], ch: CS::Char) -> &[u8] {
     if <C::Charset as Charset>::charset() == tidb_query_datatype::Charset::Utf8Mb4
         && ch.into() == char::REPLACEMENT_CHARACTER as u32
-        && width == 1
+        && data.len() == 1
     {
         UTF8_REPLACEMENT_CHARACTER
     } else {
-        &data[..width]
+        data
     }
 }
 
@@ -72,9 +68,9 @@ pub fn like<C: Collator, CS: Charset>(
                         target_bytes == pattern_bytes
                     } else {
                         let target_char_bytes =
-                            char_bytes_for_compare::<C, CS>(target_bytes, target_char, toff);
+                            char_bytes_for_compare::<C, CS>(target_bytes, target_char);
                         let pattern_char_bytes =
-                            char_bytes_for_compare::<C, CS>(pattern_bytes, pattern_char, poff);
+                            char_bytes_for_compare::<C, CS>(pattern_bytes, pattern_char);
                         matches!(
                             C::sort_compare(target_char_bytes, pattern_char_bytes, true),
                             Ok(std::cmp::Ordering::Equal)

--- a/components/tidb_query_expr/src/impl_like.rs
+++ b/components/tidb_query_expr/src/impl_like.rs
@@ -4,6 +4,27 @@ use tidb_query_codegen::rpn_fn;
 use tidb_query_common::Result;
 use tidb_query_datatype::codec::{collation::*, data_type::*};
 
+const UTF8_REPLACEMENT_CHARACTER: &[u8] = b"\xEF\xBF\xBD";
+
+// TiDB decodes malformed UTF-8 as U+FFFD when matching with a character
+// collation. Canonicalize only that case; binary collations must continue to
+// compare the original bytes.
+#[inline]
+fn char_bytes_for_compare<C: Collator, CS: Charset>(
+    data: &[u8],
+    ch: CS::Char,
+    width: usize,
+) -> &[u8] {
+    if <C::Charset as Charset>::charset() == tidb_query_datatype::Charset::Utf8Mb4
+        && ch.into() == char::REPLACEMENT_CHARACTER as u32
+        && width == 1
+    {
+        UTF8_REPLACEMENT_CHARACTER
+    } else {
+        &data[..width]
+    }
+}
+
 #[rpn_fn]
 #[inline]
 pub fn like<C: Collator, CS: Charset>(
@@ -17,8 +38,8 @@ pub fn like<C: Collator, CS: Charset>(
     // positions for backtrace.
     let (mut next_px, mut next_tx) = (0, 0);
     while px < pattern.len() || tx < target.len() {
-        if let Some((c, mut poff)) = CS::decode_one(&pattern[px..]) {
-            let code: u32 = c.into();
+        if let Some((mut pattern_char, mut poff)) = CS::decode_one(&pattern[px..]) {
+            let code: u32 = pattern_char.into();
             if code == '_' as u32 {
                 if let Some((_, toff)) = CS::decode_one(&target[tx..]) {
                     px += poff;
@@ -38,16 +59,28 @@ pub fn like<C: Collator, CS: Charset>(
             } else {
                 if code == escape && px + poff < pattern.len() {
                     px += poff;
-                    poff = if let Some((_, off)) = CS::decode_one(&pattern[px..]) {
-                        off
+                    (pattern_char, poff) = if let Some((ch, off)) = CS::decode_one(&pattern[px..]) {
+                        (ch, off)
                     } else {
                         break;
-                    }
+                    };
                 }
-                if let Some((_, toff)) = CS::decode_one(&target[tx..]) {
-                    if let Ok(std::cmp::Ordering::Equal) =
-                        C::sort_compare(&target[tx..tx + toff], &pattern[px..px + poff], true)
-                    {
+                if let Some((target_char, toff)) = CS::decode_one(&target[tx..]) {
+                    let target_bytes = &target[tx..tx + toff];
+                    let pattern_bytes = &pattern[px..px + poff];
+                    let matches = if C::LIKE_LITERAL_MATCHES_BYTES {
+                        target_bytes == pattern_bytes
+                    } else {
+                        let target_char_bytes =
+                            char_bytes_for_compare::<C, CS>(target_bytes, target_char, toff);
+                        let pattern_char_bytes =
+                            char_bytes_for_compare::<C, CS>(pattern_bytes, pattern_char, poff);
+                        matches!(
+                            C::sort_compare(target_char_bytes, pattern_char_bytes, true),
+                            Ok(std::cmp::Ordering::Equal)
+                        )
+                    };
+                    if matches {
                         tx += toff;
                         px += poff;
                         continue;
@@ -243,6 +276,104 @@ mod tests {
                 output, expected,
                 "target={}, pattern={}, escape={}",
                 target, pattern, escape
+            );
+        }
+    }
+
+    #[test]
+    fn test_like_invalid_utf8() {
+        fn eval_like(
+            target: &[u8],
+            pattern: &[u8],
+            ret_collation: Collation,
+            arg_collation: Collation,
+        ) -> Option<i64> {
+            let ret_ft = FieldTypeBuilder::new()
+                .tp(FieldTypeTp::LongLong)
+                .collation(ret_collation)
+                .build();
+            let arg_ft = FieldTypeBuilder::new()
+                .tp(FieldTypeTp::String)
+                .collation(arg_collation)
+                .build();
+            RpnFnScalarEvaluator::new()
+                .return_field_type(ret_ft)
+                .push_param_with_field_type(target.to_vec(), arg_ft.clone())
+                .push_param_with_field_type(pattern.to_vec(), arg_ft)
+                .push_param('\\' as i64)
+                .evaluate(ScalarFuncSig::LikeSig)
+                .unwrap()
+        }
+
+        // Regression tests for pingcap/tidb#66597 and pingcap/tidb#67082.
+        let issue_values = [
+            vec![0xE4],
+            vec![0x02, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA],
+        ];
+        for value in issue_values {
+            assert_eq!(
+                eval_like(&value, &value, Collation::Utf8Mb4Bin, Collation::Utf8Mb4Bin,),
+                Some(1)
+            );
+        }
+
+        let replacement = char::REPLACEMENT_CHARACTER.to_string().into_bytes();
+        let character_cases = [
+            (vec![0xE4], vec![0xAA], Some(1)),
+            (vec![0xE4], replacement.clone(), Some(1)),
+            (replacement.clone(), vec![0xE4], Some(1)),
+            (vec![0xE4], b"a".to_vec(), Some(0)),
+            (vec![0xAA], vec![b'\\', 0xE4], Some(1)),
+        ];
+        for collation in [
+            Collation::Utf8Mb4Bin,
+            Collation::Utf8Mb4GeneralCi,
+            Collation::Utf8Mb4UnicodeCi,
+            Collation::Utf8Mb40900AiCi,
+            Collation::Utf8Mb40900Bin,
+            Collation::GbkBin,
+            Collation::GbkChineseCi,
+            Collation::Gb18030ChineseCi,
+        ] {
+            for (target, pattern, expected) in &character_cases {
+                assert_eq!(
+                    eval_like(target, pattern, collation, collation),
+                    *expected,
+                    "target={target:?}, pattern={pattern:?}, collation={collation:?}"
+                );
+            }
+        }
+
+        for (target, pattern, expected) in [
+            (vec![0xE4], vec![0xE4], Some(1)),
+            (vec![0xE4], vec![0xAA], Some(0)),
+            (vec![0xE4], replacement, Some(0)),
+            ("中".as_bytes().to_vec(), "中".as_bytes().to_vec(), Some(1)),
+            ("中".as_bytes().to_vec(), "文".as_bytes().to_vec(), Some(0)),
+        ] {
+            assert_eq!(
+                eval_like(
+                    &target,
+                    &pattern,
+                    Collation::Gb18030Bin,
+                    Collation::Gb18030Bin,
+                ),
+                expected,
+                "target={target:?}, pattern={pattern:?}, collation=Gb18030Bin"
+            );
+        }
+
+        // Binary comparison must keep byte-wise semantics, including the
+        // compatibility path where UTF-8 arguments use a binary result
+        // collation.
+        for arg_collation in [Collation::Binary, Collation::Utf8Mb4Bin] {
+            assert_eq!(
+                eval_like(&[0xE4], &[0xAA], Collation::Binary, arg_collation,),
+                Some(0)
+            );
+            assert_eq!(
+                eval_like(&[0xE4], &[0xE4], Collation::Binary, arg_collation,),
+                Some(1)
             );
         }
     }


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: close #19811, ref pingcap/tidb#66597, ref pingcap/tidb#67082

What's Changed:

- Decode malformed UTF-8 in the same way as Go's `utf8.DecodeRune`: return `U+FFFD` and consume one byte.
- Canonicalize malformed UTF-8 to the replacement character for character-collation LIKE comparisons.
- Preserve byte-wise literal matching for binary and GB18030 binary collations.
- Add regression coverage for the malformed inputs that triggered both reported TiKV panics.

```commit-message
Handle malformed UTF-8 safely in coprocessor LIKE evaluation.

Previously, malformed input could produce an invalid decoded width and make
LIKE slice past the end of the input, crashing TiKV. Decode malformed UTF-8 as
the replacement character while consuming one byte, matching TiDB's Go-side
behavior, and preserve byte-wise semantics for binary collations.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Unit and static checks:

- `make format`
- `make clippy`
- All six `tidb_query_*` test binaries passed: 898 tests.
- Targeted malformed UTF-8 decoder and LIKE regression tests passed.

Manual downstream verification:

1. Confirmed both queries are pushed down to `cop[tikv]` using `EXPLAIN`.
2. Reproduced both panics on a stock nightly testbed with TiKV commit
   `bf73df27b9675a2f8e3cc0b4b921f3128c37d8a5`; each query caused the TiKV Pod
   to restart.
3. Started a local cluster with nightly TiDB commit
   `b94006d3abffd428634ecc5c499f4bcb7b4d06d1`, nightly PD commit
   `525ef58f95bd40e72d925f09fc6a4794087d5aa8`, and a TiKV binary built from
   this PR.
4. Executed the pingcap/tidb#66597 BIT(58) LIKE query 20 times and the
   pingcap/tidb#67082 malformed single-byte UTF-8 LIKE query 20 times.
5. All 40 executions succeeded. The TiKV PID remained unchanged, and the TiKV
   log contained no panic, `FATAL`, or slice-out-of-bounds message.

`make dev` was also attempted. The changed query crates and relevant tests
passed, but the complete workspace run could not finish cleanly on local macOS
because of unrelated existing timing, filesystem-path, and test-order/state
failures.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note

```release-note
Fix a TiKV panic when the coprocessor evaluates LIKE expressions containing malformed UTF-8 input.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `LIKE` matching for malformed UTF-8 under UTF8MB4, with more consistent treatment of the Unicode replacement character.
  * Fixed more byte-accurate `LIKE` semantics for binary and GB18030 binary collations.
  * Enhanced UTF8MB4 rune decoding to make invalid UTF-8 comparisons more predictable.
* **Tests**
  * Added unit coverage for UTF8MB4 single-rune decoding, including malformed sequences and expected byte-width consumption.
  * Added a regression test to validate `LIKE` behavior across multiple collations and invalid UTF-8 inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->