### PR TITLE
cloud/aws: fix custom S3 endpoints with FIPS mode (#19841)  

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7436,9 +7436,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
 dependencies = [
  "lock_api",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,9 +120,9 @@ checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
 
 [[package]]
 name = "anyhow"
-version = "1.0.75"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "api_version"
@@ -1968,9 +1968,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/components/cloud/aws/src/s3.rs
+++ b/components/cloud/aws/src/s3.rs
@@ -874,8 +874,7 @@ impl IterableStorage for S3Storage {
 
 #[cfg(test)]
 mod tests {
-    use std::assert_matches::assert_matches;
-    use std::ffi::OsString;
+    use std::{assert_matches::assert_matches, ffi::OsString};
 
     use aws_sdk_s3::{config::Credentials, primitives::SdkBody};
     use aws_smithy_runtime::{

--- a/components/cloud/aws/src/s3.rs
+++ b/components/cloud/aws/src/s3.rs
@@ -230,9 +230,15 @@ impl S3Storage {
             }
 
             let credentials_provider: io::Result<AssumeRoleProvider> = block_on(async {
-                let sdk_config =
-                    Self::load_sdk_config(&config, util::new_http_client(), credentials_provider)
-                        .await?;
+                // Keep the shared config endpoint-free. It is reused to construct the
+                // STS client for AssumeRole, and the S3 bucket endpoint must not leak
+                // into that service-specific client.
+                let sdk_config = Self::load_base_sdk_config(
+                    &config,
+                    util::new_http_client(),
+                    credentials_provider,
+                )
+                .await?;
                 builder = builder.configure(&sdk_config);
                 Ok(builder.build().await)
             });
@@ -243,7 +249,7 @@ impl S3Storage {
         }
     }
 
-    async fn load_sdk_config<Http, Creds>(
+    async fn load_base_sdk_config<Http, Creds>(
         config: &Config,
         client: Http,
         creds: Creds,
@@ -252,15 +258,17 @@ impl S3Storage {
         Http: HttpClient + 'static,
         Creds: ProvideCredentials + 'static,
     {
+        // This shared config is reused by both S3 and AssumeRole(STS) setup, so it
+        // must only carry common AWS settings such as region, credentials, and HTTP
+        // client. Service-specific endpoint overrides are applied later on the final
+        // S3 builder only.
         let bucket_region = none_to_empty(config.bucket.region.clone());
-        let bucket_endpoint = none_to_empty(config.bucket.endpoint.clone());
 
         let mut loader = aws_config::defaults(BehaviorVersion::latest())
             .stalled_stream_protection(StalledStreamProtectionConfig::disabled())
             .credentials_provider(creds);
 
         loader = util::configure_region(loader, &bucket_region)?;
-        loader = util::configure_endpoint(loader, &bucket_endpoint);
         loader = loader.http_client(client);
         Ok(loader.load().await)
     }
@@ -290,9 +298,16 @@ impl S3Storage {
         Http: HttpClient + 'static,
         Creds: ProvideCredentials + 'static,
     {
-        let sdk_config = Self::load_sdk_config(&config, client, credentials_provider).await?;
+        let sdk_config = Self::load_base_sdk_config(&config, client, credentials_provider).await?;
 
         let mut builder = aws_sdk_s3::config::Builder::from(&sdk_config);
+        if let Some(endpoint) = &config.bucket.endpoint {
+            // Apply the bucket endpoint only to the final S3 client. A custom endpoint
+            // conflicts with SDK FIPS endpoint resolution, so deployments that require
+            // FIPS must provide a FIPS endpoint explicitly here.
+            builder.set_endpoint_url(Some(endpoint.to_string()));
+            builder.set_use_fips(Some(false));
+        }
         builder.set_force_path_style(Some(config.force_path_style));
 
         let client = Client::from_conf(builder.build());
@@ -860,6 +875,7 @@ impl IterableStorage for S3Storage {
 #[cfg(test)]
 mod tests {
     use std::assert_matches::assert_matches;
+    use std::ffi::OsString;
 
     use aws_sdk_s3::{config::Credentials, primitives::SdkBody};
     use aws_smithy_runtime::{
@@ -870,6 +886,35 @@ mod tests {
 
     use super::*;
 
+    // Serialize multipart-related tests because they assert deltas on the global
+    // metric CLOUD_REQUEST_HISTOGRAM_VEC, which is shared across tests.
+    static MULTI_PART_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+    static AWS_ENV_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+    const AWS_USE_FIPS_ENDPOINT: &str = "AWS_USE_FIPS_ENDPOINT";
+
+    struct ScopedEnvVar {
+        key: &'static str,
+        old: Option<OsString>,
+    }
+
+    impl ScopedEnvVar {
+        fn set(key: &'static str, value: &str) -> Self {
+            let old = std::env::var_os(key);
+            std::env::set_var(key, value);
+            Self { key, old }
+        }
+    }
+
+    impl Drop for ScopedEnvVar {
+        fn drop(&mut self) {
+            if let Some(old) = self.old.take() {
+                std::env::set_var(self.key, old);
+            } else {
+                std::env::remove_var(self.key);
+            }
+        }
+    }
     #[test]
     fn test_s3_get_content_md5() {
         // base64 encode md5sum "helloworld"
@@ -1260,6 +1305,70 @@ mod tests {
         .unwrap();
         fail::remove(s3_sleep_injected_fp);
         fail::remove(s3_timeout_injected_fp);
+
+        client.assert_requests_match(&[]);
+    }
+
+    #[tokio::test]
+    async fn test_load_base_sdk_config_keeps_endpoint_out_of_shared_config() {
+        let _guard = AWS_ENV_TEST_LOCK.lock().await;
+        let _env = ScopedEnvVar::set(AWS_USE_FIPS_ENDPOINT, "true");
+
+        let bucket_name = StringNonEmpty::required("mybucket".to_string()).unwrap();
+        let mut bucket = BucketConf::default(bucket_name);
+        bucket.region = StringNonEmpty::opt("us-east-1".to_string());
+        bucket.endpoint =
+            StringNonEmpty::opt("https://s3-fips.us-east-1.amazonaws.com".to_string());
+        let config = Config::default(bucket);
+        let creds = Credentials::from_keys("abc".to_string(), "xyz".to_string(), None);
+
+        let sdk_config =
+            S3Storage::load_base_sdk_config(&config, crate::util::new_http_client(), creds)
+                .await
+                .unwrap();
+
+        assert_eq!(sdk_config.endpoint_url(), None);
+        assert_eq!(sdk_config.use_fips(), Some(true));
+    }
+
+    #[tokio::test]
+    async fn test_s3_storage_custom_endpoint_with_fips_mode() {
+        let _guard = AWS_ENV_TEST_LOCK.lock().await;
+        let _env = ScopedEnvVar::set(AWS_USE_FIPS_ENDPOINT, "true");
+
+        let magic_contents = "5678";
+        let bucket_name = StringNonEmpty::required("mybucket".to_string()).unwrap();
+        let mut bucket = BucketConf::default(bucket_name);
+        bucket.region = StringNonEmpty::opt("us-east-1".to_string());
+        bucket.prefix = StringNonEmpty::opt("myprefix".to_string());
+        bucket.endpoint =
+            StringNonEmpty::opt("https://s3-fips.us-east-1.amazonaws.com".to_string());
+        let mut config = Config::default(bucket);
+        config.force_path_style = true;
+
+        let client = StaticReplayClient::new(vec![ReplayEvent::new(
+            http::Request::builder()
+                .method("PUT")
+                .uri(Uri::from_static(
+                    "https://s3-fips.us-east-1.amazonaws.com/mybucket/myprefix/mykey?x-id=PutObject",
+                ))
+                .body(SdkBody::from("5678"))
+                .unwrap(),
+            http::Response::builder()
+                .status(200)
+                .body(SdkBody::from(""))
+                .unwrap(),
+        )]);
+
+        let creds = Credentials::from_keys("abc".to_string(), "xyz".to_string(), None);
+        let s = S3Storage::new_with_creds_client(config.clone(), client.clone(), creds).unwrap();
+        s.put(
+            "mykey",
+            PutResource(Box::new(magic_contents.as_bytes())),
+            magic_contents.len() as u64,
+        )
+        .await
+        .unwrap();
 
         client.assert_requests_match(&[]);
     }

--- a/deny.toml
+++ b/deny.toml
@@ -123,6 +123,18 @@ ignore = [
     #
     # See: https://github.com/http-rs/http-types/issues/534
     "RUSTSEC-2026-0174",
+    # Ignore RUSTSEC-2026-0194 and RUSTSEC-2026-0195 temporarily. Both come
+    # from quick-xml through two transitive chains:
+    #   1. pprof -> inferno -> quick-xml, which TiKV uses only to generate
+    #      local flamegraph SVG output rather than parse untrusted XML input.
+    #   2. azure_core 0.18 -> quick-xml, which requires an Azure SDK upgrade
+    #      instead of a lockfile-only update to reach quick-xml >= 0.41.
+    # The remaining practical exposure is limited to XML returned by the
+    # configured Azure endpoint over TLS, so we accept the temporary DoS risk
+    # until we schedule the SDK upgrade and pprof/inferno dependency refresh.
+    # TODO: Remove after both dependency chains can move to quick-xml >= 0.41.
+    "RUSTSEC-2026-0194",
+    "RUSTSEC-2026-0195",
 ]
 
 # TiKV is licensed under Apache 2.0, according to ASF 3RD PARTY LICENSE POLICY,

--- a/tests/integrations/raftstore/test_conf_change.rs
+++ b/tests/integrations/raftstore/test_conf_change.rs
@@ -581,16 +581,7 @@ fn test_transfer_leader_safe() {
     }
 
     // Any up-to-date follower can become leader.
-    cluster.transfer_leader(region_id, new_peer(3, 3));
-    // Retry for more stability
-    for _ in 0..20 {
-        cluster.reset_leader_of_region(region_id);
-        if cluster.leader_of_region(region_id) != Some(new_peer(3, 3)) {
-            continue;
-        }
-        break;
-    }
-    assert_eq!(cluster.leader_of_region(region_id).unwrap().get_id(), 3);
+    cluster.must_transfer_leader(region_id, new_peer(3, 3));
     let leader_id = 3;
 
     // Cannot transfer when removed peer


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

This is a manual cherry-pick of #19841

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: ref https://github.com/tikv/tikv/issues/19743, ref https://github.com/pingcap/tidb/issues/68966

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Fix the AWS SDK conflict between `AWS_USE_FIPS_ENDPOINT=true` and an explicit
S3 backend endpoint.

The previous implementation placed `bucket.endpoint` into the shared AWS
`SdkConfig`. That shared config is reused by both the final S3 client and
`AssumeRole` setup, so the S3-specific endpoint could leak into the STS client.
With FIPS enabled, this can trigger the AWS SDK error that custom endpoints
cannot be combined with FIPS.

This change keeps the shared AWS config endpoint-free and applies
`bucket.endpoint` only on the final S3 client builder. When an explicit S3
endpoint is present, the S3 builder disables SDK FIPS endpoint resolution and
uses the provided endpoint directly. This keeps shared env/profile settings
intact while scoping the custom endpoint override to S3 only.

Also add regression tests to verify that:
- the shared base `SdkConfig` does not retain the S3 bucket endpoint while still
  inheriting `AWS_USE_FIPS_ENDPOINT=true`
- S3 requests succeed with `AWS_USE_FIPS_ENDPOINT=true` and an explicit
  FIPS-style S3 endpoint
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!--
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Fix backup and restore requests that use explicit S3 endpoints when
`AWS_USE_FIPS_ENDPOINT` is enabled.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AWS role-assumption and shared client configuration to prevent custom endpoint settings from interfering with STS/AssumeRole.
  * Updated S3 client behavior to correctly apply custom bucket endpoints while avoiding conflicts with FIPS settings.
  * Ensured uploads target the intended custom S3 endpoint.

* **Tests**
  * Expanded integration coverage for endpoint/FIPS interactions and refined leader-transfer behavior in raftstore tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
