### PR TITLE
log-backup: allow tikv to flush empty metadata.

### DIFF
--- a/components/backup-stream/src/router.rs
+++ b/components/backup-stream/src/router.rs
@@ -1433,32 +1433,34 @@ impl StreamTaskHandler {
         flush_ts: TimeStamp,
     ) -> Result<Vec<String>> {
         let mut meta_files = vec![];
-        if !metadata_info.file_groups.is_empty() {
-            let mut min_begin_ts = u64::MAX;
-            for file_group in metadata_info.file_groups.as_slice() {
-                assert!(!file_group.data_files_info.is_empty());
-                for d in file_group.data_files_info.as_slice() {
-                    assert_ne!(d.min_begin_ts_in_default_cf, 0);
-                    min_begin_ts = min_begin_ts.min(d.min_begin_ts_in_default_cf)
-                }
+        let mut min_begin_ts = 0;
+        for file_group in metadata_info.file_groups.as_slice() {
+            assert!(!file_group.data_files_info.is_empty());
+            for d in file_group.data_files_info.as_slice() {
+                assert_ne!(d.min_begin_ts_in_default_cf, 0);
+                min_begin_ts = if min_begin_ts == 0 {
+                    d.min_begin_ts_in_default_cf
+                } else {
+                    min_begin_ts.min(d.min_begin_ts_in_default_cf)
+                };
             }
-            let meta_path = metadata_info.path_to_meta(min_begin_ts, flush_ts.into_inner());
-            let meta_buff = metadata_info.marshal_to()?;
-            let buflen = meta_buff.len();
-
-            self.storage
-                .write(
-                    &meta_path,
-                    UnpinReader(Box::new(Cursor::new(meta_buff))),
-                    buflen as _,
-                )
-                .await
-                .context(format_args!("flush meta {:?}", meta_path))?;
-            crate::metrics::UPLOAD_FILE_SIZE
-                .with_label_values(&["metadata"])
-                .inc_by(buflen as _);
-            meta_files.push(meta_path);
         }
+        let meta_path = metadata_info.path_to_meta(min_begin_ts, flush_ts.into_inner());
+        let meta_buff = metadata_info.marshal_to()?;
+        let buflen = meta_buff.len();
+
+        self.storage
+            .write(
+                &meta_path,
+                UnpinReader(Box::new(Cursor::new(meta_buff))),
+                buflen as _,
+            )
+            .await
+            .context(format_args!("flush meta {:?}", meta_path))?;
+        crate::metrics::UPLOAD_FILE_SIZE
+            .with_label_values(&["metadata"])
+            .inc_by(buflen as _);
+        meta_files.push(meta_path);
         Ok(meta_files)
     }
 
@@ -1799,7 +1801,14 @@ impl MetadataInfo {
     }
 
     fn make_flags(&self) -> u64 {
-        if self.has_meta_files { 0 } else { 1 }
+        let mut flags = 0;
+        if !self.has_meta_files {
+            flags |= utils::BACKUP_META_FLAG_NO_META_FILES;
+        }
+        if self.file_groups.is_empty() {
+            flags |= utils::BACKUP_META_FLAG_EMPTY;
+        }
+        flags
     }
 
     fn push(&mut self, file: DataFileGroup, is_meta: bool) {
@@ -2011,7 +2020,7 @@ mod tests {
     use external_storage::{BlobObject, ExternalData, NoopStorage};
     use futures::{AsyncReadExt, future::LocalBoxFuture, stream::LocalBoxStream};
     use kvproto::{
-        brpb::{CipherInfo, Noop, StorageBackend, StreamBackupTaskInfo},
+        brpb::{CipherInfo, StreamBackupTaskInfo},
         encryptionpb::EncryptionMethod,
     };
     use online_config::{ConfigManager, OnlineConfig};
@@ -2168,13 +2177,6 @@ mod tests {
             result.push(task);
         }
         result
-    }
-
-    fn create_noop_storage_backend() -> StorageBackend {
-        let nop = Noop::new();
-        let mut backend = StorageBackend::default();
-        backend.set_noop(nop);
-        backend
     }
 
     async fn task_handler(name: String) -> Result<(StreamBackupTaskInfo, PathBuf)> {
@@ -2553,6 +2555,7 @@ mod tests {
     async fn test_empty_resolved_ts() {
         let (tx, _rx) = dummy_scheduler();
         let tmp = std::env::temp_dir().join(format!("{}", uuid::Uuid::new_v4()));
+        let storage_dir = tempfile::tempdir().unwrap();
         let router = RouterInner::new(
             tx,
             Config {
@@ -2567,7 +2570,7 @@ mod tests {
         );
         let mut stream_task = StreamBackupTaskInfo::default();
         stream_task.set_name("nothing".to_string());
-        stream_task.set_storage(create_noop_storage_backend());
+        stream_task.set_storage(external_storage::make_local_backend(storage_dir.path()));
 
         router
             .register_task(
@@ -2592,6 +2595,25 @@ mod tests {
         };
         let rts = router.do_flush(cx).await.unwrap();
         assert_eq!(ts.into_inner(), rts);
+
+        let meta_file_paths = meta_file_names(storage_dir.path());
+        assert_eq!(meta_file_paths.len(), 1);
+        let meta_file_name = meta_file_paths[0]
+            .file_stem()
+            .and_then(OsStr::to_str)
+            .unwrap();
+        let parsed_meta_file_name = utils::parse_backupmeta_filename(meta_file_name).unwrap();
+        assert_eq!(
+            parsed_meta_file_name.flags,
+            Some(utils::BACKUP_META_FLAG_NO_META_FILES | utils::BACKUP_META_FLAG_EMPTY)
+        );
+
+        let metadata = read_and_parse_meta_files(meta_file_paths);
+        assert_eq!(metadata.len(), 1);
+        assert!(metadata[0].file_groups.is_empty());
+        assert_eq!(metadata[0].resolved_ts, ts.into_inner());
+        assert_eq!(metadata[0].store_id, 1);
+        assert!(log_file_names(storage_dir.path()).is_empty());
     }
 
     #[tokio::test]

--- a/components/backup-stream/src/utils.rs
+++ b/components/backup-stream/src/utils.rs
@@ -79,6 +79,10 @@ pub const BACKUP_META_MIN_BEGIN_TS_PREFIX: char = 'd';
 pub const BACKUP_META_MIN_TS_PREFIX: char = 'l';
 pub const BACKUP_META_MAX_TS_PREFIX: char = 'u';
 pub const BACKUP_META_FLAG_PREFIX: char = 'p';
+/// The backupmeta does not reference any TiKV meta CF log file.
+pub const BACKUP_META_FLAG_NO_META_FILES: u64 = 1;
+/// The backupmeta does not reference any log file.
+pub const BACKUP_META_FLAG_EMPTY: u64 = 1 << 1;
 
 #[derive(Debug, Clone, Copy)]
 pub struct ParsedBackupMetaFileName {

--- a/components/compact-log-backup/src/exec_hooks/observability.rs
+++ b/components/compact-log-backup/src/exec_hooks/observability.rs
@@ -6,7 +6,6 @@ use tokio::{io::AsyncWriteExt, signal::unix::SignalKind};
 
 use super::CollectStatistic;
 use crate::{
-    ErrorKind,
     errors::Result,
     execute::hooking::{
         AbortedCtx, AfterFinishCtx, BeforeStartCtx, CId, ExecHooks, SubcompactionFinishCtx,
@@ -86,12 +85,8 @@ impl ExecHooks for Observability {
     async fn after_execution_finished(&mut self, cx: AfterFinishCtx<'_>) -> Result<()> {
         if self.stats.load_meta_stat.meta_files_in == 0 {
             let url = storage_url(cx.storage);
-            if cx.this.cfg.shard.is_some() {
-                warn!("No meta files matched shard, skipping compaction."; "url" => %url);
-                return Ok(());
-            }
-            warn!("No meta files loaded, maybe wrong storage used?"; "url" => %url);
-            return Err(ErrorKind::Other(format!("Nothing loaded from {}", url)).into());
+            warn!("No non-empty meta files loaded, skipping compaction."; "url" => %url);
+            return Ok(());
         }
         info!("All compactions done.");
         Ok(())

--- a/components/compact-log-backup/src/statistic.rs
+++ b/components/compact-log-backup/src/statistic.rs
@@ -83,6 +83,8 @@ pub struct LoadMetaStatistic {
     /// The log files in this meta won't be calculated in
     /// `log_filtered_out_by_migration`.
     pub meta_filtered_out_by_migration: u64,
+    /// How many empty meta files are skipped by file name?
+    pub empty_meta_files_skipped: u64,
 }
 
 /// The statistic of loading data files for a subcompaction.

--- a/components/compact-log-backup/src/storage.rs
+++ b/components/compact-log-backup/src/storage.rs
@@ -211,12 +211,6 @@ fn intersects_ts_window(min_ts: u64, max_ts: u64, from_ts: u64, until_ts: u64) -
     max_ts >= from_ts && min_ts <= until_ts
 }
 
-fn store_id_for_sharding_from_path(path: &str) -> Result<u64> {
-    parse_backupmeta_path(path)
-        .map(|v| v.store_id)
-        .map_err(Error::from)
-}
-
 fn validate_store_id_for_sharding(
     meta_path: &str,
     meta_store_id: Option<u64>,
@@ -237,6 +231,7 @@ struct ParsedBackupMetaName {
     min_begin_ts_in_default_cf: u64,
     min_ts: u64,
     max_ts: u64,
+    is_empty: bool,
 }
 
 fn parse_backupmeta_path(path: &str) -> std::io::Result<ParsedBackupMetaName> {
@@ -266,6 +261,9 @@ fn parse_backupmeta_path(path: &str) -> std::io::Result<ParsedBackupMetaName> {
         min_begin_ts_in_default_cf: parsed.min_begin_ts,
         min_ts: parsed.min_ts,
         max_ts: parsed.max_ts,
+        is_empty: parsed
+            .flags
+            .is_some_and(|flags| flags & backup_stream::utils::BACKUP_META_FLAG_EMPTY != 0),
     })
 }
 
@@ -472,12 +470,22 @@ impl<'a> StreamMetaStorage<'a> {
                         self.stat.meta_filtered_out_by_migration += 1;
                         continue;
                     }
+                    let parsed_backupmeta = parse_backupmeta_path(&load.key);
+                    if parsed_backupmeta
+                        .as_ref()
+                        .map(|parsed| parsed.is_empty)
+                        .unwrap_or(false)
+                    {
+                        info!("Skipping an empty metadata."; "name" => %load.key);
+                        self.stat.empty_meta_files_skipped += 1;
+                        continue;
+                    }
                     let path_store_id = match self.ext.shard {
                         Some(shard) => {
-                            let store_id = match store_id_for_sharding_from_path(&load.key) {
-                                Ok(store_id) => store_id,
+                            let store_id = match parsed_backupmeta {
+                                Ok(parsed) => parsed.store_id,
                                 Err(err) => {
-                                    self.prefetch.push_back(Prefetch::ready(Err(err)));
+                                    self.prefetch.push_back(Prefetch::ready(Err(err.into())));
                                     cx.waker().wake_by_ref();
                                     return Poll::Pending;
                                 }
@@ -576,6 +584,9 @@ impl<'a> StreamMetaStorage<'a> {
             }
 
             let parsed = parse_backupmeta_path(&item.key)?;
+            if parsed.is_empty {
+                continue;
+            }
             if intersects_ts_window(parsed.min_ts, parsed.max_ts, ext.from_ts, ext.until_ts)
                 && parsed.min_begin_ts_in_default_cf > 0
             {
@@ -1135,6 +1146,43 @@ mod test {
     }
 
     #[tokio::test]
+    async fn test_load_from_ext_skips_empty_metadata_by_name() {
+        use external_storage::UnpinReader;
+        use futures::io::Cursor;
+
+        let st = TmpStorage::create();
+        let mfs = construct_storage(
+            &st,
+            |i| format!("v1/backupmeta/the-meta-{}.bin", i),
+            |i| format!("out/the-log-{}.bin", i),
+        )
+        .await;
+
+        let empty_meta = "v1/backupmeta/000000000000012C000000000000002A-d0000000000000000l0000000000000000u0000000000000000p0000000000000002.meta";
+        let invalid_content = b"not a protobuf metadata".to_vec();
+        st.storage()
+            .write(
+                empty_meta,
+                UnpinReader(Box::new(Cursor::new(invalid_content.clone()))),
+                invalid_content.len() as u64,
+            )
+            .await
+            .unwrap();
+
+        let storage = st.storage().clone() as Arc<dyn ExternalStorage>;
+        let mut sst = StreamMetaStorage::load_from_ext(&storage, Default::default())
+            .await
+            .unwrap();
+        let mut result = (&mut sst).try_collect::<Vec<_>>().await.unwrap();
+        result.sort_by(|a, b| a.name.cmp(&b.name));
+        assert_eq!(result, mfs);
+
+        let stat = sst.take_statistic();
+        assert_eq!(stat.meta_files_in, mfs.len() as u64);
+        assert_eq!(stat.empty_meta_files_skipped, 1);
+    }
+
+    #[tokio::test]
     async fn test_merge_meta_edits() {
         let meta_path = |i| format!("v1/backupmeta/00000000-{i}.meta");
         let file_path = |i| format!("v1/00000000/00000000-{i}.log");
@@ -1335,6 +1383,8 @@ mod test {
             "v1/backupmeta/000000000000012C0000000000000001-d0000000000000020l0000000000000064u00000000000000C8.meta",
             // in range, but min_begin_default is larger.
             "v1/backupmeta/000000000000012C0000000000000002-d0000000000000030l0000000000000040u00000000000000D0.meta",
+            // empty, should be counted but should not affect shift_ts.
+            "v1/backupmeta/000000000000012C0000000000000004-d0000000000000005l0000000000000040u00000000000000D0p0000000000000002.meta",
             // out of range (min_ts > until), should not affect shift_ts
             "v1/backupmeta/000000000000012C0000000000000003-d0000000000000010l0000000000000100u0000000000000120.meta",
         ];
@@ -1355,7 +1405,7 @@ mod test {
         )
         .await
         .unwrap();
-        assert_eq!(result.count, 3);
+        assert_eq!(result.count, 4);
         assert_eq!(result.shift_ts, 0x20);
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #19793

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
allow tikv to flush empty metadata.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added metadata flags to distinguish missing and empty backup metadata.
  * Empty metadata files are now identified and skipped during compaction processing.
  * Compaction statistics now report how many empty metadata files were skipped.

* **Bug Fixes**
  * Backup metadata is consistently generated, including when no data file groups exist.
  * Empty metadata no longer affects timestamp calculations or triggers compaction errors.
  * Added validation to prevent metadata from being associated with the wrong storage shard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->