### PR TITLE
*: extend Top SQL resource dimensions

### DIFF
--- a/.github/workflows/tikv-clippy-darwin.yml
+++ b/.github/workflows/tikv-clippy-darwin.yml
@@ -106,3 +106,7 @@ jobs:
       - name: Run Clippy
         run: |
           make clippy
+
+      - name: Check TiRocks
+        run: |
+          make check-tirocks

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4422,7 +4422,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git#a15c348f8713e5c492b6dfb41224c464b5824979"
+source = "git+https://github.com/pingcap/kvproto.git#78af7ed13316f15a92c766806ef106635d1e400f"
 dependencies = [
  "bytes",
  "futures 0.3.15",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4422,7 +4422,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git#78af7ed13316f15a92c766806ef106635d1e400f"
+source = "git+https://github.com/pingcap/kvproto.git?branch=codex/add-resource-metering-block-read-count#78af7ed13316f15a92c766806ef106635d1e400f"
 dependencies = [
  "bytes",
  "futures 0.3.15",
@@ -9245,7 +9245,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "static_assertions",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4422,7 +4422,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git?branch=codex/add-resource-metering-block-read-count#78af7ed13316f15a92c766806ef106635d1e400f"
+source = "git+https://github.com/pingcap/kvproto.git?branch=codex/add-resource-metering-block-read-count#fb4b0fd8706c3d9220e83f8f406b725cfd4e0a44"
 dependencies = [
  "bytes",
  "futures 0.3.15",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -381,7 +381,7 @@ grpcio-health = { version = "0.10.4", default-features = false, features = [
   "protobuf-codec",
 ] }
 tipb = { git = "https://github.com/pingcap/tipb.git" }
-kvproto = { git = "https://github.com/pingcap/kvproto.git" }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "codex/add-resource-metering-block-read-count" }
 yatp = { git = "https://github.com/tikv/yatp.git", branch = "master" }
 tokio-timer = { git = "https://github.com/tikv/tokio", branch = "tokio-timer-hotfix" }
 tokio-executor = { git = "https://github.com/tikv/tokio", branch = "tokio-timer-hotfix" }

--- a/Makefile
+++ b/Makefile
@@ -374,6 +374,9 @@ clippy: pre-clippy
 	@./scripts/deny
 	@./scripts/clippy-all
 
+check-tirocks:
+	@./scripts/check-tirocks
+
 pre-audit:
 	$(eval LATEST_AUDIT_VERSION := $(strip $(shell cargo search cargo-audit | head -n 1 | awk '{ gsub(/"/, "", $$3); print $$3 }')))
 	$(eval CURRENT_AUDIT_VERSION = $(strip $(shell (cargo audit --version 2> /dev/null || echo "noop 0") | awk '{ print $$2 }')))

--- a/components/engine_panic/src/perf_context.rs
+++ b/components/engine_panic/src/perf_context.rs
@@ -1,6 +1,6 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
-use engine_traits::{PerfContext, PerfContextExt, PerfContextKind, PerfLevel};
+use engine_traits::{PerfContext, PerfContextExt, PerfContextKind, PerfContextReport, PerfLevel};
 use tracker::TrackerToken;
 
 use crate::engine::PanicEngine;
@@ -20,7 +20,7 @@ impl PerfContext for PanicPerfContext {
         panic!()
     }
 
-    fn report_metrics(&mut self, _: &[TrackerToken]) {
+    fn report_metrics(&mut self, _: &[TrackerToken]) -> PerfContextReport {
         panic!()
     }
 }

--- a/components/engine_rocks/src/perf_context.rs
+++ b/components/engine_rocks/src/perf_context.rs
@@ -1,6 +1,6 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
-use engine_traits::{PerfContext, PerfContextExt, PerfContextKind, PerfLevel};
+use engine_traits::{PerfContext, PerfContextExt, PerfContextKind, PerfContextReport, PerfLevel};
 use tracker::TrackerToken;
 
 use crate::{engine::RocksEngine, perf_context_impl::PerfContextStatistics};
@@ -31,7 +31,7 @@ impl PerfContext for RocksPerfContext {
         self.stats.start()
     }
 
-    fn report_metrics(&mut self, trackers: &[TrackerToken]) {
+    fn report_metrics(&mut self, trackers: &[TrackerToken]) -> PerfContextReport {
         self.stats.report(trackers)
     }
 }

--- a/components/engine_rocks/src/perf_context_impl.rs
+++ b/components/engine_rocks/src/perf_context_impl.rs
@@ -3,7 +3,7 @@
 use std::{fmt::Debug, marker::PhantomData, mem, ops::Sub, time::Duration};
 
 use derive_more::{Add, AddAssign, Sub, SubAssign};
-use engine_traits::{PerfContextKind, PerfLevel};
+use engine_traits::{PerfContextKind, PerfContextReport, PerfLevel};
 use lazy_static::lazy_static;
 use slog_derive::KV;
 use tikv_util::time::Instant;
@@ -205,7 +205,7 @@ impl PerfContextStatistics {
         self.apply_perf_settings();
     }
 
-    pub fn report(&mut self, trackers: &[TrackerToken]) {
+    pub fn report(&mut self, trackers: &[TrackerToken]) -> PerfContextReport {
         match self.kind {
             PerfContextKind::RaftstoreApply => {
                 report_write_perf_context!(self, APPLY_PERF_CONTEXT_TIME_HISTOGRAM_STATIC);
@@ -217,6 +217,7 @@ impl PerfContextStatistics {
                         t.metrics.apply_write_memtable_nanos = self.write.write_memtable_time;
                     });
                 }
+                PerfContextReport::default()
             }
             PerfContextKind::RaftstoreStore => {
                 report_write_perf_context!(self, STORE_PERF_CONTEXT_TIME_HISTOGRAM_STATIC);
@@ -228,14 +229,17 @@ impl PerfContextStatistics {
                         t.metrics.store_write_memtable_nanos = self.write.write_memtable_time;
                     });
                 }
+                PerfContextReport::default()
             }
             PerfContextKind::Storage(_) | PerfContextKind::Coprocessor(_) => {
                 let perf_context = ReadPerfContext::capture();
+                let block_read_count = perf_context.block_read_count;
                 for token in trackers {
                     GLOBAL_TRACKERS.with_tracker(*token, |t| perf_context.report_to_tracker(t));
                 }
                 self.read += perf_context;
                 self.flush_read_metrics();
+                PerfContextReport { block_read_count }
             }
         }
     }

--- a/components/engine_tirocks/src/perf_context.rs
+++ b/components/engine_tirocks/src/perf_context.rs
@@ -161,7 +161,7 @@ impl engine_traits::PerfContext for RocksPerfContext {
         self.stats.start()
     }
 
-    fn report_metrics(&mut self, trackers: &[TrackerToken]) {
+    fn report_metrics(&mut self, trackers: &[TrackerToken]) -> engine_traits::PerfContextReport {
         self.stats.report(trackers)
     }
 }
@@ -291,7 +291,7 @@ impl PerfContextStatistics {
         self.apply_perf_settings();
     }
 
-    pub fn report(&mut self, trackers: &[TrackerToken]) {
+    pub fn report(&mut self, trackers: &[TrackerToken]) -> engine_traits::PerfContextReport {
         match self.kind {
             engine_traits::PerfContextKind::RaftstoreApply => {
                 report_write_perf_context!(self, APPLY_PERF_CONTEXT_TIME_HISTOGRAM_STATIC);
@@ -303,6 +303,7 @@ impl PerfContextStatistics {
                         t.metrics.apply_write_memtable_nanos = self.write.write_memtable_time;
                     });
                 }
+                engine_traits::PerfContextReport::default()
             }
             engine_traits::PerfContextKind::RaftstoreStore => {
                 report_write_perf_context!(self, STORE_PERF_CONTEXT_TIME_HISTOGRAM_STATIC);
@@ -314,15 +315,18 @@ impl PerfContextStatistics {
                         t.metrics.store_write_memtable_nanos = self.write.write_memtable_time;
                     });
                 }
+                engine_traits::PerfContextReport::default()
             }
             engine_traits::PerfContextKind::Storage(_)
             | engine_traits::PerfContextKind::Coprocessor(_) => {
                 let perf_context = ReadPerfContext::capture();
+                let block_read_count = perf_context.block_read_count;
                 for token in trackers {
                     GLOBAL_TRACKERS.with_tracker(*token, |t| perf_context.report_to_tracker(t));
                 }
                 self.read += perf_context;
                 self.maybe_flush_read_metrics();
+                engine_traits::PerfContextReport { block_read_count }
             }
         }
     }

--- a/components/engine_traits/src/perf_context.rs
+++ b/components/engine_traits/src/perf_context.rs
@@ -23,6 +23,16 @@ numeric_enum_serializing_mod! {perf_level_serde PerfLevel {
     OutOfBounds = 6,
 }}
 
+/// Lightweight, engine-agnostic report of the PerfContext delta captured
+/// during the current observation window.
+///
+/// Currently only `block_read_count` is reported, which approximates
+/// physical read IO triggered by foreground SQL requests.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct PerfContextReport {
+    pub block_read_count: u64,
+}
+
 /// Extensions for measuring engine performance.
 ///
 /// A PerfContext is created with a specific measurement level,
@@ -63,6 +73,8 @@ pub trait PerfContext: Send {
     /// Reinitializes statistics and the perf level
     fn start_observe(&mut self);
 
-    /// Reports the current collected metrics to prometheus and trackers
-    fn report_metrics(&mut self, trackers: &[TrackerToken]);
+    /// Reports the current collected metrics to prometheus and trackers,
+    /// and returns the PerfContext delta captured during this observation
+    /// window.
+    fn report_metrics(&mut self, trackers: &[TrackerToken]) -> PerfContextReport;
 }

--- a/components/engine_traits/src/perf_context.rs
+++ b/components/engine_traits/src/perf_context.rs
@@ -26,10 +26,12 @@ numeric_enum_serializing_mod! {perf_level_serde PerfLevel {
 /// Lightweight, engine-agnostic report of the PerfContext delta captured
 /// during the current observation window.
 ///
-/// Currently only `block_read_count` is reported, which approximates
-/// physical read IO triggered by foreground SQL requests.
+/// Currently only `block_read_count` is reported. Resource metering exposes it
+/// as `rocksdb_block_read_count` for the downstream `read_iops` dimension and
+/// uses it for relative attribution; it is not a device-level IOPS measurement.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct PerfContextReport {
+    /// RocksDB block read delta used for the downstream `read_iops` dimension.
     pub block_read_count: u64,
 }
 

--- a/components/raft_log_engine/src/perf_context.rs
+++ b/components/raft_log_engine/src/perf_context.rs
@@ -11,7 +11,7 @@ impl engine_traits::PerfContext for RaftEnginePerfContext {
         raft_engine::set_perf_context(Default::default());
     }
 
-    fn report_metrics(&mut self, trackers: &[TrackerToken]) {
+    fn report_metrics(&mut self, trackers: &[TrackerToken]) -> engine_traits::PerfContextReport {
         let perf_context = get_perf_context();
         for token in trackers {
             GLOBAL_TRACKERS.with_tracker(*token, |t| {
@@ -25,5 +25,6 @@ impl engine_traits::PerfContext for RaftEnginePerfContext {
                     perf_context.apply_duration.as_nanos() as u64;
             });
         }
+        engine_traits::PerfContextReport::default()
     }
 }

--- a/components/raftstore-v2/src/operation/command/mod.rs
+++ b/components/raftstore-v2/src/operation/command/mod.rs
@@ -873,7 +873,7 @@ impl<EK: KvEngine, R: ApplyResReporter> Apply<EK, R> {
                     .iter()
                     .flat_map(|(v, _)| v.write_trackers().flat_map(|t| t.as_tracker_token()))
                     .collect();
-                self.perf_context().report_metrics(&tokens);
+                let _ = self.perf_context().report_metrics(&tokens);
             }
         }
         let mut apply_res = ApplyRes::default();

--- a/components/raftstore/src/store/async_io/write.rs
+++ b/components/raftstore/src/store/async_io/write.rs
@@ -1187,7 +1187,7 @@ where
                 .iter()
                 .flat_map(|task| task.trackers.iter().flat_map(|t| t.as_tracker_token()))
                 .collect();
-            self.perf_context.report_metrics(&trackers);
+            let _ = self.perf_context.report_metrics(&trackers);
             write_raft_time = duration_to_sec(now.saturating_elapsed());
             STORE_WRITE_RAFTDB_DURATION_HISTOGRAM.observe(write_raft_time);
             // Record the last confirmed raft-log append progress on a monotonic

--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -627,7 +627,7 @@ where
                 .flat_map(|(cb, _)| cb.write_trackers())
                 .flat_map(|trackers| trackers.as_tracker_token())
                 .collect();
-            self.perf_context.report_metrics(&trackers);
+            let _ = self.perf_context.report_metrics(&trackers);
             self.sync_log_hint = false;
             let data_size = self.kv_wb().data_size();
             if data_size > APPLY_WB_SHRINK_SIZE {

--- a/components/resource_metering/src/config.rs
+++ b/components/resource_metering/src/config.rs
@@ -39,7 +39,7 @@ pub struct Config {
     /// Sampling window. (only for cpu module)
     pub precision: ReadableDuration,
 
-    /// Whether to collect network traffic and logical io
+    /// Whether to collect network traffic, logical IO and RocksDB block read
     pub enable_network_io_collection: bool,
 }
 

--- a/components/resource_metering/src/config.rs
+++ b/components/resource_metering/src/config.rs
@@ -31,7 +31,12 @@ pub struct Config {
     /// Data reporting interval.
     pub report_receiver_interval: ReadableDuration,
 
-    /// The maximum number of groups by [ResourceMeteringTag].
+    /// The maximum number of candidate groups by [ResourceMeteringTag] for
+    /// each resource dimension.
+    ///
+    /// When network IO collection is enabled, the reported groups are the
+    /// union of candidates selected by CPU, network IO, logical read, logical
+    /// write, and RocksDB block read count. The union can exceed this value.
     ///
     /// [ResourceMeteringTag]: crate::ResourceMeteringTag
     pub max_resource_groups: usize,

--- a/components/resource_metering/src/config.rs
+++ b/components/resource_metering/src/config.rs
@@ -16,9 +16,36 @@ const MAX_PRECISION: ReadableDuration = ReadableDuration::hours(1);
 const MAX_MAX_RESOURCE_GROUPS: usize = 5_000;
 const MIN_REPORT_RECEIVER_INTERVAL: ReadableDuration = ReadableDuration::millis(500);
 const DEFAULT_ENABLE_NETWORK_IO_COLLECTION: bool = false;
+const DEFAULT_ENABLE_DETAILED_IO_COLLECTION: bool = false;
 
 pub static ENABLE_NETWORK_IO_COLLECTION: AtomicBool =
     AtomicBool::new(DEFAULT_ENABLE_NETWORK_IO_COLLECTION);
+
+/// Whether detailed IO collection is effective at runtime.
+///
+/// The configured detailed IO switch is subordinate to network IO collection,
+/// so this value is true only when both switches are enabled.
+pub static ENABLE_DETAILED_IO_COLLECTION: AtomicBool =
+    AtomicBool::new(DEFAULT_ENABLE_DETAILED_IO_COLLECTION);
+
+pub(crate) fn set_io_collection_config(
+    enable_network_io_collection: bool,
+    enable_detailed_io_collection: bool,
+) {
+    use std::sync::atomic::Ordering::Relaxed;
+
+    let detailed_io_collection_enabled =
+        enable_network_io_collection && enable_detailed_io_collection;
+    if detailed_io_collection_enabled {
+        ENABLE_NETWORK_IO_COLLECTION.store(true, Relaxed);
+        ENABLE_DETAILED_IO_COLLECTION.store(true, Relaxed);
+    } else {
+        // Keep the runtime invariant that detailed IO implies network IO even
+        // while recorders observe a dynamic configuration update.
+        ENABLE_DETAILED_IO_COLLECTION.store(false, Relaxed);
+        ENABLE_NETWORK_IO_COLLECTION.store(enable_network_io_collection, Relaxed);
+    }
+}
 
 /// Public configuration of resource metering module.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, OnlineConfig)]
@@ -34,9 +61,11 @@ pub struct Config {
     /// The maximum number of candidate groups by [ResourceMeteringTag] for
     /// each resource dimension.
     ///
-    /// When network IO collection is enabled, the reported groups are the
-    /// union of candidates selected by CPU, network IO, logical read, logical
-    /// write, and RocksDB block read count. The union can exceed this value.
+    /// With network IO collection enabled, the reported groups are the union of
+    /// candidates selected by CPU, network IO, and logical IO. When detailed IO
+    /// collection is also enabled, logical IO is split into logical read and
+    /// logical write, and RocksDB block read count is added as a fifth
+    /// dimension. The union can exceed this value.
     ///
     /// [ResourceMeteringTag]: crate::ResourceMeteringTag
     pub max_resource_groups: usize,
@@ -44,8 +73,15 @@ pub struct Config {
     /// Sampling window. (only for cpu module)
     pub precision: ReadableDuration,
 
-    /// Whether to collect network traffic, logical IO and RocksDB block read
+    /// Whether to collect network traffic and logical IO.
     pub enable_network_io_collection: bool,
+
+    /// Whether to collect and attribute detailed IO for `read_iops` analysis.
+    ///
+    /// This controls RocksDB block read count collection and separate TopN
+    /// selection for logical reads, logical writes, and RocksDB block reads. It
+    /// is effective only when `enable_network_io_collection` is also enabled.
+    pub enable_detailed_io_collection: bool,
 }
 
 impl Default for Config {
@@ -56,11 +92,17 @@ impl Default for Config {
             max_resource_groups: 100,
             precision: ReadableDuration::secs(1),
             enable_network_io_collection: DEFAULT_ENABLE_NETWORK_IO_COLLECTION,
+            enable_detailed_io_collection: DEFAULT_ENABLE_DETAILED_IO_COLLECTION,
         }
     }
 }
 
 impl Config {
+    /// Returns whether detailed IO collection is effective for this config.
+    pub fn detailed_io_collection_enabled(&self) -> bool {
+        self.enable_network_io_collection && self.enable_detailed_io_collection
+    }
+
     /// Check whether the configuration is legal.
     pub fn validate(&self) -> Result<(), Box<dyn Error>> {
         if !self.receiver_address.is_empty() {
@@ -153,6 +195,7 @@ mod tests {
             max_resource_groups: 2000,
             precision: ReadableDuration::secs(1),
             enable_network_io_collection: false,
+            enable_detailed_io_collection: false,
         };
         cfg.validate().unwrap();
         let cfg = Config {
@@ -161,6 +204,7 @@ mod tests {
             max_resource_groups: 2000,
             precision: ReadableDuration::secs(1),
             enable_network_io_collection: false,
+            enable_detailed_io_collection: false,
         };
         cfg.validate().unwrap_err();
         let cfg = Config {
@@ -169,6 +213,7 @@ mod tests {
             max_resource_groups: usize::MAX, // invalid
             precision: ReadableDuration::secs(1),
             enable_network_io_collection: false,
+            enable_detailed_io_collection: false,
         };
         cfg.validate().unwrap_err();
         let cfg = Config {
@@ -177,7 +222,25 @@ mod tests {
             max_resource_groups: 2000,
             precision: ReadableDuration::days(999), // invalid
             enable_network_io_collection: false,
+            enable_detailed_io_collection: false,
         };
         cfg.validate().unwrap_err();
+    }
+
+    #[test]
+    fn test_detailed_io_collection_enabled() {
+        for (network, detailed, expected) in [
+            (false, false, false),
+            (false, true, false),
+            (true, false, false),
+            (true, true, true),
+        ] {
+            let cfg = Config {
+                enable_network_io_collection: network,
+                enable_detailed_io_collection: detailed,
+                ..Default::default()
+            };
+            assert_eq!(cfg.detailed_io_collection_enabled(), expected);
+        }
     }
 }

--- a/components/resource_metering/src/lib.rs
+++ b/components/resource_metering/src/lib.rs
@@ -22,7 +22,8 @@ pub use recorder::{
     CollectorGuard, CollectorId, CollectorRegHandle,
     ConfigChangeNotifier as RecorderConfigChangeNotifier, CpuRecorder, Recorder, RecorderBuilder,
     SummaryRecorder, init_recorder, record_logical_read_bytes, record_logical_write_bytes,
-    record_network_in_bytes, record_network_out_bytes, record_read_keys, record_write_keys,
+    record_network_in_bytes, record_network_out_bytes, record_read_keys,
+    record_rocksdb_block_read_count, record_write_keys,
 };
 use recorder::{LocalStorage, LocalStorageRef, STORAGE};
 pub use reporter::{
@@ -121,6 +122,9 @@ pub struct Guard;
 // will never be cleaned up, so here we need to make some restrictions.
 const MAX_SUMMARY_RECORDS_LEN: usize = 1000;
 
+#[cfg(test)]
+pub(crate) static NETWORK_IO_COLLECTION_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 impl Drop for Guard {
     fn drop(&mut self) {
         STORAGE.with(|s| {
@@ -147,10 +151,7 @@ impl Drop for Guard {
                 return;
             }
             let cur_record = ls.summary_cur_record.take_and_reset();
-            if cur_record.read_keys.load(Relaxed) == 0
-                && cur_record.logical_read_bytes.load(Relaxed) == 0
-                && cur_record.logical_write_bytes.load(Relaxed) == 0
-            {
+            if cur_record.is_empty() {
                 return;
             }
             let mut records = ls.summary_records.lock().unwrap();
@@ -376,5 +377,52 @@ mod tests {
         })
         .join()
         .unwrap();
+    }
+
+    #[test]
+    fn test_guard_keeps_block_read_only_record() {
+        let _test_guard = NETWORK_IO_COLLECTION_TEST_LOCK.lock().unwrap();
+        let previous = ENABLE_NETWORK_IO_COLLECTION.swap(true, Relaxed);
+        std::thread::spawn(|| {
+            let resource_tag_factory = ResourceTagFactory::new_for_test();
+            let tag = ResourceMeteringTag {
+                infos: Arc::new(TagInfos {
+                    store_id: 1,
+                    region_id: 2,
+                    peer_id: 3,
+                    key_ranges: vec![],
+                    extra_attachment: Arc::new(b"block-read-only".to_vec()),
+                }),
+                resource_tag_factory,
+            };
+            STORAGE.with(|s| {
+                let ls = s.borrow_mut();
+                ls.summary_enable.store(true, SeqCst);
+                ls.summary_records.lock().unwrap().clear();
+                ls.summary_cur_record.reset();
+            });
+
+            {
+                let _guard = tag.attach();
+                record_rocksdb_block_read_count(9);
+            }
+
+            STORAGE.with(|s| {
+                let ls = s.borrow();
+                let records = ls.summary_records.lock().unwrap();
+                assert_eq!(records.len(), 1);
+                assert_eq!(
+                    records
+                        .get(&tag.infos)
+                        .unwrap()
+                        .rocksdb_block_read_count
+                        .load(Relaxed),
+                    9
+                );
+            });
+        })
+        .join()
+        .unwrap();
+        ENABLE_NETWORK_IO_COLLECTION.store(previous, Relaxed);
     }
 }

--- a/components/resource_metering/src/lib.rs
+++ b/components/resource_metering/src/lib.rs
@@ -125,6 +125,23 @@ const MAX_SUMMARY_RECORDS_LEN: usize = 1000;
 #[cfg(test)]
 pub(crate) static NETWORK_IO_COLLECTION_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
+#[cfg(test)]
+pub(crate) struct NetworkIoCollectionConfigGuard(bool);
+
+#[cfg(test)]
+impl NetworkIoCollectionConfigGuard {
+    pub(crate) fn set(enabled: bool) -> Self {
+        Self(ENABLE_NETWORK_IO_COLLECTION.swap(enabled, Relaxed))
+    }
+}
+
+#[cfg(test)]
+impl Drop for NetworkIoCollectionConfigGuard {
+    fn drop(&mut self) {
+        ENABLE_NETWORK_IO_COLLECTION.store(self.0, Relaxed);
+    }
+}
+
 impl Drop for Guard {
     fn drop(&mut self) {
         STORAGE.with(|s| {
@@ -382,7 +399,7 @@ mod tests {
     #[test]
     fn test_guard_keeps_block_read_only_record() {
         let _test_guard = NETWORK_IO_COLLECTION_TEST_LOCK.lock().unwrap();
-        let previous = ENABLE_NETWORK_IO_COLLECTION.swap(true, Relaxed);
+        let _config_guard = NetworkIoCollectionConfigGuard::set(true);
         std::thread::spawn(|| {
             let resource_tag_factory = ResourceTagFactory::new_for_test();
             let tag = ResourceMeteringTag {
@@ -423,6 +440,5 @@ mod tests {
         })
         .join()
         .unwrap();
-        ENABLE_NETWORK_IO_COLLECTION.store(previous, Relaxed);
     }
 }

--- a/components/resource_metering/src/lib.rs
+++ b/components/resource_metering/src/lib.rs
@@ -5,18 +5,19 @@
 #![allow(internal_features)]
 #![feature(core_intrinsics)]
 
+#[cfg(test)]
+use std::sync::atomic::Ordering::Relaxed;
 use std::{
     intrinsics::unlikely,
     pin::Pin,
-    sync::{
-        Arc,
-        atomic::Ordering::{Relaxed, SeqCst},
-    },
+    sync::{Arc, atomic::Ordering::SeqCst},
     task::{Context, Poll},
 };
 
 pub use collector::Collector;
-pub use config::{Config, ConfigManager, ENABLE_NETWORK_IO_COLLECTION};
+pub use config::{
+    Config, ConfigManager, ENABLE_DETAILED_IO_COLLECTION, ENABLE_NETWORK_IO_COLLECTION,
+};
 pub use model::*;
 pub use recorder::{
     CollectorGuard, CollectorId, CollectorRegHandle,
@@ -123,22 +124,31 @@ pub struct Guard;
 const MAX_SUMMARY_RECORDS_LEN: usize = 1000;
 
 #[cfg(test)]
-pub(crate) static NETWORK_IO_COLLECTION_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+pub(crate) static IO_COLLECTION_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 #[cfg(test)]
-pub(crate) struct NetworkIoCollectionConfigGuard(bool);
+pub(crate) struct IoCollectionConfigGuard {
+    network: bool,
+    detailed: bool,
+}
 
 #[cfg(test)]
-impl NetworkIoCollectionConfigGuard {
-    pub(crate) fn set(enabled: bool) -> Self {
-        Self(ENABLE_NETWORK_IO_COLLECTION.swap(enabled, Relaxed))
+impl IoCollectionConfigGuard {
+    pub(crate) fn set(network: bool, detailed: bool) -> Self {
+        let guard = Self {
+            network: ENABLE_NETWORK_IO_COLLECTION.load(Relaxed),
+            detailed: ENABLE_DETAILED_IO_COLLECTION.load(Relaxed),
+        };
+        config::set_io_collection_config(network, detailed);
+        guard
     }
 }
 
 #[cfg(test)]
-impl Drop for NetworkIoCollectionConfigGuard {
+impl Drop for IoCollectionConfigGuard {
     fn drop(&mut self) {
-        ENABLE_NETWORK_IO_COLLECTION.store(self.0, Relaxed);
+        ENABLE_NETWORK_IO_COLLECTION.store(self.network, Relaxed);
+        ENABLE_DETAILED_IO_COLLECTION.store(self.detailed, Relaxed);
     }
 }
 
@@ -398,8 +408,8 @@ mod tests {
 
     #[test]
     fn test_guard_keeps_block_read_only_record() {
-        let _test_guard = NETWORK_IO_COLLECTION_TEST_LOCK.lock().unwrap();
-        let _config_guard = NetworkIoCollectionConfigGuard::set(true);
+        let _test_guard = IO_COLLECTION_TEST_LOCK.lock().unwrap();
+        let _config_guard = IoCollectionConfigGuard::set(true, true);
         std::thread::spawn(|| {
             let resource_tag_factory = ResourceTagFactory::new_for_test();
             let tag = ResourceMeteringTag {

--- a/components/resource_metering/src/model.rs
+++ b/components/resource_metering/src/model.rs
@@ -21,25 +21,34 @@ use crate::TagInfos;
 thread_local! {
     static STATIC_CPU_BUF: Cell<Vec<u32>> = const {Cell::new(vec![])};
     static STATIC_NETWORK_BUF: Cell<Vec<u64>> = const {Cell::new(vec![])};
-    static STATIC_LOGICAL_IO_BUF: Cell<Vec<u64>> = const {Cell::new(vec![])};
+    static STATIC_LOGICAL_READ_BUF: Cell<Vec<u64>> = const {Cell::new(vec![])};
+    static STATIC_LOGICAL_WRITE_BUF: Cell<Vec<u64>> = const {Cell::new(vec![])};
+    static STATIC_ROCKSDB_BLOCK_READ_BUF: Cell<Vec<u64>> = const {Cell::new(vec![])};
 }
 
 /// Find the kth values in the iterator, returns (kth_cpu_time,
-/// kth_network_traffic, kth_logical_io)
+/// kth_network_traffic, kth_logical_read, kth_logical_write,
+/// kth_rocksdb_block_read)
 pub fn find_kth_values<'a, T: 'a>(
     iter: impl Iterator<Item = (&'a T, &'a RawRecord)>,
     k: usize,
-) -> (u32, u64, u64) {
+) -> (u32, u64, u64, u64, u64) {
     let mut cpu_buf = STATIC_CPU_BUF.with(|b| b.take());
     let mut network_buf = STATIC_NETWORK_BUF.with(|b| b.take());
-    let mut logical_io_buf = STATIC_LOGICAL_IO_BUF.with(|b| b.take());
+    let mut logical_read_buf = STATIC_LOGICAL_READ_BUF.with(|b| b.take());
+    let mut logical_write_buf = STATIC_LOGICAL_WRITE_BUF.with(|b| b.take());
+    let mut rocksdb_block_read_buf = STATIC_ROCKSDB_BLOCK_READ_BUF.with(|b| b.take());
     cpu_buf.clear();
     network_buf.clear();
-    logical_io_buf.clear();
+    logical_read_buf.clear();
+    logical_write_buf.clear();
+    rocksdb_block_read_buf.clear();
     for (_, record) in iter {
         cpu_buf.push(record.cpu_time);
         network_buf.push(record.network_in_bytes + record.network_out_bytes);
-        logical_io_buf.push(record.logical_read_bytes + record.logical_write_bytes);
+        logical_read_buf.push(record.logical_read_bytes);
+        logical_write_buf.push(record.logical_write_bytes);
+        rocksdb_block_read_buf.push(record.rocksdb_block_read_count);
     }
     pdqselect::select_by(&mut cpu_buf, k, |a, b| b.cmp(a));
     let kth_cpu = cpu_buf[k];
@@ -49,11 +58,25 @@ pub fn find_kth_values<'a, T: 'a>(
     let kth_network = network_buf[k];
     STATIC_NETWORK_BUF.with(move |b| b.set(network_buf));
 
-    pdqselect::select_by(&mut logical_io_buf, k, |a, b| b.cmp(a));
-    let kth_logical_io = logical_io_buf[k];
-    STATIC_LOGICAL_IO_BUF.with(move |b| b.set(logical_io_buf));
+    pdqselect::select_by(&mut logical_read_buf, k, |a, b| b.cmp(a));
+    let kth_logical_read = logical_read_buf[k];
+    STATIC_LOGICAL_READ_BUF.with(move |b| b.set(logical_read_buf));
 
-    (kth_cpu, kth_network, kth_logical_io)
+    pdqselect::select_by(&mut logical_write_buf, k, |a, b| b.cmp(a));
+    let kth_logical_write = logical_write_buf[k];
+    STATIC_LOGICAL_WRITE_BUF.with(move |b| b.set(logical_write_buf));
+
+    pdqselect::select_by(&mut rocksdb_block_read_buf, k, |a, b| b.cmp(a));
+    let kth_rocksdb_block_read = rocksdb_block_read_buf[k];
+    STATIC_ROCKSDB_BLOCK_READ_BUF.with(move |b| b.set(rocksdb_block_read_buf));
+
+    (
+        kth_cpu,
+        kth_network,
+        kth_logical_read,
+        kth_logical_write,
+        kth_rocksdb_block_read,
+    )
 }
 
 /// Find the kth cpu time in the iterator.
@@ -88,13 +111,18 @@ pub fn get_iter_for_cpu_time<'a, T: 'a>(
 }
 
 /// Get two iterators, first is the one whose cpu_time > kth_cpu or network_io >
-/// kth_network or logical_io > kth_logical_io, second is the one whose cpu_time
-/// <= kth_cpu and network_io <= kth_network and logical_io <= kth_logical_io.
+/// kth_network or logical_read > kth_logical_read or logical_write >
+/// kth_logical_write or rocksdb_block_read_count > kth_rocksdb_block_read,
+/// second is the one whose cpu_time <= kth_cpu and network_io <= kth_network
+/// and logical_read <= kth_logical_read and logical_write <= kth_logical_write
+/// and rocksdb_block_read_count <= kth_rocksdb_block_read.
 pub fn get_iter_for_cpu_network_io<'a, T: 'a>(
     records: &'a HashMap<T, RawRecord>,
     kth_cpu: u32,
     kth_network: u64,
-    kth_logical_io: u64,
+    kth_logical_read: u64,
+    kth_logical_write: u64,
+    kth_rocksdb_block_read: u64,
 ) -> (
     impl Iterator<Item = (&'a T, &'a RawRecord)>,
     impl Iterator<Item = (&'a T, &'a RawRecord)>,
@@ -103,12 +131,16 @@ pub fn get_iter_for_cpu_network_io<'a, T: 'a>(
         records.iter().filter(move |(_, v)| {
             v.cpu_time > kth_cpu
                 || v.network_in_bytes + v.network_out_bytes > kth_network
-                || v.logical_read_bytes + v.logical_write_bytes > kth_logical_io
+                || v.logical_read_bytes > kth_logical_read
+                || v.logical_write_bytes > kth_logical_write
+                || v.rocksdb_block_read_count > kth_rocksdb_block_read
         }),
         records.iter().filter(move |(_, v)| {
             v.cpu_time <= kth_cpu
                 && v.network_in_bytes + v.network_out_bytes <= kth_network
-                && v.logical_read_bytes + v.logical_write_bytes <= kth_logical_io
+                && v.logical_read_bytes <= kth_logical_read
+                && v.logical_write_bytes <= kth_logical_write
+                && v.rocksdb_block_read_count <= kth_rocksdb_block_read
         }),
     )
 }
@@ -132,6 +164,7 @@ where
                 logical_write_bytes_list: vec![raw_record.logical_write_bytes],
                 network_in_bytes_list: vec![raw_record.network_in_bytes],
                 network_out_bytes_list: vec![raw_record.network_out_bytes],
+                rocksdb_block_read_count_list: vec![raw_record.rocksdb_block_read_count],
             },
         );
         return;
@@ -146,6 +179,8 @@ where
         *record.logical_write_bytes_list.last_mut().unwrap() += raw_record.logical_write_bytes;
         *record.network_in_bytes_list.last_mut().unwrap() += raw_record.network_in_bytes;
         *record.network_out_bytes_list.last_mut().unwrap() += raw_record.network_out_bytes;
+        *record.rocksdb_block_read_count_list.last_mut().unwrap() +=
+            raw_record.rocksdb_block_read_count;
     } else {
         record.timestamps.push(ts);
         record.cpu_time_list.push(raw_record.cpu_time);
@@ -163,6 +198,9 @@ where
         record
             .network_out_bytes_list
             .push(raw_record.network_out_bytes);
+        record
+            .rocksdb_block_read_count_list
+            .push(raw_record.rocksdb_block_read_count);
     }
 }
 
@@ -185,9 +223,16 @@ pub fn handle_records_impl<'a, K, T>(
         return;
     }
     if enable_network_io_collection {
-        let (kth_cpu, kth_network, kth_logical_io) = find_kth_values(agg_map.iter(), n);
-        let (picked_iter, unpicked_iter) =
-            get_iter_for_cpu_network_io(agg_map, kth_cpu, kth_network, kth_logical_io);
+        let (kth_cpu, kth_network, kth_logical_read, kth_logical_write, kth_rocksdb_block_read) =
+            find_kth_values(agg_map.iter(), n);
+        let (picked_iter, unpicked_iter) = get_iter_for_cpu_network_io(
+            agg_map,
+            kth_cpu,
+            kth_network,
+            kth_logical_read,
+            kth_logical_write,
+            kth_rocksdb_block_read,
+        );
         records.append(ts, picked_iter);
         records.merge_other(ts, unpicked_iter);
     } else {
@@ -249,6 +294,7 @@ pub struct RawRecord {
     pub logical_write_bytes: u64,
     pub network_in_bytes: u64,
     pub network_out_bytes: u64,
+    pub rocksdb_block_read_count: u64,
 }
 
 impl RawRecord {
@@ -276,6 +322,7 @@ impl RawRecord {
         self.logical_write_bytes += other.logical_write_bytes;
         self.network_in_bytes += other.network_in_bytes;
         self.network_out_bytes += other.network_out_bytes;
+        self.rocksdb_block_read_count += other.rocksdb_block_read_count;
     }
 
     pub fn merge_summary(&mut self, r: &SummaryRecord) {
@@ -285,6 +332,7 @@ impl RawRecord {
         self.logical_write_bytes += r.logical_write_bytes.load(Relaxed);
         self.network_in_bytes += r.network_in_bytes.load(Relaxed);
         self.network_out_bytes += r.network_out_bytes.load(Relaxed);
+        self.rocksdb_block_read_count += r.rocksdb_block_read_count.load(Relaxed);
     }
 }
 
@@ -382,6 +430,7 @@ pub struct Record {
     pub logical_write_bytes_list: Vec<u64>,
     pub network_in_bytes_list: Vec<u64>,
     pub network_out_bytes_list: Vec<u64>,
+    pub rocksdb_block_read_count_list: Vec<u64>,
     pub total_cpu_time: u32,
 }
 
@@ -398,6 +447,7 @@ impl From<Record> for Vec<GroupTagRecordItem> {
             item.set_logical_write_bytes(record.logical_write_bytes_list[n]);
             item.set_network_in_bytes(record.network_in_bytes_list[n]);
             item.set_network_out_bytes(record.network_out_bytes_list[n]);
+            item.set_rocksdb_block_read_count(record.rocksdb_block_read_count_list[n]);
             items.push(item);
         }
         items
@@ -413,6 +463,7 @@ impl Record {
             && self.timestamps.len() == self.logical_write_bytes_list.len()
             && self.timestamps.len() == self.network_in_bytes_list.len()
             && self.timestamps.len() == self.network_out_bytes_list.len()
+            && self.timestamps.len() == self.rocksdb_block_read_count_list.len()
     }
 }
 
@@ -468,6 +519,7 @@ impl From<Records> for Vec<ResourceUsageRecord> {
                     logical_write_bytes,
                     network_in_bytes,
                     network_out_bytes,
+                    rocksdb_block_read_count,
                     ..
                 },
             ) in records.others
@@ -481,6 +533,7 @@ impl From<Records> for Vec<ResourceUsageRecord> {
                 item.set_logical_write_bytes(logical_write_bytes);
                 item.set_network_in_bytes(network_in_bytes);
                 item.set_network_out_bytes(network_out_bytes);
+                item.set_rocksdb_block_read_count(rocksdb_block_read_count);
                 items.push(item);
             }
             let mut tag_record = GroupTagRecord::new();
@@ -636,6 +689,7 @@ impl From<RegionRecords> for Vec<ResourceUsageRecord> {
                     logical_write_bytes,
                     network_in_bytes,
                     network_out_bytes,
+                    rocksdb_block_read_count,
                     ..
                 },
             ) in records.others
@@ -649,6 +703,7 @@ impl From<RegionRecords> for Vec<ResourceUsageRecord> {
                 item.set_logical_write_bytes(logical_write_bytes);
                 item.set_network_in_bytes(network_in_bytes);
                 item.set_network_out_bytes(network_out_bytes);
+                item.set_rocksdb_block_read_count(rocksdb_block_read_count);
                 items.push(item);
             }
             let mut region_record = RegionRecord::new();
@@ -736,6 +791,9 @@ pub struct SummaryRecord {
 
     /// Network output bytes.
     pub network_out_bytes: AtomicU64,
+
+    /// RocksDB block read count (physical read IO approximation).
+    pub rocksdb_block_read_count: AtomicU64,
 }
 
 impl Clone for SummaryRecord {
@@ -747,6 +805,7 @@ impl Clone for SummaryRecord {
             logical_write_bytes: AtomicU64::new(self.logical_write_bytes.load(Relaxed)),
             network_in_bytes: AtomicU64::new(self.network_in_bytes.load(Relaxed)),
             network_out_bytes: AtomicU64::new(self.network_out_bytes.load(Relaxed)),
+            rocksdb_block_read_count: AtomicU64::new(self.rocksdb_block_read_count.load(Relaxed)),
         }
     }
 }
@@ -760,6 +819,7 @@ impl SummaryRecord {
         self.logical_write_bytes.store(0, Relaxed);
         self.network_in_bytes.store(0, Relaxed);
         self.network_out_bytes.store(0, Relaxed);
+        self.rocksdb_block_read_count.store(0, Relaxed);
     }
 
     /// Add two items.
@@ -776,6 +836,8 @@ impl SummaryRecord {
             .fetch_add(other.network_in_bytes.load(Relaxed), Relaxed);
         self.network_out_bytes
             .fetch_add(other.network_out_bytes.load(Relaxed), Relaxed);
+        self.rocksdb_block_read_count
+            .fetch_add(other.rocksdb_block_read_count.load(Relaxed), Relaxed);
     }
 
     /// Gets the value and writes it to zero.
@@ -788,7 +850,21 @@ impl SummaryRecord {
             logical_write_bytes: AtomicU64::new(self.logical_write_bytes.swap(0, Relaxed)),
             network_in_bytes: AtomicU64::new(self.network_in_bytes.swap(0, Relaxed)),
             network_out_bytes: AtomicU64::new(self.network_out_bytes.swap(0, Relaxed)),
+            rocksdb_block_read_count: AtomicU64::new(
+                self.rocksdb_block_read_count.swap(0, Relaxed),
+            ),
         }
+    }
+
+    /// Returns true if all fields are zero.
+    pub fn is_empty(&self) -> bool {
+        self.read_keys.load(Relaxed) == 0
+            && self.write_keys.load(Relaxed) == 0
+            && self.logical_read_bytes.load(Relaxed) == 0
+            && self.logical_write_bytes.load(Relaxed) == 0
+            && self.network_in_bytes.load(Relaxed) == 0
+            && self.network_out_bytes.load(Relaxed) == 0
+            && self.rocksdb_block_read_count.load(Relaxed) == 0
     }
 }
 
@@ -799,6 +875,21 @@ mod tests {
     use super::*;
     use crate::TagInfos;
 
+    fn record_with_block_read_count(block_read_count: u64) -> Record {
+        Record {
+            timestamps: vec![1],
+            cpu_time_list: vec![2],
+            read_keys_list: vec![3],
+            write_keys_list: vec![4],
+            logical_read_bytes_list: vec![5],
+            logical_write_bytes_list: vec![6],
+            network_in_bytes_list: vec![7],
+            network_out_bytes_list: vec![8],
+            rocksdb_block_read_count_list: vec![block_read_count],
+            total_cpu_time: 2,
+        }
+    }
+
     #[test]
     fn test_summary_record() {
         let record = SummaryRecord {
@@ -808,6 +899,7 @@ mod tests {
             network_out_bytes: AtomicU64::new(20),
             logical_read_bytes: AtomicU64::new(100),
             logical_write_bytes: AtomicU64::new(200),
+            rocksdb_block_read_count: AtomicU64::new(300),
         };
         assert_eq!(record.read_keys.load(Relaxed), 1);
         assert_eq!(record.write_keys.load(Relaxed), 2);
@@ -815,6 +907,7 @@ mod tests {
         assert_eq!(record.network_out_bytes.load(Relaxed), 20);
         assert_eq!(record.logical_read_bytes.load(Relaxed), 100);
         assert_eq!(record.logical_write_bytes.load(Relaxed), 200);
+        assert_eq!(record.rocksdb_block_read_count.load(Relaxed), 300);
         let record2 = record.clone();
         assert_eq!(record2.read_keys.load(Relaxed), 1);
         assert_eq!(record2.write_keys.load(Relaxed), 2);
@@ -822,6 +915,7 @@ mod tests {
         assert_eq!(record2.network_out_bytes.load(Relaxed), 20);
         assert_eq!(record2.logical_read_bytes.load(Relaxed), 100);
         assert_eq!(record2.logical_write_bytes.load(Relaxed), 200);
+        assert_eq!(record2.rocksdb_block_read_count.load(Relaxed), 300);
         record.merge(&SummaryRecord {
             read_keys: AtomicU32::new(3),
             write_keys: AtomicU32::new(4),
@@ -829,6 +923,7 @@ mod tests {
             network_out_bytes: AtomicU64::new(40),
             logical_read_bytes: AtomicU64::new(300),
             logical_write_bytes: AtomicU64::new(400),
+            rocksdb_block_read_count: AtomicU64::new(500),
         });
         assert_eq!(record.read_keys.load(Relaxed), 4);
         assert_eq!(record.write_keys.load(Relaxed), 6);
@@ -836,6 +931,7 @@ mod tests {
         assert_eq!(record.network_out_bytes.load(Relaxed), 60);
         assert_eq!(record.logical_read_bytes.load(Relaxed), 400);
         assert_eq!(record.logical_write_bytes.load(Relaxed), 600);
+        assert_eq!(record.rocksdb_block_read_count.load(Relaxed), 800);
         let record2 = record.take_and_reset();
         assert_eq!(record.read_keys.load(Relaxed), 0);
         assert_eq!(record.write_keys.load(Relaxed), 0);
@@ -843,12 +939,14 @@ mod tests {
         assert_eq!(record.network_out_bytes.load(Relaxed), 0);
         assert_eq!(record.logical_read_bytes.load(Relaxed), 0);
         assert_eq!(record.logical_write_bytes.load(Relaxed), 0);
+        assert_eq!(record.rocksdb_block_read_count.load(Relaxed), 0);
         assert_eq!(record2.read_keys.load(Relaxed), 4);
         assert_eq!(record2.write_keys.load(Relaxed), 6);
         assert_eq!(record2.network_in_bytes.load(Relaxed), 40);
         assert_eq!(record2.network_out_bytes.load(Relaxed), 60);
         assert_eq!(record2.logical_read_bytes.load(Relaxed), 400);
         assert_eq!(record2.logical_write_bytes.load(Relaxed), 600);
+        assert_eq!(record2.rocksdb_block_read_count.load(Relaxed), 800);
         record2.reset();
         assert_eq!(record2.read_keys.load(Relaxed), 0);
         assert_eq!(record2.write_keys.load(Relaxed), 0);
@@ -856,6 +954,75 @@ mod tests {
         assert_eq!(record2.network_out_bytes.load(Relaxed), 0);
         assert_eq!(record2.logical_read_bytes.load(Relaxed), 0);
         assert_eq!(record2.logical_write_bytes.load(Relaxed), 0);
+        assert_eq!(record2.rocksdb_block_read_count.load(Relaxed), 0);
+    }
+
+    #[test]
+    fn test_summary_record_is_empty_checks_every_field() {
+        let record = SummaryRecord::default();
+        assert!(record.is_empty());
+
+        record.read_keys.store(1, Relaxed);
+        assert!(!record.is_empty());
+        record.reset();
+        record.write_keys.store(1, Relaxed);
+        assert!(!record.is_empty());
+        record.reset();
+        record.logical_read_bytes.store(1, Relaxed);
+        assert!(!record.is_empty());
+        record.reset();
+        record.logical_write_bytes.store(1, Relaxed);
+        assert!(!record.is_empty());
+        record.reset();
+        record.network_in_bytes.store(1, Relaxed);
+        assert!(!record.is_empty());
+        record.reset();
+        record.network_out_bytes.store(1, Relaxed);
+        assert!(!record.is_empty());
+        record.reset();
+        record.rocksdb_block_read_count.store(1, Relaxed);
+        assert!(!record.is_empty());
+    }
+
+    #[test]
+    fn test_block_read_count_proto_for_others_and_regions() {
+        let mut records = Records::default();
+        records.others.insert(
+            1,
+            RawRecord {
+                rocksdb_block_read_count: 11,
+                ..Default::default()
+            },
+        );
+        let records: Vec<ResourceUsageRecord> = records.into();
+        assert_eq!(records.len(), 1);
+        assert_eq!(
+            records[0].get_record().get_items()[0].get_rocksdb_block_read_count(),
+            11
+        );
+
+        let mut regions = RegionRecords::default();
+        regions.records.insert(42, record_with_block_read_count(22));
+        regions.others.insert(
+            1,
+            RawRecord {
+                rocksdb_block_read_count: 33,
+                ..Default::default()
+            },
+        );
+        let mut regions: Vec<ResourceUsageRecord> = regions.into();
+        regions.sort_by_key(|record| record.get_region_record().get_region_id());
+        assert_eq!(regions.len(), 2);
+        assert_eq!(regions[0].get_region_record().get_region_id(), 0);
+        assert_eq!(
+            regions[0].get_region_record().get_items()[0].get_rocksdb_block_read_count(),
+            33
+        );
+        assert_eq!(regions[1].get_region_record().get_region_id(), 42);
+        assert_eq!(
+            regions[1].get_region_record().get_items()[0].get_rocksdb_block_read_count(),
+            22
+        );
     }
 
     #[test]
@@ -893,6 +1060,7 @@ mod tests {
                 network_out_bytes: 2222,
                 logical_read_bytes: 3333,
                 logical_write_bytes: 4444,
+                rocksdb_block_read_count: 55,
                 ..Default::default()
             },
         );
@@ -906,6 +1074,7 @@ mod tests {
                 network_out_bytes: 5555,
                 logical_read_bytes: 6666,
                 logical_write_bytes: 7777,
+                rocksdb_block_read_count: 66,
                 ..Default::default()
             },
         );
@@ -919,6 +1088,7 @@ mod tests {
                 network_out_bytes: 8888,
                 logical_read_bytes: 9999,
                 logical_write_bytes: 11110,
+                rocksdb_block_read_count: 77,
                 ..Default::default()
             },
         );
@@ -931,6 +1101,95 @@ mod tests {
         assert_eq!(records.records.len(), 0);
         records.append(raw.begin_unix_time_secs, agg_map.iter());
         assert_eq!(records.records.len(), 3);
+
+        let mut report: Vec<ResourceUsageRecord> = records.into();
+        report.sort_by_key(|record| record.get_record().get_resource_group_tag().to_vec());
+        assert_eq!(report.len(), 3);
+        assert_eq!(
+            report[0].get_record().get_items()[0].get_rocksdb_block_read_count(),
+            55
+        );
+        assert_eq!(
+            report[1].get_record().get_items()[0].get_rocksdb_block_read_count(),
+            66
+        );
+        assert_eq!(
+            report[2].get_record().get_items()[0].get_rocksdb_block_read_count(),
+            77
+        );
+    }
+
+    #[test]
+    fn test_pick_top_k_rocksdb_block_read() {
+        let mut records = HashMap::default();
+        for (tag, block_read_count) in [(b"a", 100), (b"b", 80), (b"c", 5), (b"d", 5), (b"e", 5)] {
+            records.insert(
+                Arc::new(tag.to_vec()),
+                RawRecord {
+                    rocksdb_block_read_count: block_read_count,
+                    ..Default::default()
+                },
+            );
+        }
+
+        let (kth_cpu, kth_network, kth_logical_read, kth_logical_write, kth_rocksdb_block_read) =
+            find_kth_values(records.iter(), 2);
+        assert_eq!(kth_rocksdb_block_read, 5);
+        let (picked, evicted) = get_iter_for_cpu_network_io(
+            &records,
+            kth_cpu,
+            kth_network,
+            kth_logical_read,
+            kth_logical_write,
+            kth_rocksdb_block_read,
+        );
+        let picked: HashMap<_, _> = picked.collect();
+        assert_eq!(picked.len(), 2);
+        assert!(picked.contains_key(&Arc::new(b"a".to_vec())));
+        assert!(picked.contains_key(&Arc::new(b"b".to_vec())));
+        assert_eq!(evicted.count(), 3);
+    }
+
+    #[test]
+    fn test_pick_top_k_separates_logical_read_and_write() {
+        let mut records = HashMap::default();
+        records.insert(
+            Arc::new(b"read".to_vec()),
+            RawRecord {
+                logical_read_bytes: 100,
+                ..Default::default()
+            },
+        );
+        records.insert(
+            Arc::new(b"write".to_vec()),
+            RawRecord {
+                logical_read_bytes: 1,
+                logical_write_bytes: 10,
+                ..Default::default()
+            },
+        );
+        records.insert(
+            Arc::new(b"middle".to_vec()),
+            RawRecord {
+                logical_read_bytes: 50,
+                ..Default::default()
+            },
+        );
+
+        let (kth_cpu, kth_network, kth_logical_read, kth_logical_write, kth_rocksdb_block_read) =
+            find_kth_values(records.iter(), 1);
+        let (picked, _) = get_iter_for_cpu_network_io(
+            &records,
+            kth_cpu,
+            kth_network,
+            kth_logical_read,
+            kth_logical_write,
+            kth_rocksdb_block_read,
+        );
+        let picked: HashMap<_, _> = picked.collect();
+        assert_eq!(picked.len(), 2);
+        assert!(picked.contains_key(&Arc::new(b"read".to_vec())));
+        assert!(picked.contains_key(&Arc::new(b"write".to_vec())));
     }
 
     #[test]
@@ -1548,9 +1807,16 @@ mod tests {
         };
 
         let agg_map = rs.aggregate_by_extra_tag();
-        let (kth_cpu, kth_network, kth_logical_io) = find_kth_values(agg_map.iter(), 2);
-        let (top, evicted) =
-            get_iter_for_cpu_network_io(&agg_map, kth_cpu, kth_network, kth_logical_io);
+        let (kth_cpu, kth_network, kth_logical_read, kth_logical_write, kth_rocksdb_block_read) =
+            find_kth_values(agg_map.iter(), 2);
+        let (top, evicted) = get_iter_for_cpu_network_io(
+            &agg_map,
+            kth_cpu,
+            kth_network,
+            kth_logical_read,
+            kth_logical_write,
+            kth_rocksdb_block_read,
+        );
         let others = evicted
             .map(|(_, v)| v)
             .fold(RawRecord::default(), |mut others, r| {
@@ -1610,9 +1876,16 @@ mod tests {
             records,
         };
         let agg_map = rs.aggregate_by_extra_tag();
-        let (kth_cpu, kth_network, kth_logical_io) = find_kth_values(agg_map.iter(), 2);
-        let (top, evicted) =
-            get_iter_for_cpu_network_io(&agg_map, kth_cpu, kth_network, kth_logical_io);
+        let (kth_cpu, kth_network, kth_logical_read, kth_logical_write, kth_rocksdb_block_read) =
+            find_kth_values(agg_map.iter(), 2);
+        let (top, evicted) = get_iter_for_cpu_network_io(
+            &agg_map,
+            kth_cpu,
+            kth_network,
+            kth_logical_read,
+            kth_logical_write,
+            kth_rocksdb_block_read,
+        );
         let others = evicted
             .map(|(_, v)| v)
             .fold(RawRecord::default(), |mut others, r| {

--- a/components/resource_metering/src/model.rs
+++ b/components/resource_metering/src/model.rs
@@ -204,10 +204,11 @@ where
     }
 }
 
-/// Pick top n agged raw records, then append picked topN records and merge
-/// unpicked ones to others. If enable_network_io_collection is true, pick top n
-/// records by cpu_time, network_io and logical_io, otherwise, pick top n
-/// records by cpu_time only.
+/// Pick top n candidate raw records per resource dimension, then append their
+/// union and merge unpicked records to others. If network IO collection is
+/// enabled, candidates are selected by CPU time, network IO, logical read,
+/// logical write, and RocksDB block read count; otherwise, they are selected
+/// by CPU time only.
 pub fn handle_records_impl<'a, K, T>(
     records: &'a mut T,
     enable_network_io_collection: bool,

--- a/components/resource_metering/src/model.rs
+++ b/components/resource_metering/src/model.rs
@@ -21,15 +21,47 @@ use crate::TagInfos;
 thread_local! {
     static STATIC_CPU_BUF: Cell<Vec<u32>> = const {Cell::new(vec![])};
     static STATIC_NETWORK_BUF: Cell<Vec<u64>> = const {Cell::new(vec![])};
+    static STATIC_LOGICAL_IO_BUF: Cell<Vec<u64>> = const {Cell::new(vec![])};
     static STATIC_LOGICAL_READ_BUF: Cell<Vec<u64>> = const {Cell::new(vec![])};
     static STATIC_LOGICAL_WRITE_BUF: Cell<Vec<u64>> = const {Cell::new(vec![])};
     static STATIC_ROCKSDB_BLOCK_READ_BUF: Cell<Vec<u64>> = const {Cell::new(vec![])};
 }
 
 /// Find the kth values in the iterator, returns (kth_cpu_time,
-/// kth_network_traffic, kth_logical_read, kth_logical_write,
-/// kth_rocksdb_block_read)
+/// kth_network_traffic, kth_logical_io).
 pub fn find_kth_values<'a, T: 'a>(
+    iter: impl Iterator<Item = (&'a T, &'a RawRecord)>,
+    k: usize,
+) -> (u32, u64, u64) {
+    let mut cpu_buf = STATIC_CPU_BUF.with(|b| b.take());
+    let mut network_buf = STATIC_NETWORK_BUF.with(|b| b.take());
+    let mut logical_io_buf = STATIC_LOGICAL_IO_BUF.with(|b| b.take());
+    cpu_buf.clear();
+    network_buf.clear();
+    logical_io_buf.clear();
+    for (_, record) in iter {
+        cpu_buf.push(record.cpu_time);
+        network_buf.push(record.network_in_bytes + record.network_out_bytes);
+        logical_io_buf.push(record.logical_read_bytes + record.logical_write_bytes);
+    }
+    pdqselect::select_by(&mut cpu_buf, k, |a, b| b.cmp(a));
+    let kth_cpu = cpu_buf[k];
+    STATIC_CPU_BUF.with(move |b| b.set(cpu_buf));
+
+    pdqselect::select_by(&mut network_buf, k, |a, b| b.cmp(a));
+    let kth_network = network_buf[k];
+    STATIC_NETWORK_BUF.with(move |b| b.set(network_buf));
+
+    pdqselect::select_by(&mut logical_io_buf, k, |a, b| b.cmp(a));
+    let kth_logical_io = logical_io_buf[k];
+    STATIC_LOGICAL_IO_BUF.with(move |b| b.set(logical_io_buf));
+
+    (kth_cpu, kth_network, kth_logical_io)
+}
+
+/// Find the kth values for detailed IO selection, returning CPU, network,
+/// logical read, logical write, and RocksDB block read thresholds.
+pub fn find_kth_detailed_io_values<'a, T: 'a>(
     iter: impl Iterator<Item = (&'a T, &'a RawRecord)>,
     k: usize,
 ) -> (u32, u64, u64, u64, u64) {
@@ -111,12 +143,33 @@ pub fn get_iter_for_cpu_time<'a, T: 'a>(
 }
 
 /// Get two iterators, first is the one whose cpu_time > kth_cpu or network_io >
-/// kth_network or logical_read > kth_logical_read or logical_write >
-/// kth_logical_write or rocksdb_block_read_count > kth_rocksdb_block_read,
-/// second is the one whose cpu_time <= kth_cpu and network_io <= kth_network
-/// and logical_read <= kth_logical_read and logical_write <= kth_logical_write
-/// and rocksdb_block_read_count <= kth_rocksdb_block_read.
+/// kth_network or logical_io > kth_logical_io, second is the one whose cpu_time
+/// <= kth_cpu and network_io <= kth_network and logical_io <= kth_logical_io.
 pub fn get_iter_for_cpu_network_io<'a, T: 'a>(
+    records: &'a HashMap<T, RawRecord>,
+    kth_cpu: u32,
+    kth_network: u64,
+    kth_logical_io: u64,
+) -> (
+    impl Iterator<Item = (&'a T, &'a RawRecord)>,
+    impl Iterator<Item = (&'a T, &'a RawRecord)>,
+) {
+    (
+        records.iter().filter(move |(_, v)| {
+            v.cpu_time > kth_cpu
+                || v.network_in_bytes + v.network_out_bytes > kth_network
+                || v.logical_read_bytes + v.logical_write_bytes > kth_logical_io
+        }),
+        records.iter().filter(move |(_, v)| {
+            v.cpu_time <= kth_cpu
+                && v.network_in_bytes + v.network_out_bytes <= kth_network
+                && v.logical_read_bytes + v.logical_write_bytes <= kth_logical_io
+        }),
+    )
+}
+
+/// Get picked and unpicked iterators for detailed IO TopN selection.
+pub fn get_iter_for_detailed_io<'a, T: 'a>(
     records: &'a HashMap<T, RawRecord>,
     kth_cpu: u32,
     kth_network: u64,
@@ -204,14 +257,12 @@ where
     }
 }
 
-/// Pick top n candidate raw records per resource dimension, then append their
-/// union and merge unpicked records to others. If network IO collection is
-/// enabled, candidates are selected by CPU time, network IO, logical read,
-/// logical write, and RocksDB block read count; otherwise, they are selected
-/// by CPU time only.
+/// Pick top n candidate raw records per effective resource dimension, append
+/// their union, and merge unpicked records into others.
 pub fn handle_records_impl<'a, K, T>(
     records: &'a mut T,
     enable_network_io_collection: bool,
+    enable_detailed_io_collection: bool,
     agg_map: &'a HashMap<K, crate::RawRecord>,
     ts: u64,
     n: usize,
@@ -223,10 +274,10 @@ pub fn handle_records_impl<'a, K, T>(
         records.append(ts, agg_map.iter());
         return;
     }
-    if enable_network_io_collection {
+    if enable_network_io_collection && enable_detailed_io_collection {
         let (kth_cpu, kth_network, kth_logical_read, kth_logical_write, kth_rocksdb_block_read) =
-            find_kth_values(agg_map.iter(), n);
-        let (picked_iter, unpicked_iter) = get_iter_for_cpu_network_io(
+            find_kth_detailed_io_values(agg_map.iter(), n);
+        let (picked_iter, unpicked_iter) = get_iter_for_detailed_io(
             agg_map,
             kth_cpu,
             kth_network,
@@ -234,6 +285,12 @@ pub fn handle_records_impl<'a, K, T>(
             kth_logical_write,
             kth_rocksdb_block_read,
         );
+        records.append(ts, picked_iter);
+        records.merge_other(ts, unpicked_iter);
+    } else if enable_network_io_collection {
+        let (kth_cpu, kth_network, kth_logical_io) = find_kth_values(agg_map.iter(), n);
+        let (picked_iter, unpicked_iter) =
+            get_iter_for_cpu_network_io(agg_map, kth_cpu, kth_network, kth_logical_io);
         records.append(ts, picked_iter);
         records.merge_other(ts, unpicked_iter);
     } else {
@@ -295,6 +352,8 @@ pub struct RawRecord {
     pub logical_write_bytes: u64,
     pub network_in_bytes: u64,
     pub network_out_bytes: u64,
+    /// RocksDB block reads used for the downstream `read_iops` dimension. This
+    /// is a relative attribution signal, not device-level IOPS.
     pub rocksdb_block_read_count: u64,
 }
 
@@ -793,7 +852,8 @@ pub struct SummaryRecord {
     /// Network output bytes.
     pub network_out_bytes: AtomicU64,
 
-    /// RocksDB block read count (physical read IO approximation).
+    /// RocksDB block reads used for the downstream `read_iops` dimension. This
+    /// is a relative attribution signal, not device-level IOPS.
     pub rocksdb_block_read_count: AtomicU64,
 }
 
@@ -872,6 +932,8 @@ impl SummaryRecord {
 #[cfg(test)]
 mod tests {
     use std::sync::atomic::Ordering::Relaxed;
+
+    use collections::HashSet;
 
     use super::*;
     use crate::TagInfos;
@@ -1134,9 +1196,9 @@ mod tests {
         }
 
         let (kth_cpu, kth_network, kth_logical_read, kth_logical_write, kth_rocksdb_block_read) =
-            find_kth_values(records.iter(), 2);
+            find_kth_detailed_io_values(records.iter(), 2);
         assert_eq!(kth_rocksdb_block_read, 5);
-        let (picked, evicted) = get_iter_for_cpu_network_io(
+        let (picked, evicted) = get_iter_for_detailed_io(
             &records,
             kth_cpu,
             kth_network,
@@ -1178,8 +1240,8 @@ mod tests {
         );
 
         let (kth_cpu, kth_network, kth_logical_read, kth_logical_write, kth_rocksdb_block_read) =
-            find_kth_values(records.iter(), 1);
-        let (picked, _) = get_iter_for_cpu_network_io(
+            find_kth_detailed_io_values(records.iter(), 1);
+        let (picked, _) = get_iter_for_detailed_io(
             &records,
             kth_cpu,
             kth_network,
@@ -1191,6 +1253,61 @@ mod tests {
         assert_eq!(picked.len(), 2);
         assert!(picked.contains_key(&Arc::new(b"read".to_vec())));
         assert!(picked.contains_key(&Arc::new(b"write".to_vec())));
+    }
+
+    #[test]
+    fn test_handle_records_respects_detailed_io_scope() {
+        let mut raw = HashMap::default();
+        raw.insert(
+            Arc::new(b"read".to_vec()),
+            RawRecord {
+                logical_read_bytes: 100,
+                ..Default::default()
+            },
+        );
+        raw.insert(
+            Arc::new(b"write".to_vec()),
+            RawRecord {
+                logical_write_bytes: 90,
+                ..Default::default()
+            },
+        );
+        raw.insert(
+            Arc::new(b"combined".to_vec()),
+            RawRecord {
+                logical_read_bytes: 60,
+                logical_write_bytes: 60,
+                ..Default::default()
+            },
+        );
+        raw.insert(
+            Arc::new(b"block".to_vec()),
+            RawRecord {
+                rocksdb_block_read_count: 1_000,
+                ..Default::default()
+            },
+        );
+
+        let picked = |network, detailed| {
+            let mut records = Records::default();
+            handle_records_impl(&mut records, network, detailed, &raw, 1, 1);
+            records.records.keys().cloned().collect::<HashSet<_>>()
+        };
+
+        assert!(picked(false, false).is_empty());
+        assert!(picked(false, true).is_empty());
+        let legacy = [Arc::new(b"combined".to_vec())]
+            .into_iter()
+            .collect::<HashSet<_>>();
+        assert_eq!(picked(true, false), legacy);
+        let detailed = [
+            Arc::new(b"read".to_vec()),
+            Arc::new(b"write".to_vec()),
+            Arc::new(b"block".to_vec()),
+        ]
+        .into_iter()
+        .collect::<HashSet<_>>();
+        assert_eq!(picked(true, true), detailed);
     }
 
     #[test]
@@ -1808,16 +1925,9 @@ mod tests {
         };
 
         let agg_map = rs.aggregate_by_extra_tag();
-        let (kth_cpu, kth_network, kth_logical_read, kth_logical_write, kth_rocksdb_block_read) =
-            find_kth_values(agg_map.iter(), 2);
-        let (top, evicted) = get_iter_for_cpu_network_io(
-            &agg_map,
-            kth_cpu,
-            kth_network,
-            kth_logical_read,
-            kth_logical_write,
-            kth_rocksdb_block_read,
-        );
+        let (kth_cpu, kth_network, kth_logical_io) = find_kth_values(agg_map.iter(), 2);
+        let (top, evicted) =
+            get_iter_for_cpu_network_io(&agg_map, kth_cpu, kth_network, kth_logical_io);
         let others = evicted
             .map(|(_, v)| v)
             .fold(RawRecord::default(), |mut others, r| {
@@ -1877,16 +1987,9 @@ mod tests {
             records,
         };
         let agg_map = rs.aggregate_by_extra_tag();
-        let (kth_cpu, kth_network, kth_logical_read, kth_logical_write, kth_rocksdb_block_read) =
-            find_kth_values(agg_map.iter(), 2);
-        let (top, evicted) = get_iter_for_cpu_network_io(
-            &agg_map,
-            kth_cpu,
-            kth_network,
-            kth_logical_read,
-            kth_logical_write,
-            kth_rocksdb_block_read,
-        );
+        let (kth_cpu, kth_network, kth_logical_io) = find_kth_values(agg_map.iter(), 2);
+        let (top, evicted) =
+            get_iter_for_cpu_network_io(&agg_map, kth_cpu, kth_network, kth_logical_io);
         let others = evicted
             .map(|(_, v)| v)
             .fold(RawRecord::default(), |mut others, r| {

--- a/components/resource_metering/src/recorder/mod.rs
+++ b/components/resource_metering/src/recorder/mod.rs
@@ -31,7 +31,8 @@ pub use self::{
         cpu::CpuRecorder,
         summary::{
             SummaryRecorder, record_logical_read_bytes, record_logical_write_bytes,
-            record_network_in_bytes, record_network_out_bytes, record_read_keys, record_write_keys,
+            record_network_in_bytes, record_network_out_bytes, record_read_keys,
+            record_rocksdb_block_read_count, record_write_keys,
         },
     },
 };

--- a/components/resource_metering/src/recorder/mod.rs
+++ b/components/resource_metering/src/recorder/mod.rs
@@ -2,7 +2,7 @@
 
 use std::{
     fmt::{self, Display, Formatter},
-    sync::{Arc, atomic::Ordering::Relaxed},
+    sync::Arc,
     time::Duration,
 };
 
@@ -17,8 +17,7 @@ use tikv_util::{
 
 use self::{collector_reg::CollectorReg, sub_recorder::SubRecorder};
 use crate::{
-    Config, RawRecords, ResourceTagFactory, collector::Collector,
-    config::ENABLE_NETWORK_IO_COLLECTION,
+    Config, RawRecords, ResourceTagFactory, collector::Collector, config::set_io_collection_config,
 };
 mod collector_reg;
 mod localstorage;
@@ -130,7 +129,10 @@ impl Recorder {
 
     fn handle_config_change(&mut self, config: Config) {
         self.precision_ms = config.precision.as_millis();
-        ENABLE_NETWORK_IO_COLLECTION.store(config.enable_network_io_collection, Relaxed);
+        set_io_collection_config(
+            config.enable_network_io_collection,
+            config.enable_detailed_io_collection,
+        );
     }
 
     fn tick(&mut self) {
@@ -304,14 +306,15 @@ impl ConfigChangeNotifier {
 pub fn init_recorder(
     precision_ms: u64,
     enable_network_io_collection: bool,
+    enable_detailed_io_collection: bool,
 ) -> (
     ConfigChangeNotifier,
     CollectorRegHandle,
     ResourceTagFactory,
     Box<LazyWorker<Task>>,
 ) {
-    // initialize the global flag for network io collection
-    ENABLE_NETWORK_IO_COLLECTION.store(enable_network_io_collection, Relaxed);
+    // Initialize the global IO collection switches.
+    set_io_collection_config(enable_network_io_collection, enable_detailed_io_collection);
     let recorder = RecorderBuilder::default()
         .precision_ms(precision_ms)
         .add_sub_recorder(Box::<CpuRecorder>::default())

--- a/components/resource_metering/src/recorder/sub_recorder/summary.rs
+++ b/components/resource_metering/src/recorder/sub_recorder/summary.rs
@@ -85,6 +85,20 @@ pub fn record_logical_write_bytes(bytes: u64) {
     })
 }
 
+/// Records RocksDB block read count (physical read IO approximation) in the
+/// current context.
+pub fn record_rocksdb_block_read_count(count: u64) {
+    if count == 0 || !ENABLE_NETWORK_IO_COLLECTION.load(Relaxed) {
+        return;
+    }
+    STORAGE.with(|s| {
+        s.borrow()
+            .summary_cur_record
+            .rocksdb_block_read_count
+            .fetch_add(count, Relaxed);
+    })
+}
+
 /// An implementation of [SubRecorder] for collecting summary data.
 ///
 /// `SummaryRecorder` uses some special methods
@@ -146,5 +160,50 @@ impl SubRecorder for SummaryRecorder {
 
     fn thread_created(&mut self, _id: Pid, store: &LocalStorage) {
         store.summary_enable.store(self.enabled, SeqCst);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::Ordering::Relaxed;
+
+    use super::*;
+    use crate::NETWORK_IO_COLLECTION_TEST_LOCK;
+
+    #[test]
+    fn test_record_rocksdb_block_read_count_respects_config() {
+        let _test_guard = NETWORK_IO_COLLECTION_TEST_LOCK.lock().unwrap();
+        let previous = ENABLE_NETWORK_IO_COLLECTION.swap(false, Relaxed);
+        std::thread::spawn(|| {
+            STORAGE.with(|s| {
+                s.borrow().summary_cur_record.reset();
+            });
+            record_rocksdb_block_read_count(7);
+            STORAGE.with(|s| {
+                assert_eq!(
+                    s.borrow()
+                        .summary_cur_record
+                        .rocksdb_block_read_count
+                        .load(Relaxed),
+                    0
+                );
+            });
+
+            ENABLE_NETWORK_IO_COLLECTION.store(true, Relaxed);
+            record_rocksdb_block_read_count(7);
+            record_rocksdb_block_read_count(0);
+            STORAGE.with(|s| {
+                assert_eq!(
+                    s.borrow()
+                        .summary_cur_record
+                        .rocksdb_block_read_count
+                        .load(Relaxed),
+                    7
+                );
+            });
+        })
+        .join()
+        .unwrap();
+        ENABLE_NETWORK_IO_COLLECTION.store(previous, Relaxed);
     }
 }

--- a/components/resource_metering/src/recorder/sub_recorder/summary.rs
+++ b/components/resource_metering/src/recorder/sub_recorder/summary.rs
@@ -168,12 +168,12 @@ mod tests {
     use std::sync::atomic::Ordering::Relaxed;
 
     use super::*;
-    use crate::NETWORK_IO_COLLECTION_TEST_LOCK;
+    use crate::{NETWORK_IO_COLLECTION_TEST_LOCK, NetworkIoCollectionConfigGuard};
 
     #[test]
     fn test_record_rocksdb_block_read_count_respects_config() {
         let _test_guard = NETWORK_IO_COLLECTION_TEST_LOCK.lock().unwrap();
-        let previous = ENABLE_NETWORK_IO_COLLECTION.swap(false, Relaxed);
+        let _config_guard = NetworkIoCollectionConfigGuard::set(false);
         std::thread::spawn(|| {
             STORAGE.with(|s| {
                 s.borrow().summary_cur_record.reset();
@@ -204,6 +204,5 @@ mod tests {
         })
         .join()
         .unwrap();
-        ENABLE_NETWORK_IO_COLLECTION.store(previous, Relaxed);
     }
 }

--- a/components/resource_metering/src/recorder/sub_recorder/summary.rs
+++ b/components/resource_metering/src/recorder/sub_recorder/summary.rs
@@ -6,7 +6,7 @@ use collections::HashMap;
 use tikv_util::sys::thread::Pid;
 
 use crate::{
-    ENABLE_NETWORK_IO_COLLECTION, RawRecords,
+    ENABLE_DETAILED_IO_COLLECTION, ENABLE_NETWORK_IO_COLLECTION, RawRecords,
     recorder::{
         SubRecorder,
         localstorage::{LocalStorage, STORAGE},
@@ -85,10 +85,12 @@ pub fn record_logical_write_bytes(bytes: u64) {
     })
 }
 
-/// Records RocksDB block read count (physical read IO approximation) in the
-/// current context.
+/// Records RocksDB block reads used as the per-request `read_iops` signal.
+///
+/// This is a relative attribution signal for Top SQL, not a device-level IOPS
+/// measurement.
 pub fn record_rocksdb_block_read_count(count: u64) {
-    if count == 0 || !ENABLE_NETWORK_IO_COLLECTION.load(Relaxed) {
+    if count == 0 || !ENABLE_DETAILED_IO_COLLECTION.load(Relaxed) {
         return;
     }
     STORAGE.with(|s| {
@@ -168,39 +170,35 @@ mod tests {
     use std::sync::atomic::Ordering::Relaxed;
 
     use super::*;
-    use crate::{NETWORK_IO_COLLECTION_TEST_LOCK, NetworkIoCollectionConfigGuard};
+    use crate::{
+        IO_COLLECTION_TEST_LOCK, IoCollectionConfigGuard, config::set_io_collection_config,
+    };
 
     #[test]
     fn test_record_rocksdb_block_read_count_respects_config() {
-        let _test_guard = NETWORK_IO_COLLECTION_TEST_LOCK.lock().unwrap();
-        let _config_guard = NetworkIoCollectionConfigGuard::set(false);
+        let _test_guard = IO_COLLECTION_TEST_LOCK.lock().unwrap();
+        let _config_guard = IoCollectionConfigGuard::set(false, false);
         std::thread::spawn(|| {
-            STORAGE.with(|s| {
-                s.borrow().summary_cur_record.reset();
-            });
-            record_rocksdb_block_read_count(7);
-            STORAGE.with(|s| {
-                assert_eq!(
-                    s.borrow()
-                        .summary_cur_record
-                        .rocksdb_block_read_count
-                        .load(Relaxed),
-                    0
-                );
-            });
-
-            ENABLE_NETWORK_IO_COLLECTION.store(true, Relaxed);
-            record_rocksdb_block_read_count(7);
-            record_rocksdb_block_read_count(0);
-            STORAGE.with(|s| {
-                assert_eq!(
-                    s.borrow()
-                        .summary_cur_record
-                        .rocksdb_block_read_count
-                        .load(Relaxed),
-                    7
-                );
-            });
+            for (network, detailed, expected) in [
+                (false, false, 0),
+                (false, true, 0),
+                (true, false, 0),
+                (true, true, 7),
+            ] {
+                set_io_collection_config(network, detailed);
+                STORAGE.with(|s| s.borrow().summary_cur_record.reset());
+                record_rocksdb_block_read_count(7);
+                record_rocksdb_block_read_count(0);
+                STORAGE.with(|s| {
+                    assert_eq!(
+                        s.borrow()
+                            .summary_cur_record
+                            .rocksdb_block_read_count
+                            .load(Relaxed),
+                        expected
+                    );
+                });
+            }
         })
         .join()
         .unwrap();

--- a/components/resource_metering/src/reporter/mod.rs
+++ b/components/resource_metering/src/reporter/mod.rs
@@ -99,12 +99,27 @@ impl Reporter {
         let ts = records.begin_unix_time_secs;
         let n = self.config.max_resource_groups;
         if self.config.enable_network_io_collection {
+            let enable_detailed_io_collection = self.config.detailed_io_collection_enabled();
             let (agg_tag_map, agg_region_map) = records.aggregate_by_extra_tag_and_region();
-            handle_records_impl(&mut self.records, true, &agg_tag_map, ts, n);
-            handle_records_impl(&mut self.region_records, true, &agg_region_map, ts, n);
+            handle_records_impl(
+                &mut self.records,
+                true,
+                enable_detailed_io_collection,
+                &agg_tag_map,
+                ts,
+                n,
+            );
+            handle_records_impl(
+                &mut self.region_records,
+                true,
+                enable_detailed_io_collection,
+                &agg_region_map,
+                ts,
+                n,
+            );
         } else {
             let agg_map = records.aggregate_by_extra_tag();
-            handle_records_impl(&mut self.records, false, &agg_map, ts, n);
+            handle_records_impl(&mut self.records, false, false, &agg_map, ts, n);
         }
     }
 
@@ -301,6 +316,7 @@ mod tests {
             max_resource_groups: 3000,
             precision: ReadableDuration::secs(2),
             enable_network_io_collection: false,
+            enable_detailed_io_collection: false,
         }));
         assert_eq!(r.get_interval(), Duration::from_secs(120));
         let mut records = HashMap::default();
@@ -421,6 +437,7 @@ mod tests {
             max_resource_groups: 3000,
             precision: ReadableDuration::secs(2),
             enable_network_io_collection: true,
+            enable_detailed_io_collection: false,
         }));
         assert_eq!(r.get_interval(), Duration::from_secs(120));
         let mut records = HashMap::default();

--- a/components/resource_metering/tests/recorder_test.rs
+++ b/components/resource_metering/tests/recorder_test.rs
@@ -179,7 +179,8 @@ mod tests {
 
     #[test]
     fn test_cpu_recorder_heavy_single_thread() {
-        let (_, collector_reg_handle, resource_tag_factory, worker) = init_recorder(1000, false);
+        let (_, collector_reg_handle, resource_tag_factory, worker) =
+            init_recorder(1000, false, false);
 
         let collector = DummyCollector::default();
         let _handle = collector_reg_handle.register(Box::new(collector.clone()), false);
@@ -198,7 +199,8 @@ mod tests {
 
     #[test]
     fn test_cpu_recorder_sleep_single_thread() {
-        let (_, collector_reg_handle, resource_tag_factory, worker) = init_recorder(1000, false);
+        let (_, collector_reg_handle, resource_tag_factory, worker) =
+            init_recorder(1000, false, false);
 
         let collector = DummyCollector::default();
         let _handle = collector_reg_handle.register(Box::new(collector.clone()), false);
@@ -217,7 +219,8 @@ mod tests {
 
     #[test]
     fn test_cpu_recorder_hybrid_single_thread() {
-        let (_, collector_reg_handle, resource_tag_factory, worker) = init_recorder(1000, false);
+        let (_, collector_reg_handle, resource_tag_factory, worker) =
+            init_recorder(1000, false, false);
 
         // Hybrid workload with 1 thread
         let collector = DummyCollector::default();
@@ -245,7 +248,8 @@ mod tests {
 
     #[test]
     fn test_cpu_recorder_heavy_multiple_threads() {
-        let (_, collector_reg_handle, resource_tag_factory, worker) = init_recorder(1000, false);
+        let (_, collector_reg_handle, resource_tag_factory, worker) =
+            init_recorder(1000, false, false);
 
         // Heavy CPU with 3 threads
         let collector = DummyCollector::default();
@@ -277,7 +281,8 @@ mod tests {
 
     #[test]
     fn test_cpu_recorder_hybrid_multiple_threads() {
-        let (_, collector_reg_handle, resource_tag_factory, worker) = init_recorder(1000, false);
+        let (_, collector_reg_handle, resource_tag_factory, worker) =
+            init_recorder(1000, false, false);
 
         // Hybrid workload with 3 threads
         let collector = DummyCollector::default();

--- a/components/resource_metering/tests/summary_test.rs
+++ b/components/resource_metering/tests/summary_test.rs
@@ -47,8 +47,11 @@ fn test_summary() {
         ..Default::default()
     };
 
-    let (_, collector_reg_handle, resource_tag_factory, mut recorder_worker) =
-        init_recorder(cfg.precision.as_millis(), cfg.enable_network_io_collection);
+    let (_, collector_reg_handle, resource_tag_factory, mut recorder_worker) = init_recorder(
+        cfg.precision.as_millis(),
+        cfg.enable_network_io_collection,
+        cfg.enable_detailed_io_collection,
+    );
     let (_, data_sink_reg_handle, mut reporter_worker) = init_reporter(cfg, collector_reg_handle);
 
     let data_sink = MockDataSink::default();

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -680,6 +680,10 @@ where
                     .config
                     .resource_metering
                     .enable_network_io_collection,
+                self.core
+                    .config
+                    .resource_metering
+                    .enable_detailed_io_collection,
             );
         self.core.to_stop.push(recorder_worker);
         let (reporter_notifier, data_sink_reg_handle, reporter_worker) =

--- a/components/server/src/server2.rs
+++ b/components/server/src/server2.rs
@@ -548,6 +548,10 @@ where
                     .config
                     .resource_metering
                     .enable_network_io_collection,
+                self.core
+                    .config
+                    .resource_metering
+                    .enable_detailed_io_collection,
             );
         self.core.to_stop.push(recorder_worker);
         let (reporter_notifier, data_sink_reg_handle, reporter_worker) =

--- a/components/test_raftstore-v2/src/server.rs
+++ b/components/test_raftstore-v2/src/server.rs
@@ -781,6 +781,7 @@ impl<EK: KvEngine> ServerCluster<EK> {
             resource_metering::init_recorder(
                 cfg.precision.as_millis(),
                 cfg.enable_network_io_collection,
+                cfg.enable_detailed_io_collection,
             );
         let (_, data_sink_reg_handle, reporter_worker) =
             resource_metering::init_reporter(cfg.clone(), collector_reg_handle.clone());

--- a/components/test_raftstore/src/server.rs
+++ b/components/test_raftstore/src/server.rs
@@ -258,6 +258,7 @@ impl ServerCluster {
             resource_metering::init_recorder(
                 cfg.precision.as_millis(),
                 cfg.enable_network_io_collection,
+                cfg.enable_detailed_io_collection,
             );
         let (_, data_sink_reg_handle, reporter_worker) =
             resource_metering::init_reporter(cfg.clone(), collector_reg_handle.clone());

--- a/doc/maintenance-guides/src/coprocessor.md
+++ b/doc/maintenance-guides/src/coprocessor.md
@@ -103,6 +103,12 @@ It is a read-heavy hot path and directly impacts query latency.
 - wait-time and snapshot-time metrics
 - request-type metrics and execution summaries
 - slow-log behavior driven by endpoint thresholds
+- Resource metering / TopSQL records the per-request RocksDB PerfContext
+  `block_read_count` delta as `rocksdb_block_read_count` when
+  `resource-metering.enable-network-io-collection` is enabled. It is a
+  physical-read-IO approximation rather than device IOPS. Unary and streaming
+  handler futures must keep this PerfContext accounting poll-scoped so TLS
+  metrics cannot be attributed to another request.
 - Start with `src/coprocessor/metrics.rs`. High-value signals include:
   `tikv_coprocessor_request_duration_seconds` family,
   `tikv_coprocessor_request_wait_seconds`,

--- a/doc/maintenance-guides/src/coprocessor.md
+++ b/doc/maintenance-guides/src/coprocessor.md
@@ -104,11 +104,13 @@ It is a read-heavy hot path and directly impacts query latency.
 - request-type metrics and execution summaries
 - slow-log behavior driven by endpoint thresholds
 - Resource metering / TopSQL records the per-request RocksDB PerfContext
-  `block_read_count` delta as `rocksdb_block_read_count` when
-  `resource-metering.enable-network-io-collection` is enabled. It is a
-  physical-read-IO approximation rather than device IOPS. Unary and streaming
-  handler futures must keep this PerfContext accounting poll-scoped so TLS
-  metrics cannot be attributed to another request.
+  `block_read_count` delta as `rocksdb_block_read_count` when both
+  `resource-metering.enable-network-io-collection` and
+  `resource-metering.enable-detailed-io-collection` are enabled. The field is
+  used for the downstream `read_iops` dimension and relative attribution; it is
+  not a device-level IOPS measurement. Unary and streaming handler futures must
+  keep this PerfContext accounting poll-scoped so TLS metrics cannot be
+  attributed to another request.
 - Start with `src/coprocessor/metrics.rs`. High-value signals include:
   `tikv_coprocessor_request_duration_seconds` family,
   `tikv_coprocessor_request_wait_seconds`,

--- a/doc/maintenance-guides/src/storage.md
+++ b/doc/maintenance-guides/src/storage.md
@@ -135,6 +135,17 @@ High-risk contracts:
 - MVCC conflict, read, and GC-related metrics
 - flow-control and memory-quota behavior
 - lock-wait and deadlock diagnostics
+- Resource metering / TopSQL records logical IO and, when
+  `resource-metering.enable-network-io-collection` is enabled,
+  `rocksdb_block_read_count`. The latter is the foreground SQL request's
+  RocksDB PerfContext delta and is an approximation of physical read IO, not
+  device-level IOPS. Storage command boundaries in `metrics.rs` own this
+  attribution for read-only commands and read phases of write commands. In
+  particular, transactional writes and `raw_compare_and_swap` must retain the
+  `Storage` PerfContext because CAS reads the prior value before deciding
+  whether to write. Do not attribute Raftstore apply/store write-worker
+  activity to the request: those paths use write-only PerfContext metrics and
+  may batch work from multiple requests.
 
 Start triage with:
 

--- a/doc/maintenance-guides/src/storage.md
+++ b/doc/maintenance-guides/src/storage.md
@@ -135,17 +135,19 @@ High-risk contracts:
 - MVCC conflict, read, and GC-related metrics
 - flow-control and memory-quota behavior
 - lock-wait and deadlock diagnostics
-- Resource metering / TopSQL records logical IO and, when
-  `resource-metering.enable-network-io-collection` is enabled,
-  `rocksdb_block_read_count`. The latter is the foreground SQL request's
-  RocksDB PerfContext delta and is an approximation of physical read IO, not
-  device-level IOPS. Storage command boundaries in `metrics.rs` own this
-  attribution for read-only commands and read phases of write commands. In
-  particular, transactional writes and `raw_compare_and_swap` must retain the
-  `Storage` PerfContext because CAS reads the prior value before deciding
-  whether to write. Do not attribute Raftstore apply/store write-worker
-  activity to the request: those paths use write-only PerfContext metrics and
-  may batch work from multiple requests.
+- Resource metering / TopSQL records logical IO when
+  `resource-metering.enable-network-io-collection` is enabled. With
+  `resource-metering.enable-detailed-io-collection` also enabled, logical reads
+  and writes are selected independently and the foreground SQL request's
+  RocksDB PerfContext delta is recorded as `rocksdb_block_read_count`. This
+  field feeds the downstream `read_iops` dimension for relative attribution; it
+  is not a device-level IOPS measurement. Storage command boundaries in
+  `metrics.rs` own this attribution for read-only commands and read phases of
+  write commands. In particular, transactional writes and
+  `raw_compare_and_swap` must retain the `Storage` PerfContext because CAS reads
+  the prior value before deciding whether to write. Do not attribute Raftstore
+  apply/store write-worker activity to the request: those paths use write-only
+  PerfContext metrics and may batch work from multiple requests.
 
 Start triage with:
 

--- a/scripts/check-tirocks
+++ b/scripts/check-tirocks
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Compile the workspace-excluded TiRocks implementation in an isolated
+# workspace configuration. The original manifest and lockfile are restored
+# even when Cargo fails.
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+tmpdir=$(mktemp -d)
+manifest_backup="$tmpdir/Cargo.toml"
+lockfile_backup="$tmpdir/Cargo.lock"
+workspace_lock="$repo_root/target/check-tirocks.lock"
+
+while ! mkdir "$workspace_lock" 2>/dev/null; do
+    echo "waiting for another TiRocks workspace check to finish"
+    sleep 1
+done
+
+cleanup() {
+    cp "$manifest_backup" "$repo_root/Cargo.toml"
+    if [[ -f "$lockfile_backup" ]]; then
+        cp "$lockfile_backup" "$repo_root/Cargo.lock"
+    else
+        rm -f "$repo_root/Cargo.lock"
+    fi
+    rmdir "$workspace_lock"
+    rm -rf "$tmpdir"
+}
+trap cleanup EXIT
+
+cp "$repo_root/Cargo.toml" "$manifest_backup"
+if [[ -f "$repo_root/Cargo.lock" ]]; then
+    cp "$repo_root/Cargo.lock" "$lockfile_backup"
+fi
+
+sed -i.bak '/"components\/engine_tirocks",/d' "$repo_root/Cargo.toml"
+rm -f "$repo_root/Cargo.toml.bak"
+
+cd "$repo_root"
+CARGO_TARGET_DIR="$repo_root/target/tirocks-check" cargo check -p engine_tirocks

--- a/scripts/check-tirocks
+++ b/scripts/check-tirocks
@@ -10,20 +10,26 @@ manifest_backup="$tmpdir/Cargo.toml"
 lockfile_backup="$tmpdir/Cargo.lock"
 workspace_lock="$repo_root/target/check-tirocks.lock"
 
+mkdir -p "$(dirname "$workspace_lock")"
 while ! mkdir "$workspace_lock" 2>/dev/null; do
     echo "waiting for another TiRocks workspace check to finish"
     sleep 1
 done
 
 cleanup() {
-    cp "$manifest_backup" "$repo_root/Cargo.toml"
-    if [[ -f "$lockfile_backup" ]]; then
-        cp "$lockfile_backup" "$repo_root/Cargo.lock"
-    else
-        rm -f "$repo_root/Cargo.lock"
+    local status=$?
+    set +e
+    if [[ -f "$manifest_backup" ]]; then
+        cp "$manifest_backup" "$repo_root/Cargo.toml"
+        if [[ -f "$lockfile_backup" ]]; then
+            cp "$lockfile_backup" "$repo_root/Cargo.lock"
+        else
+            rm -f "$repo_root/Cargo.lock"
+        fi
     fi
-    rmdir "$workspace_lock"
+    rmdir "$workspace_lock" 2>/dev/null || true
     rm -rf "$tmpdir"
+    exit "$status"
 }
 trap cleanup EXIT
 

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -823,13 +823,15 @@ impl<E: Engine> Endpoint<E> {
 
             loop {
                 let result = {
-                    tracker.on_begin_item();
-
-                    let result = handler.handle_streaming_request().await;
+                    let result = track(
+                        handler.handle_streaming_request(),
+                        tracker.as_mut(),
+                    )
+                    .await;
 
                     let mut storage_stats = Statistics::default();
                     handler.collect_scan_statistics(&mut storage_stats);
-                    tracker.on_finish_item(Some(storage_stats));
+                    tracker.collect_storage_statistics(storage_stats);
 
                     result
                 };

--- a/src/coprocessor/tracker.rs
+++ b/src/coprocessor/tracker.rs
@@ -7,6 +7,7 @@ use engine_traits::{PerfContext, PerfContextExt, PerfContextKind};
 use kvproto::{kvrpcpb, kvrpcpb::ScanDetailV2};
 use pd_client::BucketMeta;
 use protobuf::Message;
+use resource_metering::record_rocksdb_block_read_count;
 use tikv_kv::Engine;
 use tikv_util::{
     memory::HeapSize,
@@ -181,9 +182,10 @@ impl<E: Engine> Tracker<E> {
             if let Some(storage_stats) = some_storage_stats {
                 self.total_storage_stats.add(&storage_stats);
             }
-            self.with_perf_context(|perf_context| {
-                perf_context.report_metrics(&[get_tls_tracker_token()]);
+            let report = self.with_perf_context(|perf_context| {
+                perf_context.report_metrics(&[get_tls_tracker_token()])
             });
+            record_rocksdb_block_read_count(report.block_read_count);
             self.current_stage = TrackerState::ItemFinished(now);
         } else {
             unreachable!()

--- a/src/storage/metrics.rs
+++ b/src/storage/metrics.rs
@@ -12,6 +12,7 @@ use pd_client::{BucketMeta, RegionWriteCfCopDetail};
 use prometheus::*;
 use prometheus_static_metric::*;
 use raftstore::store::{ReadStats, util::build_key_range};
+use resource_metering::record_rocksdb_block_read_count;
 use tikv_kv::Engine;
 use tracker::get_tls_tracker_token;
 
@@ -344,6 +345,7 @@ where
         static RESOLVE_LOCK_LITE: RefCell<Option<Box<dyn PerfContext>>> = RefCell::new(None);
         static FLUSH: RefCell<Option<Box<dyn PerfContext>>> = RefCell::new(None);
         static BUFFER_BATCH_GET: RefCell<Option<Box<dyn PerfContext>>> = RefCell::new(None);
+        static RAW_COMPARE_AND_SWAP: RefCell<Option<Box<dyn PerfContext>>> = RefCell::new(None);
     }
     let tls_cell = match cmd {
         CommandKind::get => &GET,
@@ -364,6 +366,7 @@ where
         CommandKind::resolve_lock => &RESOLVE_LOCK,
         CommandKind::resolve_lock_lite => &RESOLVE_LOCK_LITE,
         CommandKind::flush => &FLUSH,
+        CommandKind::raw_compare_and_swap => &RAW_COMPARE_AND_SWAP,
         _ => return f(),
     };
     tls_cell.with(|c| {
@@ -376,7 +379,8 @@ where
         });
         perf_context.start_observe();
         let res = f();
-        perf_context.report_metrics(&[get_tls_tracker_token()]);
+        let report = perf_context.report_metrics(&[get_tls_tracker_token()]);
+        record_rocksdb_block_read_count(report.block_read_count);
         res
     })
 }

--- a/tests/integrations/resource_metering/test_dynamic_config.rs
+++ b/tests/integrations/resource_metering/test_dynamic_config.rs
@@ -3,7 +3,7 @@
 use std::{iter, thread::sleep, time::Duration};
 
 use rand::prelude::SliceRandom;
-use resource_metering::ENABLE_NETWORK_IO_COLLECTION;
+use resource_metering::{ENABLE_DETAILED_IO_COLLECTION, ENABLE_NETWORK_IO_COLLECTION};
 use test_util::alloc_port;
 use tikv_util::config::ReadableDuration;
 use tokio::time::Instant;
@@ -18,6 +18,7 @@ pub fn test_enable() {
         max_resource_groups: 5000,
         precision: ReadableDuration::secs(1),
         enable_network_io_collection: false,
+        enable_detailed_io_collection: false,
     });
 
     let port = alloc_port();
@@ -63,6 +64,7 @@ pub fn test_report_interval() {
         max_resource_groups: 5000,
         precision: ReadableDuration::secs(1),
         enable_network_io_collection: false,
+        enable_detailed_io_collection: false,
     });
     test_suite.start_receiver_at(port);
 
@@ -104,6 +106,7 @@ pub fn test_max_resource_groups() {
         max_resource_groups: 5000,
         precision: ReadableDuration::secs(2),
         enable_network_io_collection: false,
+        enable_detailed_io_collection: false,
     });
     test_suite.start_receiver_at(port);
 
@@ -147,6 +150,7 @@ pub fn test_precision() {
         max_resource_groups: 5000,
         precision: ReadableDuration::secs(1),
         enable_network_io_collection: false,
+        enable_detailed_io_collection: false,
     });
     test_suite.start_receiver_at(port);
 
@@ -193,14 +197,26 @@ pub fn test_enable_network_io_collection() {
         max_resource_groups: 5000,
         precision: ReadableDuration::secs(1),
         enable_network_io_collection: false,
+        enable_detailed_io_collection: false,
     });
     test_suite.start_receiver_at(port);
     // Workload
     // [req-1]
     test_suite.setup_workload(vec!["req-1"]);
 
+    test_suite.cfg_enable_detailed_io_collection("true");
+    test_suite.flush_receiver();
+    let _res = test_suite.block_receive_one();
+    assert!(!ENABLE_DETAILED_IO_COLLECTION.load(std::sync::atomic::Ordering::Relaxed));
+
     test_suite.cfg_enable_network_io_collection("true");
     test_suite.flush_receiver();
     let _res = test_suite.block_receive_one();
     assert!(ENABLE_NETWORK_IO_COLLECTION.load(std::sync::atomic::Ordering::Relaxed));
+    assert!(ENABLE_DETAILED_IO_COLLECTION.load(std::sync::atomic::Ordering::Relaxed));
+
+    test_suite.cfg_enable_network_io_collection("false");
+    test_suite.flush_receiver();
+    let _res = test_suite.block_receive_one();
+    assert!(!ENABLE_DETAILED_IO_COLLECTION.load(std::sync::atomic::Ordering::Relaxed));
 }

--- a/tests/integrations/resource_metering/test_read_keys.rs
+++ b/tests/integrations/resource_metering/test_read_keys.rs
@@ -160,6 +160,7 @@ fn test_read_keys_coprocessor() {
         resource_metering::init_recorder(
             cfg.precision.as_millis(),
             cfg.enable_network_io_collection,
+            cfg.enable_detailed_io_collection,
         );
     let (_, data_sink_reg_handle, reporter_worker) =
         resource_metering::init_reporter(cfg, collector_reg_handle);

--- a/tests/integrations/resource_metering/test_receiver.rs
+++ b/tests/integrations/resource_metering/test_receiver.rs
@@ -16,6 +16,7 @@ pub fn test_alter_receiver_address() {
         max_resource_groups: 5000,
         precision: ReadableDuration::secs(1),
         enable_network_io_collection: false,
+        enable_detailed_io_collection: false,
     });
     test_suite.start_receiver_at(port);
 
@@ -53,6 +54,7 @@ pub fn test_receiver_blocking() {
         max_resource_groups: 5000,
         precision: ReadableDuration::secs(1),
         enable_network_io_collection: false,
+        enable_detailed_io_collection: false,
     });
     test_suite.start_receiver_at(port);
 
@@ -92,6 +94,7 @@ pub fn test_receiver_shutdown() {
         max_resource_groups: 5000,
         precision: ReadableDuration::secs(1),
         enable_network_io_collection: false,
+        enable_detailed_io_collection: false,
     });
     test_suite.start_receiver_at(port);
 

--- a/tests/integrations/resource_metering/test_suite/mod.rs
+++ b/tests/integrations/resource_metering/test_suite/mod.rs
@@ -58,6 +58,7 @@ impl TestSuite {
             resource_metering::init_recorder(
                 cfg.precision.as_millis(),
                 cfg.enable_network_io_collection,
+                cfg.enable_detailed_io_collection,
             );
         let (reporter_notifier, data_sink_reg_handle, reporter_worker) =
             resource_metering::init_reporter(cfg.clone(), collector_reg_handle);
@@ -165,6 +166,13 @@ impl TestSuite {
         let flag = flag.into();
         self.cfg_controller
             .update_config("resource-metering.enable-network-io-collection", &flag)
+            .unwrap();
+    }
+
+    pub fn cfg_enable_detailed_io_collection(&self, flag: impl Into<String>) {
+        let flag = flag.into();
+        self.cfg_controller
+            .update_config("resource-metering.enable-detailed-io-collection", &flag)
             .unwrap();
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: ref #19867

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

- Report foreground RocksDB block-read deltas from storage and coprocessor request contexts through resource metering / Top SQL.
- Split logical IO into logical-read and logical-write dimensions, preserve block-read-only records, and report the new fields in resource-usage protobuf records.
- Select Top-N candidates per resource dimension; reported groups are their union and can exceed `max_resource_groups`.
- Attribute conditional reads in raw compare-and-swap, but exclude batched Raftstore apply/store write workers.
- Add a TiRocks compile check and document the attribution boundary.
- Depends on https://github.com/pingcap/kvproto/pull/1498.

```commit-message
*: extend Top SQL resource dimensions

Extend Top SQL resource dimensions with logical read, logical write, and
foreground RocksDB block-read deltas. Include conditional reads made by raw
compare-and-swap while excluding asynchronous Raftstore write workers.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Validation:

- `cargo fmt --check`
- `cargo metadata --locked --no-deps --format-version=1`
- kvproto: `make check` and `make go`
- `cargo test -p resource_metering --lib --tests` reached the gRPC C++ build but could not reach Rust tests because installed Homebrew Protobuf headers conflict with grpcio-sys's bundled upb headers.
- `make check-tirocks` verified the script setup and cleanup, but the local TiRocks dev dependency fails to compile due to a private `SequenceNumber` import; it also encounters the same grpcio-sys/Homebrew Protobuf conflict.
- The follow-up review fixes passed `cargo fmt --check`, `bash -n scripts/check-tirocks`, and an interrupted `make check-tirocks` cleanup check.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Add RocksDB block-read counts to Top SQL resource usage records.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Resource metering now captures RocksDB block-read counts for improved request and command observability.
  * Detailed I/O collection supports separate logical read, logical write, and block-read metrics in top-resource summaries.
  * Detailed I/O collection can be enabled through configuration and is active only alongside network I/O collection.
* **Bug Fixes**
  * Preserved records containing only block-read metrics.
* **Documentation**
  * Added guidance on block-read attribution and poll-scoped accounting.
* **Chores**
  * Added automated TiRocks verification to macOS checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
