### PR TITLE
resource_control: do no enable priority scheduling if only background control is config

### DIFF
--- a/components/resource_control/src/resource_group.rs
+++ b/components/resource_control/src/resource_group.rs
@@ -465,9 +465,6 @@ impl ResourceGroupManager {
                 .get_write_io_limiter()
                 .set_rate_limit(f64::INFINITY);
         }
-        self.registry.read().iter().for_each(|controller| {
-            controller.set_has_background(any_has_bg);
-        });
     }
 
     fn build_resource_limiter(&self, rg: &PbResourceGroup) -> Option<Arc<ResourceLimiter>> {
@@ -538,7 +535,6 @@ impl ResourceGroupManager {
             let ru_quota = Self::get_ru_setting(&g.value().group, controller.is_read);
             controller.add_resource_group(g.key().clone().into_bytes(), ru_quota, g.group.priority);
         }
-        controller.set_has_background(self.has_background.load(Ordering::Acquire));
         controller
     }
 
@@ -1061,8 +1057,6 @@ pub struct ResourceController {
     last_rest_vt_time: Cell<Instant>,
     // whether the settings are customized by user
     customized: AtomicBool,
-    // whether any resource group has background settings configured
-    has_background: AtomicBool,
     // Shared config. Read on the hot path to check enable_fair_scheduling.
     config: Arc<VersionTrack<Config>>,
 }
@@ -1082,7 +1076,6 @@ impl ResourceController {
             max_ru_quota: Mutex::new(DEFAULT_MAX_RU_QUOTA),
             last_rest_vt_time: Cell::new(Instant::now_coarse()),
             customized: AtomicBool::new(false),
-            has_background: AtomicBool::new(false),
             config,
         }
     }
@@ -1198,11 +1191,7 @@ impl ResourceController {
     }
 
     pub fn is_customized(&self) -> bool {
-        self.customized.load(Ordering::Acquire) || self.has_background.load(Ordering::Acquire)
-    }
-
-    pub fn set_has_background(&self, has_background: bool) {
-        self.has_background.store(has_background, Ordering::Release);
+        self.customized.load(Ordering::Acquire)
     }
 
     #[inline]
@@ -1800,6 +1789,29 @@ pub(crate) mod tests {
         resource_manager.add_resource_group(group);
         assert_eq!(resource_ctl_write.resource_group(b"test1").weight, 200);
         assert_eq!(resource_ctl_write.resource_group(b"default").weight, 10);
+    }
+
+    #[test]
+    fn test_background_settings_do_not_customize_resource_controller() {
+        let resource_manager = ResourceGroupManager::default();
+        let resource_ctl = resource_manager.derive_controller("test_write".into(), false);
+
+        let default_group = new_background_resource_group_ru(
+            DEFAULT_RESOURCE_GROUP_NAME.into(),
+            MAX_RU_QUOTA,
+            MEDIUM_PRIORITY,
+            vec!["br".into()],
+        );
+        resource_manager.add_resource_group(default_group);
+
+        assert!(!resource_ctl.is_customized());
+
+        let group = new_resource_group_ru("test".into(), 5000, MEDIUM_PRIORITY);
+        resource_manager.add_resource_group(group);
+        assert!(resource_ctl.is_customized());
+
+        resource_manager.remove_resource_group("test");
+        assert!(!resource_ctl.is_customized());
     }
 
     #[cfg(feature = "failpoints")]

--- a/doc/maintenance-guides/components/resource_control.md
+++ b/doc/maintenance-guides/components/resource_control.md
@@ -97,6 +97,11 @@ Hot contracts to review carefully:
 - `worker.rs` adjusts background quota and related runtime state periodically.
 - `config.rs` defines dynamic policy knobs such as fair scheduling and
   admission-control thresholds.
+- Background quota limiting is independent of priority-queue selection. A
+  background limiter can throttle a task in place even when the transaction
+  scheduler uses its vanilla queue.
+- `ResourceController::is_customized` reflects non-default resource groups;
+  background configuration is tracked separately by `ResourceGroupManager`.
 
 ## Critical Invariants
 

--- a/doc/maintenance-guides/src/storage.md
+++ b/doc/maintenance-guides/src/storage.md
@@ -98,6 +98,9 @@ High-risk contracts:
   handoff.
 - `txn/commands/*` defines concrete transactional commands.
 - `txn/task.rs`, `txn/sched_pool.rs`, and `txn/tracker.rs` support execution.
+- `txn/sched_pool.rs` selects the priority queue only for customized resource
+  groups. Background-only control stays on the vanilla queue and throttles
+  matching long-running tasks inside the pool.
 
 ### MVCC
 

--- a/src/storage/txn/sched_pool.rs
+++ b/src/storage/txn/sched_pool.rs
@@ -275,6 +275,9 @@ impl SchedPool {
         f: impl futures::Future<Output = ()> + Send + 'static,
         write_bytes: u64,
     ) -> Result<(), Full> {
+        if request_source.is_empty() {
+            return self.vanilla.spawn(priority_level, f);
+        }
         let resource_mgr = &self.priority.as_ref().unwrap().resource_mgr;
         let group_name = std::str::from_utf8(metadata.group_name()).unwrap_or_default();
         let resource_limiter =

--- a/src/storage/txn/sched_pool.rs
+++ b/src/storage/txn/sched_pool.rs
@@ -135,12 +135,17 @@ impl PriorityQueue {
             request_source,
             override_priority,
         );
+        let is_background = resource_limiter
+            .as_ref()
+            .is_some_and(|limiter| limiter.is_background());
+        let measure_only = !is_background;
+        let skip_compaction_pressure = !is_background;
         self.worker_pool.spawn_with_extras(
             with_resource_limiter(
                 ControlledFuture::new(f, self.resource_ctl.clone(), group_name),
                 resource_limiter,
-                true, // skip compaction pressure for foreground jobs
-                true, // measure-only: build debt, never sleep inside pool
+                skip_compaction_pressure,
+                measure_only,
                 Some(self.resource_mgr.clone()),
                 write_bytes,
             ),
@@ -250,10 +255,44 @@ impl SchedPool {
                     )
                 } else {
                     fail_point!("single_queue_pool_task");
-                    self.vanilla.spawn(priority_level, f)
+                    self.spawn_vanilla_with_background_control(
+                        request_source,
+                        metadata,
+                        priority_level,
+                        f,
+                        write_bytes,
+                    )
                 }
             }
         }
+    }
+
+    fn spawn_vanilla_with_background_control(
+        &self,
+        request_source: &str,
+        metadata: TaskMetadata<'_>,
+        priority_level: CommandPri,
+        f: impl futures::Future<Output = ()> + Send + 'static,
+        write_bytes: u64,
+    ) -> Result<(), Full> {
+        let resource_mgr = &self.priority.as_ref().unwrap().resource_mgr;
+        let group_name = std::str::from_utf8(metadata.group_name()).unwrap_or_default();
+        let resource_limiter =
+            resource_mgr.get_background_resource_limiter(group_name, request_source);
+        if let Some(resource_limiter) = resource_limiter {
+            return self.vanilla.spawn(
+                priority_level,
+                with_resource_limiter(
+                    f,
+                    Some(resource_limiter),
+                    false, // enforce compaction-pressure limits for background writes
+                    false, // throttle long-running background tasks inside the pool
+                    None,
+                    write_bytes,
+                ),
+            );
+        }
+        self.vanilla.spawn(priority_level, f)
     }
 
     pub fn scale_pool_size(&self, pool_size: usize) {

--- a/src/storage/txn/sched_pool.rs
+++ b/src/storage/txn/sched_pool.rs
@@ -118,6 +118,7 @@ impl PriorityQueue {
         priority_level: CommandPri,
         f: impl futures::Future<Output = ()> + Send + 'static,
         write_bytes: u64,
+        measure_only: bool,
     ) -> Result<(), Full> {
         let fixed_level = match priority_level {
             CommandPri::High => Some(0),
@@ -138,7 +139,7 @@ impl PriorityQueue {
         let is_background = resource_limiter
             .as_ref()
             .is_some_and(|limiter| limiter.is_background());
-        let measure_only = !is_background;
+        let measure_only = measure_only || !is_background;
         let skip_compaction_pressure = !is_background;
         self.worker_pool.spawn_with_extras(
             with_resource_limiter(
@@ -241,6 +242,25 @@ impl SchedPool {
         f: impl futures::Future<Output = ()> + Send + 'static,
         write_bytes: u64,
     ) -> Result<(), Full> {
+        self.spawn_opt(
+            request_source,
+            metadata,
+            priority_level,
+            f,
+            write_bytes,
+            false,
+        )
+    }
+
+    pub fn spawn_opt(
+        &self,
+        request_source: &str,
+        metadata: TaskMetadata<'_>,
+        priority_level: CommandPri,
+        f: impl futures::Future<Output = ()> + Send + 'static,
+        write_bytes: u64,
+        measure_only: bool,
+    ) -> Result<(), Full> {
         match self.queue_type {
             QueueType::Vanilla => self.vanilla.spawn(priority_level, f),
             QueueType::Dynamic => {
@@ -252,6 +272,7 @@ impl SchedPool {
                         priority_level,
                         f,
                         write_bytes,
+                        measure_only,
                     )
                 } else {
                     fail_point!("single_queue_pool_task");
@@ -261,6 +282,7 @@ impl SchedPool {
                         priority_level,
                         f,
                         write_bytes,
+                        measure_only,
                     )
                 }
             }
@@ -274,6 +296,7 @@ impl SchedPool {
         priority_level: CommandPri,
         f: impl futures::Future<Output = ()> + Send + 'static,
         write_bytes: u64,
+        measure_only: bool,
     ) -> Result<(), Full> {
         let resource_mgr = &self.priority.as_ref().unwrap().resource_mgr;
         let group_name = std::str::from_utf8(metadata.group_name()).unwrap_or_default();
@@ -286,7 +309,7 @@ impl SchedPool {
                     f,
                     Some(resource_limiter),
                     false, // enforce compaction-pressure limits for background writes
-                    false, // throttle long-running background tasks inside the pool
+                    measure_only,
                     None,
                     write_bytes,
                 ),

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -555,7 +555,6 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
         let cb = SchedulerTaskCallback::NormalRequestCallback(callback);
         let metadata = TaskMetadata::from_ctx(cmd.resource_control_ctx());
         let priority = cmd.priority();
-        let write_bytes = cmd.write_bytes() as u64;
         let request_source = cmd.ctx().request_source.clone();
         let mem_quota = self.inner.memory_quota.clone();
         let rm = self.inner.resource_manager.as_ref().unwrap().clone();
@@ -572,7 +571,16 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
         };
         self.inner
             .sched_worker_pool
-            .spawn(&request_source, metadata, priority, execution, write_bytes)
+            .spawn_opt(
+                &request_source,
+                metadata,
+                priority,
+                execution,
+                // Timer only waits and enqueues; actual execution accounts write bytes in
+                // `self.execute(task)`
+                0,
+                true,
+            )
             .unwrap();
     }
 

--- a/tests/failpoints/cases/test_storage.rs
+++ b/tests/failpoints/cases/test_storage.rs
@@ -366,9 +366,11 @@ fn test_scheduler_pool_auto_switch_for_resource_ctl() {
     ctx.set_region_epoch(region.get_region_epoch().clone());
     ctx.set_peer(cluster.leader_of_region(region.id).unwrap());
 
-    let do_prewrite = |key: &[u8], val: &[u8]| {
+    let do_prewrite = |key: &[u8], val: &[u8], request_source: &str| {
         // prewrite
         let (prewrite_tx, prewrite_rx) = channel();
+        let mut request_ctx = ctx.clone();
+        request_ctx.set_request_source(request_source.to_owned());
         storage
             .sched_txn_command(
                 commands::Prewrite::new(
@@ -383,7 +385,7 @@ fn test_scheduler_pool_auto_switch_for_resource_ctl() {
                     None,
                     false,
                     AssertionLevel::Off,
-                    ctx.clone(),
+                    request_ctx,
                 ),
                 Box::new(move |res: storage::Result<_>| {
                     let _ = prewrite_tx.send(res);
@@ -408,14 +410,41 @@ fn test_scheduler_pool_auto_switch_for_resource_ctl() {
     .unwrap();
 
     // Default is use single queue
-    assert_eq!(do_prewrite(b"k1", b"v1").is_ok(), true);
+    assert_eq!(do_prewrite(b"k1", b"v1", "").is_ok(), true);
     assert_eq!(
         receiver.recv_timeout(Duration::from_millis(500)).unwrap(),
         "single_queue"
     );
 
-    // Add group use priority queue
+    // Background control alone keeps using the single queue. The background
+    // limiter is applied independently of queue selection.
     use kvproto::resource_manager::{GroupMode, GroupRequestUnitSettings, ResourceGroup};
+    let mut default_group = ResourceGroup::new();
+    default_group.set_name("default".to_string());
+    default_group.set_mode(GroupMode::RuMode);
+    default_group.set_priority(8);
+    let mut default_ru_setting = GroupRequestUnitSettings::new();
+    default_ru_setting
+        .mut_r_u()
+        .mut_settings()
+        .set_fill_rate(i32::MAX as u64);
+    default_group.set_r_u_settings(default_ru_setting);
+    default_group
+        .mut_background_settings()
+        .set_job_types(vec!["br".to_string()].into());
+    resource_manager.add_resource_group(default_group);
+    assert!(
+        resource_manager
+            .get_background_resource_limiter("default", "br")
+            .is_some()
+    );
+    assert_eq!(do_prewrite(b"k2", b"v2", "br").is_ok(), true);
+    assert_eq!(
+        receiver.recv_timeout(Duration::from_millis(500)).unwrap(),
+        "single_queue"
+    );
+
+    // Add a custom group to switch to the priority queue.
     let mut group = ResourceGroup::new();
     group.set_name("rg1".to_string());
     group.set_mode(GroupMode::RuMode);
@@ -424,7 +453,7 @@ fn test_scheduler_pool_auto_switch_for_resource_ctl() {
     group.set_r_u_settings(ru_setting);
     resource_manager.add_resource_group(group);
     thread::sleep(Duration::from_millis(200));
-    assert_eq!(do_prewrite(b"k2", b"v2").is_ok(), true);
+    assert_eq!(do_prewrite(b"k3", b"v3", "").is_ok(), true);
     assert_eq!(
         receiver.recv_timeout(Duration::from_millis(500)).unwrap(),
         "priority_queue"
@@ -433,7 +462,7 @@ fn test_scheduler_pool_auto_switch_for_resource_ctl() {
     // Delete group use single queue
     resource_manager.remove_resource_group("rg1");
     thread::sleep(Duration::from_millis(200));
-    assert_eq!(do_prewrite(b"k3", b"v3").is_ok(), true);
+    assert_eq!(do_prewrite(b"k4", b"v4", "br").is_ok(), true);
     assert_eq!(
         receiver.recv_timeout(Duration::from_millis(500)).unwrap(),
         "single_queue"


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: close #19858,   ref pingcap/tidb#69741, ref pingcap/tidb#69765, ref pingcap/tidb#69472

In the previous implmentation, due to the performance overhead of the priority queue, we added a switch based on the resource group settings to determine which type of task queue should be used.  In the current logic, if user has created at least 1 resource group or set background tasks it will use the priority queue. This cause performance regression in write only workload when tidb tried to set "stats" as background tasks by default. But since background tasks only use the resource limiter to restrict its cpu/io usage, it has nothing to do with the priority queue.

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Do not switch the task queue (for txn scheduler) to priority queue from vanilla fifo queue when use has created no resource groups but only set background task types.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
  - In the internal benchmark, after this change, the performance regression has gone and the background task control on  "stats" (mainly auto-analyze tasks) is still working as expected.
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **Bug Fixes**
  * Background quota limiting no longer influences whether a resource group is considered “customized,” preventing unintended queue selection changes.

* **New Features**
  * Enhanced scheduler pool spawning to apply background-specific resource-limiter flags, with an added `spawn_opt` option to control measurement behavior.

* **Tests**
  * Expanded scheduler and failpoint tests to validate background vs non-background queue selection across adding/removing background resource-group settings.

* **Documentation**
  * Updated maintenance guides to clarify background limiting independence from priority-queue/customized selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->