### PR TITLE
server: fix StoreSafeTS and CheckLeader grpc duration metrics

### DIFF
--- a/src/server/metrics.rs
+++ b/src/server/metrics.rs
@@ -63,6 +63,7 @@ make_auto_flush_static_metric! {
         split_region,
         read_index,
         check_leader,
+        get_store_safe_ts,
         batch_commands,
         kv_flush,
         kv_buffer_batch_get,

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -1208,11 +1208,6 @@ impl<E: Engine, L: LockManager, F: KvFormat> Tikv for Service<E, L, F> {
                 }
                 return Err(Error::from(e));
             }
-            let elapsed = begin_instant.saturating_elapsed();
-            GRPC_MSG_HISTOGRAM_STATIC
-                .check_leader
-                .unknown
-                .observe(elapsed.as_secs_f64());
             ServerResult::Ok(())
         }
         .map_err(move |e| {
@@ -1231,6 +1226,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> Tikv for Service<E, L, F> {
         mut request: StoreSafeTsRequest,
         sink: UnarySink<StoreSafeTsResponse>,
     ) {
+        let begin_instant = Instant::now();
         let key_range = request.take_key_range();
         let (cb, resp) = paired_future_callback();
         let check_leader_scheduler = self.check_leader_scheduler.clone();
@@ -1239,9 +1235,14 @@ impl<E: Engine, L: LockManager, F: KvFormat> Tikv for Service<E, L, F> {
                 .schedule(CheckLeaderTask::GetStoreTs { key_range, cb })
                 .map_err(|e| Error::Other(format!("{}", e).into()))?;
             let store_safe_ts = resp.await?;
+            let elapsed = begin_instant.saturating_elapsed();
             let mut resp = StoreSafeTsResponse::default();
             resp.set_safe_ts(store_safe_ts);
             sink.success(resp).await?;
+            GRPC_MSG_HISTOGRAM_STATIC
+                .get_store_safe_ts
+                .unknown
+                .observe(elapsed.as_secs_f64());
             ServerResult::Ok(())
         }
         .map_err(|e| {


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #19815

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

Add `get_store_safe_ts` to `tikv_grpc_msg_duration_seconds` so StoreSafeTS RPC latency is visible separately from CheckLeader.

Also remove the second CheckLeader duration observation to avoid double-counting the same request.

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [x] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved latency tracking for store safe timestamp requests, ensuring histogram metrics are recorded only after successful completion for more accurate monitoring.
  * Updated available request-type label values for store safe timestamp operations to improve clarity in exported monitoring metrics.
  * Adjusted leader-check latency reporting to avoid incorrect observations in the prior completion/error path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->