### PR TITLE
txn: add slow log for KvGet and KvBatchGet

### DIFF
--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -258,9 +258,15 @@
 ## The default value is 2 if the number of CPU cores is less than 16, otherwise 3.
 # background-thread-count = 2
 
-## If handle time is larger than the threshold, it will print slow log in endpoint.
+## If wait time + process time of a coprocessor request exceeds the threshold,
+## it will print slow log.
 ## The default value is 1s.
 # end-point-slow-log-threshold = "1s"
+
+## If wait time + process time of KvGet or KvBatchGet exceeds the threshold,
+## it will print slow log.
+## The default value is 300ms.
+# kv-command-slow-log-threshold = "300ms"
 
 [storage]
 ## The path to RocksDB directory.

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -232,6 +232,10 @@ pub struct Config {
     // If handle time is larger than the threshold, it will print slow log in end point.
     #[online_config(skip)]
     pub end_point_slow_log_threshold: ReadableDuration,
+    // If handle time of KvGet or KvBatchGet is larger than the threshold,
+    // it will print slow log.
+    #[online_config(skip)]
+    pub kv_command_slow_log_threshold: ReadableDuration,
     /// Max connections per address for forwarding request.
     #[online_config(skip)]
     pub forward_max_connections_per_address: usize,
@@ -355,6 +359,7 @@ impl Default for Config {
             reject_messages_on_memory_ratio: 0.2,
             background_thread_count,
             end_point_slow_log_threshold: ReadableDuration::secs(1),
+            kv_command_slow_log_threshold: ReadableDuration::millis(300),
             // Go tikv client uses 4 as well.
             forward_max_connections_per_address: 4,
             simplify_metrics: false,

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -232,8 +232,8 @@ pub struct Config {
     // If handle time is larger than the threshold, it will print slow log in end point.
     #[online_config(skip)]
     pub end_point_slow_log_threshold: ReadableDuration,
-    // If handle time of KvGet or KvBatchGet is larger than the threshold,
-    // it will print slow log.
+    // If wait time + process time of KvGet or KvBatchGet is larger than the
+    // threshold, it will print slow log.
     #[online_config(skip)]
     pub kv_command_slow_log_threshold: ReadableDuration,
     /// Max connections per address for forwarding request.

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -233,6 +233,7 @@ where
             health_controller.clone(),
             health_feedback_interval,
             raft_message_filter,
+            cfg.value().kv_command_slow_log_threshold.0,
         );
 
         let mem_quota = ResourceQuota::new(Some("ServerMemQuota"))

--- a/src/server/service/batch.rs
+++ b/src/server/service/batch.rs
@@ -291,6 +291,10 @@ fn future_batch_get_command<E: Engine, L: LockManager, F: KvFormat>(
         .copied()
         .zip(trackers.iter().copied())
         .collect();
+    // NOTE: per-request slow-log is not available on the ReqBatcher path
+    // because batch_get_command does not expose individual StageLatencyStats.
+    // Follow-up work needed to either plumb stats through the consumer or
+    // re-evaluate whether a batch-level threshold is sufficient.
     let res = storage.batch_get_command(
         gets,
         requests,

--- a/src/server/service/batch.rs
+++ b/src/server/service/batch.rs
@@ -2,6 +2,7 @@
 
 // #[PerformanceCriticalPath]
 use std::collections::HashMap;
+use std::time::Duration;
 
 use api_version::KvFormat;
 use kvproto::kvrpcpb::*;
@@ -17,12 +18,15 @@ use txn_types::ValueEntry;
 use crate::{
     server::{
         metrics::{GrpcTypeKind, REQUEST_BATCH_SIZE_HISTOGRAM_VEC, ResourcePriority},
-        service::kv::{GrpcRequestDuration, MeasuredSingleResponse, batch_commands_response},
+        service::kv::{
+            GrpcRequestDuration, MeasuredSingleResponse, batch_commands_response,
+            slow_kv_times,
+        },
     },
     storage::{
-        ResponseBatchConsumer, Result, Storage,
+        KvGetStatistics, ResponseBatchConsumer, Result, Storage,
         errors::{extract_key_error, extract_region_error},
-        kv::{Engine, Statistics},
+        kv::Engine,
         lock_manager::LockManager,
     },
 };
@@ -30,6 +34,14 @@ use crate::{
 pub const MAX_BATCH_GET_REQUEST_COUNT: usize = 10;
 pub const MIN_BATCH_GET_REQUEST_COUNT: usize = 4;
 pub const MAX_QUEUE_SIZE_PER_WORKER: usize = 16;
+
+/// Per-request context for slow-log emission in the ReqBatcher path.
+pub(crate) struct SlowKvRequestContext {
+    pub(crate) region_id: u64,
+    pub(crate) peer_id: u64,
+    pub(crate) store_id: u64,
+    pub(crate) txn_start_ts: u64,
+}
 
 pub struct ReqBatcher {
     gets: Vec<GetRequest>,
@@ -39,10 +51,16 @@ pub struct ReqBatcher {
     raw_get_ids: Vec<u64>,
     begin_instant: Instant,
     batch_size: usize,
+    slow_log_threshold: Duration,
+    remote_host: String,
 }
 
 impl ReqBatcher {
-    pub fn new(batch_size: usize) -> ReqBatcher {
+    pub fn new(
+        batch_size: usize,
+        slow_log_threshold: Duration,
+        remote_host: String,
+    ) -> ReqBatcher {
         let begin_instant = Instant::now();
         ReqBatcher {
             gets: vec![],
@@ -52,6 +70,8 @@ impl ReqBatcher {
             raw_get_ids: vec![],
             begin_instant,
             batch_size: std::cmp::min(batch_size, MAX_BATCH_GET_REQUEST_COUNT),
+            slow_log_threshold,
+            remote_host,
         }
     }
 
@@ -91,7 +111,16 @@ impl ReqBatcher {
             let gets = std::mem::take(&mut self.gets);
             let ids = std::mem::take(&mut self.get_ids);
             let trackers = std::mem::take(&mut self.get_trackers);
-            future_batch_get_command(storage, ids, gets, trackers, tx.clone(), self.begin_instant);
+            future_batch_get_command(
+                storage,
+                ids,
+                gets,
+                trackers,
+                tx.clone(),
+                self.begin_instant,
+                self.slow_log_threshold,
+                self.remote_host.clone(),
+            );
         }
 
         if self.raw_gets.len() >= self.batch_size {
@@ -114,6 +143,8 @@ impl ReqBatcher {
                 self.get_trackers,
                 tx.clone(),
                 self.begin_instant,
+                self.slow_log_threshold,
+                self.remote_host,
             );
         }
         if !self.raw_gets.is_empty() {
@@ -131,13 +162,17 @@ impl ReqBatcher {
 pub struct BatcherBuilder {
     pool_size: usize,
     enable_batch: bool,
+    slow_log_threshold: Duration,
+    remote_host: String,
 }
 
 impl BatcherBuilder {
-    pub fn new(enable_batch: bool, pool_size: usize) -> Self {
+    pub fn new(enable_batch: bool, pool_size: usize, slow_log_threshold: Duration, remote_host: String) -> Self {
         BatcherBuilder {
             enable_batch,
             pool_size,
+            slow_log_threshold,
+            remote_host,
         }
     }
     pub fn build(&self, queue_per_worker: usize, req_batch_size: usize) -> Option<ReqBatcher> {
@@ -147,12 +182,20 @@ impl BatcherBuilder {
         if req_batch_size > self.pool_size * MIN_BATCH_GET_REQUEST_COUNT
             && queue_per_worker >= MIN_BATCH_GET_REQUEST_COUNT
         {
-            return Some(ReqBatcher::new(req_batch_size / self.pool_size));
+            return Some(ReqBatcher::new(
+                req_batch_size / self.pool_size,
+                self.slow_log_threshold,
+                self.remote_host.clone(),
+            ));
         }
         if req_batch_size >= MIN_BATCH_GET_REQUEST_COUNT
             && queue_per_worker >= MAX_QUEUE_SIZE_PER_WORKER
         {
-            return Some(ReqBatcher::new(req_batch_size));
+            return Some(ReqBatcher::new(
+                req_batch_size,
+                self.slow_log_threshold,
+                self.remote_host.clone(),
+            ));
         }
         None
     }
@@ -161,28 +204,35 @@ impl BatcherBuilder {
 pub struct GetCommandResponseConsumer {
     tx: Sender<MeasuredSingleResponse>,
     trackers: HashMap<u64, TrackerToken>,
+    slow_log_threshold: Duration,
+    remote_host: String,
+    slow_log_ctx: HashMap<u64, SlowKvRequestContext>,
+    // Per-request enqueue instants from tracker req_info.begin (std Instant),
+    // used for accurate total_lifetime in the slow log.
+    req_begins: HashMap<u64, std::time::Instant>,
 }
 
-impl ResponseBatchConsumer<(Option<ValueEntry>, Statistics)> for GetCommandResponseConsumer {
+impl ResponseBatchConsumer<(Option<ValueEntry>, KvGetStatistics)> for GetCommandResponseConsumer {
     fn consume(
         &self,
         id: u64,
-        res: Result<(Option<ValueEntry>, Statistics)>,
+        res: Result<(Option<ValueEntry>, KvGetStatistics)>,
         begin: Instant,
         request_source: String,
         resource_priority: ResourcePriority,
     ) {
         let mut resp = GetResponse::default();
+        let mut slow = None;
         if let Some(err) = extract_region_error(&res) {
             resp.set_region_error(err);
         } else {
             match res {
-                Ok((val, statistics)) => {
+                Ok((val, kv_stats)) => {
                     let exec_detail_v2 = resp.mut_exec_details_v2();
                     let tracker = self.trackers.get(&id).copied();
                     {
                         let scan_detail_v2 = exec_detail_v2.mut_scan_detail_v2();
-                        statistics.write_scan_detail(scan_detail_v2);
+                        kv_stats.stats.write_scan_detail(scan_detail_v2);
                         if let Some(tracker) = tracker {
                             let _ = GLOBAL_TRACKERS.with_tracker(tracker, |tracker| {
                                 tracker.write_scan_detail(scan_detail_v2);
@@ -194,6 +244,7 @@ impl ResponseBatchConsumer<(Option<ValueEntry>, Statistics)> for GetCommandRespo
                             tracker.write_ru_v2(exec_detail_v2.mut_ru_v2());
                         });
                     }
+                    slow = slow_kv_times(&kv_stats.latency_stats, self.slow_log_threshold);
                     match val {
                         Some(val) => {
                             resp.set_value(val.value);
@@ -206,6 +257,27 @@ impl ResponseBatchConsumer<(Option<ValueEntry>, Statistics)> for GetCommandRespo
                 }
                 Err(e) => resp.set_error(extract_key_error(&e)),
             }
+        }
+
+        if let Some(times) = slow {
+            let ctx = self.slow_log_ctx.get(&id);
+            // Per-request total_lifetime from the tracker's req_info.begin,
+            // not the shared batch begin_instant.
+            let total_time = self
+                .req_begins
+                .get(&id)
+                .map(|b| b.elapsed())
+                .unwrap_or_else(|| begin.saturating_elapsed());
+            info!(#"slow_log", "slow-query";
+                "region_id" => ctx.map_or(0, |c| c.region_id),
+                "peer_id" => ctx.map_or(0, |c| c.peer_id),
+                "store_id" => ctx.map_or(0, |c| c.store_id),
+                "command" => "kv_batch_get_command",
+                "remote" => &self.remote_host,
+                "total_time" => ?total_time,
+                "wait_time" => ?times.wait_time,
+                "process_time" => ?times.process_time,
+            );
         }
 
         let res = batch_commands_response::Response {
@@ -268,6 +340,8 @@ fn future_batch_get_command<E: Engine, L: LockManager, F: KvFormat>(
     trackers: Vec<TrackerToken>,
     tx: Sender<MeasuredSingleResponse>,
     begin_instant: tikv_util::time::Instant,
+    slow_log_threshold: Duration,
+    remote_host: String,
 ) {
     REQUEST_BATCH_SIZE_HISTOGRAM_VEC
         .kv_get
@@ -291,10 +365,37 @@ fn future_batch_get_command<E: Engine, L: LockManager, F: KvFormat>(
         .copied()
         .zip(trackers.iter().copied())
         .collect();
-    // NOTE: per-request slow-log is not available on the ReqBatcher path
-    // because batch_get_command does not expose individual StageLatencyStats.
-    // Follow-up work needed to either plumb stats through the consumer or
-    // re-evaluate whether a batch-level threshold is sufficient.
+
+    let slow_log_ctx: HashMap<u64, SlowKvRequestContext> = gets
+        .iter()
+        .zip(requests.iter())
+        .map(|(req, id)| {
+            let ctx = req.get_context();
+            let peer = ctx.get_peer();
+            (
+                *id,
+                SlowKvRequestContext {
+                    region_id: ctx.get_region_id(),
+                    peer_id: peer.get_id(),
+                    store_id: peer.get_store_id(),
+                    txn_start_ts: req.get_version(),
+                },
+            )
+        })
+        .collect();
+
+    // Per-request enqueue instants from tracker req_info.begin, used for
+    // accurate total_lifetime in slow logs.
+    let req_begins: HashMap<u64, std::time::Instant> = trackers
+        .iter()
+        .zip(requests.iter())
+        .filter_map(|(tracker, id)| {
+            GLOBAL_TRACKERS
+                .with_tracker(*tracker, |t| t.req_info.begin)
+                .map(|begin| (*id, begin))
+        })
+        .collect();
+
     let res = storage.batch_get_command(
         gets,
         requests,
@@ -302,6 +403,10 @@ fn future_batch_get_command<E: Engine, L: LockManager, F: KvFormat>(
         GetCommandResponseConsumer {
             tx: tx.clone(),
             trackers: trackers_by_id,
+            slow_log_threshold,
+            remote_host,
+            slow_log_ctx,
+            req_begins,
         },
         begin_instant,
     );
@@ -365,6 +470,10 @@ fn future_batch_raw_get_command<E: Engine, L: LockManager, F: KvFormat>(
         GetCommandResponseConsumer {
             tx: tx.clone(),
             trackers: HashMap::default(),
+            slow_log_threshold: Duration::ZERO,
+            remote_host: String::new(),
+            slow_log_ctx: HashMap::default(),
+            req_begins: HashMap::default(),
         },
     );
     let f = async move {
@@ -402,7 +511,6 @@ mod tests {
     use txn_types::{TimeStamp, ValueEntry};
 
     use super::*;
-    use crate::storage::kv::Statistics;
 
     #[test]
     fn test_get_command_response_consumer_sets_commit_ts() {
@@ -410,13 +518,17 @@ mod tests {
         let consumer = GetCommandResponseConsumer {
             tx,
             trackers: HashMap::default(),
+            slow_log_threshold: Duration::ZERO,
+            remote_host: String::new(),
+            slow_log_ctx: HashMap::default(),
+            req_begins: HashMap::default(),
         };
 
         consumer.consume(
             7,
             Ok((
                 Some(ValueEntry::new(b"v".to_vec(), Some(TimeStamp::new(42)))),
-                Statistics::default(),
+                KvGetStatistics::default(),
             )),
             Instant::now(),
             "".to_string(),
@@ -438,13 +550,17 @@ mod tests {
         let consumer = GetCommandResponseConsumer {
             tx,
             trackers: HashMap::default(),
+            slow_log_threshold: Duration::ZERO,
+            remote_host: String::new(),
+            slow_log_ctx: HashMap::default(),
+            req_begins: HashMap::default(),
         };
 
         consumer.consume(
             8,
             Ok((
                 Some(ValueEntry::from_value(b"v".to_vec())),
-                Statistics::default(),
+                KvGetStatistics::default(),
             )),
             Instant::now(),
             "".to_string(),

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -141,6 +141,9 @@ pub struct Service<E: Engine, L: LockManager, F: KvFormat> {
     health_feedback_seq: Arc<AtomicU64>,
 
     raft_message_filter: Arc<dyn RaftGrpcMessageFilter>,
+
+    // If handle time of KvGet/KvBatchGet exceeds this threshold, a slow log will be printed.
+    kv_slow_log_threshold: Duration,
 }
 
 impl<E: Engine, L: LockManager, F: KvFormat> Drop for Service<E, L, F> {
@@ -169,6 +172,7 @@ impl<E: Engine + Clone, L: LockManager + Clone, F: KvFormat> Clone for Service<E
             health_feedback_seq: self.health_feedback_seq.clone(),
             health_feedback_interval: self.health_feedback_interval,
             raft_message_filter: self.raft_message_filter.clone(),
+            kv_slow_log_threshold: self.kv_slow_log_threshold,
         }
     }
 }
@@ -192,6 +196,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> Service<E, L, F> {
         health_controller: HealthController,
         health_feedback_interval: Option<Duration>,
         raft_message_filter: Arc<dyn RaftGrpcMessageFilter>,
+        kv_slow_log_threshold: Duration,
     ) -> Self {
         let now_unix = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -215,6 +220,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> Service<E, L, F> {
             health_feedback_interval,
             health_feedback_seq: Arc::new(AtomicU64::new(now_unix)),
             raft_message_filter,
+            kv_slow_log_threshold,
         }
     }
 
@@ -336,7 +342,52 @@ macro_rules! set_total_time {
 }
 
 impl<E: Engine, L: LockManager, F: KvFormat> Tikv for Service<E, L, F> {
-    handle_request!(kv_get, future_get, GetRequest, GetResponse, has_time_detail);
+    // kv_get and kv_batch_get are manually inlined from the handle_request! macro
+    // expansion (see the macro definition above). The only difference is that these
+    // pass self.kv_slow_log_threshold to future_get / future_batch_get so slow-log
+    // decisions use wait_time + process_time rather than total wall-clock time.
+    fn kv_get(&mut self, ctx: RpcContext<'_>, req: GetRequest, sink: UnarySink<GetResponse>) {
+        reject_if_cluster_id_mismatch!(req, self, ctx, sink);
+        forward_unary!(self.proxy, kv_get, ctx, req, sink);
+        let begin_instant = Instant::now();
+
+        let source = req.get_context().get_request_source().to_owned();
+        let resource_control_ctx = req.get_context().get_resource_control_context();
+        let mut resource_group_priority = ResourcePriority::unknown;
+        if let Some(resource_manager) = &self.resource_manager {
+            resource_manager.consume_penalty(resource_control_ctx);
+            resource_group_priority = ResourcePriority::from(resource_control_ctx.override_priority);
+        }
+        GRPC_RESOURCE_GROUP_COUNTER_VEC
+            .with_label_values(&[
+                resource_control_ctx.get_resource_group_name(),
+                resource_control_ctx.get_resource_group_name(),
+            ])
+            .inc();
+        let resp = future_get(&self.storage, self.kv_slow_log_threshold, req);
+        let task = async move {
+            let resp = resp.await?;
+            let elapsed = begin_instant.saturating_elapsed();
+            set_total_time!(resp, elapsed, has_time_detail);
+            sink.success(resp).await?;
+            GRPC_MSG_HISTOGRAM_STATIC
+                .kv_get
+                .get(resource_group_priority)
+                .observe(elapsed.as_secs_f64());
+            record_request_source_metrics(source, elapsed);
+            ServerResult::Ok(())
+        }
+        .map_err(|e| {
+            log_net_error!(e, "kv rpc failed";
+                "request" => "kv_get"
+            );
+            GRPC_MSG_FAIL_COUNTER.kv_get.inc();
+        })
+        .map(|_| ());
+
+        ctx.spawn(task);
+    }
+
     handle_request!(kv_scan, future_scan, ScanRequest, ScanResponse);
     handle_request!(
         kv_prewrite,
@@ -367,12 +418,54 @@ impl<E: Engine, L: LockManager, F: KvFormat> Tikv for Service<E, L, F> {
         has_time_detail
     );
     handle_request!(kv_cleanup, future_cleanup, CleanupRequest, CleanupResponse);
-    handle_request!(
-        kv_batch_get,
-        future_batch_get,
-        BatchGetRequest,
-        BatchGetResponse
-    );
+
+    fn kv_batch_get(
+        &mut self,
+        ctx: RpcContext<'_>,
+        req: BatchGetRequest,
+        sink: UnarySink<BatchGetResponse>,
+    ) {
+        reject_if_cluster_id_mismatch!(req, self, ctx, sink);
+        forward_unary!(self.proxy, kv_batch_get, ctx, req, sink);
+        let begin_instant = Instant::now();
+
+        let source = req.get_context().get_request_source().to_owned();
+        let resource_control_ctx = req.get_context().get_resource_control_context();
+        let mut resource_group_priority = ResourcePriority::unknown;
+        if let Some(resource_manager) = &self.resource_manager {
+            resource_manager.consume_penalty(resource_control_ctx);
+            resource_group_priority = ResourcePriority::from(resource_control_ctx.override_priority);
+        }
+        GRPC_RESOURCE_GROUP_COUNTER_VEC
+            .with_label_values(&[
+                resource_control_ctx.get_resource_group_name(),
+                resource_control_ctx.get_resource_group_name(),
+            ])
+            .inc();
+        let resp = future_batch_get(&self.storage, self.kv_slow_log_threshold, req);
+        let task = async move {
+            let resp = resp.await?;
+            let elapsed = begin_instant.saturating_elapsed();
+            set_total_time!(resp, elapsed, no_time_detail);
+            sink.success(resp).await?;
+            GRPC_MSG_HISTOGRAM_STATIC
+                .kv_batch_get
+                .get(resource_group_priority)
+                .observe(elapsed.as_secs_f64());
+            record_request_source_metrics(source, elapsed);
+            ServerResult::Ok(())
+        }
+        .map_err(|e| {
+            log_net_error!(e, "kv rpc failed";
+                "request" => "kv_batch_get"
+            );
+            GRPC_MSG_FAIL_COUNTER.kv_batch_get.inc();
+        })
+        .map(|_| ());
+
+        ctx.spawn(task);
+    }
+
     handle_request!(
         kv_batch_rollback,
         future_batch_rollback,
@@ -1406,7 +1499,10 @@ fn handle_batch_commands_request<E: Engine, L: LockManager, F: KvFormat>(
                     } else {
                        let begin_instant = Instant::now();
                        let source = req.get_context().get_request_source().to_owned();
-                       let resp = future_get(storage, req)
+                       // Duration::MAX disables the per-request slow-log threshold check
+                       // here; the batch-commands path already tracks overall response time
+                       // via GrpcRequestDuration in handle_measures_for_batch_commands.
+                       let resp = future_get(storage, Duration::MAX, req)
                             .map_ok(oneof!(batch_commands_response::response::Cmd::Get))
                             .map_err(|e| {GRPC_MSG_FAIL_COUNTER.kv_get.inc(); e});
                         response_batch_commands_request(id, resp, tx.clone(), begin_instant, GrpcTypeKind::kv_get, source, resource_group_priority);
@@ -1511,7 +1607,10 @@ fn handle_batch_commands_request<E: Engine, L: LockManager, F: KvFormat>(
         Prewrite, future_prewrite(storage), kv_prewrite;
         Commit, future_commit(storage), kv_commit;
         Cleanup, future_cleanup(storage), kv_cleanup;
-        BatchGet, future_batch_get(storage), kv_batch_get;
+        // Duration::MAX for BatchGet disables per-request slow-log in the
+        // batch-commands path; overall timing is measured separately via
+        // GrpcRequestDuration in handle_measures_for_batch_commands.
+        BatchGet, future_batch_get(storage, Duration::MAX), kv_batch_get;
         BatchRollback, future_batch_rollback(storage), kv_batch_rollback;
         TxnHeartBeat, future_txn_heart_beat(storage), kv_txn_heart_beat;
         CheckTxnStatus, future_check_txn_status(storage), kv_check_txn_status;
@@ -1613,6 +1712,7 @@ async fn future_handle_empty(
 
 fn future_get<E: Engine, L: LockManager, F: KvFormat>(
     storage: &Storage<E, L, F>,
+    slow_log_threshold: Duration,
     mut req: GetRequest,
 ) -> impl Future<Output = ServerResult<GetResponse>> {
     let tracker = GLOBAL_TRACKERS.insert(Tracker::new(RequestInfo::new(
@@ -1624,6 +1724,9 @@ fn future_get<E: Engine, L: LockManager, F: KvFormat>(
     with_tls_tracker(|tracker| {
         tracker.metrics.grpc_req_size = req.compute_size() as u64;
     });
+
+    let region_id = req.get_context().get_region_id();
+    let peer = req.get_context().get_peer().get_store_id();
     let start = Instant::now();
     let v = storage.get_entry(
         req.take_context(),
@@ -1651,6 +1754,24 @@ fn future_get<E: Engine, L: LockManager, F: KvFormat>(
                         tracker.write_ru_v2(exec_detail_v2.mut_ru_v2());
                     });
                     set_time_detail(exec_detail_v2, duration, &stats.latency_stats);
+                    if Duration::from_nanos(
+                        stats.latency_stats.wait_wall_time_ns
+                            + stats.latency_stats.process_wall_time_ns,
+                    ) >= slow_log_threshold
+                    {
+                        info!(#"slow_log", "slow-query";
+                            "region_id" => region_id,
+                            "peer" => peer,
+                            "command" => "kv_get",
+                            "total_time" => ?duration,
+                            "wait_time" => ?Duration::from_nanos(
+                                stats.latency_stats.wait_wall_time_ns,
+                            ),
+                            "process_time" => ?Duration::from_nanos(
+                                stats.latency_stats.process_wall_time_ns,
+                            ),
+                        );
+                    }
                     match val {
                         Some(val) => {
                             resp.set_value(val.value);
@@ -1745,6 +1866,7 @@ fn future_scan<E: Engine, L: LockManager, F: KvFormat>(
 
 fn future_batch_get<E: Engine, L: LockManager, F: KvFormat>(
     storage: &Storage<E, L, F>,
+    slow_log_threshold: Duration,
     mut req: BatchGetRequest,
 ) -> impl Future<Output = ServerResult<BatchGetResponse>> {
     let tracker = GLOBAL_TRACKERS.insert(Tracker::new(RequestInfo::new(
@@ -1753,6 +1875,10 @@ fn future_batch_get<E: Engine, L: LockManager, F: KvFormat>(
         req.get_version(),
     )));
     set_tls_tracker_token(tracker);
+
+    let region_id = req.get_context().get_region_id();
+    let peer = req.get_context().get_peer().get_store_id();
+    let key_count = req.get_keys().len();
     let start = Instant::now();
     with_tls_tracker(|tracker| {
         tracker.metrics.grpc_req_size = req.compute_size() as u64;
@@ -1785,6 +1911,25 @@ fn future_batch_get<E: Engine, L: LockManager, F: KvFormat>(
                         tracker.write_ru_v2(exec_detail_v2.mut_ru_v2());
                     });
                     set_time_detail(exec_detail_v2, duration, &stats.latency_stats);
+                    if Duration::from_nanos(
+                        stats.latency_stats.wait_wall_time_ns
+                            + stats.latency_stats.process_wall_time_ns,
+                    ) >= slow_log_threshold
+                    {
+                        info!(#"slow_log", "slow-query";
+                            "region_id" => region_id,
+                            "peer" => peer,
+                            "command" => "kv_batch_get",
+                            "key_count" => key_count,
+                            "total_time" => ?duration,
+                            "wait_time" => ?Duration::from_nanos(
+                                stats.latency_stats.wait_wall_time_ns,
+                            ),
+                            "process_time" => ?Duration::from_nanos(
+                                stats.latency_stats.process_wall_time_ns,
+                            ),
+                        );
+                    }
                     resp.set_pairs(pairs.into());
                 }
                 Err(e) => {
@@ -2823,7 +2968,7 @@ mod tests {
         req.set_context(Context::default());
         req.set_key(b"ruv2_get".to_vec());
         req.set_version(10);
-        let resp = block_on(future_get(&storage, req)).unwrap();
+        let resp = block_on(future_get(&storage, Duration::MAX, req)).unwrap();
         assert_eq!(
             resp.get_exec_details_v2()
                 .get_ru_v2()
@@ -2844,7 +2989,7 @@ mod tests {
         req.set_version(10);
         req.mut_keys().push(b"ruv2_batch_get_1".to_vec());
         req.mut_keys().push(b"ruv2_batch_get_2".to_vec());
-        let resp = block_on(future_batch_get(&storage, req)).unwrap();
+        let resp = block_on(future_batch_get(&storage, Duration::MAX, req)).unwrap();
         assert_eq!(
             resp.get_exec_details_v2()
                 .get_ru_v2()

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -285,6 +285,10 @@ macro_rules! handle_request {
         handle_request!($fn_name, $future_name, $req_ty, $resp_ty, no_time_detail);
     };
     ($fn_name: ident, $future_name: ident, $req_ty: ident, $resp_ty: ident, $time_detail: tt) => {
+        handle_request!($fn_name, $future_name(), $req_ty, $resp_ty, $time_detail);
+    };
+    // Arm with extra args for the future function (e.g. slow_log_threshold).
+    ($fn_name: ident, $future_name: ident ( $($extra_arg: expr),* ), $req_ty: ident, $resp_ty: ident, $time_detail: tt) => {
         fn $fn_name(&mut self, ctx: RpcContext<'_>, req: $req_ty, sink: UnarySink<$resp_ty>) {
             reject_if_cluster_id_mismatch!(req, self, ctx, sink);
             forward_unary!(self.proxy, $fn_name, ctx, req, sink);
@@ -300,7 +304,7 @@ macro_rules! handle_request {
             GRPC_RESOURCE_GROUP_COUNTER_VEC
                     .with_label_values(&[resource_control_ctx.get_resource_group_name(), resource_control_ctx.get_resource_group_name()])
                     .inc();
-            let resp = $future_name(&self.storage, req);
+            let resp = $future_name(&self.storage, $($extra_arg,)* req);
             let task = async move {
                 let resp = resp.await?;
                 let elapsed = begin_instant.saturating_elapsed();
@@ -342,52 +346,7 @@ macro_rules! set_total_time {
 }
 
 impl<E: Engine, L: LockManager, F: KvFormat> Tikv for Service<E, L, F> {
-    // kv_get and kv_batch_get are manually inlined from the handle_request! macro
-    // expansion (see the macro definition above). The only difference is that these
-    // pass self.kv_slow_log_threshold to future_get / future_batch_get so slow-log
-    // decisions use wait_time + process_time rather than total wall-clock time.
-    fn kv_get(&mut self, ctx: RpcContext<'_>, req: GetRequest, sink: UnarySink<GetResponse>) {
-        reject_if_cluster_id_mismatch!(req, self, ctx, sink);
-        forward_unary!(self.proxy, kv_get, ctx, req, sink);
-        let begin_instant = Instant::now();
-
-        let source = req.get_context().get_request_source().to_owned();
-        let resource_control_ctx = req.get_context().get_resource_control_context();
-        let mut resource_group_priority = ResourcePriority::unknown;
-        if let Some(resource_manager) = &self.resource_manager {
-            resource_manager.consume_penalty(resource_control_ctx);
-            resource_group_priority = ResourcePriority::from(resource_control_ctx.override_priority);
-        }
-        GRPC_RESOURCE_GROUP_COUNTER_VEC
-            .with_label_values(&[
-                resource_control_ctx.get_resource_group_name(),
-                resource_control_ctx.get_resource_group_name(),
-            ])
-            .inc();
-        let resp = future_get(&self.storage, self.kv_slow_log_threshold, req);
-        let task = async move {
-            let resp = resp.await?;
-            let elapsed = begin_instant.saturating_elapsed();
-            set_total_time!(resp, elapsed, has_time_detail);
-            sink.success(resp).await?;
-            GRPC_MSG_HISTOGRAM_STATIC
-                .kv_get
-                .get(resource_group_priority)
-                .observe(elapsed.as_secs_f64());
-            record_request_source_metrics(source, elapsed);
-            ServerResult::Ok(())
-        }
-        .map_err(|e| {
-            log_net_error!(e, "kv rpc failed";
-                "request" => "kv_get"
-            );
-            GRPC_MSG_FAIL_COUNTER.kv_get.inc();
-        })
-        .map(|_| ());
-
-        ctx.spawn(task);
-    }
-
+    handle_request!(kv_get, future_get(self.kv_slow_log_threshold), GetRequest, GetResponse, has_time_detail);
     handle_request!(kv_scan, future_scan, ScanRequest, ScanResponse);
     handle_request!(
         kv_prewrite,
@@ -418,53 +377,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> Tikv for Service<E, L, F> {
         has_time_detail
     );
     handle_request!(kv_cleanup, future_cleanup, CleanupRequest, CleanupResponse);
-
-    fn kv_batch_get(
-        &mut self,
-        ctx: RpcContext<'_>,
-        req: BatchGetRequest,
-        sink: UnarySink<BatchGetResponse>,
-    ) {
-        reject_if_cluster_id_mismatch!(req, self, ctx, sink);
-        forward_unary!(self.proxy, kv_batch_get, ctx, req, sink);
-        let begin_instant = Instant::now();
-
-        let source = req.get_context().get_request_source().to_owned();
-        let resource_control_ctx = req.get_context().get_resource_control_context();
-        let mut resource_group_priority = ResourcePriority::unknown;
-        if let Some(resource_manager) = &self.resource_manager {
-            resource_manager.consume_penalty(resource_control_ctx);
-            resource_group_priority = ResourcePriority::from(resource_control_ctx.override_priority);
-        }
-        GRPC_RESOURCE_GROUP_COUNTER_VEC
-            .with_label_values(&[
-                resource_control_ctx.get_resource_group_name(),
-                resource_control_ctx.get_resource_group_name(),
-            ])
-            .inc();
-        let resp = future_batch_get(&self.storage, self.kv_slow_log_threshold, req);
-        let task = async move {
-            let resp = resp.await?;
-            let elapsed = begin_instant.saturating_elapsed();
-            set_total_time!(resp, elapsed, no_time_detail);
-            sink.success(resp).await?;
-            GRPC_MSG_HISTOGRAM_STATIC
-                .kv_batch_get
-                .get(resource_group_priority)
-                .observe(elapsed.as_secs_f64());
-            record_request_source_metrics(source, elapsed);
-            ServerResult::Ok(())
-        }
-        .map_err(|e| {
-            log_net_error!(e, "kv rpc failed";
-                "request" => "kv_batch_get"
-            );
-            GRPC_MSG_FAIL_COUNTER.kv_batch_get.inc();
-        })
-        .map(|_| ());
-
-        ctx.spawn(task);
-    }
+    handle_request!(kv_batch_get, future_batch_get(self.kv_slow_log_threshold), BatchGetRequest, BatchGetResponse, no_time_detail);
 
     handle_request!(
         kv_batch_rollback,
@@ -1142,6 +1055,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> Tikv for Service<E, L, F> {
         let pool_size = storage.get_normal_pool_size();
         let batch_builder = BatcherBuilder::new(self.enable_req_batch, pool_size);
         let resource_manager = self.resource_manager.clone();
+        let kv_slow_log_threshold = self.kv_slow_log_threshold;
         let cluster_id = self.cluster_id;
         let mut health_feedback_attacher = HealthFeedbackAttacher::new(
             self.store_id,
@@ -1168,6 +1082,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> Tikv for Service<E, L, F> {
                         req,
                         &tx,
                         &resource_manager,
+                        kv_slow_log_threshold,
                     )
                 {
                     let e = RpcStatus::with_message(
@@ -1444,6 +1359,7 @@ fn handle_batch_commands_request<E: Engine, L: LockManager, F: KvFormat>(
     req: batch_commands_request::Request,
     tx: &Sender<MeasuredSingleResponse>,
     resource_manager: &Option<Arc<ResourceGroupManager>>,
+    slow_log_threshold: Duration,
 ) -> Result<(), Error> {
     macro_rules! handle_cluster_id_mismatch {
         ($cluster_id:expr, $req:expr) => {
@@ -1499,10 +1415,7 @@ fn handle_batch_commands_request<E: Engine, L: LockManager, F: KvFormat>(
                     } else {
                        let begin_instant = Instant::now();
                        let source = req.get_context().get_request_source().to_owned();
-                       // Duration::MAX disables the per-request slow-log threshold check
-                       // here; the batch-commands path already tracks overall response time
-                       // via GrpcRequestDuration in handle_measures_for_batch_commands.
-                       let resp = future_get(storage, Duration::MAX, req)
+                       let resp = future_get(storage, slow_log_threshold, req)
                             .map_ok(oneof!(batch_commands_response::response::Cmd::Get))
                             .map_err(|e| {GRPC_MSG_FAIL_COUNTER.kv_get.inc(); e});
                         response_batch_commands_request(id, resp, tx.clone(), begin_instant, GrpcTypeKind::kv_get, source, resource_group_priority);
@@ -1607,10 +1520,10 @@ fn handle_batch_commands_request<E: Engine, L: LockManager, F: KvFormat>(
         Prewrite, future_prewrite(storage), kv_prewrite;
         Commit, future_commit(storage), kv_commit;
         Cleanup, future_cleanup(storage), kv_cleanup;
-        // Duration::MAX for BatchGet disables per-request slow-log in the
-        // batch-commands path; overall timing is measured separately via
-        // GrpcRequestDuration in handle_measures_for_batch_commands.
-        BatchGet, future_batch_get(storage, Duration::MAX), kv_batch_get;
+        // ReqBatcher path (future_batch_get_command) does not have per-request
+        // StageLatencyStats, so slow-log requires follow-up work.
+        // Individual non-batched BatchGet requests here use the real threshold.
+        BatchGet, future_batch_get(storage, slow_log_threshold), kv_batch_get;
         BatchRollback, future_batch_rollback(storage), kv_batch_rollback;
         TxnHeartBeat, future_txn_heart_beat(storage), kv_txn_heart_beat;
         CheckTxnStatus, future_check_txn_status(storage), kv_check_txn_status;
@@ -1710,6 +1623,12 @@ async fn future_handle_empty(
     Ok(res)
 }
 
+/// Returns true when the combined wait + process wall time exceeds the
+/// configured threshold, indicating a slow kv operation.
+fn is_slow_kv_operation(wait_wall_time_ns: u64, process_wall_time_ns: u64, threshold: Duration) -> bool {
+    Duration::from_nanos(wait_wall_time_ns.saturating_add(process_wall_time_ns)) >= threshold
+}
+
 fn future_get<E: Engine, L: LockManager, F: KvFormat>(
     storage: &Storage<E, L, F>,
     slow_log_threshold: Duration,
@@ -1726,7 +1645,9 @@ fn future_get<E: Engine, L: LockManager, F: KvFormat>(
     });
 
     let region_id = req.get_context().get_region_id();
-    let peer = req.get_context().get_peer().get_store_id();
+    let peer = req.get_context().get_peer();
+    let peer_id = peer.get_id();
+    let store_id = peer.get_store_id();
     let start = Instant::now();
     let v = storage.get_entry(
         req.take_context(),
@@ -1739,6 +1660,7 @@ fn future_get<E: Engine, L: LockManager, F: KvFormat>(
         let v = v.await;
         let duration = start.saturating_elapsed();
         let mut resp = GetResponse::default();
+        let mut is_slow = false;
         if let Some(err) = extract_region_error(&v) {
             resp.set_region_error(err);
         } else {
@@ -1754,24 +1676,11 @@ fn future_get<E: Engine, L: LockManager, F: KvFormat>(
                         tracker.write_ru_v2(exec_detail_v2.mut_ru_v2());
                     });
                     set_time_detail(exec_detail_v2, duration, &stats.latency_stats);
-                    if Duration::from_nanos(
-                        stats.latency_stats.wait_wall_time_ns
-                            + stats.latency_stats.process_wall_time_ns,
-                    ) >= slow_log_threshold
-                    {
-                        info!(#"slow_log", "slow-query";
-                            "region_id" => region_id,
-                            "peer" => peer,
-                            "command" => "kv_get",
-                            "total_time" => ?duration,
-                            "wait_time" => ?Duration::from_nanos(
-                                stats.latency_stats.wait_wall_time_ns,
-                            ),
-                            "process_time" => ?Duration::from_nanos(
-                                stats.latency_stats.process_wall_time_ns,
-                            ),
-                        );
-                    }
+                    is_slow = is_slow_kv_operation(
+                        stats.latency_stats.wait_wall_time_ns,
+                        stats.latency_stats.process_wall_time_ns,
+                        slow_log_threshold,
+                    );
                     match val {
                         Some(val) => {
                             resp.set_value(val.value);
@@ -1784,6 +1693,15 @@ fn future_get<E: Engine, L: LockManager, F: KvFormat>(
                 }
                 Err(e) => resp.set_error(extract_key_error(&e)),
             }
+        }
+        if is_slow {
+            info!(#"slow_log", "slow-query";
+                "region_id" => region_id,
+                "peer_id" => peer_id,
+                "store_id" => store_id,
+                "command" => "kv_get",
+                "total_time" => ?duration,
+            );
         }
         GLOBAL_TRACKERS.remove(tracker);
         Ok(resp)
@@ -1877,7 +1795,9 @@ fn future_batch_get<E: Engine, L: LockManager, F: KvFormat>(
     set_tls_tracker_token(tracker);
 
     let region_id = req.get_context().get_region_id();
-    let peer = req.get_context().get_peer().get_store_id();
+    let peer = req.get_context().get_peer();
+    let peer_id = peer.get_id();
+    let store_id = peer.get_store_id();
     let key_count = req.get_keys().len();
     let start = Instant::now();
     with_tls_tracker(|tracker| {
@@ -1895,6 +1815,7 @@ fn future_batch_get<E: Engine, L: LockManager, F: KvFormat>(
         let v = v.await;
         let duration = start.saturating_elapsed();
         let mut resp = BatchGetResponse::default();
+        let mut is_slow = false;
         if let Some(err) = extract_region_error(&v) {
             resp.set_region_error(err);
         } else {
@@ -1911,25 +1832,11 @@ fn future_batch_get<E: Engine, L: LockManager, F: KvFormat>(
                         tracker.write_ru_v2(exec_detail_v2.mut_ru_v2());
                     });
                     set_time_detail(exec_detail_v2, duration, &stats.latency_stats);
-                    if Duration::from_nanos(
-                        stats.latency_stats.wait_wall_time_ns
-                            + stats.latency_stats.process_wall_time_ns,
-                    ) >= slow_log_threshold
-                    {
-                        info!(#"slow_log", "slow-query";
-                            "region_id" => region_id,
-                            "peer" => peer,
-                            "command" => "kv_batch_get",
-                            "key_count" => key_count,
-                            "total_time" => ?duration,
-                            "wait_time" => ?Duration::from_nanos(
-                                stats.latency_stats.wait_wall_time_ns,
-                            ),
-                            "process_time" => ?Duration::from_nanos(
-                                stats.latency_stats.process_wall_time_ns,
-                            ),
-                        );
-                    }
+                    is_slow = is_slow_kv_operation(
+                        stats.latency_stats.wait_wall_time_ns,
+                        stats.latency_stats.process_wall_time_ns,
+                        slow_log_threshold,
+                    );
                     resp.set_pairs(pairs.into());
                 }
                 Err(e) => {
@@ -1941,6 +1848,16 @@ fn future_batch_get<E: Engine, L: LockManager, F: KvFormat>(
                     resp.mut_pairs().push(pair);
                 }
             }
+        }
+        if is_slow {
+            info!(#"slow_log", "slow-query";
+                "region_id" => region_id,
+                "peer_id" => peer_id,
+                "store_id" => store_id,
+                "command" => "kv_batch_get",
+                "key_count" => key_count,
+                "total_time" => ?duration,
+            );
         }
         GLOBAL_TRACKERS.remove(tracker);
         Ok(resp)
@@ -3177,5 +3094,82 @@ mod tests {
                 i
             );
         }
+    }
+
+    #[test]
+    fn test_is_slow_kv_operation_below_threshold() {
+        // 50ms combined < 300ms threshold -> not slow
+        let threshold = Duration::from_millis(300);
+        assert!(!is_slow_kv_operation(
+            25_000_000,  // 25ms wait
+            25_000_000,  // 25ms process
+            threshold,
+        ));
+    }
+
+    #[test]
+    fn test_is_slow_kv_operation_above_threshold() {
+        // 500ms combined > 300ms threshold -> slow
+        let threshold = Duration::from_millis(300);
+        assert!(is_slow_kv_operation(
+            250_000_000,  // 250ms wait
+            250_000_000,  // 250ms process
+            threshold,
+        ));
+    }
+
+    #[test]
+    fn test_is_slow_kv_operation_exactly_at_threshold() {
+        // Exactly 300ms combined >= 300ms -> slow
+        let threshold = Duration::from_millis(300);
+        assert!(is_slow_kv_operation(
+            150_000_000,  // 150ms wait
+            150_000_000,  // 150ms process
+            threshold,
+        ));
+    }
+
+    #[test]
+    fn test_is_slow_kv_operation_zero_threshold() {
+        // Any positive wait+process >= 0 -> slow
+        assert!(is_slow_kv_operation(1, 0, Duration::ZERO));
+        // 0ns + 0ns >= 0ns -> slow
+        assert!(is_slow_kv_operation(0, 0, Duration::ZERO));
+    }
+
+    #[test]
+    fn test_future_get_with_slow_log_threshold() {
+        // Verifies future_get doesn't panic with a real threshold.
+        // The mock storage won't produce real latency stats but the path
+        // exercises is_slow_kv_operation with whatever stats come back.
+        let storage = crate::storage::TestStorageBuilderApiV1::new(
+            crate::storage::lock_manager::MockLockManager::new(),
+        )
+        .build()
+        .unwrap();
+        let mut req = GetRequest::default();
+        req.set_context(Context::default());
+        req.set_key(b"slow_get".to_vec());
+        req.set_version(10);
+        let resp = block_on(future_get(&storage, Duration::from_millis(300), req)).unwrap();
+        assert!(resp.get_not_found());
+        // No assertion on slow-log output; this just proves the path compiles
+        // and runs to completion with the real threshold wired in.
+    }
+
+    #[test]
+    fn test_future_batch_get_with_slow_log_threshold() {
+        let storage = crate::storage::TestStorageBuilderApiV1::new(
+            crate::storage::lock_manager::MockLockManager::new(),
+        )
+        .build()
+        .unwrap();
+        let mut req = BatchGetRequest::default();
+        req.set_context(Context::default());
+        req.set_version(10);
+        req.mut_keys().push(b"slow_batch_1".to_vec());
+        let resp =
+            block_on(future_batch_get(&storage, Duration::from_millis(300), req)).unwrap();
+        assert_eq!(resp.get_pairs().len(), 0);
     }
 }

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -1048,12 +1048,17 @@ impl<E: Engine, L: LockManager, F: KvFormat> Tikv for Service<E, L, F> {
 
         let (tx, rx) = unbounded(WakePolicy::TillReach(GRPC_MSG_NOTIFY_SIZE));
         let ctx = Arc::new(ctx);
-        let peer = ctx.peer();
+        let peer = ctx.peer().to_owned();
         let storage = self.storage.clone();
         let copr = self.copr.clone();
         let copr_v2 = self.copr_v2.clone();
         let pool_size = storage.get_normal_pool_size();
-        let batch_builder = BatcherBuilder::new(self.enable_req_batch, pool_size);
+        let batch_builder = BatcherBuilder::new(
+            self.enable_req_batch,
+            pool_size,
+            self.kv_slow_log_threshold,
+            peer.clone(),
+        );
         let resource_manager = self.resource_manager.clone();
         let kv_slow_log_threshold = self.kv_slow_log_threshold;
         let cluster_id = self.cluster_id;
@@ -1520,9 +1525,6 @@ fn handle_batch_commands_request<E: Engine, L: LockManager, F: KvFormat>(
         Prewrite, future_prewrite(storage), kv_prewrite;
         Commit, future_commit(storage), kv_commit;
         Cleanup, future_cleanup(storage), kv_cleanup;
-        // ReqBatcher path (future_batch_get_command) does not have per-request
-        // StageLatencyStats, so slow-log requires follow-up work.
-        // Individual non-batched BatchGet requests here use the real threshold.
         BatchGet, future_batch_get(storage, slow_log_threshold), kv_batch_get;
         BatchRollback, future_batch_rollback(storage), kv_batch_rollback;
         TxnHeartBeat, future_txn_heart_beat(storage), kv_txn_heart_beat;
@@ -1623,10 +1625,26 @@ async fn future_handle_empty(
     Ok(res)
 }
 
-/// Returns true when the combined wait + process wall time exceeds the
-/// configured threshold, indicating a slow kv operation.
-fn is_slow_kv_operation(wait_wall_time_ns: u64, process_wall_time_ns: u64, threshold: Duration) -> bool {
-    Duration::from_nanos(wait_wall_time_ns.saturating_add(process_wall_time_ns)) >= threshold
+/// Breakdown of a slow kv operation's wait and process times.
+pub(crate) struct SlowKvTimes {
+    pub(crate) wait_time: Duration,
+    pub(crate) process_time: Duration,
+}
+
+/// Returns the wait + process wall times if the combined duration meets or
+/// exceeds `threshold`. Returns `None` for fast operations so callers can
+/// skip slow-log construction entirely.
+pub(crate) fn slow_kv_times(stats: &StageLatencyStats, threshold: Duration) -> Option<SlowKvTimes> {
+    let total_ns = stats
+        .wait_wall_time_ns
+        .saturating_add(stats.process_wall_time_ns);
+    if Duration::from_nanos(total_ns) < threshold {
+        return None;
+    }
+    Some(SlowKvTimes {
+        wait_time: Duration::from_nanos(stats.wait_wall_time_ns),
+        process_time: Duration::from_nanos(stats.process_wall_time_ns),
+    })
 }
 
 fn future_get<E: Engine, L: LockManager, F: KvFormat>(
@@ -1660,7 +1678,7 @@ fn future_get<E: Engine, L: LockManager, F: KvFormat>(
         let v = v.await;
         let duration = start.saturating_elapsed();
         let mut resp = GetResponse::default();
-        let mut is_slow = false;
+        let mut slow = None;
         if let Some(err) = extract_region_error(&v) {
             resp.set_region_error(err);
         } else {
@@ -1676,11 +1694,7 @@ fn future_get<E: Engine, L: LockManager, F: KvFormat>(
                         tracker.write_ru_v2(exec_detail_v2.mut_ru_v2());
                     });
                     set_time_detail(exec_detail_v2, duration, &stats.latency_stats);
-                    is_slow = is_slow_kv_operation(
-                        stats.latency_stats.wait_wall_time_ns,
-                        stats.latency_stats.process_wall_time_ns,
-                        slow_log_threshold,
-                    );
+                    slow = slow_kv_times(&stats.latency_stats, slow_log_threshold);
                     match val {
                         Some(val) => {
                             resp.set_value(val.value);
@@ -1694,13 +1708,15 @@ fn future_get<E: Engine, L: LockManager, F: KvFormat>(
                 Err(e) => resp.set_error(extract_key_error(&e)),
             }
         }
-        if is_slow {
+        if let Some(times) = slow {
             info!(#"slow_log", "slow-query";
                 "region_id" => region_id,
                 "peer_id" => peer_id,
                 "store_id" => store_id,
                 "command" => "kv_get",
                 "total_time" => ?duration,
+                "wait_time" => ?times.wait_time,
+                "process_time" => ?times.process_time,
             );
         }
         GLOBAL_TRACKERS.remove(tracker);
@@ -1815,7 +1831,7 @@ fn future_batch_get<E: Engine, L: LockManager, F: KvFormat>(
         let v = v.await;
         let duration = start.saturating_elapsed();
         let mut resp = BatchGetResponse::default();
-        let mut is_slow = false;
+        let mut slow = None;
         if let Some(err) = extract_region_error(&v) {
             resp.set_region_error(err);
         } else {
@@ -1832,11 +1848,7 @@ fn future_batch_get<E: Engine, L: LockManager, F: KvFormat>(
                         tracker.write_ru_v2(exec_detail_v2.mut_ru_v2());
                     });
                     set_time_detail(exec_detail_v2, duration, &stats.latency_stats);
-                    is_slow = is_slow_kv_operation(
-                        stats.latency_stats.wait_wall_time_ns,
-                        stats.latency_stats.process_wall_time_ns,
-                        slow_log_threshold,
-                    );
+                    slow = slow_kv_times(&stats.latency_stats, slow_log_threshold);
                     resp.set_pairs(pairs.into());
                 }
                 Err(e) => {
@@ -1849,7 +1861,7 @@ fn future_batch_get<E: Engine, L: LockManager, F: KvFormat>(
                 }
             }
         }
-        if is_slow {
+        if let Some(times) = slow {
             info!(#"slow_log", "slow-query";
                 "region_id" => region_id,
                 "peer_id" => peer_id,
@@ -1857,6 +1869,8 @@ fn future_batch_get<E: Engine, L: LockManager, F: KvFormat>(
                 "command" => "kv_batch_get",
                 "key_count" => key_count,
                 "total_time" => ?duration,
+                "wait_time" => ?times.wait_time,
+                "process_time" => ?times.process_time,
             );
         }
         GLOBAL_TRACKERS.remove(tracker);
@@ -3097,51 +3111,79 @@ mod tests {
     }
 
     #[test]
-    fn test_is_slow_kv_operation_below_threshold() {
-        // 50ms combined < 300ms threshold -> not slow
+    fn test_slow_kv_times_below_threshold() {
+        // 50ms combined < 300ms threshold -> None
         let threshold = Duration::from_millis(300);
-        assert!(!is_slow_kv_operation(
-            25_000_000,  // 25ms wait
-            25_000_000,  // 25ms process
-            threshold,
-        ));
+        let stats = StageLatencyStats {
+            wait_wall_time_ns: 25_000_000,
+            process_wall_time_ns: 25_000_000,
+            ..Default::default()
+        };
+        assert!(slow_kv_times(&stats, threshold).is_none());
     }
 
     #[test]
-    fn test_is_slow_kv_operation_above_threshold() {
-        // 500ms combined > 300ms threshold -> slow
+    fn test_slow_kv_times_above_threshold() {
+        // 500ms combined > 300ms threshold -> Some
         let threshold = Duration::from_millis(300);
-        assert!(is_slow_kv_operation(
-            250_000_000,  // 250ms wait
-            250_000_000,  // 250ms process
-            threshold,
-        ));
+        let stats = StageLatencyStats {
+            wait_wall_time_ns: 250_000_000,
+            process_wall_time_ns: 250_000_000,
+            ..Default::default()
+        };
+        let times = slow_kv_times(&stats, threshold).unwrap();
+        assert_eq!(times.wait_time, Duration::from_millis(250));
+        assert_eq!(times.process_time, Duration::from_millis(250));
     }
 
     #[test]
-    fn test_is_slow_kv_operation_exactly_at_threshold() {
-        // Exactly 300ms combined >= 300ms -> slow
+    fn test_slow_kv_times_exactly_at_threshold() {
+        // Exactly 300ms combined >= 300ms -> Some
         let threshold = Duration::from_millis(300);
-        assert!(is_slow_kv_operation(
-            150_000_000,  // 150ms wait
-            150_000_000,  // 150ms process
-            threshold,
-        ));
+        let stats = StageLatencyStats {
+            wait_wall_time_ns: 150_000_000,
+            process_wall_time_ns: 150_000_000,
+            ..Default::default()
+        };
+        let times = slow_kv_times(&stats, threshold).unwrap();
+        assert_eq!(times.wait_time, Duration::from_millis(150));
+        assert_eq!(times.process_time, Duration::from_millis(150));
     }
 
     #[test]
-    fn test_is_slow_kv_operation_zero_threshold() {
-        // Any positive wait+process >= 0 -> slow
-        assert!(is_slow_kv_operation(1, 0, Duration::ZERO));
-        // 0ns + 0ns >= 0ns -> slow
-        assert!(is_slow_kv_operation(0, 0, Duration::ZERO));
+    fn test_slow_kv_times_zero_threshold() {
+        // Any wait+process >= 0 -> Some
+        let stats = StageLatencyStats {
+            wait_wall_time_ns: 1,
+            process_wall_time_ns: 0,
+            ..Default::default()
+        };
+        assert!(slow_kv_times(&stats, Duration::ZERO).is_some());
+        // 0ns + 0ns >= 0ns -> Some
+        let stats = StageLatencyStats::default();
+        assert!(slow_kv_times(&stats, Duration::ZERO).is_some());
+    }
+
+    #[test]
+    fn test_slow_kv_times_saturating_u64_max() {
+        // u64::MAX + u64::MAX is extremely large, saturating_add handles it.
+        let threshold = Duration::from_secs(1);
+        let stats = StageLatencyStats {
+            wait_wall_time_ns: u64::MAX,
+            process_wall_time_ns: u64::MAX,
+            ..Default::default()
+        };
+        let times = slow_kv_times(&stats, threshold).unwrap();
+        // Both saturated to u64::MAX nanos (approx 584 years in Duration).
+        assert_eq!(times.wait_time, Duration::from_nanos(u64::MAX));
+        assert_eq!(times.process_time, Duration::from_nanos(u64::MAX));
     }
 
     #[test]
     fn test_future_get_with_slow_log_threshold() {
         // Verifies future_get doesn't panic with a real threshold.
         // The mock storage won't produce real latency stats but the path
-        // exercises is_slow_kv_operation with whatever stats come back.
+        // exercises slow_kv_times with whatever stats come back.
         let storage = crate::storage::TestStorageBuilderApiV1::new(
             crate::storage::lock_manager::MockLockManager::new(),
         )

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -818,7 +818,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
     /// Only writes that are committed before their respective `start_ts` are
     /// visible.
     pub fn batch_get_command<
-        P: 'static + ResponseBatchConsumer<(Option<ValueEntry>, Statistics)>,
+        P: 'static + ResponseBatchConsumer<(Option<ValueEntry>, KvGetStatistics)>,
     >(
         &self,
         requests: Vec<GetRequest>,
@@ -865,6 +865,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
         // Unset the TLS tracker because the future below does not belong to any
         // specific request
         clear_tls_tracker_token();
+        let stage_begin_ts = Instant::now();
         self.read_pool_spawn_with_busy_check(
             busy_threshold,
             async move {
@@ -873,6 +874,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
                     .get(CMD)
                     .observe(requests.len() as f64);
                 let command_duration = Instant::now();
+                let schedule_wait_time = command_duration.saturating_duration_since(stage_begin_ts);
                 let read_id = Some(ThreadReadId::new());
                 let mut statistics = Statistics::default();
                 let mut req_snaps = vec![];
@@ -962,7 +964,12 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
                         tracker,
                         deadline,
                     ) = req_snap;
+                    let snap_start = Instant::now();
                     let snap_res = snap.await;
+                    let snap_recv_ts = Instant::now();
+                    let snapshot_wait_time =
+                        snap_recv_ts.saturating_duration_since(snap_start);
+                    let wait_wall_time = snap_recv_ts.saturating_duration_since(stage_begin_ts);
                     if let Err(e) = deadline.check() {
                         consumer.consume(
                             id,
@@ -987,6 +994,9 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
                             {
                                 Ok(mut point_getter) => {
                                     let v = point_getter.get_entry(&key, need_commit_ts);
+                                    let process_done = Instant::now();
+                                    let process_wall_time =
+                                        process_done.saturating_duration_since(snap_recv_ts);
                                     with_tls_tracker(|tracker| {
                                         tracker.metrics.storage_processed_keys_get = tracker
                                             .metrics
@@ -1007,10 +1017,24 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
                                     });
                                     record_network_out_bytes(value_size);
                                     record_logical_read_bytes(statistics.processed_size as u64);
+                                    let latency_stats = StageLatencyStats {
+                                        schedule_wait_time_ns: schedule_wait_time
+                                            .as_nanos() as u64,
+                                        snapshot_wait_time_ns: snapshot_wait_time
+                                            .as_nanos() as u64,
+                                        wait_wall_time_ns: wait_wall_time
+                                            .as_nanos() as u64,
+                                        process_wall_time_ns: process_wall_time
+                                            .as_nanos() as u64,
+                                    };
+                                    let kv_stats = KvGetStatistics {
+                                        stats: stat,
+                                        latency_stats,
+                                    };
                                     consumer.consume(
                                         id,
                                         v.map_err(|e| Error::from(txn::Error::from(e)))
-                                            .map(|v| (v, stat)),
+                                            .map(|v| (v, kv_stats)),
                                         begin_instant,
                                         source,
                                         resource_priority,
@@ -4314,11 +4338,11 @@ pub mod test_util {
         }
     }
 
-    impl ResponseBatchConsumer<(Option<ValueEntry>, Statistics)> for GetConsumer {
+    impl ResponseBatchConsumer<(Option<ValueEntry>, KvGetStatistics)> for GetConsumer {
         fn consume(
             &self,
             id: u64,
-            res: Result<(Option<ValueEntry>, Statistics)>,
+            res: Result<(Option<ValueEntry>, KvGetStatistics)>,
             _: Instant,
             _source: String,
             _resource_priority: ResourcePriority,


### PR DESCRIPTION
## What
Add slow logging for KvGet and KvBatchGet commands. When the combined wait + process time exceeds a configurable threshold (default 300ms), a slow log is emitted following the coprocessor tracker pattern.

## Changes
- `src/server/config.rs`: Add `kv_command_slow_log_threshold` config option (default 300ms)
- `src/server/server.rs`: Wire config into `KvService::new()`
- `src/server/service/kv.rs`: Implement slow log emission in `future_get` and `future_batch_get`

## References
- Issue: #8944
- Dependencies #8942 and #8945 are closed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable slow-operation logging threshold for `KvGet` and `KvBatchGet` requests (`kv-command-slow-log-threshold`, default: 300ms), using **wait time + processing time**.
* **Bug Fixes**
  * Improved slow-log timing and propagation across batching paths so slow logs are based on per-request wait/process metrics.
  * Raw batch-get handling no longer produces slow logs without applicable timing context.
* **Tests**
  * Updated and added tests covering threshold behavior and slow-log emission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->