### PR TITLE
backup-stream: remove safepoint if log backup task is stopped

### DIFF
--- a/components/backup-stream/src/checkpoint_manager.rs
+++ b/components/backup-stream/src/checkpoint_manager.rs
@@ -497,15 +497,37 @@ impl<PD> BasicFlushObserver<PD> {
     }
 }
 
-#[async_trait::async_trait]
-impl<PD: PdClient + 'static> FlushObserver for BasicFlushObserver<PD> {
-    async fn before(&mut self, _checkpoints: Vec<ResolveResult>) {}
+fn flush_safe_point_service_id(task: &str, store_id: u64) -> String {
+    format!("{}-{}-{}", BACKUP_STREAM_THREAD, task, store_id)
+}
 
-    async fn after(&mut self, task: &str, rts: u64) -> Result<()> {
+pub(crate) async fn remove_flush_safe_point<PD: PdClient + 'static>(
+    pd_cli: Arc<PD>,
+    store_id: u64,
+    task: &str,
+) {
+    if let Err(err) = pd_cli
+        .update_service_safe_point(
+            flush_safe_point_service_id(task, store_id),
+            TimeStamp::zero(),
+            Duration::new(0, 0),
+        )
+        .await
+        .map_err(Error::from)
+    {
+        err.report(format!(
+            "failed to remove flush safe point for task {}",
+            task
+        ));
+    }
+}
+
+impl<PD: PdClient + 'static> BasicFlushObserver<PD> {
+    async fn update_after_flush(&self, task: &str, rts: u64) {
         if let Err(err) = self
             .pd_cli
             .update_service_safe_point(
-                format!("{}-{}-{}", BACKUP_STREAM_THREAD, task, self.store_id),
+                flush_safe_point_service_id(task, self.store_id),
                 TimeStamp::new(rts.saturating_sub(1)),
                 // Add a service safe point for 2 hours.
                 // We make it the same duration as we meet fatal errors because TiKV may be
@@ -520,6 +542,15 @@ impl<PD: PdClient + 'static> FlushObserver for BasicFlushObserver<PD> {
             Error::from(err).report("failed to update service safe point!");
             // don't give up?
         }
+    }
+}
+
+#[async_trait::async_trait]
+impl<PD: PdClient + 'static> FlushObserver for BasicFlushObserver<PD> {
+    async fn before(&mut self, _checkpoints: Vec<ResolveResult>) {}
+
+    async fn after(&mut self, task: &str, rts: u64) -> Result<()> {
+        self.update_after_flush(task, rts).await;
 
         // Currently, we only support one task at the same time,
         // so use the task as label would be ok.
@@ -624,7 +655,7 @@ pub mod tests {
     use tikv_util::thread_name_prefix::BACKUP_STREAM_THREAD;
     use txn_types::TimeStamp;
 
-    use super::{BasicFlushObserver, FlushObserver, RegionIdWithVersion};
+    use super::{BasicFlushObserver, FlushObserver, RegionIdWithVersion, remove_flush_safe_point};
     use crate::{
         GetCheckpointResult,
         subscription_track::{CheckpointType, ResolveResult},
@@ -913,8 +944,8 @@ pub mod tests {
     async fn test_after() {
         let store_id = 1;
         let pd_cli = Arc::new(MockPdClient::new());
-        let mut flush_observer = BasicFlushObserver::new(pd_cli.clone(), store_id);
         let task = String::from("test");
+        let mut flush_observer = BasicFlushObserver::new(pd_cli.clone(), store_id);
         let rts = 12345;
 
         let r = flush_observer.after(&task, rts).await;
@@ -923,5 +954,30 @@ pub mod tests {
         let service_id = format!("{}-{}-{}", BACKUP_STREAM_THREAD, task, store_id);
         let r = pd_cli.get_service_safe_point(service_id).unwrap();
         assert_eq!(r.into_inner(), rts - 1);
+    }
+
+    #[tokio::test]
+    async fn test_remove_flush_safe_point() {
+        let store_id = 1;
+        let pd_cli = Arc::new(MockPdClient::new());
+        let task = String::from("test");
+        let service_id = format!("{}-{}-{}", BACKUP_STREAM_THREAD, task, store_id);
+
+        let mut flush_observer = BasicFlushObserver::new(pd_cli.clone(), store_id);
+        flush_observer.after(&task, 12345).await.unwrap();
+        let r = pd_cli.get_service_safe_point(service_id.clone()).unwrap();
+        assert_eq!(r.into_inner(), 12344);
+
+        remove_flush_safe_point(pd_cli.clone(), store_id, &task).await;
+        let r = pd_cli.get_service_safe_point(service_id.clone()).unwrap();
+        assert_eq!(r.into_inner(), 0);
+
+        flush_observer.after(&task, 34567).await.unwrap();
+        let r = pd_cli.get_service_safe_point(service_id.clone()).unwrap();
+        assert_eq!(r.into_inner(), 34566);
+
+        remove_flush_safe_point(pd_cli.clone(), store_id, &task).await;
+        let r = pd_cli.get_service_safe_point(service_id).unwrap();
+        assert_eq!(r.into_inner(), 0);
     }
 }

--- a/components/backup-stream/src/endpoint.rs
+++ b/components/backup-stream/src/endpoint.rs
@@ -57,7 +57,7 @@ use crate::{
     annotate,
     checkpoint_manager::{
         BasicFlushObserver, CheckpointManager, CheckpointV3FlushObserver, FlushObserver,
-        GetCheckpointResult, RegionIdWithVersion, Subscription,
+        GetCheckpointResult, RegionIdWithVersion, Subscription, remove_flush_safe_point,
     },
     errors::{Error, ReportableResult, Result},
     event_loader::InitialDataLoader,
@@ -835,6 +835,11 @@ where
     pub fn on_unregister(&self, task_name: &str) -> Option<StreamBackupTaskInfo> {
         let info = self.unload_task(task_name);
         self.clean_pause_guard_id_for_task(task_name);
+        self.pool.block_on(remove_flush_safe_point(
+            self.pd_client.clone(),
+            self.store_id,
+            task_name,
+        ));
         self.remove_metrics_after_unregister(task_name);
         info
     }
@@ -913,6 +918,7 @@ where
         flush_ts: TimeStamp,
     ) -> future![Result<()>] {
         let router = self.range_router.clone();
+        let sched = self.scheduler.clone();
         let store_id = self.store_id;
         let mut flush_ob = self.flush_observer();
         async move {
@@ -939,7 +945,19 @@ where
                     // We cannot advance the resolved ts for now.
                     return Ok(());
                 }
-                flush_ob.after(&task, rts).await?
+                fail::fail_point!("before_flush_observer_after");
+                flush_ob.after(&task, rts).await?;
+                if !router.has_task(&task) {
+                    // `router.do_flush` releases the task's flushing flag before this observer
+                    // tail runs. An unregister, or another trailing flush for the same removed
+                    // task, can race with `flush_ob.after` and recreate the safe point. The task
+                    // map is the liveness boundary, so ask the endpoint actor to clean up the
+                    // just-updated safe point when no task with this name is still registered.
+                    // The actor re-checks liveness so same-name re-registration is ordered with
+                    // this cleanup.
+                    fail::fail_point!("before_schedule_cleanup_flush_safe_point");
+                    try_send!(sched, Task::CleanupFlushSafePoint(task.clone()));
+                }
             }
             Ok(())
         }
@@ -1199,10 +1217,22 @@ where
             }
             Task::MarkFailover(t) => self.failover_time = Some(t),
             Task::ExecFlush(task, min_ts, flush_ts) => self.on_exec_flush(task, min_ts, flush_ts),
+            Task::CleanupFlushSafePoint(task) => self.on_cleanup_flush_safe_point(&task),
             Task::RegionCheckpointsOp(s) => self.handle_region_checkpoints_op(s),
             Task::UpdateGlobalCheckpoint(task) => self.on_update_global_checkpoint(task),
             Task::Flushed(result) => self.on_flushed(result),
         }
+    }
+
+    fn on_cleanup_flush_safe_point(&self, task: &str) {
+        if self.range_router.has_task(task) {
+            return;
+        }
+        self.pool.block_on(remove_flush_safe_point(
+            self.pd_client.clone(),
+            self.store_id,
+            task,
+        ));
     }
 
     fn on_flushed(&mut self, result: FlushResult) {
@@ -1480,6 +1510,9 @@ pub enum Task {
     /// Execute the flush with the calculated resolved result.
     /// This is an internal command only issued by the `Flush` task.
     ExecFlush(String, ResolvedRegions, TimeStamp),
+    /// Remove the flush safe point if the task is still absent in the endpoint
+    /// actor.
+    CleanupFlushSafePoint(String),
     /// The command for getting region checkpoints.
     RegionCheckpointsOp(RegionCheckpointOperation),
     /// update global-checkpoint-ts to storage.
@@ -1599,6 +1632,9 @@ impl fmt::Debug for Task {
                 .field(&arg1.global_checkpoint())
                 .field(&arg2)
                 .finish(),
+            Self::CleanupFlushSafePoint(task) => {
+                f.debug_tuple("CleanupFlushSafePoint").field(task).finish()
+            }
             Self::RegionCheckpointsOp(s) => f.debug_tuple("GetRegionCheckpoints").field(s).finish(),
             Self::UpdateGlobalCheckpoint(task) => {
                 f.debug_tuple("UpdateGlobalCheckpoint").field(task).finish()
@@ -1640,6 +1676,7 @@ impl Task {
             Task::Sync(..) => "sync",
             Task::MarkFailover(_) => "mark_failover",
             Task::ExecFlush(..) => "flush_with_min_ts",
+            Task::CleanupFlushSafePoint(_) => "cleanup_flush_safe_point",
             Task::RegionCheckpointsOp(..) => "get_checkpoints",
             Task::UpdateGlobalCheckpoint(..) => "update_global_checkpoint",
         }

--- a/components/backup-stream/src/router.rs
+++ b/components/backup-stream/src/router.rs
@@ -635,6 +635,10 @@ impl RouterInner {
         })
     }
 
+    pub fn has_task(&self, task_name: &str) -> bool {
+        self.tasks.contains_key(task_name)
+    }
+
     /// get the task name by a key.
     pub fn get_task_by_key(&self, key: &[u8]) -> Option<String> {
         let r = self.ranges.read().unwrap();

--- a/components/backup-stream/tests/failpoints/mod.rs
+++ b/components/backup-stream/tests/failpoints/mod.rs
@@ -12,8 +12,9 @@ mod all {
     use core::panic;
     use std::{
         sync::{
-            Arc,
+            Arc, Mutex,
             atomic::{AtomicBool, Ordering},
+            mpsc::sync_channel,
         },
         time::Duration,
     };
@@ -37,6 +38,7 @@ mod all {
         HandyRwLock, box_err,
         config::{ReadableDuration, ReadableSize},
         defer,
+        thread_name_prefix::BACKUP_STREAM_THREAD,
     };
     use txn_types::Key;
     use walkdir::WalkDir;
@@ -612,5 +614,131 @@ mod all {
             suite.flushed_files.path(),
             keyset.iter().map(|v| v.as_slice()),
         )
+    }
+
+    #[test]
+    fn unregister_during_flush_cleans_flush_safe_point() {
+        let mut suite = SuiteBuilder::new_named("unregister_during_flush")
+            .nodes(1)
+            .build();
+        let task = "unregister_during_flush";
+        let service_id = format!("{}-{}-{}", BACKUP_STREAM_THREAD, task, 1);
+        let (paused_tx, paused_rx) = sync_channel(0);
+        let (resume_tx, resume_rx) = sync_channel(0);
+        let resume_rx = Mutex::new(resume_rx);
+
+        fail::cfg_callback("before_flush_observer_after", move || {
+            paused_tx.send(()).unwrap();
+            resume_rx.lock().unwrap().recv().unwrap();
+        })
+        .unwrap();
+        defer! {
+            fail::remove("before_flush_observer_after")
+        }
+
+        suite.must_register_task(1, task);
+        suite.sync();
+        run_async_test(suite.write_records(0, 1, 1));
+
+        let (flush_tx, mut flush_rx) = tokio::sync::mpsc::channel(1);
+        suite.run(|| Task::ForceFlush(TaskSelector::ByName(task.to_owned()), flush_tx.clone()));
+        drop(flush_tx);
+        paused_rx
+            .recv_timeout(Duration::from_secs(10))
+            .expect("flush should reach observer tail");
+
+        run_async_test(suite.meta_store.delete(Keys::Key(MetaKey::task_of(task)))).unwrap();
+        suite.wait_with_router(|router| !router.has_task(task));
+
+        resume_tx.send(()).unwrap();
+        run_async_test(async {
+            while let Some(result) = tokio::time::timeout(Duration::from_secs(30), flush_rx.recv())
+                .await
+                .expect("flush should finish after releasing failpoint")
+            {
+                assert!(result.error.is_none(), "{:?}", result.error);
+            }
+        });
+
+        let safepoints = suite.cluster.pd_client.gc_safepoints.rl();
+        assert!(
+            !safepoints
+                .iter()
+                .any(|sp| sp.service == service_id && sp.safepoint.into_inner() > 0),
+            "{:?}",
+            safepoints
+        );
+    }
+
+    #[test]
+    fn cleanup_flush_safe_point_keeps_same_name_registered_task() {
+        let mut suite = SuiteBuilder::new_named("cleanup_same_name_task")
+            .nodes(1)
+            .build();
+        let task = "cleanup_same_name_task";
+        let service_id = format!("{}-{}-{}", BACKUP_STREAM_THREAD, task, 1);
+        let (observer_paused_tx, observer_paused_rx) = sync_channel(0);
+        let (observer_resume_tx, observer_resume_rx) = sync_channel(0);
+        let observer_resume_rx = Mutex::new(observer_resume_rx);
+        let (cleanup_paused_tx, cleanup_paused_rx) = sync_channel(0);
+        let (cleanup_resume_tx, cleanup_resume_rx) = sync_channel(0);
+        let cleanup_resume_rx = Mutex::new(cleanup_resume_rx);
+
+        fail::cfg_callback("before_flush_observer_after", move || {
+            observer_paused_tx.send(()).unwrap();
+            observer_resume_rx.lock().unwrap().recv().unwrap();
+        })
+        .unwrap();
+        defer! {
+            fail::remove("before_flush_observer_after")
+        }
+        fail::cfg_callback("before_schedule_cleanup_flush_safe_point", move || {
+            cleanup_paused_tx.send(()).unwrap();
+            cleanup_resume_rx.lock().unwrap().recv().unwrap();
+        })
+        .unwrap();
+        defer! {
+            fail::remove("before_schedule_cleanup_flush_safe_point")
+        }
+
+        suite.must_register_task(1, task);
+        suite.sync();
+        run_async_test(suite.write_records(0, 1, 1));
+
+        let (flush_tx, mut flush_rx) = tokio::sync::mpsc::channel(1);
+        suite.run(|| Task::ForceFlush(TaskSelector::ByName(task.to_owned()), flush_tx.clone()));
+        drop(flush_tx);
+        observer_paused_rx
+            .recv_timeout(Duration::from_secs(10))
+            .expect("flush should reach observer tail");
+
+        run_async_test(suite.meta_store.delete(Keys::Key(MetaKey::task_of(task)))).unwrap();
+        suite.wait_with_router(|router| !router.has_task(task));
+
+        observer_resume_tx.send(()).unwrap();
+        cleanup_paused_rx
+            .recv_timeout(Duration::from_secs(10))
+            .expect("flush should try to schedule safe point cleanup");
+
+        suite.must_register_task(1, task);
+        cleanup_resume_tx.send(()).unwrap();
+        run_async_test(async {
+            while let Some(result) = tokio::time::timeout(Duration::from_secs(30), flush_rx.recv())
+                .await
+                .expect("flush should finish after releasing failpoint")
+            {
+                assert!(result.error.is_none(), "{:?}", result.error);
+            }
+        });
+        suite.sync();
+
+        let safepoints = suite.cluster.pd_client.gc_safepoints.rl();
+        assert!(
+            safepoints
+                .iter()
+                .any(|sp| sp.service == service_id && !sp.ttl.is_zero()),
+            "{:?}",
+            safepoints
+        );
     }
 }

--- a/components/test_pd_client/src/pd.rs
+++ b/components/test_pd_client/src/pd.rs
@@ -1989,12 +1989,22 @@ impl PdClient for TestPdClient {
         safepoint: TimeStamp,
         ttl: Duration,
     ) -> PdFuture<()> {
+        let mut gc_safepoints = self.gc_safepoints.wl();
+        if ttl.is_zero() {
+            gc_safepoints.retain(|sp| sp.service != name);
+            return Box::pin(ok(()));
+        }
         if ttl.as_secs() > 0 {
-            self.gc_safepoints.wl().push(ServiceSafePoint {
-                service: name,
-                ttl,
-                safepoint,
-            });
+            if let Some(sp) = gc_safepoints.iter_mut().find(|sp| sp.service == name) {
+                sp.ttl = ttl;
+                sp.safepoint = safepoint;
+            } else {
+                gc_safepoints.push(ServiceSafePoint {
+                    service: name,
+                    ttl,
+                    safepoint,
+                });
+            }
         }
         Box::pin(ok(()))
     }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #19832

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
remove safepoint if log backup task is stopped
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Flush safe points are now removed when backup tasks are unregistered.
  - Safe points are also cleaned up when a task disappears during an in-progress flush.
  - Prevents stale safe points from affecting cleanup after task removal.
  - Re-registering a task with the same name preserves correct safe-point tracking and refreshes it during subsequent flushes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->