### PR TITLE
raftstore: resolve current peer for load-based split

### DIFF
--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -64,7 +64,7 @@ use tikv_util::{
     sys::disk::DiskUsage,
     time::{Instant as TiInstant, SlowTimer, monotonic_raw_now},
     trace, warn, warn_or_debug,
-    worker::Scheduler,
+    worker::{ScheduleError, Scheduler},
 };
 use tracker::GLOBAL_TRACKERS;
 use txn_types::WriteBatchFlags;
@@ -174,26 +174,6 @@ fn validate_split_region_for_source(
     Ok(())
 }
 
-fn new_ask_batch_split_task<EK: KvEngine>(
-    region: Region,
-    peer: metapb::Peer,
-    split_keys: Vec<Vec<u8>>,
-    callback: Callback<EK::Snapshot>,
-    source: &str,
-    configured_right_derive: bool,
-    share_source_region_size: bool,
-) -> PdTask<EK> {
-    PdTask::AskBatchSplit {
-        region,
-        split_keys,
-        peer,
-        right_derive: right_derive_for_source(source, configured_right_derive),
-        share_source_region_size,
-        callback,
-        split_reason: split_reason_for_source(source),
-    }
-}
-
 static SNAP_GEN_PRECHECK_RESPONSE_LOG_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 pub const MAX_PROPOSAL_SIZE_RATIO: f64 = 0.4;
@@ -293,14 +273,7 @@ where
         while let Ok(msg) = self.receiver.try_recv() {
             let callback = match msg {
                 PeerMsg::RaftCommand(cmd) => cmd.callback,
-                PeerMsg::CasualMessage(box CasualMessage::SplitRegion {
-                    callback, source, ..
-                }) => {
-                    if source == AUTO_SPLIT_SOURCE {
-                        LOAD_BASE_SPLIT_EVENT.split_failed.inc();
-                    }
-                    callback
-                }
+                PeerMsg::CasualMessage(box CasualMessage::SplitRegion { callback, .. }) => callback,
                 PeerMsg::RaftMessage(im, _) => {
                     raft_messages_size += im.heap_size;
                     continue;
@@ -1341,13 +1314,6 @@ where
         if self.fsm.peer.pending_remove == Some(PendingRemoveReason::ReadyToDestroy) {
             // It means that the peer will be asynchronously removed, it's no
             // need to execute the consequentail CasualMessages.
-            if matches!(
-                &*msg,
-                CasualMessage::SplitRegion { source, .. }
-                    if source == AUTO_SPLIT_SOURCE
-            ) {
-                LOAD_BASE_SPLIT_EVENT.split_failed.inc();
-            }
             return;
         }
         match *msg {
@@ -6732,7 +6698,6 @@ where
         source: &str,
         share_source_region_size: bool,
     ) {
-        let is_auto_split = source == AUTO_SPLIT_SOURCE;
         info!(
             "on split";
             "region_id" => self.fsm.region_id(),
@@ -6748,9 +6713,6 @@ where
                 "region_id" => self.fsm.region_id(),
                 "peer_id" => self.fsm.peer_id(),
             );
-            if is_auto_split {
-                LOAD_BASE_SPLIT_EVENT.split_failed.inc();
-            }
             cb.invoke_with_response(new_error(Error::NotLeader(
                 self.region_id(),
                 self.fsm.peer.get_peer_from_cache(self.fsm.peer.leader_id()),
@@ -6772,39 +6734,30 @@ where
                 "peer_id" => self.fsm.peer_id(),
                 "source" => %source
             );
-            if is_auto_split {
-                LOAD_BASE_SPLIT_EVENT.split_failed.inc();
-            }
             cb.invoke_with_response(new_error(e));
             return;
         }
         let region = self.fsm.peer.region();
-        let task = new_ask_batch_split_task(
-            region.clone(),
-            self.fsm.peer.peer.clone(),
+        let task = PdTask::AskBatchSplit {
+            region: region.clone(),
             split_keys,
-            cb,
-            source,
-            self.ctx.cfg.right_derive_when_split,
+            peer: self.fsm.peer.peer.clone(),
+            right_derive: right_derive_for_source(source, self.ctx.cfg.right_derive_when_split),
             share_source_region_size,
-        );
-        if let Err(e) = self.ctx.pd_scheduler.schedule(task) {
-            let err = e.to_string();
+            callback: cb,
+            split_reason: split_reason_for_source(source),
+        };
+        if let Err(ScheduleError::Stopped(t)) = self.ctx.pd_scheduler.schedule(task) {
             warn!(
-                "failed to notify pd to split";
+                "failed to notify pd to split: Stopped";
                 "region_id" => self.fsm.region_id(),
                 "peer_id" => self.fsm.peer_id(),
-                "err" => %err,
             );
-            match e.into_inner() {
+            match t {
                 PdTask::AskBatchSplit { callback, .. } => {
-                    if is_auto_split {
-                        LOAD_BASE_SPLIT_EVENT.split_failed.inc();
-                    }
                     callback.invoke_with_response(new_error(box_err!(
-                        "{} failed to split: {}",
-                        self.fsm.peer.tag,
-                        err
+                        "{} failed to split: Stopped",
+                        self.fsm.peer.tag
                     )));
                 }
                 _ => unreachable!(),
@@ -7923,44 +7876,6 @@ mod tests {
             SplitReason::Size
         );
         assert_eq!(split_reason_for_source("test"), SplitReason::Admin);
-    }
-
-    #[test]
-    fn test_auto_split_task_uses_current_peer() {
-        let mut region = Region::default();
-        region.set_id(42);
-        let mut current_peer = metapb::Peer::default();
-        current_peer.set_id(101);
-
-        let task: PdTask<KvTestEngine> = new_ask_batch_split_task(
-            region.clone(),
-            current_peer.clone(),
-            vec![b"k".to_vec()],
-            Callback::None,
-            AUTO_SPLIT_SOURCE,
-            false,
-            false,
-        );
-        match task {
-            PdTask::AskBatchSplit {
-                region: task_region,
-                split_keys,
-                peer,
-                right_derive,
-                share_source_region_size,
-                callback,
-                split_reason,
-            } => {
-                assert_eq!(task_region, region);
-                assert_eq!(split_keys, vec![b"k".to_vec()]);
-                assert_eq!(peer, current_peer);
-                assert!(right_derive);
-                assert!(!share_source_region_size);
-                assert!(matches!(callback, Callback::None));
-                assert_eq!(split_reason, SplitReason::Load);
-            }
-            _ => panic!("unexpected PD task"),
-        }
     }
 
     #[test]

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -64,7 +64,7 @@ use tikv_util::{
     sys::disk::DiskUsage,
     time::{Instant as TiInstant, SlowTimer, monotonic_raw_now},
     trace, warn, warn_or_debug,
-    worker::{ScheduleError, Scheduler},
+    worker::Scheduler,
 };
 use tracker::GLOBAL_TRACKERS;
 use txn_types::WriteBatchFlags;
@@ -91,7 +91,10 @@ use crate::{
         local_metrics::{RaftMetrics, TimeTracker},
         memory::*,
         metrics::*,
-        msg::{Callback, CampaignType, ExtCallback, InspectedRaftMessage, PeerClearMetaStat},
+        msg::{
+            AUTO_SPLIT_SOURCE, Callback, CampaignType, ExtCallback, InspectedRaftMessage,
+            PeerClearMetaStat,
+        },
         peer::{
             ConsistencyState, Peer, PendingRemoveReason, PersistSnapshotResult, StaleState,
             TransferLeaderContext,
@@ -139,6 +142,57 @@ const UNSAFE_RECOVERY_STATE_TIMEOUT: Duration = Duration::from_secs(60);
 const SNAP_GEN_PRECHECK_RESPONSE_INFO_SAMPLE_RATE: u64 = 100;
 const SNAP_GEN_PRECHECK_REJECTED_RESPONSE_INFO_SAMPLE_RATE: u64 = 10;
 const SNAP_GEN_PRECHECK_IGNORED_RESPONSE_INFO_SAMPLE_RATE: u64 = 1024;
+
+const LOAD_SPLIT_CHECKER_SOURCE: &str = "split_checker_by_load";
+
+fn split_reason_for_source(source: &str) -> SplitReason {
+    match source {
+        "split_checker_by_size" => SplitReason::Size,
+        LOAD_SPLIT_CHECKER_SOURCE | AUTO_SPLIT_SOURCE => SplitReason::Load,
+        _ => SplitReason::Admin,
+    }
+}
+
+fn right_derive_for_source(source: &str, configured: bool) -> bool {
+    source == AUTO_SPLIT_SOURCE || configured
+}
+
+fn validate_split_region_for_source(
+    region_id: u64,
+    peer_id: u64,
+    region: &Region,
+    epoch: &RegionEpoch,
+    split_keys: &[Vec<u8>],
+    source: &str,
+) -> Result<()> {
+    util::validate_split_region(region_id, peer_id, region, epoch, split_keys)?;
+    if source == AUTO_SPLIT_SOURCE {
+        split_keys
+            .iter()
+            .try_for_each(|key| util::check_key_in_region_exclusive(key, region))?;
+    }
+    Ok(())
+}
+
+fn new_ask_batch_split_task<EK: KvEngine>(
+    region: Region,
+    peer: metapb::Peer,
+    split_keys: Vec<Vec<u8>>,
+    callback: Callback<EK::Snapshot>,
+    source: &str,
+    configured_right_derive: bool,
+    share_source_region_size: bool,
+) -> PdTask<EK> {
+    PdTask::AskBatchSplit {
+        region,
+        split_keys,
+        peer,
+        right_derive: right_derive_for_source(source, configured_right_derive),
+        share_source_region_size,
+        callback,
+        split_reason: split_reason_for_source(source),
+    }
+}
 
 static SNAP_GEN_PRECHECK_RESPONSE_LOG_COUNTER: AtomicU64 = AtomicU64::new(0);
 
@@ -239,7 +293,14 @@ where
         while let Ok(msg) = self.receiver.try_recv() {
             let callback = match msg {
                 PeerMsg::RaftCommand(cmd) => cmd.callback,
-                PeerMsg::CasualMessage(box CasualMessage::SplitRegion { callback, .. }) => callback,
+                PeerMsg::CasualMessage(box CasualMessage::SplitRegion {
+                    callback, source, ..
+                }) => {
+                    if source == AUTO_SPLIT_SOURCE {
+                        LOAD_BASE_SPLIT_EVENT.split_failed.inc();
+                    }
+                    callback
+                }
                 PeerMsg::RaftMessage(im, _) => {
                     raft_messages_size += im.heap_size;
                     continue;
@@ -1280,6 +1341,13 @@ where
         if self.fsm.peer.pending_remove == Some(PendingRemoveReason::ReadyToDestroy) {
             // It means that the peer will be asynchronously removed, it's no
             // need to execute the consequentail CasualMessages.
+            if matches!(
+                &*msg,
+                CasualMessage::SplitRegion { source, .. }
+                    if source == AUTO_SPLIT_SOURCE
+            ) {
+                LOAD_BASE_SPLIT_EVENT.split_failed.inc();
+            }
             return;
         }
         match *msg {
@@ -6664,6 +6732,7 @@ where
         source: &str,
         share_source_region_size: bool,
     ) {
+        let is_auto_split = source == AUTO_SPLIT_SOURCE;
         info!(
             "on split";
             "region_id" => self.fsm.region_id(),
@@ -6679,18 +6748,22 @@ where
                 "region_id" => self.fsm.region_id(),
                 "peer_id" => self.fsm.peer_id(),
             );
+            if is_auto_split {
+                LOAD_BASE_SPLIT_EVENT.split_failed.inc();
+            }
             cb.invoke_with_response(new_error(Error::NotLeader(
                 self.region_id(),
                 self.fsm.peer.get_peer_from_cache(self.fsm.peer.leader_id()),
             )));
             return;
         }
-        if let Err(e) = util::validate_split_region(
+        if let Err(e) = validate_split_region_for_source(
             self.fsm.region_id(),
             self.fsm.peer_id(),
             self.region(),
             &region_epoch,
             &split_keys,
+            source,
         ) {
             info!(
                 "invalid split request";
@@ -6699,35 +6772,39 @@ where
                 "peer_id" => self.fsm.peer_id(),
                 "source" => %source
             );
+            if is_auto_split {
+                LOAD_BASE_SPLIT_EVENT.split_failed.inc();
+            }
             cb.invoke_with_response(new_error(e));
             return;
         }
         let region = self.fsm.peer.region();
-        let split_reason = match source {
-            "split_checker_by_size" => SplitReason::Size,
-            "split_checker_by_load" => SplitReason::Load,
-            _ => SplitReason::Admin,
-        };
-        let task = PdTask::AskBatchSplit {
-            region: region.clone(),
+        let task = new_ask_batch_split_task(
+            region.clone(),
+            self.fsm.peer.peer.clone(),
             split_keys,
-            peer: self.fsm.peer.peer.clone(),
-            right_derive: self.ctx.cfg.right_derive_when_split,
+            cb,
+            source,
+            self.ctx.cfg.right_derive_when_split,
             share_source_region_size,
-            callback: cb,
-            split_reason,
-        };
-        if let Err(ScheduleError::Stopped(t)) = self.ctx.pd_scheduler.schedule(task) {
+        );
+        if let Err(e) = self.ctx.pd_scheduler.schedule(task) {
+            let err = e.to_string();
             warn!(
-                "failed to notify pd to split: Stopped";
+                "failed to notify pd to split";
                 "region_id" => self.fsm.region_id(),
                 "peer_id" => self.fsm.peer_id(),
+                "err" => %err,
             );
-            match t {
+            match e.into_inner() {
                 PdTask::AskBatchSplit { callback, .. } => {
+                    if is_auto_split {
+                        LOAD_BASE_SPLIT_EVENT.split_failed.inc();
+                    }
                     callback.invoke_with_response(new_error(box_err!(
-                        "{} failed to split: Stopped",
-                        self.fsm.peer.tag
+                        "{} failed to split: {}",
+                        self.fsm.peer.tag,
+                        err
                     )));
                 }
                 _ => unreachable!(),
@@ -6978,7 +7055,7 @@ where
         if source == "bucket" {
             return;
         }
-        let reason = if source == "auto_split" {
+        let reason = if source == AUTO_SPLIT_SOURCE {
             SplitReason::Load
         } else {
             SplitReason::Admin
@@ -7827,6 +7904,114 @@ mod tests {
         local_metrics::RaftMetrics,
         msg::{Callback, ExtCallback, RaftCommand},
     };
+
+    #[test]
+    fn test_auto_split_source_semantics() {
+        assert_eq!(
+            split_reason_for_source(AUTO_SPLIT_SOURCE),
+            SplitReason::Load
+        );
+        assert!(right_derive_for_source(AUTO_SPLIT_SOURCE, false));
+
+        assert_eq!(
+            split_reason_for_source(LOAD_SPLIT_CHECKER_SOURCE),
+            SplitReason::Load
+        );
+        assert!(!right_derive_for_source(LOAD_SPLIT_CHECKER_SOURCE, false));
+        assert_eq!(
+            split_reason_for_source("split_checker_by_size"),
+            SplitReason::Size
+        );
+        assert_eq!(split_reason_for_source("test"), SplitReason::Admin);
+    }
+
+    #[test]
+    fn test_auto_split_task_uses_current_peer() {
+        let mut region = Region::default();
+        region.set_id(42);
+        let mut current_peer = metapb::Peer::default();
+        current_peer.set_id(101);
+
+        let task: PdTask<KvTestEngine> = new_ask_batch_split_task(
+            region.clone(),
+            current_peer.clone(),
+            vec![b"k".to_vec()],
+            Callback::None,
+            AUTO_SPLIT_SOURCE,
+            false,
+            false,
+        );
+        match task {
+            PdTask::AskBatchSplit {
+                region: task_region,
+                split_keys,
+                peer,
+                right_derive,
+                share_source_region_size,
+                callback,
+                split_reason,
+            } => {
+                assert_eq!(task_region, region);
+                assert_eq!(split_keys, vec![b"k".to_vec()]);
+                assert_eq!(peer, current_peer);
+                assert!(right_derive);
+                assert!(!share_source_region_size);
+                assert!(matches!(callback, Callback::None));
+                assert_eq!(split_reason, SplitReason::Load);
+            }
+            _ => panic!("unexpected PD task"),
+        }
+    }
+
+    #[test]
+    fn test_auto_split_key_must_be_inside_region_exclusively() {
+        let mut region = Region::default();
+        region.set_id(1);
+        region.set_start_key(b"a".to_vec());
+        region.set_end_key(b"z".to_vec());
+        region.mut_region_epoch().set_version(2);
+        let epoch = region.get_region_epoch().clone();
+
+        validate_split_region_for_source(
+            region.get_id(),
+            10,
+            &region,
+            &epoch,
+            &[b"a".to_vec()],
+            "test",
+        )
+        .unwrap();
+        validate_split_region_for_source(
+            region.get_id(),
+            10,
+            &region,
+            &epoch,
+            &[b"a".to_vec()],
+            AUTO_SPLIT_SOURCE,
+        )
+        .unwrap_err();
+        validate_split_region_for_source(
+            region.get_id(),
+            10,
+            &region,
+            &epoch,
+            &[b"m".to_vec()],
+            AUTO_SPLIT_SOURCE,
+        )
+        .unwrap();
+
+        let mut stale_epoch = epoch;
+        stale_epoch.set_version(1);
+        validate_split_region_for_source(
+            region.get_id(),
+            10,
+            &region,
+            &stale_epoch,
+            &[b"m".to_vec()],
+            AUTO_SPLIT_SOURCE,
+        )
+        .unwrap_err();
+    }
 
     #[test]
     fn test_batch_raft_cmd_request_builder() {

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -6706,9 +6706,6 @@ where
             "source" => source,
         );
 
-        // A load-based split candidate that is rejected here never creates an
-        // admin command, so it is counted as failed at the rejection point.
-        let is_load_split = split_reason_for_source(source) == SplitReason::Load;
         if !self.fsm.peer.is_leader() {
             // region on this store is no longer leader, skipped.
             info!(
@@ -6716,9 +6713,6 @@ where
                 "region_id" => self.fsm.region_id(),
                 "peer_id" => self.fsm.peer_id(),
             );
-            if is_load_split {
-                LOAD_BASE_SPLIT_EVENT.split_failed.inc();
-            }
             cb.invoke_with_response(new_error(Error::NotLeader(
                 self.region_id(),
                 self.fsm.peer.get_peer_from_cache(self.fsm.peer.leader_id()),
@@ -6740,9 +6734,6 @@ where
                 "peer_id" => self.fsm.peer_id(),
                 "source" => %source
             );
-            if is_load_split {
-                LOAD_BASE_SPLIT_EVENT.split_failed.inc();
-            }
             cb.invoke_with_response(new_error(e));
             return;
         }
@@ -6756,20 +6747,22 @@ where
             callback: cb,
             split_reason: split_reason_for_source(source),
         };
-        if let Err(ScheduleError::Stopped(t)) = self.ctx.pd_scheduler.schedule(task) {
+        if let Err(e) = self.ctx.pd_scheduler.schedule(task) {
+            let error_kind: &'static str = match &e {
+                ScheduleError::Stopped(_) => "Stopped",
+                ScheduleError::Full(_) => "Full",
+            };
             warn!(
-                "failed to notify pd to split: Stopped";
+                "failed to notify pd to split";
                 "region_id" => self.fsm.region_id(),
                 "peer_id" => self.fsm.peer_id(),
+                "reason" => error_kind,
             );
-            if is_load_split {
-                LOAD_BASE_SPLIT_EVENT.split_failed.inc();
-            }
-            match t {
+            match e.into_inner() {
                 PdTask::AskBatchSplit { callback, .. } => {
                     callback.invoke_with_response(new_error(box_err!(
-                        "{} failed to split: Stopped",
-                        self.fsm.peer.tag
+                        "{} failed to split: {}",
+                        self.fsm.peer.tag, error_kind
                     )));
                 }
                 _ => unreachable!(),

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -6706,6 +6706,9 @@ where
             "source" => source,
         );
 
+        // A load-based split candidate that is rejected here never creates an
+        // admin command, so it is counted as failed at the rejection point.
+        let is_load_split = split_reason_for_source(source) == SplitReason::Load;
         if !self.fsm.peer.is_leader() {
             // region on this store is no longer leader, skipped.
             info!(
@@ -6713,6 +6716,9 @@ where
                 "region_id" => self.fsm.region_id(),
                 "peer_id" => self.fsm.peer_id(),
             );
+            if is_load_split {
+                LOAD_BASE_SPLIT_EVENT.split_failed.inc();
+            }
             cb.invoke_with_response(new_error(Error::NotLeader(
                 self.region_id(),
                 self.fsm.peer.get_peer_from_cache(self.fsm.peer.leader_id()),
@@ -6734,6 +6740,9 @@ where
                 "peer_id" => self.fsm.peer_id(),
                 "source" => %source
             );
+            if is_load_split {
+                LOAD_BASE_SPLIT_EVENT.split_failed.inc();
+            }
             cb.invoke_with_response(new_error(e));
             return;
         }
@@ -6753,6 +6762,9 @@ where
                 "region_id" => self.fsm.region_id(),
                 "peer_id" => self.fsm.peer_id(),
             );
+            if is_load_split {
+                LOAD_BASE_SPLIT_EVENT.split_failed.inc();
+            }
             match t {
                 PdTask::AskBatchSplit { callback, .. } => {
                     callback.invoke_with_response(new_error(box_err!(

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -143,12 +143,13 @@ const SNAP_GEN_PRECHECK_RESPONSE_INFO_SAMPLE_RATE: u64 = 100;
 const SNAP_GEN_PRECHECK_REJECTED_RESPONSE_INFO_SAMPLE_RATE: u64 = 10;
 const SNAP_GEN_PRECHECK_IGNORED_RESPONSE_INFO_SAMPLE_RATE: u64 = 1024;
 
-const LOAD_SPLIT_CHECKER_SOURCE: &str = "split_checker_by_load";
+const LOAD_SPLIT_CHECKER_SOURCE_BY_LOAD: &str = "split_checker_by_load";
+const LOAD_SPLIT_CHECKER_SOURCE_BY_SIZE: &str = "split_checker_by_size";
 
 fn split_reason_for_source(source: &str) -> SplitReason {
     match source {
-        "split_checker_by_size" => SplitReason::Size,
-        LOAD_SPLIT_CHECKER_SOURCE | AUTO_SPLIT_SOURCE => SplitReason::Load,
+        LOAD_SPLIT_CHECKER_SOURCE_BY_SIZE => SplitReason::Size,
+        LOAD_SPLIT_CHECKER_SOURCE_BY_LOAD | AUTO_SPLIT_SOURCE => SplitReason::Load,
         _ => SplitReason::Admin,
     }
 }
@@ -6762,7 +6763,8 @@ where
                 PdTask::AskBatchSplit { callback, .. } => {
                     callback.invoke_with_response(new_error(box_err!(
                         "{} failed to split: {}",
-                        self.fsm.peer.tag, error_kind
+                        self.fsm.peer.tag,
+                        error_kind
                     )));
                 }
                 _ => unreachable!(),
@@ -7872,12 +7874,15 @@ mod tests {
         assert!(right_derive_for_source(AUTO_SPLIT_SOURCE, false));
 
         assert_eq!(
-            split_reason_for_source(LOAD_SPLIT_CHECKER_SOURCE),
+            split_reason_for_source(LOAD_SPLIT_CHECKER_SOURCE_BY_LOAD),
             SplitReason::Load
         );
-        assert!(!right_derive_for_source(LOAD_SPLIT_CHECKER_SOURCE, false));
+        assert!(!right_derive_for_source(
+            LOAD_SPLIT_CHECKER_SOURCE_BY_LOAD,
+            false
+        ));
         assert_eq!(
-            split_reason_for_source("split_checker_by_size"),
+            split_reason_for_source(LOAD_SPLIT_CHECKER_SOURCE_BY_SIZE),
             SplitReason::Size
         );
         assert_eq!(split_reason_for_source("test"), SplitReason::Admin);

--- a/components/raftstore/src/store/metrics.rs
+++ b/components/raftstore/src/store/metrics.rs
@@ -277,7 +277,7 @@ make_static_metric! {
         cpu_fallback_grpc_busy,
         // Load-base split admin command succeeds.
         split_success,
-        // A normal load-base split candidate dispatch or load-base split admin command fails.
+        // Load-base split admin command fails.
         split_failed,
         // Hottest key range for the top hot CPU region could not be found.
         empty_hottest_key_range,

--- a/components/raftstore/src/store/metrics.rs
+++ b/components/raftstore/src/store/metrics.rs
@@ -277,7 +277,7 @@ make_static_metric! {
         cpu_fallback_grpc_busy,
         // Load-base split admin command succeeds.
         split_success,
-        // Load-base split admin command fails.
+        // A normal load-base split candidate dispatch or load-base split admin command fails.
         split_failed,
         // Hottest key range for the top hot CPU region could not be found.
         empty_hottest_key_range,

--- a/components/raftstore/src/store/msg.rs
+++ b/components/raftstore/src/store/msg.rs
@@ -600,6 +600,9 @@ pub enum CampaignType {
     UnsafeSplitCampaign,
 }
 
+/// Source used by normal load-based auto-split requests.
+pub(super) const AUTO_SPLIT_SOURCE: &str = "auto_split";
+
 /// Message that will be sent to a peer.
 ///
 /// These messages are not significant and can be dropped occasionally.

--- a/components/raftstore/src/store/msg.rs
+++ b/components/raftstore/src/store/msg.rs
@@ -600,7 +600,7 @@ pub enum CampaignType {
     UnsafeSplitCampaign,
 }
 
-/// Source used by normal load-based auto-split requests.
+/// Source used by load-based auto-split requests.
 pub(super) const AUTO_SPLIT_SOURCE: &str = "auto_split";
 
 /// Message that will be sent to a peer.

--- a/components/raftstore/src/store/worker/pd.rs
+++ b/components/raftstore/src/store/worker/pd.rs
@@ -56,7 +56,7 @@ use tikv_util::{
     timer::GLOBAL_TIMER_HANDLE,
     topn::TopN,
     warn,
-    worker::{Runnable, ScheduleError, Scheduler},
+    worker::{Runnable, Scheduler},
 };
 use yatp::Remote;
 
@@ -69,6 +69,7 @@ use crate::{
         SnapManager, StoreMsg, StoreTick, TxnExt,
         cmd_resp::new_error,
         metrics::*,
+        msg::AUTO_SPLIT_SOURCE,
         unsafe_recovery::{
             UnsafeRecoveryExecutePlanSyncer, UnsafeRecoveryForceLeaderSyncer, UnsafeRecoveryHandle,
         },
@@ -87,6 +88,20 @@ pub const NUM_COLLECT_STORE_INFOS_PER_HEARTBEAT: u32 = 2;
 const STATS_CHANNEL_CAPACITY_LIMIT: usize = 128;
 
 type RecordPairVec = Vec<pdpb::RecordPair>;
+
+fn take_auto_split_message<EK: KvEngine>(
+    region_epoch: metapb::RegionEpoch,
+    split_info: &mut SplitInfo,
+) -> Option<CasualMessage<EK>> {
+    let split_key = split_info.split_key.take()?;
+    Some(CasualMessage::SplitRegion {
+        region_epoch,
+        split_keys: vec![split_key],
+        callback: Callback::None,
+        source: AUTO_SPLIT_SOURCE.into(),
+        share_source_region_size: false,
+    })
+}
 
 #[derive(Default, Debug, Clone)]
 pub struct FlowStatistics {
@@ -628,10 +643,21 @@ where
     }
 
     fn auto_split(&self, split_infos: Vec<SplitInfo>) {
-        let task = Task::AutoSplit { split_infos };
-        if let Err(e) = self.0.schedule(task) {
+        if split_infos.is_empty() {
+            return;
+        }
+        let candidate_count = split_infos.len() as u64;
+        let normal_candidate_count = split_infos
+            .iter()
+            .filter(|split_info| split_info.split_key.is_some())
+            .count() as u64;
+        if let Err(e) = self.0.schedule(Task::AutoSplit { split_infos }) {
+            LOAD_BASE_SPLIT_EVENT
+                .split_failed
+                .inc_by(normal_candidate_count);
             warn!(
-                "failed to send split infos to pd worker";
+                "failed to send auto split candidates to pd worker";
+                "candidate_count" => candidate_count,
                 "err" => ?e,
             );
         }
@@ -1369,15 +1395,24 @@ where
         remote: Remote<yatp::task::future::TaskCell>,
         reason: pdpb::SplitReason,
     ) {
+        let is_load_split = reason == pdpb::SplitReason::Load;
+        // Normal-key auto split preserves the old `share_source_region_size = false`
+        // behavior. CPU fallback reaches this function with sharing enabled.
+        let is_normal_load_split = is_load_split && !share_source_region_size;
         if split_keys.is_empty() {
             info!("empty split key, skip ask batch split";
                 "region_id" => region.get_id());
+            if is_normal_load_split {
+                LOAD_BASE_SPLIT_EVENT.split_failed.inc();
+            }
             return;
         }
         if reason != pdpb::SplitReason::Admin && split_validator.is_disabled(region.get_id()) {
+            if is_normal_load_split {
+                LOAD_BASE_SPLIT_EVENT.split_failed.inc();
+            }
             return;
         }
-        let is_load_split = reason == pdpb::SplitReason::Load;
         let resp = pd_client.ask_batch_split(region.clone(), split_keys.len(), reason);
         let f = async move {
             match resp.await {
@@ -1435,13 +1470,15 @@ where
                         callback,
                         split_reason: reason,
                     };
-                    if let Err(ScheduleError::Stopped(t)) = scheduler.schedule(task) {
+                    if let Err(e) = scheduler.schedule(task) {
+                        let err = e.to_string();
                         error!(
-                            "failed to notify pd to split: Stopped";
+                            "failed to notify pd to split";
                             "region_id" => region_id,
-                            "peer_id" =>  peer_id
+                            "peer_id" => peer_id,
+                            "err" => %err,
                         );
-                        match t {
+                        match e.into_inner() {
                             Task::AskSplit {
                                 callback,
                                 split_reason,
@@ -1451,7 +1488,8 @@ where
                                     LOAD_BASE_SPLIT_EVENT.split_failed.inc();
                                 }
                                 callback.invoke_with_response(new_error(box_err!(
-                                    "failed to split: Stopped"
+                                    "failed to split: {}",
+                                    err
                                 )));
                             }
                             _ => unreachable!(),
@@ -2587,34 +2625,51 @@ where
             Task::AutoSplit { split_infos } => {
                 let pd_client = self.pd_client.clone();
                 let router = self.router.clone();
-                let scheduler = self.scheduler.clone();
-                let remote = self.remote.clone();
-                let split_validator = self.split_validator.clone();
 
                 let f = async move {
-                    for split_info in split_infos {
-                        let Ok(Some(region)) =
-                            pd_client.get_region_by_id(split_info.region_id).await
-                        else {
-                            continue;
+                    for mut split_info in split_infos {
+                        let region_id = split_info.region_id;
+                        let is_normal_split = split_info.split_key.is_some();
+                        let region = match pd_client.get_region_by_id(region_id).await {
+                            Ok(Some(region)) => region,
+                            Ok(None) => {
+                                if is_normal_split {
+                                    LOAD_BASE_SPLIT_EVENT.split_failed.inc();
+                                    warn!(
+                                        "region disappeared before auto split dispatch";
+                                        "region_id" => region_id,
+                                    );
+                                }
+                                continue;
+                            }
+                            Err(e) => {
+                                if is_normal_split {
+                                    LOAD_BASE_SPLIT_EVENT.split_failed.inc();
+                                    warn!(
+                                        "failed to load region before auto split dispatch";
+                                        "region_id" => region_id,
+                                        "err" => ?e,
+                                    );
+                                }
+                                continue;
+                            }
                         };
                         // Try to split the region with the given split key.
-                        if let Some(split_key) = split_info.split_key {
-                            Self::handle_ask_batch_split(
-                                router.clone(),
-                                scheduler.clone(),
-                                pd_client.clone(),
-                                split_validator.clone(),
-                                region,
-                                vec![split_key],
-                                split_info.peer,
-                                true,
-                                false,
-                                Callback::None,
-                                String::from("auto_split"),
-                                remote.clone(),
-                                pdpb::SplitReason::Load,
-                            );
+                        // The sampled peer can be empty or stale, so the current peer FSM
+                        // resolves the execution identity.
+                        if let Some(msg) = take_auto_split_message(
+                            region.get_region_epoch().clone(),
+                            &mut split_info,
+                        ) {
+                            let result = router.send_casual_msg(region_id, msg);
+                            if let Err(e) = result {
+                                LOAD_BASE_SPLIT_EVENT.split_failed.inc();
+                                warn!(
+                                    "failed to route auto split through current peer";
+                                    "region_id" => region_id,
+                                    "err" => ?e,
+                                );
+                            }
                         // Try to split the region on half within the given key
                         // range if there is no `split_key` been given.
                         } else if split_info.start_key.is_some() && split_info.end_key.is_some() {
@@ -2628,7 +2683,7 @@ where
                                 start_key: Some(start_key.clone()),
                                 end_key: Some(end_key.clone()),
                                 policy: pdpb::CheckPolicy::Scan,
-                                source: "auto_split",
+                                source: AUTO_SPLIT_SOURCE,
                                 cb: Callback::None,
                             });
                             if let Err(e) = router.send(region_id, PeerMsg::CasualMessage(msg)) {
@@ -3083,6 +3138,43 @@ mod tests {
     use crate::store::util::build_key_range;
 
     const DEFAULT_TEST_STORE_ID: u64 = 1;
+
+    #[test]
+    fn test_auto_split_message_ignores_sampled_peer() {
+        let mut epoch = metapb::RegionEpoch::default();
+        epoch.set_version(7);
+        let mut sampled_peer = metapb::Peer::default();
+        sampled_peer.set_id(99);
+        let mut split_info = SplitInfo {
+            region_id: 42,
+            peer: sampled_peer,
+            split_key: Some(b"k".to_vec()),
+            start_key: None,
+            end_key: None,
+        };
+        let msg = take_auto_split_message::<KvTestEngine>(epoch.clone(), &mut split_info).unwrap();
+
+        match msg {
+            CasualMessage::SplitRegion {
+                region_epoch,
+                split_keys,
+                callback,
+                source,
+                share_source_region_size,
+            } => {
+                assert_eq!(region_epoch, epoch);
+                assert_eq!(split_keys, vec![b"k".to_vec()]);
+                assert!(matches!(callback, Callback::None));
+                assert_eq!(source, AUTO_SPLIT_SOURCE);
+                assert!(!share_source_region_size);
+                // The shared candidate retains this field for raftstore-v2, but the
+                // classic execution message carries no peer identity.
+                assert_eq!(split_info.peer.get_id(), 99);
+                assert!(split_info.split_key.is_none());
+            }
+            _ => panic!("unexpected auto split message"),
+        }
+    }
 
     #[cfg(not(target_os = "macos"))]
     #[test]

--- a/components/raftstore/src/store/worker/pd.rs
+++ b/components/raftstore/src/store/worker/pd.rs
@@ -56,7 +56,7 @@ use tikv_util::{
     timer::GLOBAL_TIMER_HANDLE,
     topn::TopN,
     warn,
-    worker::{Runnable, Scheduler},
+    worker::{Runnable, ScheduleError, Scheduler},
 };
 use yatp::Remote;
 
@@ -643,21 +643,10 @@ where
     }
 
     fn auto_split(&self, split_infos: Vec<SplitInfo>) {
-        if split_infos.is_empty() {
-            return;
-        }
-        let candidate_count = split_infos.len() as u64;
-        let normal_candidate_count = split_infos
-            .iter()
-            .filter(|split_info| split_info.split_key.is_some())
-            .count() as u64;
-        if let Err(e) = self.0.schedule(Task::AutoSplit { split_infos }) {
-            LOAD_BASE_SPLIT_EVENT
-                .split_failed
-                .inc_by(normal_candidate_count);
+        let task = Task::AutoSplit { split_infos };
+        if let Err(e) = self.0.schedule(task) {
             warn!(
-                "failed to send auto split candidates to pd worker";
-                "candidate_count" => candidate_count,
+                "failed to send split infos to pd worker";
                 "err" => ?e,
             );
         }
@@ -1395,24 +1384,15 @@ where
         remote: Remote<yatp::task::future::TaskCell>,
         reason: pdpb::SplitReason,
     ) {
-        let is_load_split = reason == pdpb::SplitReason::Load;
-        // Normal-key auto split preserves the old `share_source_region_size = false`
-        // behavior. CPU fallback reaches this function with sharing enabled.
-        let is_normal_load_split = is_load_split && !share_source_region_size;
         if split_keys.is_empty() {
             info!("empty split key, skip ask batch split";
                 "region_id" => region.get_id());
-            if is_normal_load_split {
-                LOAD_BASE_SPLIT_EVENT.split_failed.inc();
-            }
             return;
         }
         if reason != pdpb::SplitReason::Admin && split_validator.is_disabled(region.get_id()) {
-            if is_normal_load_split {
-                LOAD_BASE_SPLIT_EVENT.split_failed.inc();
-            }
             return;
         }
+        let is_load_split = reason == pdpb::SplitReason::Load;
         let resp = pd_client.ask_batch_split(region.clone(), split_keys.len(), reason);
         let f = async move {
             match resp.await {
@@ -1470,15 +1450,13 @@ where
                         callback,
                         split_reason: reason,
                     };
-                    if let Err(e) = scheduler.schedule(task) {
-                        let err = e.to_string();
+                    if let Err(ScheduleError::Stopped(t)) = scheduler.schedule(task) {
                         error!(
-                            "failed to notify pd to split";
+                            "failed to notify pd to split: Stopped";
                             "region_id" => region_id,
-                            "peer_id" => peer_id,
-                            "err" => %err,
+                            "peer_id" =>  peer_id
                         );
-                        match e.into_inner() {
+                        match t {
                             Task::AskSplit {
                                 callback,
                                 split_reason,
@@ -1488,8 +1466,7 @@ where
                                     LOAD_BASE_SPLIT_EVENT.split_failed.inc();
                                 }
                                 callback.invoke_with_response(new_error(box_err!(
-                                    "failed to split: {}",
-                                    err
+                                    "failed to split: Stopped"
                                 )));
                             }
                             _ => unreachable!(),
@@ -2629,41 +2606,19 @@ where
                 let f = async move {
                     for mut split_info in split_infos {
                         let region_id = split_info.region_id;
-                        let is_normal_split = split_info.split_key.is_some();
-                        let region = match pd_client.get_region_by_id(region_id).await {
-                            Ok(Some(region)) => region,
-                            Ok(None) => {
-                                if is_normal_split {
-                                    LOAD_BASE_SPLIT_EVENT.split_failed.inc();
-                                    warn!(
-                                        "region disappeared before auto split dispatch";
-                                        "region_id" => region_id,
-                                    );
-                                }
-                                continue;
-                            }
-                            Err(e) => {
-                                if is_normal_split {
-                                    LOAD_BASE_SPLIT_EVENT.split_failed.inc();
-                                    warn!(
-                                        "failed to load region before auto split dispatch";
-                                        "region_id" => region_id,
-                                        "err" => ?e,
-                                    );
-                                }
-                                continue;
-                            }
+                        let Ok(Some(region)) = pd_client.get_region_by_id(region_id).await else {
+                            continue;
                         };
                         // Try to split the region with the given split key.
-                        // The sampled peer can be empty or stale, so the current peer FSM
-                        // resolves the execution identity.
+                        // Classic raftstore intentionally ignores the telemetry peer here.
+                        // The current peer FSM owns execution identity and rejects a leader
+                        // transfer locally instead of forwarding the candidate.
                         if let Some(msg) = take_auto_split_message(
                             region.get_region_epoch().clone(),
                             &mut split_info,
                         ) {
                             let result = router.send_casual_msg(region_id, msg);
                             if let Err(e) = result {
-                                LOAD_BASE_SPLIT_EVENT.split_failed.inc();
                                 warn!(
                                     "failed to route auto split through current peer";
                                     "region_id" => region_id,

--- a/components/raftstore/src/store/worker/pd.rs
+++ b/components/raftstore/src/store/worker/pd.rs
@@ -647,17 +647,8 @@ where
             return;
         }
         let candidate_count = split_infos.len() as u64;
-        // CPU half-split candidates are accounted by the split checker stage;
-        // split_failed tracks normal split-key candidates only.
-        let split_key_candidate_count = split_infos
-            .iter()
-            .filter(|split_info| split_info.split_key.is_some())
-            .count() as u64;
         let task = Task::AutoSplit { split_infos };
         if let Err(e) = self.0.schedule(task) {
-            LOAD_BASE_SPLIT_EVENT
-                .split_failed
-                .inc_by(split_key_candidate_count);
             warn!(
                 "failed to send split infos to pd worker";
                 "candidate_count" => candidate_count,
@@ -1464,13 +1455,18 @@ where
                         callback,
                         split_reason: reason,
                     };
-                    if let Err(ScheduleError::Stopped(t)) = scheduler.schedule(task) {
+                    if let Err(e) = scheduler.schedule(task) {
+                        let error_kind: &'static str = match &e {
+                            ScheduleError::Stopped(_) => "Stopped",
+                            ScheduleError::Full(_) => "Full",
+                        };
                         error!(
-                            "failed to notify pd to split: Stopped";
+                            "failed to notify pd to split";
                             "region_id" => region_id,
-                            "peer_id" =>  peer_id
+                            "peer_id" => peer_id,
+                            "reason" => error_kind,
                         );
-                        match t {
+                        match e.into_inner() {
                             Task::AskSplit {
                                 callback,
                                 split_reason,
@@ -1480,7 +1476,8 @@ where
                                     LOAD_BASE_SPLIT_EVENT.split_failed.inc();
                                 }
                                 callback.invoke_with_response(new_error(box_err!(
-                                    "failed to split: Stopped"
+                                    "failed to split: {}",
+                                    error_kind
                                 )));
                             }
                             _ => unreachable!(),
@@ -2620,13 +2617,9 @@ where
                 let f = async move {
                     for mut split_info in split_infos {
                         let region_id = split_info.region_id;
-                        let is_split_key = split_info.split_key.is_some();
                         let region = match pd_client.get_region_by_id(region_id).await {
                             Ok(Some(region)) => region,
                             Ok(None) => {
-                                if is_split_key {
-                                    LOAD_BASE_SPLIT_EVENT.split_failed.inc();
-                                }
                                 warn!(
                                     "region disappeared before auto split dispatch";
                                     "region_id" => region_id,
@@ -2634,9 +2627,6 @@ where
                                 continue;
                             }
                             Err(e) => {
-                                if is_split_key {
-                                    LOAD_BASE_SPLIT_EVENT.split_failed.inc();
-                                }
                                 warn!(
                                     "failed to load region before auto split dispatch";
                                     "region_id" => region_id,
@@ -2655,7 +2645,6 @@ where
                         ) {
                             let result = router.send_casual_msg(region_id, msg);
                             if let Err(e) = result {
-                                LOAD_BASE_SPLIT_EVENT.split_failed.inc();
                                 warn!(
                                     "failed to route auto split through current peer";
                                     "region_id" => region_id,
@@ -3124,42 +3113,12 @@ mod tests {
 
     use kvproto::{kvrpcpb, pdpb::QueryKind};
     use pd_client::{BucketMeta, new_bucket_stats};
-    use tikv_util::worker::{LazyWorker, dummy_scheduler};
+    use tikv_util::worker::LazyWorker;
 
     use super::*;
     use crate::store::util::build_key_range;
 
     const DEFAULT_TEST_STORE_ID: u64 = 1;
-
-    #[test]
-    fn test_auto_split_schedule_failure_only_records_split_key_candidates() {
-        let (scheduler, receiver) = dummy_scheduler::<Task<KvTestEngine>>();
-        let reporter = WrappedScheduler(scheduler);
-        drop(receiver);
-
-        let failed_before = LOAD_BASE_SPLIT_EVENT.split_failed.get();
-        reporter.auto_split(vec![SplitInfo {
-            region_id: 42,
-            peer: metapb::Peer::default(),
-            split_key: None,
-            start_key: Some(b"a".to_vec()),
-            end_key: Some(b"z".to_vec()),
-        }]);
-        assert_eq!(
-            LOAD_BASE_SPLIT_EVENT.split_failed.get(),
-            failed_before,
-            "CPU half-split candidates are accounted by the split checker stage"
-        );
-
-        reporter.auto_split(vec![SplitInfo {
-            region_id: 42,
-            peer: metapb::Peer::default(),
-            split_key: Some(b"k".to_vec()),
-            start_key: None,
-            end_key: None,
-        }]);
-        assert_eq!(LOAD_BASE_SPLIT_EVENT.split_failed.get(), failed_before + 1);
-    }
 
     #[test]
     fn test_auto_split_message_ignores_sampled_peer() {

--- a/components/raftstore/src/store/worker/pd.rs
+++ b/components/raftstore/src/store/worker/pd.rs
@@ -1469,12 +1469,8 @@ where
                         match e.into_inner() {
                             Task::AskSplit {
                                 callback,
-                                split_reason,
                                 ..
                             } => {
-                                if split_reason == pdpb::SplitReason::Load {
-                                    LOAD_BASE_SPLIT_EVENT.split_failed.inc();
-                                }
                                 callback.invoke_with_response(new_error(box_err!(
                                     "failed to split: {}",
                                     error_kind

--- a/components/raftstore/src/store/worker/pd.rs
+++ b/components/raftstore/src/store/worker/pd.rs
@@ -643,10 +643,24 @@ where
     }
 
     fn auto_split(&self, split_infos: Vec<SplitInfo>) {
+        if split_infos.is_empty() {
+            return;
+        }
+        let candidate_count = split_infos.len() as u64;
+        // CPU half-split candidates are accounted by the split checker stage;
+        // split_failed tracks normal split-key candidates only.
+        let split_key_candidate_count = split_infos
+            .iter()
+            .filter(|split_info| split_info.split_key.is_some())
+            .count() as u64;
         let task = Task::AutoSplit { split_infos };
         if let Err(e) = self.0.schedule(task) {
+            LOAD_BASE_SPLIT_EVENT
+                .split_failed
+                .inc_by(split_key_candidate_count);
             warn!(
                 "failed to send split infos to pd worker";
+                "candidate_count" => candidate_count,
                 "err" => ?e,
             );
         }
@@ -2606,8 +2620,30 @@ where
                 let f = async move {
                     for mut split_info in split_infos {
                         let region_id = split_info.region_id;
-                        let Ok(Some(region)) = pd_client.get_region_by_id(region_id).await else {
-                            continue;
+                        let is_split_key = split_info.split_key.is_some();
+                        let region = match pd_client.get_region_by_id(region_id).await {
+                            Ok(Some(region)) => region,
+                            Ok(None) => {
+                                if is_split_key {
+                                    LOAD_BASE_SPLIT_EVENT.split_failed.inc();
+                                }
+                                warn!(
+                                    "region disappeared before auto split dispatch";
+                                    "region_id" => region_id,
+                                );
+                                continue;
+                            }
+                            Err(e) => {
+                                if is_split_key {
+                                    LOAD_BASE_SPLIT_EVENT.split_failed.inc();
+                                }
+                                warn!(
+                                    "failed to load region before auto split dispatch";
+                                    "region_id" => region_id,
+                                    "err" => ?e,
+                                );
+                                continue;
+                            }
                         };
                         // Try to split the region with the given split key.
                         // Classic raftstore intentionally ignores the telemetry peer here.
@@ -2619,6 +2655,7 @@ where
                         ) {
                             let result = router.send_casual_msg(region_id, msg);
                             if let Err(e) = result {
+                                LOAD_BASE_SPLIT_EVENT.split_failed.inc();
                                 warn!(
                                     "failed to route auto split through current peer";
                                     "region_id" => region_id,
@@ -3087,12 +3124,42 @@ mod tests {
 
     use kvproto::{kvrpcpb, pdpb::QueryKind};
     use pd_client::{BucketMeta, new_bucket_stats};
-    use tikv_util::worker::LazyWorker;
+    use tikv_util::worker::{LazyWorker, dummy_scheduler};
 
     use super::*;
     use crate::store::util::build_key_range;
 
     const DEFAULT_TEST_STORE_ID: u64 = 1;
+
+    #[test]
+    fn test_auto_split_schedule_failure_only_records_split_key_candidates() {
+        let (scheduler, receiver) = dummy_scheduler::<Task<KvTestEngine>>();
+        let reporter = WrappedScheduler(scheduler);
+        drop(receiver);
+
+        let failed_before = LOAD_BASE_SPLIT_EVENT.split_failed.get();
+        reporter.auto_split(vec![SplitInfo {
+            region_id: 42,
+            peer: metapb::Peer::default(),
+            split_key: None,
+            start_key: Some(b"a".to_vec()),
+            end_key: Some(b"z".to_vec()),
+        }]);
+        assert_eq!(
+            LOAD_BASE_SPLIT_EVENT.split_failed.get(),
+            failed_before,
+            "CPU half-split candidates are accounted by the split checker stage"
+        );
+
+        reporter.auto_split(vec![SplitInfo {
+            region_id: 42,
+            peer: metapb::Peer::default(),
+            split_key: Some(b"k".to_vec()),
+            start_key: None,
+            end_key: None,
+        }]);
+        assert_eq!(LOAD_BASE_SPLIT_EVENT.split_failed.get(), failed_before + 1);
+    }
 
     #[test]
     fn test_auto_split_message_ignores_sampled_peer() {

--- a/components/raftstore/src/store/worker/pd.rs
+++ b/components/raftstore/src/store/worker/pd.rs
@@ -1467,10 +1467,7 @@ where
                             "reason" => error_kind,
                         );
                         match e.into_inner() {
-                            Task::AskSplit {
-                                callback,
-                                ..
-                            } => {
+                            Task::AskSplit { callback, .. } => {
                                 callback.invoke_with_response(new_error(box_err!(
                                     "failed to split: {}",
                                     error_kind

--- a/components/raftstore/src/store/worker/pd.rs
+++ b/components/raftstore/src/store/worker/pd.rs
@@ -2633,8 +2633,8 @@ where
                         };
                         // Try to split the region with the given split key.
                         // Classic raftstore intentionally ignores the telemetry peer here.
-                        // The current peer FSM owns execution identity and rejects a leader
-                        // transfer locally instead of forwarding the candidate.
+                        // The current peer FSM owns execution identity and rejects candidates
+                        // received after leadership is lost instead of forwarding them.
                         if let Some(msg) = take_auto_split_message(
                             region.get_region_epoch().clone(),
                             &mut split_info,

--- a/doc/maintenance-guides/components/raftstore.md
+++ b/doc/maintenance-guides/components/raftstore.md
@@ -63,6 +63,9 @@ Concrete startup anchors:
 High-risk contracts:
 
 - `RaftCmdRequest` header validation against region epoch and peer identity
+- classic load-based split candidates may outlive the peer identity observed
+  with their read statistics; execution must re-enter the current peer FSM and
+  build the split request from its current Region and peer
 - persisted apply/raft state alignment in `peer_storage.rs`
 - callback/result semantics in `store/msg.rs` and `store/fsm/apply.rs`
 
@@ -139,6 +142,8 @@ High-risk contracts:
 
 - Region epoch checks must remain strict. Most stale command and split/merge
   safety depends on this.
+- Normal load-based split keys must be validated against the current Region's
+  exclusive range before requesting split IDs from PD.
 - A `Peer` must preserve role, applied index, raft log, and lease/read-progress
   consistency across ticks and messages.
 - Snapshot lifecycle must not leak:

--- a/doc/maintenance-guides/components/raftstore.md
+++ b/doc/maintenance-guides/components/raftstore.md
@@ -65,7 +65,8 @@ High-risk contracts:
 - `RaftCmdRequest` header validation against region epoch and peer identity
 - classic load-based split candidates may outlive the peer identity observed
   with their read statistics; execution must re-enter the current peer FSM and
-  build the split request from its current Region and peer
+  build the split request from its current Region and peer; a local follower
+  rejects the candidate rather than forwarding it to the current leader
 - persisted apply/raft state alignment in `peer_storage.rs`
 - callback/result semantics in `store/msg.rs` and `store/fsm/apply.rs`
 

--- a/doc/maintenance-guides/components/raftstore.md
+++ b/doc/maintenance-guides/components/raftstore.md
@@ -159,6 +159,11 @@ High-risk contracts:
 ## Observability And Operational Signals
 
 - metrics under `store/metrics.rs`, `store/local_metrics.rs`, and worker metrics
+- `split_success` and `split_failed` cover load-split attempts after they reach
+  PD split-ID allocation or admin-request handling; candidates rejected earlier
+  by routing, leadership, epoch/key validation, or scheduler delivery are
+  logged where applicable and are not included; CPU half-split candidates use
+  the split-check outcome metrics
 - PD heartbeat and region/store statistics
 - logs around snapshot, split/merge, peer lifecycle, disk-full, and unsafe
   recovery paths


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: Close #19850

What's Changed:

```commit-message
Classic raftstore currently builds normal load-based split commands with the
Peer sampled alongside read statistics. That Peer can be empty or stale after
local peer replacement.

Refresh the Region through PD as an existence/version fence, then route the
normal candidate through the current local peer FSM. The FSM validates current
leadership, Region version, and the exclusive split-key range before requesting
split IDs from PD, and builds AskBatchSplit from its current Region and Peer.

Preserve the existing normal auto-split behavior of SplitReason::Load,
right_derive=true, and share_source_region_size=false. If the local peer is no longer leader, the FSM rejects the candidate instead of
forwarding it to the remote leader.

Keep split_failed scoped to load-split attempts that reach PD split-ID
allocation or admin-request handling. Candidates rejected earlier by reporter
scheduling, PD Region refresh, local routing, leadership or epoch/key validation,
or PD-task scheduling are logged where applicable and are not counted. CPU
half-split candidates remain on the existing split-check accounting path.
```

This PR is limited to classic raftstore. The shared `SplitInfo.peer` field
remains because raftstore-v2 still consumes it, but classic raftstore no longer
uses it for normal load-based split execution. The existing CPU half-split path
is unchanged.

This PR is independent of #19813 and #19851.

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`
- [ ] Need to cherry-pick to the release branch

### Check List

Tests

- [x] Unit test coverage added

Relevant test commands:

- `cargo test -p raftstore --lib test_auto_split`
- `cargo test -p raftstore --lib test_auto_split_key_must_be_inside_region_exclusively`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved load-based region splitting by rebuilding requests from current region state.
  * Added validation to reject stale or invalid split keys before processing.
  * Improved split failure reporting and tracking for applicable requests.
  * Updated half-split handling for consistent load-based split behavior.
  * Improved batch split error reporting when scheduling cannot proceed.

* **Documentation**
  * Clarified safeguards and validation requirements for load-based region splitting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


### Release note

```release-note
Fix classic raftstore load-based auto-split execution to use the current local peer and Region metadata.
```






