### PR TITLE
raftstore: harden load split sampling

### DIFF
--- a/components/raftstore/src/store/worker/split_config.rs
+++ b/components/raftstore/src/store/worker/split_config.rs
@@ -1,6 +1,6 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::sync::Arc;
+use std::{convert::TryFrom, sync::Arc};
 
 use lazy_static::lazy_static;
 use online_config::{ConfigChange, ConfigManager, OnlineConfig};
@@ -14,6 +14,16 @@ use tikv_util::{
 const DEFAULT_DETECT_TIMES: u64 = 10;
 const DEFAULT_SAMPLE_THRESHOLD: u64 = 100;
 pub(crate) const DEFAULT_SAMPLE_NUM: usize = 20;
+// Item-count limits, not global byte limits. Key payloads, spare Vec capacity,
+// producer threads, and active Regions add memory beyond these counts.
+// 1024 leaves more than 50x tuning room over the default per-round reservoir.
+const MAX_SAMPLE_NUM: usize = 1024;
+// 4096 leaves more than 20x tuning room over the default 20 * 10 history while
+// bounding both a Region's retained sample items and split-key selection work.
+// `Recorder::collect` can compare up to 2 * sample_num candidate keys with
+// sample_num * detect_times retained ranges. Benchmark before raising either
+// limit.
+const MAX_RECORDED_SAMPLES_PER_REGION: usize = 4096;
 pub const DEFAULT_QPS_THRESHOLD: usize = 3000;
 pub const DEFAULT_BIG_REGION_QPS_THRESHOLD: usize = 7000;
 pub const DEFAULT_BYTE_THRESHOLD: usize = 30 * 1024 * 1024;
@@ -115,6 +125,35 @@ impl Default for SplitConfig {
 
 impl SplitConfig {
     pub fn validate(&self) -> std::result::Result<(), Box<dyn std::error::Error>> {
+        if !(1..=MAX_SAMPLE_NUM).contains(&self.sample_num) {
+            return Err(format!(
+                "sample_num should be between 1 and {} for load-base-split.",
+                MAX_SAMPLE_NUM
+            )
+            .into());
+        }
+        if self.detect_times == 0 {
+            return Err("detect_times must be greater than 0 for load-base-split.".into());
+        }
+        let recorded_sample_num = usize::try_from(self.detect_times)
+            .ok()
+            .and_then(|detect_times| self.sample_num.checked_mul(detect_times));
+        let recorded_sample_num = match recorded_sample_num {
+            Some(sample_num) if sample_num <= MAX_RECORDED_SAMPLES_PER_REGION => sample_num,
+            _ => {
+                return Err(format!(
+                    "sample_num * detect_times should not exceed {} for load-base-split.",
+                    MAX_RECORDED_SAMPLES_PER_REGION
+                )
+                .into());
+            }
+        };
+        if self.sample_threshold > recorded_sample_num as u64 {
+            return Err(
+                "sample_threshold should not exceed sample_num * detect_times for load-base-split."
+                    .into(),
+            );
+        }
         if self.split_balance_score > 1.0
             || self.split_balance_score < 0.0
             || self.split_contained_score > 1.0
@@ -208,8 +247,18 @@ impl ConfigManager for SplitConfigManager {
     ) -> std::result::Result<(), Box<dyn std::error::Error>> {
         {
             let change = change.clone();
-            self.0
-                .update(move |cfg: &mut SplitConfig| cfg.update(change))?;
+            self.0.update(
+                move |cfg: &mut SplitConfig| -> std::result::Result<_, Box<dyn std::error::Error>> {
+                    // ConfigController validates before acquiring its commit lock, so
+                    // another update can make that snapshot stale. Validate the combined
+                    // value while holding VersionTrack's write lock.
+                    let mut candidate = cfg.clone();
+                    candidate.update(change)?;
+                    candidate.validate()?;
+                    *cfg = candidate;
+                    Ok(())
+                },
+            )?;
         }
         info!(
             "load base split config changed";
@@ -236,7 +285,10 @@ mod tests {
 
     use crate::store::{
         SplitConfig, SplitConfigManager,
-        worker::split_config::{DEFAULT_SAMPLE_NUM, get_sample_num},
+        worker::split_config::{
+            DEFAULT_DETECT_TIMES, DEFAULT_SAMPLE_NUM, MAX_RECORDED_SAMPLES_PER_REGION,
+            MAX_SAMPLE_NUM, get_sample_num,
+        },
     };
 
     #[test]
@@ -254,5 +306,64 @@ mod tests {
         cfg_manager.dispatch(config_change).unwrap();
 
         assert_eq!(get_sample_num(), 50);
+    }
+
+    #[test]
+    fn test_validate_sampling_memory_budget() {
+        let mut config = SplitConfig {
+            qps_threshold: Some(usize::MAX),
+            ..Default::default()
+        };
+
+        config.sample_num = 0;
+        assert!(config.validate().is_err());
+
+        config.sample_num = MAX_SAMPLE_NUM + 1;
+        assert!(config.validate().is_err());
+
+        config.sample_num = MAX_SAMPLE_NUM;
+        config.detect_times = (MAX_RECORDED_SAMPLES_PER_REGION / MAX_SAMPLE_NUM) as u64;
+        config.validate().unwrap();
+
+        config.detect_times += 1;
+        assert!(config.validate().is_err());
+
+        config.sample_num = 1;
+        config.detect_times = 0;
+        assert!(config.validate().is_err());
+
+        config.detect_times = u64::MAX;
+        assert!(config.validate().is_err());
+
+        config.sample_num = DEFAULT_SAMPLE_NUM;
+        config.detect_times = DEFAULT_DETECT_TIMES;
+        config.sample_threshold = (DEFAULT_SAMPLE_NUM as u64) * DEFAULT_DETECT_TIMES;
+        config.validate().unwrap();
+
+        config.sample_threshold += 1;
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn test_online_update_validates_current_sampling_budget() {
+        let config = Arc::new(VersionTrack::new(SplitConfig::default()));
+        // Avoid changing the process-wide producer sampling configuration in this
+        // manager-only test.
+        let mut cfg_manager = SplitConfigManager(config);
+
+        // Each value is valid with the defaults, but their combination exceeds
+        // the retained-sample budget.
+        let mut config_change = ConfigChange::new();
+        config_change.insert(String::from("sample_num"), ConfigValue::Usize(300));
+        cfg_manager.dispatch(config_change).unwrap();
+        let before_rejected_update = cfg_manager.value().clone();
+
+        let mut config_change = ConfigChange::new();
+        config_change.insert(String::from("detect_times"), ConfigValue::U64(14));
+        let err = cfg_manager.dispatch(config_change).unwrap_err().to_string();
+        assert!(err.contains("sample_num * detect_times should not exceed"));
+
+        let current = cfg_manager.value();
+        assert_eq!(&*current, &before_rejected_update);
     }
 }

--- a/components/raftstore/src/store/worker/split_config.rs
+++ b/components/raftstore/src/store/worker/split_config.rs
@@ -135,12 +135,12 @@ impl SplitConfig {
             )
             .into());
         }
-        let max_recorded_samples = u128::from(self.sample_num)
+        let max_recorded_samples = (self.sample_num as u128)
             .checked_mul(u128::from(self.detect_times))
             .ok_or_else(|| {
                 "sample_num * detect_times overflowed for load-base-split.".to_owned()
             })?;
-        if max_recorded_samples > u128::from(MAX_RECORDED_SAMPLES_PER_REGION) {
+        if max_recorded_samples > MAX_RECORDED_SAMPLES_PER_REGION as u128 {
             return Err(format!(
                 "sample_num * detect_times should not exceed {} for load-base-split.",
                 MAX_RECORDED_SAMPLES_PER_REGION
@@ -363,8 +363,10 @@ mod tests {
         let err = cfg_manager.dispatch(config_change).unwrap_err().to_string();
         assert!(err.contains("sample_num should be less than qps_threshold"));
 
-        let current = cfg_manager.value();
-        assert_eq!(&*current, &before_rejected_update);
+        {
+            let current = cfg_manager.value();
+            assert_eq!(&*current, &before_rejected_update);
+        }
 
         // Zero disables the QPS gate and must not reject every positive sample
         // size.

--- a/components/raftstore/src/store/worker/split_config.rs
+++ b/components/raftstore/src/store/worker/split_config.rs
@@ -383,7 +383,7 @@ mod tests {
             sample_threshold: 4,
             ..Default::default()
         };
-        let mut cfg_manager = SplitConfigManager::new(Arc::new(VersionTrack::new(config)));
+        let mut cfg_manager = SplitConfigManager(Arc::new(VersionTrack::new(config)));
         let before_rejected_update = cfg_manager.value().clone();
 
         let mut config_change = ConfigChange::new();

--- a/components/raftstore/src/store/worker/split_config.rs
+++ b/components/raftstore/src/store/worker/split_config.rs
@@ -1,6 +1,6 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::{convert::TryFrom, sync::Arc};
+use std::sync::Arc;
 
 use lazy_static::lazy_static;
 use online_config::{ConfigChange, ConfigManager, OnlineConfig};
@@ -14,16 +14,12 @@ use tikv_util::{
 const DEFAULT_DETECT_TIMES: u64 = 10;
 const DEFAULT_SAMPLE_THRESHOLD: u64 = 100;
 pub(crate) const DEFAULT_SAMPLE_NUM: usize = 20;
-// Item-count limits, not global byte limits. Key payloads, spare Vec capacity,
-// producer threads, and active Regions add memory beyond these counts.
-// 1024 leaves more than 50x tuning room over the default per-round reservoir.
-const MAX_SAMPLE_NUM: usize = 1024;
-// 4096 leaves more than 20x tuning room over the default 20 * 10 history while
-// bounding both a Region's retained sample items and split-key selection work.
-// `Recorder::collect` can compare up to 2 * sample_num candidate keys with
-// sample_num * detect_times retained ranges. Benchmark before raising either
-// limit.
-const MAX_RECORDED_SAMPLES_PER_REGION: usize = 4096;
+// Keep sampling work close to the defaults. These are item-count limits, not
+// global byte limits: key payloads, producer threads, active Regions, and
+// spare Vec capacity add memory beyond the retained ranges.
+const MAX_SAMPLE_NUM: usize = 64;
+const MAX_DETECT_TIMES: u64 = 20;
+const MAX_RECORDED_SAMPLES_PER_REGION: usize = MAX_SAMPLE_NUM * MAX_DETECT_TIMES as usize;
 pub const DEFAULT_QPS_THRESHOLD: usize = 3000;
 pub const DEFAULT_BIG_REGION_QPS_THRESHOLD: usize = 7000;
 pub const DEFAULT_BYTE_THRESHOLD: usize = 30 * 1024 * 1024;
@@ -132,23 +128,26 @@ impl SplitConfig {
             )
             .into());
         }
-        if self.detect_times == 0 {
-            return Err("detect_times must be greater than 0 for load-base-split.".into());
+        if !(1..=MAX_DETECT_TIMES).contains(&self.detect_times) {
+            return Err(format!(
+                "detect_times should be between 1 and {} for load-base-split.",
+                MAX_DETECT_TIMES
+            )
+            .into());
         }
-        let recorded_sample_num = usize::try_from(self.detect_times)
-            .ok()
-            .and_then(|detect_times| self.sample_num.checked_mul(detect_times));
-        let recorded_sample_num = match recorded_sample_num {
-            Some(sample_num) if sample_num <= MAX_RECORDED_SAMPLES_PER_REGION => sample_num,
-            _ => {
-                return Err(format!(
-                    "sample_num * detect_times should not exceed {} for load-base-split.",
-                    MAX_RECORDED_SAMPLES_PER_REGION
-                )
-                .into());
-            }
-        };
-        if self.sample_threshold > recorded_sample_num as u64 {
+        let max_recorded_samples = u128::from(self.sample_num)
+            .checked_mul(u128::from(self.detect_times))
+            .ok_or_else(|| {
+                "sample_num * detect_times overflowed for load-base-split.".to_owned()
+            })?;
+        if max_recorded_samples > u128::from(MAX_RECORDED_SAMPLES_PER_REGION) {
+            return Err(format!(
+                "sample_num * detect_times should not exceed {} for load-base-split.",
+                MAX_RECORDED_SAMPLES_PER_REGION
+            )
+            .into());
+        }
+        if u128::from(self.sample_threshold) > max_recorded_samples {
             return Err(
                 "sample_threshold should not exceed sample_num * detect_times for load-base-split."
                     .into(),
@@ -163,7 +162,7 @@ impl SplitConfig {
                 ("split_balance_score or split_contained_score should be between 0 and 1.").into(),
             );
         }
-        if self.sample_num >= self.qps_threshold() {
+        if self.qps_threshold() > 0 && self.sample_num >= self.qps_threshold() {
             return Err(
                 ("sample_num should be less than qps_threshold for load-base-split.").into(),
             );
@@ -309,7 +308,7 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_sampling_memory_budget() {
+    fn test_validate_sampling_limits() {
         let mut config = SplitConfig {
             qps_threshold: Some(usize::MAX),
             ..Default::default()
@@ -322,6 +321,9 @@ mod tests {
         assert!(config.validate().is_err());
 
         config.sample_num = MAX_SAMPLE_NUM;
+        config.detect_times = 0;
+        assert!(config.validate().is_err());
+
         config.detect_times = (MAX_RECORDED_SAMPLES_PER_REGION / MAX_SAMPLE_NUM) as u64;
         config.validate().unwrap();
 
@@ -329,41 +331,65 @@ mod tests {
         assert!(config.validate().is_err());
 
         config.sample_num = 1;
-        config.detect_times = 0;
+        config.detect_times = u64::MAX;
         assert!(config.validate().is_err());
 
-        config.detect_times = u64::MAX;
+        config.sample_num = MAX_SAMPLE_NUM;
+        config.detect_times = (MAX_RECORDED_SAMPLES_PER_REGION / MAX_SAMPLE_NUM) as u64;
+        config.sample_threshold = MAX_RECORDED_SAMPLES_PER_REGION as u64;
+        config.validate().unwrap();
+
+        config.sample_threshold += 1;
         assert!(config.validate().is_err());
 
         config.sample_num = DEFAULT_SAMPLE_NUM;
         config.detect_times = DEFAULT_DETECT_TIMES;
         config.sample_threshold = (DEFAULT_SAMPLE_NUM as u64) * DEFAULT_DETECT_TIMES;
         config.validate().unwrap();
-
-        config.sample_threshold += 1;
-        assert!(config.validate().is_err());
     }
 
     #[test]
-    fn test_online_update_validates_current_sampling_budget() {
+    fn test_online_update_validates_combined_sampling_config() {
         let config = Arc::new(VersionTrack::new(SplitConfig::default()));
-        // Avoid changing the process-wide producer sampling configuration in this
-        // manager-only test.
         let mut cfg_manager = SplitConfigManager(config);
 
-        // Each value is valid with the defaults, but their combination exceeds
-        // the retained-sample budget.
         let mut config_change = ConfigChange::new();
-        config_change.insert(String::from("sample_num"), ConfigValue::Usize(300));
+        config_change.insert(String::from("sample_num"), ConfigValue::Usize(10));
         cfg_manager.dispatch(config_change).unwrap();
         let before_rejected_update = cfg_manager.value().clone();
 
         let mut config_change = ConfigChange::new();
-        config_change.insert(String::from("detect_times"), ConfigValue::U64(14));
+        config_change.insert(String::from("qps_threshold"), ConfigValue::Usize(10));
         let err = cfg_manager.dispatch(config_change).unwrap_err().to_string();
-        assert!(err.contains("sample_num * detect_times should not exceed"));
+        assert!(err.contains("sample_num should be less than qps_threshold"));
 
         let current = cfg_manager.value();
         assert_eq!(&*current, &before_rejected_update);
+
+        // Zero disables the QPS gate and must not reject every positive sample
+        // size.
+        let mut config_change = ConfigChange::new();
+        config_change.insert(String::from("qps_threshold"), ConfigValue::Usize(0));
+        cfg_manager.dispatch(config_change).unwrap();
+        assert_eq!(cfg_manager.value().qps_threshold(), 0);
+    }
+
+    #[test]
+    fn test_online_update_rejects_threshold_above_retained_window() {
+        let config = SplitConfig {
+            qps_threshold: Some(100),
+            sample_num: 2,
+            detect_times: 2,
+            sample_threshold: 4,
+            ..Default::default()
+        };
+        let mut cfg_manager = SplitConfigManager::new(Arc::new(VersionTrack::new(config)));
+        let before_rejected_update = cfg_manager.value().clone();
+
+        let mut config_change = ConfigChange::new();
+        config_change.insert(String::from("sample_threshold"), ConfigValue::U64(5));
+        let err = cfg_manager.dispatch(config_change).unwrap_err().to_string();
+        assert!(err.contains("sample_threshold should not exceed"));
+        assert_eq!(&*cfg_manager.value(), &before_rejected_update);
     }
 }

--- a/components/raftstore/src/store/worker/split_controller.rs
+++ b/components/raftstore/src/store/worker/split_controller.rs
@@ -2,7 +2,7 @@
 
 use std::{
     cmp::{Ordering, min},
-    collections::{BinaryHeap, HashSet},
+    collections::{BinaryHeap, HashSet, VecDeque},
     slice::{Iter, IterMut},
     sync::{Arc, mpsc::Receiver},
     time::{Duration, SystemTime},
@@ -34,7 +34,7 @@ use crate::store::{
     util::build_key_range,
     worker::{
         FlowStatistics, SplitConfig, SplitConfigManager, SplitValidator,
-        split_config::get_sample_num,
+        split_config::{DEFAULT_SAMPLE_NUM, get_sample_num},
     },
 };
 
@@ -269,27 +269,50 @@ impl Samples {
 // sample and split them according to the split config appropriately.
 pub struct Recorder {
     pub detect_times: usize,
+    sample_num: usize,
     pub peer: Peer,
-    pub key_ranges: Vec<Vec<KeyRange>>,
+    // Advancing a full observation window should not shift all retained rounds.
+    // Every retained round uses this recorder's detect_times and sample_num.
+    pub key_ranges: VecDeque<Vec<KeyRange>>,
     pub create_time: SystemTime,
     pub cpu_usage: f64,
     pub hottest_key_range: Option<KeyRange>,
 }
 
 impl Recorder {
-    fn new(detect_times: u64) -> Recorder {
+    fn new(detect_times: u64, sample_num: usize) -> Recorder {
         Recorder {
             detect_times: detect_times as usize,
+            sample_num,
             peer: Peer::default(),
-            key_ranges: vec![],
+            key_ranges: VecDeque::new(),
             create_time: SystemTime::now(),
             cpu_usage: 0.0,
             hottest_key_range: None,
         }
     }
 
-    fn record(&mut self, key_ranges: Vec<KeyRange>) {
-        self.key_ranges.push(key_ranges);
+    fn record(&mut self, mut key_ranges: Vec<KeyRange>, detect_times: u64, sample_num: usize) {
+        let detect_times = detect_times as usize;
+        // Mixing rounds sampled under different parameters biases the retained
+        // history. Start a new observation window after either parameter changes.
+        if self.detect_times != detect_times || self.sample_num != sample_num {
+            self.detect_times = detect_times;
+            self.sample_num = sample_num;
+            self.key_ranges.clear();
+            self.create_time = SystemTime::now();
+        }
+        if self.detect_times == 0 || sample_num == 0 {
+            self.key_ranges.clear();
+            return;
+        }
+        // Production callers already sample this round with the current
+        // sample_num. Retain a defensive bound for direct and future callers.
+        key_ranges.truncate(sample_num);
+        while self.key_ranges.len() >= self.detect_times {
+            let _ = self.key_ranges.pop_front();
+        }
+        self.key_ranges.push_back(key_ranges);
     }
 
     fn update_peer(&mut self, peer: &Peer) {
@@ -307,7 +330,7 @@ impl Recorder {
     }
 
     fn is_ready(&self) -> bool {
-        self.key_ranges.len() >= self.detect_times
+        self.detect_times > 0 && self.key_ranges.len() >= self.detect_times
     }
 
     // collect the split keys from the recorded key_ranges.
@@ -315,7 +338,8 @@ impl Recorder {
     // evaluate the samples according to the given key range, and compute the split
     // keys finally.
     fn collect(&self, config: &SplitConfig) -> Vec<u8> {
-        let sampled_key_ranges = sample(config.sample_num, self.key_ranges.clone(), |x| x);
+        let recorded_rounds: Vec<_> = self.key_ranges.iter().cloned().collect();
+        let sampled_key_ranges = sample(config.sample_num, recorded_rounds, |x| x);
         let mut samples = Samples::from(sampled_key_ranges);
         let recorded_key_ranges: Vec<&KeyRange> = self.key_ranges.iter().flatten().collect();
         // Because we need to observe the number of `no_enough_key` of all the actual
@@ -351,7 +375,10 @@ impl RegionInfo {
             sample_num,
             query_stats: QueryStats::default(),
             cop_detail: RegionWriteCfCopDetail::default(),
-            key_ranges: Vec::with_capacity(sample_num),
+            // Most Regions only see a few requests in one reporting window. Let
+            // larger reservoirs grow with observations instead of eagerly
+            // reserving the full capacity for every active Region.
+            key_ranges: Vec::with_capacity(sample_num.min(DEFAULT_SAMPLE_NUM)),
             peer: Peer::default(),
             flow: FlowStatistics::default(),
         }
@@ -366,12 +393,18 @@ impl RegionInfo {
     }
 
     fn add_key_ranges(&mut self, key_ranges: Vec<KeyRange>) {
+        self.add_key_ranges_with_rng(key_ranges, &mut rand::thread_rng());
+    }
+
+    fn add_key_ranges_with_rng<R: Rng + ?Sized>(&mut self, key_ranges: Vec<KeyRange>, rng: &mut R) {
         for (i, key_range) in key_ranges.into_iter().enumerate() {
             let n = self.get_read_qps() + i;
-            if n == 0 || self.key_ranges.len() < self.sample_num {
+            if self.key_ranges.len() < self.sample_num {
                 self.key_ranges.push(key_range);
             } else {
-                let j = rand::thread_rng().gen_range(0..n);
+                // This is the (n + 1)th observation, so it must be selected with
+                // probability sample_num / (n + 1).
+                let j = rng.gen_range(0..=n);
                 if j < self.sample_num {
                     self.key_ranges[j] = key_range;
                 }
@@ -666,12 +699,11 @@ impl AutoSplitController {
         let read_stats_vec = ctx.batch_recv_read_stats(read_stats_receiver);
         // RegionID -> Vec<RegionInfo>, collect the RegionInfo from different threads.
         let mut region_infos_map = HashMap::default();
-        let capacity = read_stats_vec.len();
         for read_stats in read_stats_vec.drain(..) {
             for (region_id, region_info) in read_stats.region_infos {
                 let region_infos = region_infos_map
                     .entry(region_id)
-                    .or_insert_with(|| Vec::with_capacity(capacity));
+                    .or_insert_with(|| Vec::with_capacity(1));
                 region_infos.push(region_info);
             }
         }
@@ -852,7 +884,7 @@ impl AutoSplitController {
             let recorder = self
                 .recorders
                 .entry(region_id)
-                .or_insert_with(|| Recorder::new(detect_times));
+                .or_insert_with(|| Recorder::new(detect_times, self.cfg.sample_num));
             recorder.update_peer(&region_infos[0].peer);
             recorder.update_cpu_usage(cpu_usage);
             if let Some(hottest_key_range) = hottest_key_range {
@@ -868,7 +900,7 @@ impl AutoSplitController {
                 LOAD_BASE_SPLIT_EVENT.empty_statistical_key.inc();
                 continue;
             }
-            recorder.record(key_ranges);
+            recorder.record(key_ranges, detect_times, self.cfg.sample_num);
             if recorder.is_ready() {
                 let key = recorder.collect(&self.cfg);
                 if !key.is_empty() {
@@ -1069,6 +1101,7 @@ mod tests {
     use std::sync::mpsc::{self, TryRecvError};
 
     use online_config::{ConfigChange, ConfigManager, ConfigValue};
+    use rand::rngs::mock::StepRng;
     use resource_metering::{RawRecord, TagInfos};
     use tikv_util::config::{ReadableSize, VersionTrack};
     use txn_types::Key;
@@ -1168,17 +1201,96 @@ mod tests {
         config.detect_times = 10;
         config.sample_threshold = 20;
 
-        let mut recorder = Recorder::new(config.detect_times);
+        let mut recorder = Recorder::new(config.detect_times, config.sample_num);
         for _ in 0..config.detect_times {
             assert!(!recorder.is_ready());
-            recorder.record(vec![
-                build_key_range(b"a", b"b", false),
-                build_key_range(b"b", b"c", false),
-            ]);
+            recorder.record(
+                vec![
+                    build_key_range(b"a", b"b", false),
+                    build_key_range(b"b", b"c", false),
+                ],
+                config.detect_times,
+                config.sample_num,
+            );
         }
         assert!(recorder.is_ready());
         let key = recorder.collect(&config);
         assert_eq!(key, b"b");
+    }
+
+    #[test]
+    fn test_recorder_failed_collection_keeps_latest_bounded_window() {
+        let config = SplitConfig {
+            detect_times: 3,
+            sample_num: 2,
+            sample_threshold: 6,
+            split_balance_score: 0.0,
+            ..Default::default()
+        };
+        let mut recorder = Recorder::new(config.detect_times, config.sample_num);
+
+        for round in 0..6_u8 {
+            let ranges = (0..3_u8)
+                .map(|sample| build_key_range(&[round, sample], &[round, sample], false))
+                .collect();
+            recorder.record(ranges, config.detect_times, config.sample_num);
+
+            assert!(recorder.key_ranges.len() <= config.detect_times as usize);
+            assert!(
+                recorder.key_ranges.iter().map(Vec::len).sum::<usize>()
+                    <= config.sample_num * config.detect_times as usize
+            );
+            if round + 1 >= config.detect_times as u8 {
+                assert!(recorder.is_ready());
+                assert!(recorder.collect(&config).is_empty());
+            }
+        }
+
+        let retained_rounds: Vec<_> = recorder
+            .key_ranges
+            .iter()
+            .map(|ranges| ranges[0].start_key[0])
+            .collect();
+        assert_eq!(retained_rounds, vec![3, 4, 5]);
+        assert!(
+            recorder
+                .key_ranges
+                .iter()
+                .all(|ranges| ranges.len() == config.sample_num)
+        );
+    }
+
+    #[test]
+    fn test_recorder_resets_window_on_sampling_config_change() {
+        let mut recorder = Recorder::new(3, 4);
+        for round in 0..2_u8 {
+            let ranges = (0..4_u8)
+                .map(|sample| build_key_range(&[round, sample], &[round, sample], false))
+                .collect();
+            recorder.record(ranges, 3, 4);
+        }
+        recorder.create_time = SystemTime::UNIX_EPOCH;
+
+        let ranges = (0..3_u8)
+            .map(|sample| build_key_range(&[2, sample], &[2, sample], false))
+            .collect();
+        recorder.record(ranges, 3, 1);
+
+        assert_eq!(recorder.detect_times, 3);
+        assert_eq!(recorder.sample_num, 1);
+        assert_eq!(recorder.key_ranges.len(), 1);
+        assert_eq!(recorder.key_ranges[0][0].start_key, vec![2, 0]);
+        assert!(recorder.key_ranges.iter().all(|ranges| ranges.len() == 1));
+        assert_ne!(recorder.create_time, SystemTime::UNIX_EPOCH);
+        assert!(!recorder.is_ready());
+
+        let ranges = vec![build_key_range(&[3, 0], &[3, 0], false)];
+        recorder.record(ranges, 2, 1);
+
+        assert_eq!(recorder.detect_times, 2);
+        assert_eq!(recorder.key_ranges.len(), 1);
+        assert_eq!(recorder.key_ranges[0][0].start_key, vec![3, 0]);
+        assert!(!recorder.is_ready());
     }
 
     #[test]
@@ -1339,6 +1451,24 @@ mod tests {
             read_stats_receiver,
             cpu_stats_receiver,
         )
+    }
+
+    #[test]
+    fn test_collect_read_stats_uses_sparse_region_capacity() {
+        const REPORT_COUNT: usize = 128;
+
+        let read_stats = (1..=REPORT_COUNT)
+            .map(|region_id| gen_read_stats(region_id as u64, vec![KeyRange::default()]))
+            .collect();
+        let (mut ctx, read_stats_receiver, _) = new_auto_split_controller_ctx(read_stats, vec![]);
+
+        let region_infos = AutoSplitController::collect_read_stats(&mut ctx, &read_stats_receiver);
+
+        assert_eq!(region_infos.len(), REPORT_COUNT);
+        for infos in region_infos.values() {
+            assert_eq!(infos.len(), 1);
+            assert!(infos.capacity() < REPORT_COUNT);
+        }
     }
 
     fn check_split_key(mode: &[u8], qps_stats: Vec<ReadStats>, split_keys: Vec<&[u8]>) {
@@ -1771,6 +1901,38 @@ mod tests {
             .filter(|key_range| key_range.start_key == b"b")
             .count();
         assert!(num >= r.sample_num - 1);
+    }
+
+    #[test]
+    fn test_region_info_reservoir_replacement_boundary() {
+        let first = build_key_range(b"first", b"first", false);
+        let second = build_key_range(b"second", b"second", false);
+
+        let mut region_info = RegionInfo::new(1);
+        let mut rng = StepRng::new(0, 0);
+        region_info.add_key_ranges_with_rng(vec![first.clone(), second.clone()], &mut rng);
+        assert_eq!(region_info.key_ranges, vec![second.clone()]);
+
+        let mut region_info = RegionInfo::new(1);
+        let mut rng = StepRng::new(0x8000_0000_8000_0000, 0);
+        region_info.add_key_ranges_with_rng(vec![first.clone(), second], &mut rng);
+        assert_eq!(region_info.key_ranges, vec![first]);
+    }
+
+    #[test]
+    fn test_region_info_zero_sample_reservoir_stays_empty() {
+        let mut region_info = RegionInfo::new(0);
+        region_info.add_key_ranges(vec![build_key_range(b"a", b"b", false)]);
+
+        assert!(region_info.key_ranges.is_empty());
+    }
+
+    #[test]
+    fn test_region_info_limits_initial_reservoir_allocation() {
+        let region_info = RegionInfo::new(usize::MAX);
+
+        assert_eq!(region_info.sample_num, usize::MAX);
+        assert_eq!(region_info.key_ranges.capacity(), DEFAULT_SAMPLE_NUM);
     }
 
     const REGION_NUM: u64 = 1000;

--- a/components/raftstore/src/store/worker/split_controller.rs
+++ b/components/raftstore/src/store/worker/split_controller.rs
@@ -47,7 +47,7 @@ fn prefix_sum<F, T>(iter: Iter<'_, T>, read: F) -> Vec<usize>
 where
     F: Fn(&T) -> usize,
 {
-    let mut sum = 0;
+    let mut sum: usize = 0;
     iter.map(|item| {
         sum = sum.saturating_add(read(item));
         sum
@@ -940,12 +940,12 @@ impl AutoSplitController {
                 .with_label_values(&["read"])
                 .observe(qps as f64);
 
-            // 1. If the QPS or the byte does not meet the threshold, skip.
-            // 2. If the Unified Read Pool or the region is not hot enough, skip.
-            if qps < self.cfg.qps_threshold()
-                && byte < self.cfg.byte_threshold()
-                && (!is_unified_read_pool_busy || !is_region_busy)
-            {
+            // Load fit if QPS or bytes meet a positive threshold, or both the
+            // unified-read pool and the region are hot. A threshold of 0
+            // disables that gate instead of making every Region load-fit.
+            let qps_exceeded = self.cfg.qps_threshold() > 0 && qps >= self.cfg.qps_threshold();
+            let byte_exceeded = self.cfg.byte_threshold() > 0 && byte >= self.cfg.byte_threshold();
+            if !qps_exceeded && !byte_exceeded && (!is_unified_read_pool_busy || !is_region_busy) {
                 self.recorders.remove_entry(&region_id);
                 self.cpu_top_fallback_suppressions.remove(&region_id);
                 continue;
@@ -1576,6 +1576,45 @@ mod tests {
         }
     }
 
+    #[test]
+    fn test_zero_threshold_disables_only_that_load_fit_gate() {
+        let mut hub = AutoSplitController::default();
+        hub.cfg.qps_threshold = Some(0);
+        hub.cfg.byte_threshold = Some(50);
+
+        let mut cold_stats = gen_read_stats(1, vec![build_key_range(b"a", b"b", false)]);
+        cold_stats.region_infos.get_mut(&1).unwrap().flow.read_bytes = 1;
+        let (mut ctx, read_stats_receiver, cpu_stats_receiver) =
+            new_auto_split_controller_ctx(vec![cold_stats], vec![]);
+        hub.flush(
+            &mut ctx,
+            &read_stats_receiver,
+            &cpu_stats_receiver,
+            &mut ThreadInfoStatistics::default(),
+            &SplitValidator::new(),
+        );
+        assert!(
+            hub.recorders.is_empty(),
+            "qps_threshold = 0 must not make a cold Region load-fit"
+        );
+
+        let mut hot_bytes = gen_read_stats(2, vec![build_key_range(b"c", b"d", false)]);
+        hot_bytes.region_infos.get_mut(&2).unwrap().flow.read_bytes = 100;
+        let (mut ctx, read_stats_receiver, cpu_stats_receiver) =
+            new_auto_split_controller_ctx(vec![hot_bytes], vec![]);
+        hub.flush(
+            &mut ctx,
+            &read_stats_receiver,
+            &cpu_stats_receiver,
+            &mut ThreadInfoStatistics::default(),
+            &SplitValidator::new(),
+        );
+        assert!(
+            hub.recorders.contains_key(&2),
+            "disabling the QPS gate must still load-fit when bytes exceed the byte threshold"
+        );
+    }
+
     fn check_split_key(mode: &[u8], qps_stats: Vec<ReadStats>, split_keys: Vec<&[u8]>) {
         let mode = String::from_utf8(Vec::from(mode)).unwrap();
         let mut hub = AutoSplitController::default();
@@ -2114,12 +2153,18 @@ mod tests {
         let mut region_info = RegionInfo::new(1);
         let mut rng = StepRng::new(0, 0);
         region_info.add_key_ranges_with_rng(vec![first.clone(), second.clone()], &mut rng);
-        assert_eq!(region_info.key_ranges.iter().collect::<Vec<_>>(), vec![&second]);
+        assert_eq!(
+            region_info.key_ranges.iter().collect::<Vec<_>>(),
+            vec![&second]
+        );
 
         let mut region_info = RegionInfo::new(1);
         let mut rng = StepRng::new(0x8000_0000_8000_0000, 0);
         region_info.add_key_ranges_with_rng(vec![first.clone(), second], &mut rng);
-        assert_eq!(region_info.key_ranges.iter().collect::<Vec<_>>(), vec![&first]);
+        assert_eq!(
+            region_info.key_ranges.iter().collect::<Vec<_>>(),
+            vec![&first]
+        );
     }
 
     #[test]
@@ -2149,7 +2194,10 @@ mod tests {
         let mut rng = StepRng::new(0, 0);
 
         region_info.add_key_ranges_with_rng(
-            vec![build_key_range(b"a", b"b", false), build_key_range(b"b", b"c", false)],
+            vec![
+                build_key_range(b"a", b"b", false),
+                build_key_range(b"b", b"c", false),
+            ],
             &mut rng,
         );
 

--- a/components/raftstore/src/store/worker/split_controller.rs
+++ b/components/raftstore/src/store/worker/split_controller.rs
@@ -1,9 +1,10 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
 use std::{
-    cmp::{Ordering, min},
+    cmp::Ordering,
     collections::{BinaryHeap, HashSet, VecDeque},
-    slice::{Iter, IterMut},
+    convert::TryFrom,
+    slice::Iter,
     sync::{Arc, mpsc::Receiver},
     time::{Duration, SystemTime},
 };
@@ -26,7 +27,6 @@ use tikv_util::{
         GRPC_SERVER_THREAD, UNIFIED_READ_POOL_THREAD, matches_thread_name_prefix,
     },
     time::Instant,
-    warn,
 };
 
 use crate::store::{
@@ -38,7 +38,6 @@ use crate::store::{
     },
 };
 
-const DEFAULT_MAX_SAMPLE_LOOP_COUNT: usize = 10000;
 pub const TOP_N: usize = 10;
 
 // It will return prefix sum of the given iter,
@@ -50,28 +49,14 @@ where
 {
     let mut sum = 0;
     iter.map(|item| {
-        sum += read(item);
+        sum = sum.saturating_add(read(item));
         sum
     })
     .collect()
 }
 
-#[inline(always)]
-fn prefix_sum_mut<F, T>(iter: IterMut<'_, T>, read: F) -> Vec<usize>
-where
-    F: Fn(&mut T) -> usize,
-{
-    let mut sum = 0;
-    iter.map(|item| {
-        sum += read(item);
-        sum
-    })
-    .collect()
-}
-
-// This function uses the distributed/parallel reservoir sampling algorithm.
-// It will sample min(sample_num, all_key_ranges_num) key ranges from multiple
-// `key_ranges_provider` with the same possibility.
+// It samples min(sample_num, all_key_ranges_num) key ranges uniformly without
+// replacement from multiple providers while keeping only the output reservoir.
 fn sample<F, T>(
     sample_num: usize,
     mut key_ranges_providers: Vec<T>,
@@ -80,64 +65,37 @@ fn sample<F, T>(
 where
     F: Fn(&mut T) -> &mut Vec<KeyRange>,
 {
-    let mut sampled_key_ranges = vec![];
-    // Retain the non-empty key ranges.
-    // `key_ranges_provider` may return an empty key ranges vector, which will cause
-    // the later sampling to fall into a dead loop. So we need to filter it out
-    // here.
-    key_ranges_providers
-        .retain_mut(|key_ranges_provider| !key_ranges_getter(key_ranges_provider).is_empty());
-    if key_ranges_providers.is_empty() {
-        return sampled_key_ranges;
+    if sample_num == 0 {
+        return Vec::new();
     }
-    let prefix_sum = prefix_sum_mut(key_ranges_providers.iter_mut(), |key_ranges_provider| {
-        key_ranges_getter(key_ranges_provider).len()
-    });
-    // The last sum is the number of all the key ranges.
-    let all_key_ranges_num = *prefix_sum.last().unwrap();
-    if all_key_ranges_num == 0 {
-        return sampled_key_ranges;
-    }
-    // If the number of key ranges is less than the sample number,
-    // we will return them directly without sampling.
-    if all_key_ranges_num <= sample_num {
-        key_ranges_providers
-            .iter_mut()
-            .for_each(|key_ranges_provider| {
-                sampled_key_ranges.append(key_ranges_getter(key_ranges_provider));
-            });
-        return sampled_key_ranges;
-    }
-    // To prevent the sampling from falling into a dead loop.
-    let mut sample_loop_count = min(
-        sample_num.saturating_mul(100),
-        DEFAULT_MAX_SAMPLE_LOOP_COUNT,
-    );
+    let mut sampled_key_ranges = Vec::with_capacity(sample_num.min(DEFAULT_SAMPLE_NUM));
+    let mut seen = 0_u64;
     let mut rng = rand::thread_rng();
-    // If the number of key ranges is greater than the sample number,
-    // we will randomly sample the key ranges.
-    while sampled_key_ranges.len() < sample_num && sample_loop_count > 0 {
-        sample_loop_count -= 1;
-        // Generate a random number in [1, all_key_ranges_num].
-        // Starting from 1 is to achieve equal probability.
-        // For example, for a `prefix_sum` like [1, 2, 3, 4],
-        // if we generate a random number in [0, 4], the probability of choosing the
-        // first index is 0.4 rather than 0.25 due to that 0 and 1 will both
-        // make `binary_search` get the same result.
-        let i = prefix_sum
-            .binary_search(&rng.gen_range(1..=all_key_ranges_num))
-            .unwrap_or_else(|i| i);
-        let key_ranges = key_ranges_getter(&mut key_ranges_providers[i]);
-        if !key_ranges.is_empty() {
-            let j = rng.gen_range(0..key_ranges.len());
-            sampled_key_ranges.push(key_ranges.remove(j)); // Sampling without replacement
+    let sample_num_u64 = u64::try_from(sample_num).unwrap_or(u64::MAX);
+
+    for key_ranges_provider in &mut key_ranges_providers {
+        // Taking each provider's vector lets the consumed ranges be released as
+        // soon as they have been considered instead of building an aggregate
+        // vector proportional to the request volume.
+        for key_range in std::mem::take(key_ranges_getter(key_ranges_provider)) {
+            if sampled_key_ranges.len() < sample_num {
+                sampled_key_ranges.push(key_range);
+            } else {
+                // `seen` is the zero-based index of the current observation.
+                // Draw from [0, seen] to keep Algorithm R uniform.
+                let index = if seen == u64::MAX {
+                    rng.gen::<u64>()
+                } else {
+                    rng.gen_range(0..=seen)
+                };
+                if index < sample_num_u64 {
+                    // An index below sample_num is representable as usize on
+                    // every supported target because sample_num is a usize.
+                    sampled_key_ranges[usize::try_from(index).unwrap()] = key_range;
+                }
+            }
+            seen = seen.saturating_add(1);
         }
-    }
-    if sample_loop_count == 0 {
-        warn!("the number of sampled key ranges could be less than the sample_num, the sampling may fall into a dead loop before";
-            "sampled_key_ranges_length" => sampled_key_ranges.len(),
-            "sample_num" => sample_num,
-        );
     }
     sampled_key_ranges
 }
@@ -271,8 +229,8 @@ pub struct Recorder {
     pub detect_times: usize,
     sample_num: usize,
     pub peer: Peer,
-    // Advancing a full observation window should not shift all retained rounds.
-    // Every retained round uses this recorder's detect_times and sample_num.
+    // Keep only the latest observation rounds. A failed split-key selection
+    // must not make this history grow without bound.
     pub key_ranges: VecDeque<Vec<KeyRange>>,
     pub create_time: SystemTime,
     pub cpu_usage: f64,
@@ -293,23 +251,29 @@ impl Recorder {
     }
 
     fn record(&mut self, mut key_ranges: Vec<KeyRange>, detect_times: u64, sample_num: usize) {
-        let detect_times = detect_times as usize;
-        // Mixing rounds sampled under different parameters biases the retained
-        // history. Start a new observation window after either parameter changes.
+        let detect_times = match usize::try_from(detect_times) {
+            Ok(detect_times) => detect_times,
+            Err(_) => {
+                self.key_ranges.clear();
+                return;
+            }
+        };
+        // Do not mix rounds sampled with different parameters. Start a fresh
+        // observation window when either parameter changes.
         if self.detect_times != detect_times || self.sample_num != sample_num {
             self.detect_times = detect_times;
             self.sample_num = sample_num;
             self.key_ranges.clear();
             self.create_time = SystemTime::now();
         }
-        if self.detect_times == 0 || sample_num == 0 {
+        if detect_times == 0 || sample_num == 0 {
             self.key_ranges.clear();
             return;
         }
-        // Production callers already sample this round with the current
-        // sample_num. Retain a defensive bound for direct and future callers.
+        // The producer already applies the current sample limit. Keep this
+        // bound here as a defensive invariant for direct callers.
         key_ranges.truncate(sample_num);
-        while self.key_ranges.len() >= self.detect_times {
+        while self.key_ranges.len() >= detect_times {
             let _ = self.key_ranges.pop_front();
         }
         self.key_ranges.push_back(key_ranges);
@@ -375,17 +339,24 @@ impl RegionInfo {
             sample_num,
             query_stats: QueryStats::default(),
             cop_detail: RegionWriteCfCopDetail::default(),
-            // Most Regions only see a few requests in one reporting window. Let
-            // larger reservoirs grow with observations instead of eagerly
-            // reserving the full capacity for every active Region.
-            key_ranges: Vec::with_capacity(sample_num.min(DEFAULT_SAMPLE_NUM)),
+            // Most Regions only report flow or query counts. Allocate the
+            // reservoir when the first sampled range is observed.
+            key_ranges: Vec::new(),
             peer: Peer::default(),
             flow: FlowStatistics::default(),
         }
     }
 
+    fn read_query_num(&self) -> u64 {
+        self.query_stats
+            .0
+            .get_get()
+            .saturating_add(self.query_stats.0.get_coprocessor())
+            .saturating_add(self.query_stats.0.get_scan())
+    }
+
     fn get_read_qps(&self) -> usize {
-        self.query_stats.get_read_query_num() as usize
+        usize::try_from(self.read_query_num()).unwrap_or(usize::MAX)
     }
 
     fn get_key_ranges_mut(&mut self) -> &mut Vec<KeyRange> {
@@ -397,16 +368,34 @@ impl RegionInfo {
     }
 
     fn add_key_ranges_with_rng<R: Rng + ?Sized>(&mut self, key_ranges: Vec<KeyRange>, rng: &mut R) {
+        if !key_ranges.is_empty() && self.key_ranges.capacity() == 0 {
+            self.key_ranges
+                .reserve(self.sample_num.min(DEFAULT_SAMPLE_NUM));
+        }
         for (i, key_range) in key_ranges.into_iter().enumerate() {
-            let n = self.get_read_qps() + i;
+            // Keep the Algorithm R observation index in u64 so large query
+            // counters do not truncate on 32-bit targets or wrap on addition.
+            let n = self
+                .read_query_num()
+                .saturating_add(u64::try_from(i).unwrap_or(u64::MAX));
             if self.key_ranges.len() < self.sample_num {
                 self.key_ranges.push(key_range);
             } else {
                 // This is the (n + 1)th observation, so it must be selected with
                 // probability sample_num / (n + 1).
-                let j = rng.gen_range(0..=n);
-                if j < self.sample_num {
-                    self.key_ranges[j] = key_range;
+                // `gen_range` cannot represent an inclusive range ending at
+                // `u64::MAX` on every rand backend, so use the full-width draw
+                // for that one boundary case.
+                let j = if n == u64::MAX {
+                    rng.gen::<u64>()
+                } else {
+                    rng.gen_range(0..=n)
+                };
+                let sample_num = u64::try_from(self.sample_num).unwrap_or(u64::MAX);
+                if j < sample_num {
+                    if let Ok(index) = usize::try_from(j) {
+                        self.key_ranges[index] = key_range;
+                    }
                 }
             }
         }
@@ -645,7 +634,7 @@ impl AutoSplitController {
     fn update_grpc_thread_usage(&mut self, grpc_thread_usage: f64) {
         self.grpc_thread_usage_vec.push(grpc_thread_usage);
         let length = self.grpc_thread_usage_vec.len();
-        let detect_times = self.cfg.detect_times as usize;
+        let detect_times = usize::try_from(self.cfg.detect_times).unwrap_or(usize::MAX);
         // Only keep the last `self.cfg.detect_times` elements.
         if length > detect_times {
             self.grpc_thread_usage_vec.drain(..length - detect_times);
@@ -965,26 +954,23 @@ impl AutoSplitController {
             LOAD_BASE_SPLIT_EVENT.load_fit.inc();
 
             let detect_times = self.cfg.detect_times;
+            let sample_num = self.cfg.sample_num;
             let recorder = self
                 .recorders
                 .entry(region_id)
-                .or_insert_with(|| Recorder::new(detect_times, self.cfg.sample_num));
+                .or_insert_with(|| Recorder::new(detect_times, sample_num));
             recorder.update_peer(&region_infos[0].peer);
             recorder.update_cpu_usage(cpu_usage);
             if let Some(hottest_key_range) = hottest_key_range {
                 recorder.update_hottest_key_range(hottest_key_range);
             }
 
-            let key_ranges = sample(
-                self.cfg.sample_num,
-                region_infos,
-                RegionInfo::get_key_ranges_mut,
-            );
+            let key_ranges = sample(sample_num, region_infos, RegionInfo::get_key_ranges_mut);
             if key_ranges.is_empty() {
                 LOAD_BASE_SPLIT_EVENT.empty_statistical_key.inc();
                 continue;
             }
-            recorder.record(key_ranges, detect_times, self.cfg.sample_num);
+            recorder.record(key_ranges, detect_times, sample_num);
             if recorder.is_ready() {
                 let key = recorder.collect(&self.cfg);
                 if !key.is_empty() {
@@ -1797,7 +1783,7 @@ mod tests {
     fn test_sample_key_num() {
         let mut hub = AutoSplitController::default();
         hub.cfg.qps_threshold = Some(2000);
-        hub.cfg.sample_num = 2000;
+        hub.cfg.sample_num = 64;
         hub.cfg.sample_threshold = 0;
 
         for _ in 0..100 {
@@ -1868,6 +1854,15 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn test_sample_length_when_request_nearly_all_ranges() {
+        let key_ranges = (0..10_000)
+            .map(|_| vec![build_key_range(b"a", b"b", false)])
+            .collect();
+        let sampled_key_ranges = sample(9_999, key_ranges, |x| x);
+        assert_eq!(sampled_key_ranges.len(), 9_999);
     }
 
     #[test]
@@ -2119,12 +2114,12 @@ mod tests {
         let mut region_info = RegionInfo::new(1);
         let mut rng = StepRng::new(0, 0);
         region_info.add_key_ranges_with_rng(vec![first.clone(), second.clone()], &mut rng);
-        assert_eq!(region_info.key_ranges, vec![second.clone()]);
+        assert_eq!(region_info.key_ranges.iter().collect::<Vec<_>>(), vec![&second]);
 
         let mut region_info = RegionInfo::new(1);
         let mut rng = StepRng::new(0x8000_0000_8000_0000, 0);
         region_info.add_key_ranges_with_rng(vec![first.clone(), second], &mut rng);
-        assert_eq!(region_info.key_ranges, vec![first]);
+        assert_eq!(region_info.key_ranges.iter().collect::<Vec<_>>(), vec![&first]);
     }
 
     #[test]
@@ -2136,11 +2131,29 @@ mod tests {
     }
 
     #[test]
-    fn test_region_info_limits_initial_reservoir_allocation() {
-        let region_info = RegionInfo::new(usize::MAX);
+    fn test_region_info_allocates_reservoir_lazily() {
+        let mut region_info = RegionInfo::new(usize::MAX);
 
         assert_eq!(region_info.sample_num, usize::MAX);
+        assert_eq!(region_info.key_ranges.capacity(), 0);
+
+        region_info.add_key_ranges(vec![build_key_range(b"a", b"b", false)]);
+
         assert_eq!(region_info.key_ranges.capacity(), DEFAULT_SAMPLE_NUM);
+    }
+
+    #[test]
+    fn test_region_info_handles_large_query_count_without_index_overflow() {
+        let mut region_info = RegionInfo::new(1);
+        region_info.query_stats.0.set_get(u64::MAX);
+        let mut rng = StepRng::new(0, 0);
+
+        region_info.add_key_ranges_with_rng(
+            vec![build_key_range(b"a", b"b", false), build_key_range(b"b", b"c", false)],
+            &mut rng,
+        );
+
+        assert_eq!(region_info.key_ranges.len(), 1);
     }
 
     const REGION_NUM: u64 = 1000;

--- a/doc/maintenance-guides/components/raftstore.md
+++ b/doc/maintenance-guides/components/raftstore.md
@@ -129,6 +129,20 @@ High-risk contracts:
 - `store/worker/read.rs`: local reader and read delegates
 - `store/worker/refresh_config.rs`: runtime config propagation
 
+Load-based split sampling keeps an explicit item-count budget. `sample_num` is
+bounded independently of QPS, and each per-Region recorder keeps a sliding
+window of at most `detect_times` observation rounds. The validated
+`sample_num * detect_times` product therefore bounds retained `KeyRange` items
+per recorder. `sample_threshold` cannot exceed that product, so a full window
+can satisfy the minimum sample requirement. The limits allow more than 50 times
+the default per-round sample count and more than 20 times the default retained
+history. They are not a global byte limit: key payloads, producer threads,
+active Regions, and `Vec` spare capacity add memory beyond the item counts.
+Producer reservoirs initially reserve at most the default sample count and grow
+with observations. Split-key collection can compare up to twice `sample_num`
+candidate keys against `sample_num * detect_times` retained ranges, so changes
+to either upper bound require benchmarking.
+
 ### Coprocessor hooks
 
 - `coprocessor/dispatcher.rs` hosts raftstore observers.

--- a/doc/maintenance-guides/components/raftstore.md
+++ b/doc/maintenance-guides/components/raftstore.md
@@ -138,18 +138,17 @@ High-risk contracts:
 - `store/worker/refresh_config.rs`: runtime config propagation
 
 Load-based split sampling keeps an explicit item-count budget. `sample_num` is
-bounded independently of QPS, and each per-Region recorder keeps a sliding
-window of at most `detect_times` observation rounds. The validated
-`sample_num * detect_times` product therefore bounds retained `KeyRange` items
-per recorder. `sample_threshold` cannot exceed that product, so a full window
-can satisfy the minimum sample requirement. The limits allow more than 50 times
-the default per-round sample count and more than 20 times the default retained
-history. They are not a global byte limit: key payloads, producer threads,
-active Regions, and `Vec` spare capacity add memory beyond the item counts.
-Producer reservoirs initially reserve at most the default sample count and grow
-with observations. Split-key collection can compare up to twice `sample_num`
-candidate keys against `sample_num * detect_times` retained ranges, so changes
-to either upper bound require benchmarking.
+bounded to 1..=64, `detect_times` to 1..=20, and the product
+`sample_num * detect_times` to 1280. Each per-Region recorder keeps a sliding
+window of at most `detect_times` observation rounds, and each round is limited
+to `sample_num` ranges. `sample_threshold` must not exceed
+`sample_num * detect_times`, so a full retained window can satisfy the minimum
+observation requirement. These are not global byte limits: key payloads,
+producer threads, active Regions, and spare `Vec` capacity add memory beyond the
+item counts. Producer reservoirs initially reserve at most the default sample
+count and grow with observations. Split-key collection can compare up to twice
+`sample_num` candidate keys against the bounded retained history, so changes to
+either limit require benchmarking.
 
 ### Coprocessor hooks
 

--- a/doc/maintenance-guides/components/raftstore.md
+++ b/doc/maintenance-guides/components/raftstore.md
@@ -137,6 +137,10 @@ High-risk contracts:
 - `store/worker/read.rs`: local reader and read delegates
 - `store/worker/refresh_config.rs`: runtime config propagation
 
+A `qps_threshold` or `byte_threshold` of 0 disables that load-fit gate; the
+other gates still apply. `qps_threshold = 0` must not treat every Region as
+hot.
+
 Load-based split sampling keeps an explicit item-count budget. `sample_num` is
 bounded to 1..=64, `detect_times` to 1..=20, and the product
 `sample_num * detect_times` to 1280. Each per-Region recorder keeps a sliding


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: Close #19848, close #19849

What's Changed:

```commit-message
Bound load-based split sampling independently of QPS thresholds. Require
sample-num to be between 1 and 64 and detect-times to be between 1 and 20,
rejecting invalid startup and online configurations instead of accepting
unbounded values. The limits keep per-recorder retained ranges and split-key
selection work close to the defaults.

Require sample_num * detect_times to be no greater than 1280 and require
sample_threshold to fit in the retained observation window.

Keep each recorder's latest detect-times rounds in a bounded VecDeque and clear
the window when sampling parameters change, so repeated failed split-key
selection cannot grow retained history without bound.

Allocate each RegionInfo's key-range reservoir lazily on the first sampled
range and reserve at most the default sample count initially, so flow-only
Regions and oversized configurations do not eagerly allocate.

Size collected per-Region read stats vectors by observed reports instead of
the drained batch length.

Include the current observation in the reservoir replacement draw. RegionInfo
uses a zero-based observation index, so drawing from 0..=n restores Algorithm
R's inclusion probability.
```

The defaults remain unchanged (`sample-num = 20`, `detect-times = 10`). This is
an intentional compatibility restriction: existing explicit configurations
outside the bounds will be rejected.

This shape matches what already runs in production in the cloud-engine fork,
keeping the two codebases aligned. Retained recorder history remains bounded
even when split-key selection repeatedly fails, and sampling parameters reset
the retained window before observations collected with the new values are used.

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`
- [ ] Need to cherry-pick to the release branch

### Check List

Tests

- [x] Unit test coverage added

Relevant test commands:

- `cargo test -p raftstore --lib -- split_config`
- `cargo test -p raftstore --lib -- split_controller::tests::test_recorder split_controller::tests::test_region_info split_controller::tests::test_collect_read_stats`

### Release note

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable sampling limits for region split detection.
  - Sampling now maintains a bounded sliding window across detection rounds.
  - Sampling settings reset retained observations when changed.

- **Bug Fixes**
  - Invalid or excessive sampling configurations are rejected before being applied.
  - Reduced unnecessary memory allocation for sparse region statistics and large sampling requests.
  - Improved deterministic handling of sampled split-key candidates.

- **Documentation**
  - Added guidance on sampling budgets, retention limits, memory considerations, and configuration constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
