### PR TITLE
copr: cherry-pick LIKE fixes to release-8.5-20260714-v8.5.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6535,9 +6535,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.10.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
+checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
 dependencies = [
  "lock_api",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,9 +120,9 @@ checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
 
 [[package]]
 name = "anyhow"
-version = "1.0.75"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "api_version"
@@ -1844,9 +1844,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -4021,9 +4021,9 @@ dependencies = [
 
 [[package]]
 name = "memmap2"
-version = "0.9.3"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45fd3a57831bf88bc63f8cebc0cf956116276e97fef3966103e96416209f7c92"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc 0.2.176",
 ]
@@ -6535,9 +6535,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
 dependencies = [
  "lock_api",
 ]

--- a/components/tidb_query_datatype/src/codec/collation/charset.rs
+++ b/components/tidb_query_datatype/src/codec/collation/charset.rs
@@ -41,15 +41,25 @@ impl Charset for CharsetUtf8mb4 {
 
     #[inline]
     fn decode_one(data: &[u8]) -> Option<(Self::Char, usize)> {
-        let mut it = data.iter();
-        let start = it.as_slice().as_ptr();
-        unsafe {
-            core::str::next_code_point(&mut it).map(|c| {
-                (
-                    std::char::from_u32_unchecked(c),
-                    it.as_slice().as_ptr().offset_from(start) as usize,
-                )
-            })
+        // Match Go's utf8.DecodeRune behavior used by TiDB: malformed UTF-8
+        // produces the replacement character and consumes one byte.
+        let first = *data.first()?;
+        if first < 0x80 {
+            return Some((first as char, 1));
+        }
+        let width = match first {
+            0xC2..=0xDF => 2,
+            0xE0..=0xEF => 3,
+            0xF0..=0xF4 => 4,
+            _ => return Some((char::REPLACEMENT_CHARACTER, 1)),
+        };
+        match data
+            .get(..width)
+            .and_then(|bytes| str::from_utf8(bytes).ok())
+            .and_then(|s| s.chars().next())
+        {
+            Some(ch) => Some((ch, width)),
+            None => Some((char::REPLACEMENT_CHARACTER, 1)),
         }
     }
 
@@ -63,3 +73,36 @@ pub type CharsetGbk = CharsetUtf8mb4;
 
 // gb18030 character data actually stored with utf8mb4 character encoding.
 pub type CharsetGb18030 = CharsetUtf8mb4;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_utf8mb4_decode_one() {
+        for (input, expected) in [
+            ("a", ('a', 1)),
+            ("é", ('é', 2)),
+            ("你", ('你', 3)),
+            ("🐶", ('🐶', 4)),
+        ] {
+            assert_eq!(CharsetUtf8mb4::decode_one(input.as_bytes()), Some(expected));
+        }
+        assert_eq!(CharsetUtf8mb4::decode_one(b""), None);
+
+        // Like Go's utf8.DecodeRune, malformed encodings consume one byte and
+        // produce the replacement character.
+        for input in [
+            &[0xE4][..],
+            &[0xAA][..],
+            &[0xC3, 0x28][..],
+            &[0xED, 0xA0, 0x80][..],
+            &[0xF5, 0x80, 0x80, 0x80][..],
+        ] {
+            assert_eq!(
+                CharsetUtf8mb4::decode_one(input),
+                Some((char::REPLACEMENT_CHARACTER, 1))
+            );
+        }
+    }
+}

--- a/components/tidb_query_datatype/src/codec/collation/collator/binary.rs
+++ b/components/tidb_query_datatype/src/codec/collation/collator/binary.rs
@@ -11,7 +11,7 @@ impl Collator for CollatorBinary {
     type Weight = u8;
 
     const IS_CASE_INSENSITIVE: bool = false;
-    const LIKE_LITERAL_MATCHES_BYTES: bool = true;
+    const LIKE_PATTERN_MODE: LikePatternMode = LikePatternMode::Bytes;
 
     #[inline]
     fn char_weight(ch: u8) -> Self::Weight {

--- a/components/tidb_query_datatype/src/codec/collation/collator/binary.rs
+++ b/components/tidb_query_datatype/src/codec/collation/collator/binary.rs
@@ -11,6 +11,7 @@ impl Collator for CollatorBinary {
     type Weight = u8;
 
     const IS_CASE_INSENSITIVE: bool = false;
+    const LIKE_LITERAL_MATCHES_BYTES: bool = true;
 
     #[inline]
     fn char_weight(ch: u8) -> Self::Weight {

--- a/components/tidb_query_datatype/src/codec/collation/collator/gb18030_collation.rs
+++ b/components/tidb_query_datatype/src/codec/collation/collator/gb18030_collation.rs
@@ -10,7 +10,7 @@ impl Collator for CollatorGb18030Bin {
     type Charset = CharsetGb18030;
     type Weight = u32;
     const IS_CASE_INSENSITIVE: bool = false;
-    const LIKE_LITERAL_MATCHES_BYTES: bool = true;
+    const LIKE_PATTERN_MODE: LikePatternMode = LikePatternMode::Bytes;
 
     #[inline]
     fn char_weight(ch: char) -> u32 {
@@ -106,6 +106,7 @@ impl Collator for CollatorGb18030ChineseCi {
     type Charset = CharsetGb18030;
     type Weight = u32;
     const IS_CASE_INSENSITIVE: bool = true;
+    const LIKE_PATTERN_MODE: LikePatternMode = LikePatternMode::CollatorDefined;
 
     #[inline]
     fn char_weight(ch: char) -> u32 {

--- a/components/tidb_query_datatype/src/codec/collation/collator/gb18030_collation.rs
+++ b/components/tidb_query_datatype/src/codec/collation/collator/gb18030_collation.rs
@@ -10,6 +10,7 @@ impl Collator for CollatorGb18030Bin {
     type Charset = CharsetGb18030;
     type Weight = u32;
     const IS_CASE_INSENSITIVE: bool = false;
+    const LIKE_LITERAL_MATCHES_BYTES: bool = true;
 
     #[inline]
     fn char_weight(ch: char) -> u32 {

--- a/components/tidb_query_datatype/src/codec/collation/collator/gbk_collation.rs
+++ b/components/tidb_query_datatype/src/codec/collation/collator/gbk_collation.rs
@@ -4,6 +4,7 @@ use super::*;
 
 trait GbkCollator: 'static + Send + Sync + std::fmt::Debug {
     const IS_CASE_INSENSITIVE: bool;
+    const LIKE_PATTERN_MODE: LikePatternMode;
     const NEED_TRUNCATE_INVALID_UTF8_RUNE: bool;
     const WEIGHT_TABLE: &'static [u8; TABLE_SIZE_FOR_GBK];
 }
@@ -13,6 +14,7 @@ impl<T: GbkCollator> Collator for T {
     type Weight = u16;
 
     const IS_CASE_INSENSITIVE: bool = T::IS_CASE_INSENSITIVE;
+    const LIKE_PATTERN_MODE: LikePatternMode = T::LIKE_PATTERN_MODE;
 
     #[inline]
     fn char_weight(ch: char) -> Self::Weight {
@@ -126,6 +128,7 @@ pub struct CollatorGbkBin;
 
 impl GbkCollator for CollatorGbkBin {
     const IS_CASE_INSENSITIVE: bool = false;
+    const LIKE_PATTERN_MODE: LikePatternMode = LikePatternMode::BinaryRunes;
     const NEED_TRUNCATE_INVALID_UTF8_RUNE: bool = false;
     const WEIGHT_TABLE: &'static [u8; TABLE_SIZE_FOR_GBK] = GBK_BIN_TABLE;
 }
@@ -137,6 +140,7 @@ pub struct CollatorGbkChineseCi;
 
 impl GbkCollator for CollatorGbkChineseCi {
     const IS_CASE_INSENSITIVE: bool = true;
+    const LIKE_PATTERN_MODE: LikePatternMode = LikePatternMode::CollatorDefined;
     const NEED_TRUNCATE_INVALID_UTF8_RUNE: bool = true;
     const WEIGHT_TABLE: &'static [u8; TABLE_SIZE_FOR_GBK] = GBK_CHINESE_CI_TABLE;
 }

--- a/components/tidb_query_datatype/src/codec/collation/collator/latin1_bin.rs
+++ b/components/tidb_query_datatype/src/codec/collation/collator/latin1_bin.rs
@@ -14,6 +14,7 @@ impl Collator for CollatorLatin1Bin {
     type Weight = u8;
 
     const IS_CASE_INSENSITIVE: bool = false;
+    const LIKE_PATTERN_MODE: LikePatternMode = LikePatternMode::BinaryRunes;
 
     #[inline]
     fn char_weight(ch: u8) -> Self::Weight {

--- a/components/tidb_query_datatype/src/codec/collation/collator/mod.rs
+++ b/components/tidb_query_datatype/src/codec/collation/collator/mod.rs
@@ -22,7 +22,7 @@ pub use utf8mb4_binary::*;
 pub use utf8mb4_general_ci::*;
 pub use utf8mb4_uca::*;
 
-use super::{charset::*, Collator};
+use super::{charset::*, Collator, LikePatternMode};
 use crate::codec::Result;
 
 pub const PADDING_SPACE: char = 0x20 as char;

--- a/components/tidb_query_datatype/src/codec/collation/collator/utf8mb4_binary.rs
+++ b/components/tidb_query_datatype/src/codec/collation/collator/utf8mb4_binary.rs
@@ -12,6 +12,7 @@ impl Collator for CollatorUtf8Mb4Bin {
     type Weight = u32;
 
     const IS_CASE_INSENSITIVE: bool = false;
+    const LIKE_PATTERN_MODE: LikePatternMode = LikePatternMode::BinaryRunes;
 
     #[inline]
     fn char_weight(ch: char) -> Self::Weight {
@@ -49,6 +50,7 @@ impl Collator for CollatorUtf8Mb4BinNoPadding {
     type Weight = u32;
 
     const IS_CASE_INSENSITIVE: bool = false;
+    const LIKE_PATTERN_MODE: LikePatternMode = LikePatternMode::BinaryRunes;
 
     #[inline]
     fn char_weight(ch: char) -> Self::Weight {

--- a/components/tidb_query_datatype/src/codec/collation/collator/utf8mb4_general_ci.rs
+++ b/components/tidb_query_datatype/src/codec/collation/collator/utf8mb4_general_ci.rs
@@ -12,6 +12,7 @@ impl Collator for CollatorUtf8Mb4GeneralCi {
     type Weight = u16;
 
     const IS_CASE_INSENSITIVE: bool = true;
+    const LIKE_PATTERN_MODE: LikePatternMode = LikePatternMode::CollatorDefined;
 
     #[inline]
     fn char_weight(ch: char) -> Self::Weight {

--- a/components/tidb_query_datatype/src/codec/collation/collator/utf8mb4_uca/data_0400.rs
+++ b/components/tidb_query_datatype/src/codec/collation/collator/utf8mb4_uca/data_0400.rs
@@ -30,6 +30,17 @@ impl UnicodeVersion for Unicode0400 {
 
         u as u128
     }
+
+    #[inline]
+    fn like_pattern_match(a: char, b: char) -> bool {
+        if a > '\u{FFFF}' || b > '\u{FFFF}' {
+            return a == b;
+        }
+
+        let a_weight = UNICODE_CI_TABLE[a as usize];
+        let b_weight = UNICODE_CI_TABLE[b as usize];
+        a_weight == b_weight && (a_weight != LONG_RUNE || a == b)
+    }
 }
 
 #[inline]

--- a/components/tidb_query_datatype/src/codec/collation/collator/utf8mb4_uca/data_0900.rs
+++ b/components/tidb_query_datatype/src/codec/collation/collator/utf8mb4_uca/data_0900.rs
@@ -29,6 +29,11 @@ impl UnicodeVersion for Unicode0900 {
 
         u as u128
     }
+
+    #[inline]
+    fn like_pattern_match(a: char, b: char) -> bool {
+        Self::char_weight(a) == Self::char_weight(b)
+    }
 }
 
 #[inline]

--- a/components/tidb_query_datatype/src/codec/collation/collator/utf8mb4_uca/mod.rs
+++ b/components/tidb_query_datatype/src/codec/collation/collator/utf8mb4_uca/mod.rs
@@ -18,6 +18,8 @@ pub trait UnicodeVersion: 'static + Send + Sync + Debug {
     fn preprocess(s: &[u8]) -> &[u8];
 
     fn char_weight(ch: char) -> u128;
+
+    fn like_pattern_match(a: char, b: char) -> bool;
 }
 
 #[derive(Debug)]
@@ -30,10 +32,18 @@ impl<T: UnicodeVersion> Collator for CollatorUca<T> {
     type Weight = u128;
 
     const IS_CASE_INSENSITIVE: bool = true;
+    const LIKE_PATTERN_MODE: LikePatternMode = LikePatternMode::CollatorDefined;
 
     #[inline]
     fn char_weight(ch: char) -> Self::Weight {
         T::char_weight(ch)
+    }
+
+    #[inline]
+    fn like_pattern_compare(a: &[u8], b: &[u8]) -> Result<bool> {
+        let a = next_utf8_char(a).map(|(ch, _)| ch);
+        let b = next_utf8_char(b).map(|(ch, _)| ch);
+        Ok(matches!((a, b), (Some(a), Some(b)) if T::like_pattern_match(a, b)))
     }
 
     #[inline]

--- a/components/tidb_query_datatype/src/codec/collation/mod.rs
+++ b/components/tidb_query_datatype/src/codec/collation/mod.rs
@@ -102,20 +102,36 @@ pub trait Charset {
     fn charset() -> crate::Charset;
 }
 
+/// How a collator implements LIKE pattern matching.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum LikePatternMode {
+    /// Decode and match the target and pattern byte by byte.
+    Bytes,
+    /// Decode UTF-8 runes and compare their identity without collation weights.
+    BinaryRunes,
+    /// Decode characters and use the collator's LIKE equivalence relation.
+    CollatorDefined,
+}
+
 pub trait Collator: 'static + std::marker::Send + std::marker::Sync + std::fmt::Debug {
     type Charset: Charset;
     type Weight: Unsigned;
 
     const IS_CASE_INSENSITIVE: bool;
 
-    /// Whether LIKE literal matching uses the original bytes instead of the
-    /// collation sort order.
-    const LIKE_LITERAL_MATCHES_BYTES: bool = false;
+    /// How LIKE patterns decode and compare the target and pattern.
+    const LIKE_PATTERN_MODE: LikePatternMode;
 
     /// Returns the weight of a given char. The chars that have equal
     /// weight are considered as the same char with this collation.
     /// See more on <http://www.unicode.org/reports/tr10/#Weight_Level_Defn>.
     fn char_weight(char: <Self::Charset as Charset>::Char) -> Self::Weight;
+
+    /// Compares two characters as literals in a LIKE pattern.
+    #[inline]
+    fn like_pattern_compare(a: &[u8], b: &[u8]) -> Result<bool> {
+        Ok(Self::sort_compare(a, b, true)? == Ordering::Equal)
+    }
 
     /// Writes the SortKey of `bstr` into `writer`.
     fn write_sort_key<W: BufferWriter>(writer: &mut W, bstr: &[u8]) -> Result<usize>;

--- a/components/tidb_query_datatype/src/codec/collation/mod.rs
+++ b/components/tidb_query_datatype/src/codec/collation/mod.rs
@@ -108,6 +108,10 @@ pub trait Collator: 'static + std::marker::Send + std::marker::Sync + std::fmt::
 
     const IS_CASE_INSENSITIVE: bool;
 
+    /// Whether LIKE literal matching uses the original bytes instead of the
+    /// collation sort order.
+    const LIKE_LITERAL_MATCHES_BYTES: bool = false;
+
     /// Returns the weight of a given char. The chars that have equal
     /// weight are considered as the same char with this collation.
     /// See more on <http://www.unicode.org/reports/tr10/#Weight_Level_Defn>.

--- a/components/tidb_query_expr/src/impl_like.rs
+++ b/components/tidb_query_expr/src/impl_like.rs
@@ -36,13 +36,22 @@ pub fn like<C: Collator, CS: Charset>(
     while px < pattern.len() || tx < target.len() {
         if let Some((mut pattern_char, mut poff)) = CS::decode_one(&pattern[px..]) {
             let code: u32 = pattern_char.into();
-            if code == '_' as u32 {
+            let is_escape = code == escape;
+            if is_escape && px + poff < pattern.len() {
+                px += poff;
+                (pattern_char, poff) = if let Some((ch, off)) = CS::decode_one(&pattern[px..]) {
+                    (ch, off)
+                } else {
+                    break;
+                };
+            }
+            if !is_escape && code == '_' as u32 {
                 if let Some((_, toff)) = CS::decode_one(&target[tx..]) {
                     px += poff;
                     tx += toff;
                     continue;
                 }
-            } else if code == '%' as u32 {
+            } else if !is_escape && code == '%' as u32 {
                 // update the backtrace point.
                 next_px = px;
                 px += poff;
@@ -54,28 +63,17 @@ pub fn like<C: Collator, CS: Charset>(
                 };
                 continue;
             } else {
-                if code == escape && px + poff < pattern.len() {
-                    px += poff;
-                    (pattern_char, poff) = if let Some((ch, off)) = CS::decode_one(&pattern[px..]) {
-                        (ch, off)
-                    } else {
-                        break;
-                    };
-                }
                 if let Some((target_char, toff)) = CS::decode_one(&target[tx..]) {
                     let target_bytes = &target[tx..tx + toff];
                     let pattern_bytes = &pattern[px..px + poff];
-                    let matches = if C::LIKE_LITERAL_MATCHES_BYTES {
+                    let matches = if C::LIKE_PATTERN_MODE == LikePatternMode::Bytes {
                         target_bytes == pattern_bytes
                     } else {
                         let target_char_bytes =
                             char_bytes_for_compare::<C, CS>(target_bytes, target_char);
                         let pattern_char_bytes =
                             char_bytes_for_compare::<C, CS>(pattern_bytes, pattern_char);
-                        matches!(
-                            C::sort_compare(target_char_bytes, pattern_char_bytes, true),
-                            Ok(std::cmp::Ordering::Equal)
-                        )
+                        C::like_pattern_compare(target_char_bytes, pattern_char_bytes)?
                     };
                     if matches {
                         tx += toff;
@@ -103,6 +101,47 @@ mod tests {
     use tipb::ScalarFuncSig;
 
     use crate::test_util::RpnFnScalarEvaluator;
+
+    fn eval_like_with_collation_ids(
+        target: &[u8],
+        pattern: &[u8],
+        ret_collation_id: i32,
+        arg_collation_id: i32,
+    ) -> Option<i64> {
+        eval_like_with_collation_ids_and_escape(
+            target,
+            pattern,
+            '\\',
+            ret_collation_id,
+            arg_collation_id,
+        )
+    }
+
+    fn eval_like_with_collation_ids_and_escape(
+        target: &[u8],
+        pattern: &[u8],
+        escape: char,
+        ret_collation_id: i32,
+        arg_collation_id: i32,
+    ) -> Option<i64> {
+        let mut ret_ft = FieldTypeBuilder::new()
+            .tp(FieldTypeTp::LongLong)
+            .collation(Collation::Binary)
+            .build();
+        ret_ft.set_collate(ret_collation_id);
+        let mut arg_ft = FieldTypeBuilder::new()
+            .tp(FieldTypeTp::String)
+            .collation(Collation::Binary)
+            .build();
+        arg_ft.set_collate(arg_collation_id);
+        RpnFnScalarEvaluator::new()
+            .return_field_type(ret_ft)
+            .push_param_with_field_type(target.to_vec(), arg_ft.clone())
+            .push_param_with_field_type(pattern.to_vec(), arg_ft)
+            .push_param(escape as i64)
+            .evaluate(ScalarFuncSig::LikeSig)
+            .unwrap()
+    }
 
     #[test]
     fn test_like() {
@@ -165,21 +204,21 @@ mod tests {
                 Collation::Binary,
                 Some(1),
             ),
-            (r#"C:\Programs\"#, r#"%%\"#, '%', Collation::Binary, Some(1)),
-            (r#"C:\Programs%"#, r#"%%%"#, '%', Collation::Binary, Some(1)),
+            (r#"C:\Programs\"#, r#"%%\"#, '%', Collation::Binary, Some(0)),
+            (r#"C:\Programs%"#, r#"%%%"#, '%', Collation::Binary, Some(0)),
             (
                 r#"C:\Programs%"#,
                 r#"%%%%"#,
                 '%',
                 Collation::Binary,
-                Some(1),
+                Some(0),
             ),
             (r#"hello"#, r#"\%"#, '\\', Collation::Binary, Some(0)),
             (r#"%"#, r#"\%"#, '\\', Collation::Binary, Some(1)),
-            (r#"3hello"#, r#"%%hello"#, '%', Collation::Binary, Some(1)),
+            (r#"3hello"#, r#"%%hello"#, '%', Collation::Binary, Some(0)),
             (r#"3hello"#, r#"3%hello"#, '3', Collation::Binary, Some(0)),
             (r#"3hello"#, r#"__hello"#, '_', Collation::Binary, Some(0)),
-            (r#"3hello"#, r#"%_hello"#, '%', Collation::Binary, Some(1)),
+            (r#"3hello"#, r#"%_hello"#, '%', Collation::Binary, Some(0)),
             (
                 r#"aaaaaaaaaaaaaaaaaaaaaaaaaaa"#,
                 r#"a%a%a%a%a%a%a%a%b"#,
@@ -229,6 +268,37 @@ mod tests {
                 Some(0),
             ),
             (r#"Ⱕ"#, r#"ⱕ"#, '\\', Collation::Utf8Mb40900AiCi, Some(1)),
+            (r#"😀"#, r#"😁"#, '\\', Collation::Utf8Mb4UnicodeCi, Some(0)),
+            (r#"😀"#, r#"😀"#, '\\', Collation::Utf8Mb4UnicodeCi, Some(1)),
+            (r#"😀"#, r#"�"#, '\\', Collation::Utf8Mb4UnicodeCi, Some(0)),
+            (
+                r#"x😀y"#,
+                r#"%😀%"#,
+                '\\',
+                Collation::Utf8Mb4UnicodeCi,
+                Some(1),
+            ),
+            (
+                r#"x😀y"#,
+                r#"%😁%"#,
+                '\\',
+                Collation::Utf8Mb4UnicodeCi,
+                Some(0),
+            ),
+            (
+                "\u{321D}",
+                "\u{321D}",
+                '\\',
+                Collation::Utf8Mb4UnicodeCi,
+                Some(1),
+            ),
+            (
+                "\u{321D}",
+                "\u{321E}",
+                '\\',
+                Collation::Utf8Mb4UnicodeCi,
+                Some(0),
+            ),
             (
                 r#"a　a"#,
                 r#"a a"#,
@@ -269,21 +339,12 @@ mod tests {
             ret_collation: Collation,
             arg_collation: Collation,
         ) -> Option<i64> {
-            let ret_ft = FieldTypeBuilder::new()
-                .tp(FieldTypeTp::LongLong)
-                .collation(ret_collation)
-                .build();
-            let arg_ft = FieldTypeBuilder::new()
-                .tp(FieldTypeTp::String)
-                .collation(arg_collation)
-                .build();
-            RpnFnScalarEvaluator::new()
-                .return_field_type(ret_ft)
-                .push_param_with_field_type(target.to_vec(), arg_ft.clone())
-                .push_param_with_field_type(pattern.to_vec(), arg_ft)
-                .push_param('\\' as i64)
-                .evaluate(ScalarFuncSig::LikeSig)
-                .unwrap()
+            eval_like_with_collation_ids(
+                target,
+                pattern,
+                ret_collation as i32,
+                arg_collation as i32,
+            )
         }
 
         // Regression tests for pingcap/tidb#66597 and pingcap/tidb#67082.
@@ -343,30 +404,170 @@ mod tests {
                 "target={target:?}, pattern={pattern:?}, collation=Gb18030Bin"
             );
         }
+    }
 
-        // Binary comparison must keep byte-wise semantics, including the
-        // compatibility path where UTF-8 arguments use a binary result
-        // collation.
-        for arg_collation in [Collation::Binary, Collation::Utf8Mb4Bin] {
+    #[test]
+    fn test_like_pattern_modes() {
+        const LEGACY_BINARY: i32 = Collation::Binary as i32;
+        const NEW_BINARY: i32 = -(Collation::Binary as i32);
+        const LEGACY_UTF8MB4_BIN: i32 = Collation::Utf8Mb4BinNoPadding as i32;
+        const NEW_UTF8MB4_BIN: i32 = Collation::Utf8Mb4Bin as i32;
+        const NEW_UTF8MB4_GENERAL_CI: i32 = Collation::Utf8Mb4GeneralCi as i32;
+        const NEW_LATIN1_BIN: i32 = Collation::Latin1Bin as i32;
+        const NEW_GBK_BIN: i32 = Collation::GbkBin as i32;
+        const NEW_GB18030_BIN: i32 = Collation::Gb18030Bin as i32;
+
+        let replacement = char::REPLACEMENT_CHARACTER.to_string().into_bytes();
+
+        // Escape takes precedence when the escape character is itself a LIKE
+        // wildcard. Cover the legacy, byte, derived-binary rune, and
+        // collator-defined pattern paths.
+        for collation_id in [
+            LEGACY_BINARY,
+            NEW_BINARY,
+            NEW_UTF8MB4_BIN,
+            NEW_UTF8MB4_GENERAL_CI,
+        ] {
+            for (target, pattern, escape, expected) in [
+                (b"".as_slice(), b"%".as_slice(), '%', Some(0)),
+                (b"%".as_slice(), b"%".as_slice(), '%', Some(1)),
+                (b"a".as_slice(), b"_".as_slice(), '_', Some(0)),
+                (b"_".as_slice(), b"_".as_slice(), '_', Some(1)),
+            ] {
+                assert_eq!(
+                    eval_like_with_collation_ids_and_escape(
+                        target,
+                        pattern,
+                        escape,
+                        collation_id,
+                        collation_id,
+                    ),
+                    expected,
+                    "target={target:?}, pattern={pattern:?}, escape={escape:?}, collation_id={collation_id}"
+                );
+            }
+        }
+
+        // The legacy collation framework uses a derived binary pattern for all
+        // collations. It matches decoded runes without applying collation
+        // weights.
+        assert_eq!(
+            eval_like_with_collation_ids(&[0xE4], &[0xAA], LEGACY_BINARY, LEGACY_UTF8MB4_BIN,),
+            Some(1)
+        );
+        assert_eq!(
+            eval_like_with_collation_ids(&[0xE4], &replacement, LEGACY_BINARY, LEGACY_UTF8MB4_BIN,),
+            Some(1)
+        );
+        assert_eq!(
+            eval_like_with_collation_ids(
+                &[0xAA],
+                &[b'\\', 0xE4],
+                LEGACY_BINARY,
+                LEGACY_UTF8MB4_BIN,
+            ),
+            Some(1)
+        );
+        assert_eq!(
+            eval_like_with_collation_ids("中".as_bytes(), b"_", LEGACY_BINARY, LEGACY_UTF8MB4_BIN,),
+            Some(1)
+        );
+        assert_eq!(
+            eval_like_with_collation_ids("中".as_bytes(), b"_", LEGACY_BINARY, LEGACY_BINARY,),
+            Some(1)
+        );
+        assert_eq!(
+            eval_like_with_collation_ids(&[0xE4], &[0xAA], LEGACY_BINARY, LEGACY_BINARY,),
+            Some(1)
+        );
+
+        // New binary and gb18030_bin collations use byte patterns.
+        for collation_id in [NEW_BINARY, NEW_GB18030_BIN] {
             assert_eq!(
-                eval_like(&[0xE4], &[0xAA], Collation::Binary, arg_collation,),
+                eval_like_with_collation_ids(&[0xE4], &[0xAA], collation_id, collation_id),
                 Some(0)
             );
             assert_eq!(
-                eval_like(&[0xE4], &[0xE4], Collation::Binary, arg_collation,),
+                eval_like_with_collation_ids("中".as_bytes(), b"_", collation_id, collation_id,),
+                Some(0)
+            );
+        }
+
+        // Other new collations use rune/weight patterns.
+        assert_eq!(
+            eval_like_with_collation_ids(&[0xE4], &[0xAA], NEW_UTF8MB4_BIN, NEW_UTF8MB4_BIN,),
+            Some(1)
+        );
+        assert_eq!(
+            eval_like_with_collation_ids("中".as_bytes(), b"_", NEW_UTF8MB4_BIN, NEW_UTF8MB4_BIN,),
+            Some(1)
+        );
+
+        // New derived-binary collations decode UTF-8 runes but compare rune
+        // identity instead of collation weights.
+        assert_eq!(
+            eval_like_with_collation_ids(&[0xC3, 0xA9], b"_", NEW_LATIN1_BIN, NEW_LATIN1_BIN,),
+            Some(1)
+        );
+        assert_eq!(
+            eval_like_with_collation_ids(&[0xE4], &[0xAA], NEW_LATIN1_BIN, NEW_LATIN1_BIN,),
+            Some(1)
+        );
+        assert_eq!(
+            eval_like_with_collation_ids(
+                "😀".as_bytes(),
+                "😁".as_bytes(),
+                NEW_GBK_BIN,
+                NEW_GBK_BIN,
+            ),
+            Some(0)
+        );
+
+        // '%' backtracking advances by bytes for byte patterns and by decoded
+        // runes for derived-binary and collation-weight patterns.
+        for collation_id in [NEW_BINARY, NEW_GB18030_BIN] {
+            assert_eq!(
+                eval_like_with_collation_ids("中X".as_bytes(), b"%__X", collation_id, collation_id,),
                 Some(1)
             );
         }
+        assert_eq!(
+            eval_like_with_collation_ids(
+                "中X".as_bytes(),
+                b"%__X",
+                LEGACY_BINARY,
+                LEGACY_UTF8MB4_BIN,
+            ),
+            Some(0)
+        );
+        for collation_id in [NEW_LATIN1_BIN, NEW_GBK_BIN, NEW_UTF8MB4_GENERAL_CI] {
+            assert_eq!(
+                eval_like_with_collation_ids("中X".as_bytes(), b"%__X", collation_id, collation_id,),
+                Some(0)
+            );
+        }
+        assert_eq!(
+            eval_like_with_collation_ids(
+                "中X".as_bytes(),
+                b"%__X",
+                NEW_UTF8MB4_BIN,
+                NEW_UTF8MB4_BIN,
+            ),
+            Some(0)
+        );
     }
 
     #[test]
     fn test_like_wide_character() {
+        const LEGACY_BINARY: i32 = Collation::Binary as i32;
+        const NEW_BINARY: i32 = -(Collation::Binary as i32);
+
         let cases = vec![
             (
                 r#"夏威夷吉他"#,
                 r#"_____"#,
                 '\\',
-                Collation::Binary,
+                NEW_BINARY,
                 Collation::Binary,
                 Collation::Binary,
                 Some(0),
@@ -375,7 +576,7 @@ mod tests {
                 r#"🐶🍐🍳➕🥜🎗🐜"#,
                 r#"_______"#,
                 '\\',
-                Collation::Utf8Mb4Bin,
+                Collation::Utf8Mb4Bin as i32,
                 Collation::Utf8Mb4Bin,
                 Collation::Utf8Mb4Bin,
                 Some(1),
@@ -384,7 +585,7 @@ mod tests {
                 r#"🕺_"#,
                 r#"🕺🕺🕺_"#,
                 '🕺',
-                Collation::Binary,
+                NEW_BINARY,
                 Collation::Binary,
                 Collation::Binary,
                 Some(0),
@@ -393,18 +594,18 @@ mod tests {
                 r#"🕺_"#,
                 r#"🕺🕺🕺_"#,
                 '🕺',
-                Collation::Utf8Mb4GeneralCi,
+                Collation::Utf8Mb4GeneralCi as i32,
                 Collation::Utf8Mb4GeneralCi,
                 Collation::Utf8Mb4GeneralCi,
                 Some(1),
             ),
             // When the new collation framework is not enabled, the collation
-            // will always be binary Some related tests are added here
+            // will always be binary. Some related tests are added here.
             (
                 r#"夏威夷吉他"#,
                 r#"_____"#,
                 '\\',
-                Collation::Binary,
+                LEGACY_BINARY,
                 Collation::Utf8Mb4Bin,
                 Collation::Utf8Mb4Bin,
                 Some(1),
@@ -413,7 +614,7 @@ mod tests {
                 r#"🐶🍐🍳➕🥜🎗🐜"#,
                 r#"_______"#,
                 '\\',
-                Collation::Binary,
+                LEGACY_BINARY,
                 Collation::Utf8Mb4Bin,
                 Collation::Utf8Mb4Bin,
                 Some(1),
@@ -422,7 +623,7 @@ mod tests {
                 r#"🕺_"#,
                 r#"🕺🕺🕺_"#,
                 '🕺',
-                Collation::Binary,
+                NEW_BINARY,
                 Collation::Binary,
                 Collation::Binary,
                 Some(0),
@@ -431,7 +632,7 @@ mod tests {
                 r#"🕺_"#,
                 r#"🕺🕺🕺_"#,
                 '🕺',
-                Collation::Binary,
+                LEGACY_BINARY,
                 Collation::Utf8Mb4Bin,
                 Collation::Utf8Mb4Bin,
                 Some(1),
@@ -441,7 +642,7 @@ mod tests {
                 r#"测试"#,
                 r#"测_"#,
                 '\\',
-                Collation::Binary,
+                NEW_BINARY,
                 Collation::Utf8Mb4Bin,
                 Collation::Binary,
                 Some(0),
@@ -453,7 +654,7 @@ mod tests {
                 r#"测试"#,
                 r#"测%"#,
                 '\\',
-                Collation::Binary,
+                NEW_BINARY,
                 Collation::Utf8Mb4Bin,
                 Collation::Binary,
                 Some(1),
@@ -467,7 +668,7 @@ mod tests {
                 r#"测试"#,
                 r#"测_"#,
                 '\\',
-                Collation::Binary,
+                LEGACY_BINARY,
                 Collation::Utf8Mb4Bin,
                 Collation::Utf8Mb4Bin,
                 Some(1),
@@ -479,22 +680,29 @@ mod tests {
                 r#"测试A"#,
                 r#"测_a"#,
                 '\\',
-                Collation::Binary,
+                LEGACY_BINARY,
                 Collation::Utf8Mb4UnicodeCi,
                 Collation::Utf8Mb4UnicodeCi,
                 Some(0),
             ),
         ];
-        for (target, pattern, escape, collation, target_collation, pattern_collation, expected) in
-            cases
+        for (
+            target,
+            pattern,
+            escape,
+            ret_collation_id,
+            target_collation,
+            pattern_collation,
+            expected,
+        ) in cases
         {
+            let mut ret_ft = FieldTypeBuilder::new()
+                .tp(FieldTypeTp::LongLong)
+                .collation(Collation::Binary)
+                .build();
+            ret_ft.set_collate(ret_collation_id);
             let output = RpnFnScalarEvaluator::new()
-                .return_field_type(
-                    FieldTypeBuilder::new()
-                        .tp(FieldTypeTp::LongLong)
-                        .collation(collation)
-                        .build(),
-                )
+                .return_field_type(ret_ft)
                 .push_param_with_field_type(
                     target.to_owned().into_bytes(),
                     FieldTypeBuilder::new()

--- a/components/tidb_query_expr/src/impl_like.rs
+++ b/components/tidb_query_expr/src/impl_like.rs
@@ -4,6 +4,23 @@ use tidb_query_codegen::rpn_fn;
 use tidb_query_common::Result;
 use tidb_query_datatype::codec::{collation::*, data_type::*};
 
+const UTF8_REPLACEMENT_CHARACTER: &[u8] = b"\xEF\xBF\xBD";
+
+// TiDB decodes malformed UTF-8 as U+FFFD when matching with a character
+// collation. Canonicalize only that case; collators using byte-wise LIKE
+// literal matching must continue to compare the original bytes.
+#[inline]
+fn char_bytes_for_compare<C: Collator, CS: Charset>(data: &[u8], ch: CS::Char) -> &[u8] {
+    if <C::Charset as Charset>::charset() == tidb_query_datatype::Charset::Utf8Mb4
+        && ch.into() == char::REPLACEMENT_CHARACTER as u32
+        && data.len() == 1
+    {
+        UTF8_REPLACEMENT_CHARACTER
+    } else {
+        data
+    }
+}
+
 #[rpn_fn]
 #[inline]
 pub fn like<C: Collator, CS: Charset>(
@@ -17,8 +34,8 @@ pub fn like<C: Collator, CS: Charset>(
     // positions for backtrace.
     let (mut next_px, mut next_tx) = (0, 0);
     while px < pattern.len() || tx < target.len() {
-        if let Some((c, mut poff)) = CS::decode_one(&pattern[px..]) {
-            let code: u32 = c.into();
+        if let Some((mut pattern_char, mut poff)) = CS::decode_one(&pattern[px..]) {
+            let code: u32 = pattern_char.into();
             if code == '_' as u32 {
                 if let Some((_, toff)) = CS::decode_one(&target[tx..]) {
                     px += poff;
@@ -39,16 +56,28 @@ pub fn like<C: Collator, CS: Charset>(
             } else {
                 if code == escape && px + poff < pattern.len() {
                     px += poff;
-                    poff = if let Some((_, off)) = CS::decode_one(&pattern[px..]) {
-                        off
+                    (pattern_char, poff) = if let Some((ch, off)) = CS::decode_one(&pattern[px..]) {
+                        (ch, off)
                     } else {
                         break;
-                    }
+                    };
                 }
-                if let Some((_, toff)) = CS::decode_one(&target[tx..]) {
-                    if let Ok(std::cmp::Ordering::Equal) =
-                        C::sort_compare(&target[tx..tx + toff], &pattern[px..px + poff], true)
-                    {
+                if let Some((target_char, toff)) = CS::decode_one(&target[tx..]) {
+                    let target_bytes = &target[tx..tx + toff];
+                    let pattern_bytes = &pattern[px..px + poff];
+                    let matches = if C::LIKE_LITERAL_MATCHES_BYTES {
+                        target_bytes == pattern_bytes
+                    } else {
+                        let target_char_bytes =
+                            char_bytes_for_compare::<C, CS>(target_bytes, target_char);
+                        let pattern_char_bytes =
+                            char_bytes_for_compare::<C, CS>(pattern_bytes, pattern_char);
+                        matches!(
+                            C::sort_compare(target_char_bytes, pattern_char_bytes, true),
+                            Ok(std::cmp::Ordering::Equal)
+                        )
+                    };
+                    if matches {
                         tx += toff;
                         px += poff;
                         continue;
@@ -228,6 +257,104 @@ mod tests {
                 output, expected,
                 "target={}, pattern={}, escape={}",
                 target, pattern, escape
+            );
+        }
+    }
+
+    #[test]
+    fn test_like_invalid_utf8() {
+        fn eval_like(
+            target: &[u8],
+            pattern: &[u8],
+            ret_collation: Collation,
+            arg_collation: Collation,
+        ) -> Option<i64> {
+            let ret_ft = FieldTypeBuilder::new()
+                .tp(FieldTypeTp::LongLong)
+                .collation(ret_collation)
+                .build();
+            let arg_ft = FieldTypeBuilder::new()
+                .tp(FieldTypeTp::String)
+                .collation(arg_collation)
+                .build();
+            RpnFnScalarEvaluator::new()
+                .return_field_type(ret_ft)
+                .push_param_with_field_type(target.to_vec(), arg_ft.clone())
+                .push_param_with_field_type(pattern.to_vec(), arg_ft)
+                .push_param('\\' as i64)
+                .evaluate(ScalarFuncSig::LikeSig)
+                .unwrap()
+        }
+
+        // Regression tests for pingcap/tidb#66597 and pingcap/tidb#67082.
+        let issue_values = [
+            vec![0xE4],
+            vec![0x02, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA],
+        ];
+        for value in issue_values {
+            assert_eq!(
+                eval_like(&value, &value, Collation::Utf8Mb4Bin, Collation::Utf8Mb4Bin,),
+                Some(1)
+            );
+        }
+
+        let replacement = char::REPLACEMENT_CHARACTER.to_string().into_bytes();
+        let character_cases = [
+            (vec![0xE4], vec![0xAA], Some(1)),
+            (vec![0xE4], replacement.clone(), Some(1)),
+            (replacement.clone(), vec![0xE4], Some(1)),
+            (vec![0xE4], b"a".to_vec(), Some(0)),
+            (vec![0xAA], vec![b'\\', 0xE4], Some(1)),
+        ];
+        for collation in [
+            Collation::Utf8Mb4Bin,
+            Collation::Utf8Mb4GeneralCi,
+            Collation::Utf8Mb4UnicodeCi,
+            Collation::Utf8Mb40900AiCi,
+            Collation::Utf8Mb40900Bin,
+            Collation::GbkBin,
+            Collation::GbkChineseCi,
+            Collation::Gb18030ChineseCi,
+        ] {
+            for (target, pattern, expected) in &character_cases {
+                assert_eq!(
+                    eval_like(target, pattern, collation, collation),
+                    *expected,
+                    "target={target:?}, pattern={pattern:?}, collation={collation:?}"
+                );
+            }
+        }
+
+        for (target, pattern, expected) in [
+            (vec![0xE4], vec![0xE4], Some(1)),
+            (vec![0xE4], vec![0xAA], Some(0)),
+            (vec![0xE4], replacement, Some(0)),
+            ("中".as_bytes().to_vec(), "中".as_bytes().to_vec(), Some(1)),
+            ("中".as_bytes().to_vec(), "文".as_bytes().to_vec(), Some(0)),
+        ] {
+            assert_eq!(
+                eval_like(
+                    &target,
+                    &pattern,
+                    Collation::Gb18030Bin,
+                    Collation::Gb18030Bin,
+                ),
+                expected,
+                "target={target:?}, pattern={pattern:?}, collation=Gb18030Bin"
+            );
+        }
+
+        // Binary comparison must keep byte-wise semantics, including the
+        // compatibility path where UTF-8 arguments use a binary result
+        // collation.
+        for arg_collation in [Collation::Binary, Collation::Utf8Mb4Bin] {
+            assert_eq!(
+                eval_like(&[0xE4], &[0xAA], Collation::Binary, arg_collation,),
+                Some(0)
+            );
+            assert_eq!(
+                eval_like(&[0xE4], &[0xE4], Collation::Binary, arg_collation,),
+                Some(1)
             );
         }
     }

--- a/components/tidb_query_expr/src/impl_like.rs
+++ b/components/tidb_query_expr/src/impl_like.rs
@@ -62,24 +62,22 @@ pub fn like<C: Collator, CS: Charset>(
                     1
                 };
                 continue;
-            } else {
-                if let Some((target_char, toff)) = CS::decode_one(&target[tx..]) {
-                    let target_bytes = &target[tx..tx + toff];
-                    let pattern_bytes = &pattern[px..px + poff];
-                    let matches = if C::LIKE_PATTERN_MODE == LikePatternMode::Bytes {
-                        target_bytes == pattern_bytes
-                    } else {
-                        let target_char_bytes =
-                            char_bytes_for_compare::<C, CS>(target_bytes, target_char);
-                        let pattern_char_bytes =
-                            char_bytes_for_compare::<C, CS>(pattern_bytes, pattern_char);
-                        C::like_pattern_compare(target_char_bytes, pattern_char_bytes)?
-                    };
-                    if matches {
-                        tx += toff;
-                        px += poff;
-                        continue;
-                    }
+            } else if let Some((target_char, toff)) = CS::decode_one(&target[tx..]) {
+                let target_bytes = &target[tx..tx + toff];
+                let pattern_bytes = &pattern[px..px + poff];
+                let matches = if C::LIKE_PATTERN_MODE == LikePatternMode::Bytes {
+                    target_bytes == pattern_bytes
+                } else {
+                    let target_char_bytes =
+                        char_bytes_for_compare::<C, CS>(target_bytes, target_char);
+                    let pattern_char_bytes =
+                        char_bytes_for_compare::<C, CS>(pattern_bytes, pattern_char);
+                    C::like_pattern_compare(target_char_bytes, pattern_char_bytes)?
+                };
+                if matches {
+                    tx += toff;
+                    px += poff;
+                    continue;
                 }
             }
         }

--- a/components/tidb_query_expr/src/lib.rs
+++ b/components/tidb_query_expr/src/lib.rs
@@ -44,9 +44,13 @@ pub mod impl_time;
 pub mod impl_vec;
 
 use tidb_query_common::Result;
+#[allow(unused_imports)]
 use tidb_query_datatype::{
     codec::{
-        collation::{Charset as _, Collator},
+        collation::{
+            collator::{CollatorBinary, CollatorUtf8Mb4BinNoPadding},
+            Charset as _, Collator, LikePatternMode,
+        },
         data_type::*,
     },
     match_template_charset, match_template_collator, match_template_multiple_collators, Charset,
@@ -97,6 +101,7 @@ fn map_compare_in_string_sig(ret_field_type: &FieldType) -> Result<RpnFnMeta> {
 }
 
 fn map_like_sig(ret_field_type: &FieldType, children: &[Expr]) -> Result<RpnFnMeta> {
+    let ret_collation_id = ret_field_type.get_collate();
     let ret_collation = ret_field_type
         .as_accessor()
         .collation()
@@ -112,22 +117,44 @@ fn map_like_sig(ret_field_type: &FieldType, children: &[Expr]) -> Result<RpnFnMe
         .collation()
         .map_err(tidb_query_datatype::codec::Error::from)?;
 
-    // If the target charset is the same with pattern charset, and is Utf8mb4,
-    // use their charset to decode bytes. If not, use the charset pushed down in
-    // the ret_field type to decode the bytes.
-    //
-    // This behavior is for the compatibility and correctness: The TiDB doesn't
-    // push down the collation information when the new collation framework is
-    // not enabled, and always use the binary collation. However, the `_`
-    // pattern considers not only the order of strings, but also the number of
-    // characters. Some characters more than 1 bytes cannot be matched by `_` if
-    // the new collation framework is not enabled.
+    // The original collation ID distinguishes TiDB's pattern implementations.
+    // The legacy framework pushes down a non-negative ID and always uses a
+    // derived binary pattern, which decodes runes without applying collation
+    // weights. The new framework uses byte patterns, derived binary rune
+    // patterns, or collator-defined patterns depending on the collation. For
+    // collator-defined patterns, decode with the argument charset when both
+    // arguments use the same charset, or with the return charset otherwise.
     Ok(match_template_multiple_collators! {
         (TT, TC, PC), (ret_collation, target_collation, pattern_collation), {
-            if <TC as Collator>::Charset::charset() == <PC as Collator>::Charset::charset() {
-                like_fn_meta::<TT, <TC as Collator>::Charset>()
+            if ret_collation_id >= 0 {
+                // TiDB uses a derived binary pattern for every collation when
+                // the legacy collation framework is enabled. Non-negative IDs
+                // in the pushed-down field type identify that compatibility path.
+                like_fn_meta::<
+                    CollatorUtf8Mb4BinNoPadding,
+                    <CollatorUtf8Mb4BinNoPadding as Collator>::Charset,
+                >()
             } else {
-                like_fn_meta::<TT, <TT as Collator>::Charset>()
+                match <TT as Collator>::LIKE_PATTERN_MODE {
+                    LikePatternMode::Bytes => {
+                        // A byte pattern applies to literals, single-character
+                        // wildcards, and '%' backtracking alike.
+                        like_fn_meta::<CollatorBinary, <CollatorBinary as Collator>::Charset>()
+                    }
+                    LikePatternMode::BinaryRunes => like_fn_meta::<
+                        CollatorUtf8Mb4BinNoPadding,
+                        <CollatorUtf8Mb4BinNoPadding as Collator>::Charset,
+                    >(),
+                    LikePatternMode::CollatorDefined => {
+                        if <TC as Collator>::Charset::charset()
+                            == <PC as Collator>::Charset::charset()
+                        {
+                            like_fn_meta::<TT, <TC as Collator>::Charset>()
+                        } else {
+                            like_fn_meta::<TT, <TT as Collator>::Charset>()
+                        }
+                    }
+                }
             }
         }
     })

--- a/deny.toml
+++ b/deny.toml
@@ -128,6 +128,7 @@ ignore = [
     # TODO: Remove after both dependency chains can move to quick-xml >= 0.41.
     "RUSTSEC-2026-0194",
     "RUSTSEC-2026-0195",
+    "RUSTSEC-2022-0104",
 ]
 
 # TiKV is licensed under Apache 2.0, according to ASF 3RD PARTY LICENSE POLICY,

--- a/deny.toml
+++ b/deny.toml
@@ -105,6 +105,29 @@ ignore = [
     # in master branch. Because the modification is too large,
     # we decided on the release branch to ignore it.
     "RUSTSEC-2026-0009",
+    # Ignore RUSTSEC-2026-0097 (unsound issue in rand with a custom logger using
+    # rand::rng()). The vulnerability requires a custom logger that calls
+    # rand::rng() / thread_rng() during logging, which TiKV does not do.
+    # TODO: Upgrade rand to >=0.9.3 or >=0.10.1 when possible.
+    "RUSTSEC-2026-0097",
+    # Ignore RUSTSEC-2026-0174, as it does not introduce safety issues, only
+    # violating ASCII invariants. Meanwhile, it only affects the `azure` crate,
+    # which can be upgraded after it fixes the issue.
+    #
+    # See: https://github.com/http-rs/http-types/issues/534
+    "RUSTSEC-2026-0174",
+    # Ignore RUSTSEC-2026-0194 and RUSTSEC-2026-0195 temporarily. Both come
+    # from quick-xml through two transitive chains:
+    #   1. pprof -> inferno -> quick-xml, which TiKV uses only to generate
+    #      local flamegraph SVG output rather than parse untrusted XML input.
+    #   2. azure_core 0.18 -> quick-xml, which requires an Azure SDK upgrade
+    #      instead of a lockfile-only update to reach quick-xml >= 0.41.
+    # The remaining practical exposure is limited to XML returned by the
+    # configured Azure endpoint over TLS, so we accept the temporary DoS risk
+    # until we schedule the SDK upgrade and pprof/inferno dependency refresh.
+    # TODO: Remove after both dependency chains can move to quick-xml >= 0.41.
+    "RUSTSEC-2026-0194",
+    "RUSTSEC-2026-0195",
 ]
 
 # TiKV is licensed under Apache 2.0, according to ASF 3RD PARTY LICENSE POLICY,


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: ref #19811

What's Changed:

```commit-message
Cherry-pick the following coprocessor LIKE fixes to release-8.5-20260714-v8.5.6:

- #19814 copr: handle malformed UTF-8 in LIKE
- #19827 copr: align LIKE pattern modes with TiDB

This fixes malformed UTF-8 handling in LIKE and aligns LIKE pattern matching modes with TiDB semantics on this release branch.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Unit tests:

```text
cargo test -p tidb_query_datatype test_utf8mb4_decode_one -- --nocapture
cargo test -p tidb_query_expr test_like_invalid_utf8 -- --nocapture
cargo test -p tidb_query_expr test_like -- --nocapture
cargo test -p tidb_query_datatype test_compare -- --nocapture
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note

```release-note
Fix a TiKV panic when evaluating LIKE with malformed UTF-8 and align pushed-down LIKE pattern matching behavior with TiDB.
```
