### PR TITLE
[DNM] storage: add test-only txn anomaly checker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8125,7 +8125,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "static_assertions",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3837,7 +3837,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git#a6b0bb0483986cbcec14530064f53b7f14facfa2"
+source = "git+https://github.com/tikv/rust-rocksdb.git#1c17b59dcb506302ed4684b3628c4a7165e0b86d"
 dependencies = [
  "bindgen 0.65.1",
  "bzip2-sys",
@@ -3856,7 +3856,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/tikv/rust-rocksdb.git#a6b0bb0483986cbcec14530064f53b7f14facfa2"
+source = "git+https://github.com/tikv/rust-rocksdb.git#1c17b59dcb506302ed4684b3628c4a7165e0b86d"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -5880,7 +5880,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git#a6b0bb0483986cbcec14530064f53b7f14facfa2"
+source = "git+https://github.com/tikv/rust-rocksdb.git#1c17b59dcb506302ed4684b3628c4a7165e0b86d"
 dependencies = [
  "libc 0.2.176",
  "librocksdb_sys",
@@ -7624,9 +7624,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemalloc-ctl"
-version = "0.5.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e37706572f4b151dff7a0146e040804e9c26fe3a3118591112f05cf12a4216c1"
+checksum = "661f1f6a57b3a36dc9174a2c10f19513b4866816e13425d3e418b11cc37bc24c"
 dependencies = [
  "libc 0.2.176",
  "paste",
@@ -7635,20 +7635,19 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemalloc-sys"
-version = "0.5.0+5.3.0"
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aeab4310214fe0226df8bfeb893a291a58b19682e8a07e1e1d4483ad4200d315"
+checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
 dependencies = [
  "cc",
- "fs_extra",
  "libc 0.2.176",
 ]
 
 [[package]]
 name = "tikv-jemallocator"
-version = "0.5.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20612db8a13a6c06d57ec83953694185a367e16945f66565e8028d2c0bd76979"
+checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
 dependencies = [
  "libc 0.2.176",
  "tikv-jemalloc-sys",
@@ -8813,7 +8812,7 @@ checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 [[package]]
 name = "yatp"
 version = "0.0.1"
-source = "git+https://github.com/tikv/yatp.git?branch=master#793be4d789d4bd15292fe4d06e38063b4ec9d48e"
+source = "git+https://github.com/tikv/yatp.git?branch=master#9fcf102bfcc3acaa0d992b018ada7593deb04d97"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-skiplist 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ openssl-vendored = [
 # for testing configure propegate to other crates
 # https://stackoverflow.com/questions/41700543/can-we-share-test-utilites-between-crates
 testing = []
+docker_test = []  # Feature flag for Docker-specific tests
 
 [lib]
 name = "tikv"

--- a/clippy.toml
+++ b/clippy.toml
@@ -33,17 +33,6 @@ Adding hooks directly will omit system hooks, please use
 refer to https://github.com/tikv/tikv/pull/12442 and https://github.com/tikv/tikv/pull/15017 for more details.
 """
 
-# See more about RUSTSEC-2020-0071 in deny.toml.
-[[disallowed-methods]]
-path = "time::now"
-reason = "time::now is unsound, see RUSTSEC-2020-0071"
-[[disallowed-methods]]
-path = "time::at"
-reason = "time::at is unsound, see RUSTSEC-2020-0071"
-[[disallowed-methods]]
-path = "time::at_utc"
-reason = "time::at_utc is unsound, see RUSTSEC-2020-0071"
-
 # See more about RUSTSEC-2023-0072 in deny.toml.
 [[disallowed-methods]]
 path = "openssl::x509::store::X509StoreRef::objects"

--- a/components/backup-stream/src/router.rs
+++ b/components/backup-stream/src/router.rs
@@ -17,7 +17,7 @@ use dashmap::DashMap;
 use encryption::{BackupEncryptionManager, EncrypterReader, Iv, MultiMasterKeyBackend};
 use encryption_export::create_async_backend;
 use engine_traits::{CfName, CF_DEFAULT, CF_LOCK, CF_WRITE};
-use external_storage::{create_storage, BackendConfig, ExternalStorage, UnpinReader};
+use external_storage::{create_storage, BackendConfig, ExternalStorage, HdfsConfig, UnpinReader};
 use file_system::Sha256Reader;
 use futures::io::Cursor;
 use kvproto::{
@@ -343,6 +343,7 @@ pub struct Config {
     pub temp_file_size_limit: u64,
     pub temp_file_memory_quota: u64,
     pub max_flush_interval: Duration,
+    pub s3_multi_part_size: usize,
 }
 
 impl From<BackupStreamConfig> for Config {
@@ -351,11 +352,13 @@ impl From<BackupStreamConfig> for Config {
         let temp_file_size_limit = value.file_size_limit.0;
         let temp_file_memory_quota = value.temp_file_memory_quota.0;
         let max_flush_interval = value.max_flush_interval.0;
+        let s3_multi_part_size = value.s3_multi_part_size.0 as usize;
         Self {
             prefix,
             temp_file_size_limit,
             temp_file_memory_quota,
             max_flush_interval,
+            s3_multi_part_size,
         }
     }
 }
@@ -413,6 +416,9 @@ pub struct RouterInner {
 
     /// Backup encryption manager
     backup_encryption_manager: BackupEncryptionManager,
+
+    /// S3 multi part size
+    s3_multi_part_size: AtomicUsize,
 }
 
 impl std::fmt::Debug for RouterInner {
@@ -440,6 +446,7 @@ impl RouterInner {
             temp_file_memory_quota: AtomicU64::new(config.temp_file_memory_quota),
             max_flush_interval: SyncRwLock::new(config.max_flush_interval),
             backup_encryption_manager,
+            s3_multi_part_size: AtomicUsize::new(config.s3_multi_part_size),
         }
     }
 
@@ -512,12 +519,17 @@ impl RouterInner {
         let cfg = self.tempfile_config_for_task(&task);
         let backup_encryption_manager =
             self.build_backup_encryption_manager_for_task(&task).await?;
+        let backend_config = BackendConfig {
+            s3_multi_part_size: self.s3_multi_part_size.load(Ordering::Relaxed),
+            hdfs_config: HdfsConfig::default(),
+        };
         let stream_task = StreamTaskHandler::new(
             task,
             ranges.clone(),
             merged_file_size_limit,
             cfg,
             backup_encryption_manager,
+            backend_config,
         )
         .await?;
         self.tasks.insert(task_name.clone(), Arc::new(stream_task));
@@ -996,13 +1008,11 @@ impl StreamTaskHandler {
         merged_file_size_limit: u64,
         temp_pool_cfg: tempfiles::Config,
         backup_encryption_manager: BackupEncryptionManager,
+        backend_config: BackendConfig,
     ) -> Result<Self> {
         let temp_dir = &temp_pool_cfg.swap_files;
         tokio::fs::create_dir_all(temp_dir).await?;
-        let storage = Arc::from(create_storage(
-            task.info.get_storage(),
-            BackendConfig::default(),
-        )?);
+        let storage = Arc::from(create_storage(task.info.get_storage(), backend_config)?);
         let start_ts = task.info.get_start_ts();
         Ok(Self {
             task,
@@ -2101,6 +2111,7 @@ mod tests {
                 temp_file_size_limit: 1024,
                 temp_file_memory_quota: 1024 * 2,
                 max_flush_interval: Duration::from_secs(300),
+                s3_multi_part_size: ReadableSize::mb(5).0 as usize,
             },
             BackupEncryptionManager::default(),
         );
@@ -2200,6 +2211,7 @@ mod tests {
                 temp_file_size_limit: 32,
                 temp_file_memory_quota: 32 * 2,
                 max_flush_interval: Duration::from_secs(300),
+                s3_multi_part_size: ReadableSize::mb(5).0 as usize,
             },
             BackupEncryptionManager::default(),
         );
@@ -2345,6 +2357,7 @@ mod tests {
             merged_file_size_limit,
             make_tempfiles_cfg(tmp_dir.path()),
             BackupEncryptionManager::default(),
+            BackendConfig::default(),
         )
         .await
         .unwrap();
@@ -2474,6 +2487,7 @@ mod tests {
                 temp_file_size_limit: 1,
                 temp_file_memory_quota: 2,
                 max_flush_interval: Duration::from_secs(300),
+                s3_multi_part_size: ReadableSize::mb(5).0 as usize,
             },
             BackupEncryptionManager::default(),
         ));
@@ -2513,6 +2527,7 @@ mod tests {
                 temp_file_size_limit: 32,
                 temp_file_memory_quota: 32 * 2,
                 max_flush_interval: Duration::from_secs(300),
+                s3_multi_part_size: ReadableSize::mb(5).0 as usize,
             },
             BackupEncryptionManager::default(),
         );
@@ -2556,6 +2571,7 @@ mod tests {
                 temp_file_size_limit: 1,
                 temp_file_memory_quota: 2,
                 max_flush_interval: Duration::from_secs(300),
+                s3_multi_part_size: ReadableSize::mb(5).0 as usize,
             },
             BackupEncryptionManager::default(),
         ));
@@ -2611,6 +2627,7 @@ mod tests {
                 temp_file_size_limit: 1,
                 temp_file_memory_quota: 2,
                 max_flush_interval: Duration::from_secs(300),
+                s3_multi_part_size: ReadableSize::mb(5).0 as usize,
             },
             BackupEncryptionManager::default(),
         ));
@@ -2748,6 +2765,7 @@ mod tests {
             0x100000,
             make_tempfiles_cfg(tmp_dir.path()),
             backup_encryption_manager,
+            BackendConfig::default(),
         )
         .await
         .unwrap();
@@ -2905,6 +2923,7 @@ mod tests {
                 temp_file_size_limit: 1,
                 temp_file_memory_quota: 2,
                 max_flush_interval: cfg.max_flush_interval.0,
+                s3_multi_part_size: cfg.s3_multi_part_size.0 as usize,
             },
             BackupEncryptionManager::default(),
         ));
@@ -2962,6 +2981,7 @@ mod tests {
                 temp_file_size_limit: 1000,
                 temp_file_memory_quota: 2,
                 max_flush_interval: Duration::from_secs(300),
+                s3_multi_part_size: ReadableSize::mb(5).0 as usize,
             },
             BackupEncryptionManager::default(),
         ));
@@ -3114,6 +3134,7 @@ mod tests {
             merged_file_size_limit,
             make_tempfiles_cfg(tempfile::tempdir().unwrap().path()),
             backup_encryption_manager.clone(),
+            BackendConfig::default(),
         )
         .await
         .unwrap();

--- a/components/backup/src/endpoint.rs
+++ b/components/backup/src/endpoint.rs
@@ -232,7 +232,16 @@ async fn save_backup_file_worker<EK: KvEngine>(
 ) {
     while let Ok(msg) = rx.recv().await {
         let files = if msg.files.need_flush_keys() {
-            match with_resource_limiter(msg.files.save(&storage), msg.limiter.clone()).await {
+            match with_resource_limiter(
+                msg.files.save(&storage),
+                msg.limiter.clone(),
+                false,
+                false,
+                None,
+                0,
+            )
+            .await
+            {
                 Ok(mut split_files) => {
                     let mut has_err = false;
                     for file in split_files.iter_mut() {
@@ -1055,6 +1064,10 @@ impl<E: Engine, R: RegionInfoProvider + Clone + 'static> Endpoint<E, R> {
                                 resource_limiter.clone(),
                             ),
                             resource_limiter.clone(),
+                            false,
+                            false,
+                            None,
+                            0,
                         )
                         .await
                     };

--- a/components/cloud/aws/src/kms.rs
+++ b/components/cloud/aws/src/kms.rs
@@ -12,6 +12,7 @@ use aws_sdk_kms::{
     Client,
 };
 use aws_sdk_s3::config::HttpClient;
+use aws_smithy_types::error::metadata::ProvideErrorMetadata;
 use cloud::{
     error::{Error, KmsError, OtherError, Result},
     kms::{Config, CryptographyType, DataKeyPair, EncryptedKey, KeyId, KmsProvider, PlainKey},
@@ -175,7 +176,9 @@ fn classify_decrypt_error(err: SdkError<DecryptError>) -> Error {
     }
 }
 
-fn classify_error<E: std::error::Error + Send + Sync + 'static>(err: SdkError<E>) -> Error {
+fn classify_error<E: std::error::Error + ProvideErrorMetadata + Send + Sync + 'static>(
+    err: SdkError<E>,
+) -> Error {
     match &err {
         SdkError::DispatchFailure(dispatch_failure) => {
             let maybe_credentials_err = dispatch_failure

--- a/components/cloud/aws/src/s3.rs
+++ b/components/cloud/aws/src/s3.rs
@@ -366,7 +366,9 @@ fn create_error_stream(
 
 /// A helper for uploading a large files to S3 storage.
 ///
-/// Note: this uploader does not support uploading files larger than 19.5 GiB.
+/// The uploader automatically adjusts part size to respect S3's 10000 part
+/// limit. Maximum file size is approximately (part_size * 10000), but the part
+/// size will be increased automatically if needed.
 struct S3Uploader<'client> {
     client: &'client Client,
 
@@ -446,6 +448,8 @@ fn get_content_md5(object_lock_enabled: bool, content: &[u8]) -> Option<String> 
 /// Specifies the minimum size to use multi-part upload.
 /// AWS S3 requires each part to be at least 5 MiB.
 const MINIMUM_PART_SIZE: usize = 5 * 1024 * 1024;
+/// S3 has a maximum of 10000 parts per multipart upload.
+const MAX_PARTS: u64 = 10000;
 
 impl<'client> S3Uploader<'client> {
     /// Creates a new uploader with a given target location and upload
@@ -472,7 +476,26 @@ impl<'client> S3Uploader<'client> {
         reader: &mut (dyn AsyncRead + Unpin + Send),
         est_len: u64,
     ) -> Result<(), UploadError> {
-        if est_len <= self.multi_part_size as u64 {
+        let effective_part_size = if est_len > self.multi_part_size as u64 {
+            let min_part_size_for_limit = est_len.div_ceil(MAX_PARTS);
+            let adjusted_size =
+                std::cmp::max(self.multi_part_size as u64, min_part_size_for_limit) as usize;
+
+            if adjusted_size != self.multi_part_size {
+                debug!(
+                    "adjusted multipart size from {} to {} bytes for file size {} bytes (estimated {} parts)",
+                    self.multi_part_size,
+                    adjusted_size,
+                    est_len,
+                    est_len.div_ceil(adjusted_size as u64)
+                );
+            }
+            adjusted_size
+        } else {
+            self.multi_part_size
+        };
+
+        if est_len <= effective_part_size as u64 {
             // For short files, execute one put_object to upload the entire thing.
             let mut data = Vec::with_capacity(est_len as usize);
             reader.read_to_end(&mut data).await?;
@@ -482,7 +505,7 @@ impl<'client> S3Uploader<'client> {
             // Otherwise, use multipart upload to improve robustness.
             self.upload_id = retry_and_count(|| self.begin(), "begin_upload").await?;
             let upload_res = async {
-                let mut buf = vec![0; self.multi_part_size];
+                let mut buf = vec![0; effective_part_size];
                 let mut part_number = 1;
                 loop {
                     let data_size = try_read_exact(reader, &mut buf).await?;
@@ -1426,5 +1449,42 @@ mod tests {
         assert_matches!(try_read_exact(&mut data, &mut buf).await, Ok(5));
         assert_eq!(&buf[..5], b"ogia.");
         assert_matches!(try_read_exact(&mut data, &mut buf).await, Ok(0));
+    }
+
+    #[test]
+    fn test_multipart_size_adjustment() {
+        const MAX_PARTS: u64 = 10000;
+        let multi_part_size = MINIMUM_PART_SIZE; // 5MB
+
+        // Test case 1: Small file, no adjustment needed
+        let est_len = 10u64 * 1024 * 1024; // 10MB
+        let min_part_size = est_len.div_ceil(MAX_PARTS);
+        let effective_size = std::cmp::max(multi_part_size as u64, min_part_size);
+        assert_eq!(effective_size, multi_part_size as u64);
+
+        // Test case 2: File that would exceed 10000 parts with 5MB part size
+        let est_len = 60u64 * 1024 * 1024 * 1024; // 60GB
+        let min_part_size = est_len.div_ceil(MAX_PARTS);
+        let effective_size = std::cmp::max(multi_part_size as u64, min_part_size);
+        // Should be at least 6MB to fit in 10000 parts
+        assert!(effective_size > multi_part_size as u64);
+        assert!(est_len.div_ceil(effective_size) <= MAX_PARTS);
+
+        // Test case 3: Very large file (100GB)
+        let est_len = 100 * 1024 * 1024 * 1024u64; // 100GB
+        let min_part_size = est_len.div_ceil(MAX_PARTS);
+        let effective_size = std::cmp::max(multi_part_size as u64, min_part_size);
+        // Should be at least ~10MB to fit in 10000 parts
+        assert!(effective_size > multi_part_size as u64);
+        assert!(est_len.div_ceil(effective_size) <= MAX_PARTS);
+
+        // Verify the estimated parts count
+        let estimated_parts = est_len.div_ceil(effective_size);
+        assert!(
+            estimated_parts <= MAX_PARTS,
+            "estimated parts {} exceeds maximum {}",
+            estimated_parts,
+            MAX_PARTS
+        );
     }
 }

--- a/components/cloud/aws/src/s3.rs
+++ b/components/cloud/aws/src/s3.rs
@@ -15,6 +15,7 @@ use aws_sdk_s3::{
     types::{CompletedMultipartUpload, CompletedPart},
     Client,
 };
+use aws_smithy_types::error::metadata::ProvideErrorMetadata;
 use bytes::Bytes;
 use cloud::{
     blob::{
@@ -405,7 +406,7 @@ impl RetryError for UploadError {
     }
 }
 
-impl<T: 'static + StdError> From<SdkError<T>> for UploadError {
+impl<T: 'static + StdError + ProvideErrorMetadata> From<SdkError<T>> for UploadError {
     fn from(err: SdkError<T>) -> Self {
         let msg = format!("{:?}", err);
         Self::Sdk {

--- a/components/cloud/aws/src/util.rs
+++ b/components/cloud/aws/src/util.rs
@@ -14,6 +14,7 @@ use aws_credential_types::provider::{error::CredentialsError, ProvideCredentials
 use aws_sdk_kms::config::SharedHttpClient;
 use aws_sdk_s3::config::HttpClient;
 use aws_smithy_runtime::client::http::hyper_014::HyperClientBuilder;
+use aws_smithy_types::error::metadata::ProvideErrorMetadata;
 use cloud::metrics;
 use futures::{Future, TryFutureExt};
 use hyper::Client;
@@ -66,7 +67,7 @@ pub fn new_credentials_provider(http: impl HttpClient + 'static) -> DefaultCrede
     }
 }
 
-pub fn is_retryable<T>(error: &SdkError<T>) -> bool {
+pub fn is_retryable<T: ProvideErrorMetadata>(error: &SdkError<T>) -> bool {
     match error {
         SdkError::TimeoutError(_) => true,
         SdkError::DispatchFailure(_) => true,
@@ -76,7 +77,18 @@ pub fn is_retryable<T>(error: &SdkError<T>) -> bool {
         }
         SdkError::ServiceError(service_err) => {
             let code = service_err.raw().status();
-            code.is_server_error() || code.as_u16() == http::StatusCode::REQUEST_TIMEOUT.as_u16()
+            if code.is_server_error() || code.as_u16() == http::StatusCode::REQUEST_TIMEOUT.as_u16()
+            {
+                return true;
+            }
+            // S3 can return throttling errors (e.g. SlowDown) as HTTP 200 with
+            // an error code embedded in the XML response body. The SDK detects
+            // this via body_is_error() and routes it through the error path,
+            // producing a ServiceError with raw status 200 but a parsed code.
+            matches!(
+                service_err.err().code(),
+                Some("SlowDown") | Some("RequestThrottled") | Some("RequestTimeout")
+            )
         }
         _ => false,
     }
@@ -204,87 +216,137 @@ impl ProvideCredentials for DefaultCredentialsProvider {
 #[cfg(test)]
 mod tests {
     use aws_smithy_runtime_api::http::StatusCode;
-    use aws_smithy_types::body::SdkBody;
+    use aws_smithy_types::{body::SdkBody, error::ErrorMetadata};
 
     #[allow(unused_imports)]
     use super::*;
 
+    // Minimal error type that satisfies ProvideErrorMetadata for unit tests.
+    #[derive(Debug)]
+    struct TestError {
+        meta: ErrorMetadata,
+    }
+
+    impl TestError {
+        fn with_code(code: &'static str) -> Self {
+            Self {
+                meta: ErrorMetadata::builder().code(code).build(),
+            }
+        }
+
+        fn no_code() -> Self {
+            Self {
+                meta: ErrorMetadata::builder().build(),
+            }
+        }
+    }
+
+    impl std::fmt::Display for TestError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{:?}", self.meta)
+        }
+    }
+
+    impl std::error::Error for TestError {}
+
+    impl ProvideErrorMetadata for TestError {
+        fn meta(&self) -> &ErrorMetadata {
+            &self.meta
+        }
+    }
+
     #[test]
     fn test_is_retryable_response_error_5xx() {
-        // Test that ResponseError with 5xx status codes are retryable
         let response = HttpResponse::new(StatusCode::try_from(503).unwrap(), SdkBody::empty());
-        let err = SdkError::<(), _>::response_error("service unavailable", response);
+        let err = SdkError::<TestError, _>::response_error("service unavailable", response);
         assert!(is_retryable(&err));
 
         let response = HttpResponse::new(StatusCode::try_from(500).unwrap(), SdkBody::empty());
-        let err = SdkError::<(), _>::response_error("internal server error", response);
+        let err = SdkError::<TestError, _>::response_error("internal server error", response);
         assert!(is_retryable(&err));
     }
 
     #[test]
     fn test_is_retryable_response_error_4xx() {
-        // Test that ResponseError with 4xx status codes are not retryable
         let response = HttpResponse::new(StatusCode::try_from(404).unwrap(), SdkBody::empty());
-        let err = SdkError::<(), _>::response_error("not found", response);
+        let err = SdkError::<TestError, _>::response_error("not found", response);
         assert!(!is_retryable(&err));
 
         let response = HttpResponse::new(StatusCode::try_from(400).unwrap(), SdkBody::empty());
-        let err = SdkError::<(), _>::response_error("bad request", response);
+        let err = SdkError::<TestError, _>::response_error("bad request", response);
         assert!(!is_retryable(&err));
     }
 
     #[test]
     fn test_is_retryable_response_error_408() {
-        // Test that ResponseError with 408 Request Timeout is retryable
         let response = HttpResponse::new(StatusCode::try_from(408).unwrap(), SdkBody::empty());
-        let err = SdkError::<(), _>::response_error("request timeout", response);
+        let err = SdkError::<TestError, _>::response_error("request timeout", response);
         assert!(is_retryable(&err));
     }
 
     #[test]
     fn test_is_retryable_service_error_5xx() {
-        // Test that ServiceError with 5xx status codes are retryable (e.g., S3
-        // SlowDown)
         let response = HttpResponse::new(StatusCode::try_from(503).unwrap(), SdkBody::empty());
-        let err = SdkError::<(), _>::service_error((), response);
+        let err = SdkError::service_error(TestError::no_code(), response);
         assert!(is_retryable(&err));
 
         let response = HttpResponse::new(StatusCode::try_from(500).unwrap(), SdkBody::empty());
-        let err = SdkError::<(), _>::service_error((), response);
+        let err = SdkError::service_error(TestError::no_code(), response);
         assert!(is_retryable(&err));
     }
 
     #[test]
     fn test_is_retryable_service_error_4xx() {
-        // Test that ServiceError with 4xx status codes are not retryable
         let response = HttpResponse::new(StatusCode::try_from(404).unwrap(), SdkBody::empty());
-        let err = SdkError::<(), _>::service_error((), response);
+        let err = SdkError::service_error(TestError::no_code(), response);
         assert!(!is_retryable(&err));
 
         let response = HttpResponse::new(StatusCode::try_from(403).unwrap(), SdkBody::empty());
-        let err = SdkError::<(), _>::service_error((), response);
+        let err = SdkError::service_error(TestError::no_code(), response);
         assert!(!is_retryable(&err));
     }
 
     #[test]
     fn test_is_retryable_service_error_408() {
-        // Test that ServiceError with 408 Request Timeout is retryable
         let response = HttpResponse::new(StatusCode::try_from(408).unwrap(), SdkBody::empty());
-        let err = SdkError::<(), _>::service_error((), response);
+        let err = SdkError::service_error(TestError::no_code(), response);
         assert!(is_retryable(&err));
     }
 
     #[test]
+    fn test_is_retryable_service_error_slowdown_http_200() {
+        // S3 SlowDown / throttling can arrive as HTTP 200 with the error code in
+        // the XML body. Verify all three throttling codes are retryable at
+        // status 200.
+        for code in &["SlowDown", "RequestThrottled", "RequestTimeout"] {
+            let response = HttpResponse::new(StatusCode::try_from(200).unwrap(), SdkBody::empty());
+            let err = SdkError::service_error(TestError::with_code(code), response);
+            assert!(
+                is_retryable(&err),
+                "expected HTTP 200 ServiceError with code={} to be retryable",
+                code
+            );
+        }
+    }
+
+    #[test]
+    fn test_is_retryable_service_error_other_200() {
+        // A 200 ServiceError with an unrelated code must not be retried.
+        let response = HttpResponse::new(StatusCode::try_from(200).unwrap(), SdkBody::empty());
+        let err = SdkError::service_error(TestError::with_code("NoSuchKey"), response);
+        assert!(!is_retryable(&err));
+    }
+
+    #[test]
     fn test_is_retryable_timeout_error() {
-        // Test that TimeoutError is retryable
-        let err = SdkError::<(), HttpResponse>::timeout_error("operation timed out");
+        let err = SdkError::<TestError, HttpResponse>::timeout_error("operation timed out");
         assert!(is_retryable(&err));
     }
 
     #[test]
     fn test_is_retryable_construction_failure() {
-        // Test that ConstructionFailure is not retryable
-        let err = SdkError::<(), HttpResponse>::construction_failure("failed to build request");
+        let err =
+            SdkError::<TestError, HttpResponse>::construction_failure("failed to build request");
         assert!(!is_retryable(&err));
     }
 

--- a/components/raftstore/src/store/fsm/store.rs
+++ b/components/raftstore/src/store/fsm/store.rs
@@ -74,7 +74,7 @@ use tikv_util::{
     warn,
     worker::{Builder as WorkerBuilder, LazyWorker, Scheduler, Worker},
     yatp_pool::FuturePool,
-    Either, RingQueue,
+    Either, RingQueue, GLOBAL_SERVER_READINESS,
 };
 use time::{self, Timespec};
 
@@ -2876,13 +2876,26 @@ impl<'a, EK: KvEngine, ER: RaftEngine, T: Transport> StoreFsmDelegate<'a, EK, ER
             busy_apply_peers_count,
             completed_apply_peers_count,
         );
-        // If the store already pass the check, it should clear the
-        // `completed_apply_peers_count` to skip the check next time.
-        if !busy_on_apply && completed_apply_peers_count.is_some() {
-            let mut meta = self.ctx.store_meta.lock().unwrap();
-            meta.completed_apply_peers_count = None;
-            meta.busy_apply_peers.clear();
+
+        if !busy_on_apply {
+            // If the store already passes the check, it should clear the
+            // `completed_apply_peers_count` to skip the check next time.
+            if completed_apply_peers_count.is_some() {
+                let mut meta = self.ctx.store_meta.lock().unwrap();
+                meta.completed_apply_peers_count = None;
+                meta.busy_apply_peers.clear();
+            }
+
+            if GLOBAL_SERVER_READINESS
+                .raft_peers_caught_up
+                .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed)
+                .is_ok()
+            {
+                // Log when the server readiness condition changes.
+                info!("ServerReadiness: Raft pending peers have caught up applying logs");
+            }
         }
+
         let store_is_busy = self
             .ctx
             .global_stat

--- a/components/raftstore/src/store/worker/pd.rs
+++ b/components/raftstore/src/store/worker/pd.rs
@@ -50,6 +50,7 @@ use tikv_util::{
     topn::TopN,
     warn,
     worker::{Runnable, ScheduleError, Scheduler},
+    GLOBAL_SERVER_READINESS,
 };
 use yatp::Remote;
 
@@ -1390,6 +1391,15 @@ where
         let f = async move {
             match resp.await {
                 Ok(mut resp) => {
+                    if GLOBAL_SERVER_READINESS
+                        .connected_to_pd
+                        .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed)
+                        .is_ok()
+                    {
+                        // Log when the server readiness condition changes.
+                        info!("ServerReadiness: connected to PD");
+                    }
+
                     if let Some(status) = resp.replication_status.take() {
                         let _ = router.send_control(StoreMsg::UpdateReplicationMode(status));
                     }

--- a/components/resource_control/src/config.rs
+++ b/components/resource_control/src/config.rs
@@ -3,7 +3,7 @@ use std::{fmt, sync::Arc};
 
 use online_config::{ConfigManager, ConfigValue, OnlineConfig};
 use serde::{Deserialize, Serialize};
-use tikv_util::config::VersionTrack;
+use tikv_util::config::{ReadableSize, VersionTrack};
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug, OnlineConfig)]
 #[serde(default)]
@@ -12,6 +12,55 @@ pub struct Config {
     #[online_config(skip)]
     pub enabled: bool,
     pub priority_ctl_strategy: PriorityCtlStrategy,
+    /// CPU utilization percentage at which background task throttling begins.
+    /// Background budget scales linearly from full down to zero between this
+    /// value and fg_cpu_throttle_threshold.
+    pub bg_cpu_throttle_threshold: f64,
+    /// CPU utilization percentage at which foreground task protection kicks in:
+    /// background tasks are fully throttled to their minimum floor and the
+    /// background utilization limit is capped here.
+    pub fg_cpu_throttle_threshold: f64,
+    /// Compaction pressure percentage at which background write IO throttling
+    /// begins. Dynamically configurable at runtime.
+    pub bg_compaction_pressure_threshold: f64,
+    /// Maximum write IO rate allowed for background tasks when
+    /// compaction pressure is lower than the threshold.
+    pub bg_write_io_ceiling: ReadableSize,
+    /// Minimum write IO rate that background tasks are always allowed,
+    /// even under maximum compaction pressure.
+    pub bg_write_io_floor: ReadableSize,
+    /// When true, enables fair two-phase scheduling for reads: groups whose
+    /// current-minute RU rate exceeds their historical baseline are placed in
+    /// phase 1 (deprioritised in the yatp priority queue) relative to groups
+    /// within their baseline (phase 0). Protects sustained workloads from
+    /// sudden traffic spikes without hard-rejecting requests.
+    pub enable_fair_scheduling: bool,
+    /// When true, enables Tier-1 admission control for reads: high-priority
+    /// read requests from groups that are over their RU baseline are shed
+    /// (SchedTooBusy) when CPU exceeds fg_cpu_throttle_threshold.
+    pub enable_read_admission_control: bool,
+    /// When true, enables Tier-1 admission control for writes: high-priority
+    /// write requests from groups that are over their RU baseline are shed
+    /// (SchedTooBusy) when CPU exceeds fg_cpu_throttle_threshold.
+    pub enable_write_admission_control: bool,
+    /// Size of the sliding window (in minutes) used to compute per-group
+    /// historical RU baselines for fair scheduling and admission control.
+    /// The window is divided into 30-second buckets (2 per minute). Minimum 2,
+    /// maximum 60. Not hot-reloadable; changing requires a restart.
+    #[online_config(skip)]
+    pub historical_usage_window_mins: u64,
+    /// Percentage of headroom above the historical RU baseline before a group
+    /// is considered "over baseline" for two-phase scheduling and CPU
+    /// utilization throttling. For example, 20.0 means a group must exceed
+    /// 1.2× its historical rate to be deprioritized or rate-limited.
+    /// Default: 20.0 (20%).
+    pub baseline_burst_pct: f64,
+    /// Maximum number of requests that can concurrently sit in the admission
+    /// control delay phase (reads and writes combined). When this limit is
+    /// reached, additional over-baseline requests are rejected immediately
+    /// (SchedTooBusy) rather than delayed. Set to 0 to disable the limit
+    /// (unlimited delayed requests). Default: 10_000.
+    pub admission_max_delayed_count: u64,
 }
 
 impl Default for Config {
@@ -19,6 +68,17 @@ impl Default for Config {
         Self {
             enabled: true,
             priority_ctl_strategy: PriorityCtlStrategy::Moderate,
+            bg_cpu_throttle_threshold: 60.0,
+            fg_cpu_throttle_threshold: 70.0,
+            bg_compaction_pressure_threshold: 70.0,
+            bg_write_io_ceiling: ReadableSize::gb(100),
+            bg_write_io_floor: ReadableSize::mb(10),
+            enable_fair_scheduling: false,
+            enable_read_admission_control: false,
+            enable_write_admission_control: false,
+            historical_usage_window_mins: 15,
+            baseline_burst_pct: 20.0,
+            admission_max_delayed_count: 10_000,
         }
     }
 }

--- a/components/resource_control/src/future.rs
+++ b/components/resource_control/src/future.rs
@@ -15,7 +15,7 @@ use tikv_util::{time::Instant, timer::GLOBAL_TIMER_HANDLE, warn};
 use tokio_timer::Delay;
 
 use crate::{
-    resource_group::{ResourceConsumeType, ResourceController},
+    resource_group::{ResourceConsumeType, ResourceController, ResourceGroupManager},
     resource_limiter::{ResourceLimiter, ResourceType},
 };
 
@@ -69,19 +69,41 @@ pub struct LimitedFuture<F: Future> {
     #[pin]
     post_delay: OptionalFuture<Compat01As03<Delay>>,
     resource_limiter: Arc<ResourceLimiter>,
+    skip_compaction_pressure: bool,
     // if the future is first polled, we need to let it consume a 0 value
     // to compensate the debt of previously finished tasks.
     is_first_poll: bool,
+    // When true: measure CPU/IO and build token-bucket debt, but never sleep.
+    // When false: existing behavior — sleep inside the pool to throttle.
+    measure_only: bool,
+    // For measure-only mode: feed RuTracker + token-bucket via record_ru_consumption.
+    resource_mgr: Option<Arc<ResourceGroupManager>>,
+    // Known write bytes for this request (from cmd.write_bytes()), used as the
+    // write component of io_bytes passed to consume() instead of /proc iostat.
+    // Avoids syscall overhead and thread-level IO noise from compaction on the
+    // same thread. Zero means fall back to IoBytesTracker (e.g. reads, background).
+    write_bytes: u64,
 }
 
 impl<F: Future> LimitedFuture<F> {
-    pub fn new(f: F, resource_limiter: Arc<ResourceLimiter>) -> Self {
+    pub fn new(
+        f: F,
+        resource_limiter: Arc<ResourceLimiter>,
+        skip_compaction_pressure: bool,
+        measure_only: bool,
+        resource_mgr: Option<Arc<ResourceGroupManager>>,
+        write_bytes: u64,
+    ) -> Self {
         Self {
             f,
             pre_delay: None.into(),
             post_delay: None.into(),
             resource_limiter,
+            skip_compaction_pressure,
             is_first_poll: true,
+            measure_only,
+            resource_mgr,
+            write_bytes,
         }
     }
 }
@@ -91,12 +113,20 @@ impl<F: Future> Future for LimitedFuture<F> {
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let mut this = self.project();
-        if *this.is_first_poll {
+
+        // Pre-delay: pay off existing token-bucket debt before starting work.
+        // Skipped in measure-only mode — foreground pools never sleep in-pool.
+        if *this.is_first_poll && !*this.measure_only {
             debug_assert!(this.pre_delay.finished && this.post_delay.finished);
             *this.is_first_poll = false;
             let wait_dur = this
                 .resource_limiter
-                .consume(Duration::ZERO, IoBytes::default(), true)
+                .consume(
+                    Duration::ZERO,
+                    IoBytes::default(),
+                    true,
+                    *this.skip_compaction_pressure,
+                )
                 .min(MAX_WAIT_DURATION);
             if wait_dur > Duration::ZERO {
                 *this.pre_delay = Some(
@@ -106,6 +136,8 @@ impl<F: Future> Future for LimitedFuture<F> {
                 )
                 .into();
             }
+        } else if *this.is_first_poll {
+            *this.is_first_poll = false;
         }
         if !this.post_delay.finished {
             assert!(this.pre_delay.finished);
@@ -117,8 +149,7 @@ impl<F: Future> Future for LimitedFuture<F> {
                 return Poll::Pending;
             }
         }
-        // get io stats is very expensive, so we only do so if only io control is
-        // enabled.
+        // get io stats is very expensive, so we only do so if io control is enabled.
         let mut io_tracker = if this
             .resource_limiter
             .get_limiter(ResourceType::Io)
@@ -132,14 +163,29 @@ impl<F: Future> Future for LimitedFuture<F> {
         let start = Instant::now();
         let res = this.f.poll(cx);
         let dur = start.saturating_elapsed();
-        let io_bytes = io_tracker
+        let mut io_bytes = io_tracker
             .as_mut()
             .and_then(|tracker| tracker.update())
             .unwrap_or_else(IoBytes::default);
-        let mut wait_dur = this
-            .resource_limiter
-            .consume(dur, io_bytes, res.is_pending());
-        if wait_dur == Duration::ZERO || res.is_ready() {
+        // Only count write_bytes when the future completes to avoid
+        // double-counting across multiple pending polls.
+        if *this.write_bytes > 0 && res.is_ready() {
+            io_bytes.write = *this.write_bytes;
+        }
+        let mut wait_dur = this.resource_limiter.consume(
+            dur,
+            io_bytes,
+            res.is_pending(),
+            *this.skip_compaction_pressure,
+        );
+        // Feed RuTracker so admission_decision has baseline data.
+        // Only for foreground limiters — background jobs shouldn't shift the baseline.
+        if !this.resource_limiter.is_background()
+            && let Some(mgr) = &this.resource_mgr
+        {
+            mgr.record_ru_consumption(this.resource_limiter.name(), dur.as_micros() as u64);
+        }
+        if wait_dur == Duration::ZERO || res.is_ready() || *this.measure_only {
             return res;
         }
         if wait_dur > MAX_WAIT_DURATION {
@@ -157,8 +203,8 @@ impl<F: Future> Future for LimitedFuture<F> {
     }
 }
 
-/// `OptionalFuture` is similar to futures::OptionFuture, but provide an extra
-/// `finished` flag to determine if the future requires poll.
+/// `OptionalFuture` is similar to futures::OptionFuture, but provides an extra
+/// `finished` flag to determine if the future requires polling.
 #[pin_project]
 struct OptionalFuture<F> {
     #[pin]
@@ -197,9 +243,21 @@ impl<F: Future> Future for OptionalFuture<F> {
 pub async fn with_resource_limiter<F: Future>(
     f: F,
     limiter: Option<Arc<ResourceLimiter>>,
+    skip_compaction_pressure: bool,
+    measure_only: bool,
+    resource_mgr: Option<Arc<ResourceGroupManager>>,
+    write_bytes: u64,
 ) -> F::Output {
     if let Some(limiter) = limiter {
-        LimitedFuture::new(f, limiter).await
+        LimitedFuture::new(
+            f,
+            limiter,
+            skip_compaction_pressure,
+            measure_only,
+            resource_mgr,
+            write_bytes,
+        )
+        .await
     } else {
         f.await
     }
@@ -264,7 +322,10 @@ mod tests {
             <F as Future>::Output: Send,
         {
             let (sender, receiver) = channel::<()>();
-            let fut = NotifyFuture::new(LimitedFuture::new(f, limiter), sender);
+            let fut = NotifyFuture::new(
+                LimitedFuture::new(f, limiter, false, false, None, 0),
+                sender,
+            );
             pool.spawn(fut).unwrap();
             receiver.recv().unwrap();
         }

--- a/components/resource_control/src/lib.rs
+++ b/components/resource_control/src/lib.rs
@@ -2,13 +2,14 @@
 #![feature(test)]
 #![feature(let_chains)]
 
-use std::sync::Arc;
+use std::sync::{atomic::AtomicU32, Arc};
 
 use pd_client::RpcClient;
 
 mod resource_group;
 pub use resource_group::{
-    ResourceConsumeType, ResourceController, ResourceGroupManager, MIN_PRIORITY_UPDATE_INTERVAL,
+    AdmissionDecision, DelaySlotGuard, ResourceConsumeType, ResourceController,
+    ResourceGroupManager, MIN_PRIORITY_UPDATE_INTERVAL,
 };
 pub use tikv_util::resource_control::*;
 
@@ -29,7 +30,7 @@ pub mod config;
 mod resource_limiter;
 pub use resource_limiter::ResourceLimiter;
 use tikv_util::worker::Worker;
-use worker::{GroupQuotaAdjustWorker, BACKGROUND_LIMIT_ADJUST_DURATION};
+use worker::{GroupQuotaAdjustWorker, QUOTA_ADJUST_DURATION};
 
 mod metrics;
 pub mod worker;
@@ -39,6 +40,7 @@ pub fn start_periodic_tasks(
     pd_client: Arc<RpcClient>,
     bg_worker: &Worker,
     io_bandwidth: u64,
+    compaction_pending_bytes_ratio: Arc<AtomicU32>,
 ) {
     let resource_mgr_service = ResourceManagerService::new(mgr.clone(), pd_client);
     // spawn a task to periodically update the minimal virtual time of all resource
@@ -54,11 +56,12 @@ pub fn start_periodic_tasks(
     });
     // spawn a task to auto adjust background quota limiter and priority quota
     // limiter.
-    let mut worker = GroupQuotaAdjustWorker::new(mgr.clone(), io_bandwidth);
+    let mut worker =
+        GroupQuotaAdjustWorker::new(mgr.clone(), io_bandwidth, compaction_pending_bytes_ratio);
     // We disable the priority worker by default because the current adjust
     // algorithm is buggy. We may reenable it only we find a better algorithm.
     // let mut priority_worker = PriorityLimiterAdjustWorker::new(mgr.clone());
-    bg_worker.spawn_interval_task(BACKGROUND_LIMIT_ADJUST_DURATION, move || {
+    bg_worker.spawn_interval_task(QUOTA_ADJUST_DURATION, move || {
         worker.adjust_quota();
         // priority_worker.adjust();
     });

--- a/components/resource_control/src/metrics.rs
+++ b/components/resource_control/src/metrics.rs
@@ -6,20 +6,19 @@ use prometheus::*;
 lazy_static! {
     pub static ref BACKGROUND_QUOTA_LIMIT_VEC: IntGaugeVec = register_int_gauge_vec!(
         "tikv_resource_control_background_quota_limiter",
-        "The quota limiter of background resource groups per resource type",
-        &["resource_group", "type"]
+        "The quota limiter for all background tasks per resource type",
+        &["type"]
     )
     .unwrap();
     pub static ref BACKGROUND_RESOURCE_CONSUMPTION: IntCounterVec = register_int_counter_vec!(
         "tikv_resource_control_background_resource_consumption",
-        "Total resource consumed of background resource groups per resource type",
-        &["resource_group", "type"]
+        "Total resource consumed by all background tasks (aggregated across all background resource groups) per resource type",
+        &["type"]
     )
     .unwrap();
-    pub static ref BACKGROUND_TASKS_WAIT_DURATION: IntCounterVec = register_int_counter_vec!(
+    pub static ref BACKGROUND_TASKS_WAIT_DURATION: IntCounter = register_int_counter!(
         "tikv_resource_control_background_task_wait_duration",
-        "Total wait duration of background tasks per resource group",
-        &["resource_group"]
+        "Total wait duration of all background tasks (aggregated across all background resource groups)"
     )
     .unwrap();
     pub static ref PRIORITY_QUOTA_LIMIT_VEC: IntGaugeVec = register_int_gauge_vec!(
@@ -48,12 +47,71 @@ lazy_static! {
         &["type"]
     )
     .unwrap();
+
+    pub static ref TWO_PHASE_THROTTLED_REQUESTS: IntCounterVec = register_int_counter_vec!(
+        "tikv_resource_control_two_phase_throttled_requests_total",
+        "Total requests assigned to phase 1 (RU rate above 15-min baseline) per resource group",
+        &["resource_group"]
+    )
+    .unwrap();
+
+    pub static ref GROUP_RU_HISTORICAL_RATE: GaugeVec = register_gauge_vec!(
+        "tikv_resource_control_group_ru_historical_rate",
+        "Historical CPU utilization % per resource group (sliding window average)",
+        &["resource_group"]
+    )
+    .unwrap();
+
+    pub static ref GROUP_RU_CURRENT_RATE: GaugeVec = register_gauge_vec!(
+        "tikv_resource_control_group_ru_current_rate",
+        "Current CPU utilization % per resource group (latest bucket)",
+        &["resource_group"]
+    )
+    .unwrap();
+
+    pub static ref GROUP_QUOTA_LIMIT_VEC: GaugeVec = register_gauge_vec!(
+        "tikv_resource_control_group_quota_limit",
+        "Current rate limit per resource group per resource type (CPU as utilization %, 0 means unlimited)",
+        &["resource_group", "type"]
+    )
+    .unwrap();
+
+    pub static ref ADMISSION_CURRENTLY_DELAYED: IntGauge = register_int_gauge!(
+        "tikv_resource_control_admission_currently_delayed",
+        "Current number of requests sitting in admission control delay"
+    )
+    .unwrap();
+
+    pub static ref ADMISSION_DELAYED_REQUESTS: IntCounterVec = register_int_counter_vec!(
+        "tikv_resource_control_admission_delayed_requests_total",
+        "Total requests delayed by admission control per resource group",
+        &["resource_group"]
+    )
+    .unwrap();
+    pub static ref ADMISSION_REJECTED_REQUESTS: IntCounterVec = register_int_counter_vec!(
+        "tikv_resource_control_admission_rejected_requests_total",
+        "Total requests rejected by admission control per resource group",
+        &["resource_group"]
+    )
+    .unwrap();
+    pub static ref ADMISSION_DELAY_DURATION: HistogramVec = register_histogram_vec!(
+        "tikv_resource_control_admission_delay_duration_seconds",
+        "Histogram of delay duration imposed by admission control",
+        &["resource_group"],
+        exponential_buckets(1e-4, 2.0, 20).unwrap() // 100us ~ 52s
+    )
+    .unwrap();
 }
 
 pub fn deregister_metrics(name: &str) {
-    for ty in ["cpu", "io"] {
-        _ = BACKGROUND_QUOTA_LIMIT_VEC.remove_label_values(&[name, ty]);
-        _ = BACKGROUND_RESOURCE_CONSUMPTION.remove_label_values(&[name, ty]);
-    }
-    _ = BACKGROUND_TASKS_WAIT_DURATION.remove_label_values(&[name]);
+    _ = TWO_PHASE_THROTTLED_REQUESTS.remove_label_values(&[name]);
+    _ = GROUP_QUOTA_LIMIT_VEC.remove_label_values(&[name, "cpu"]);
+    _ = GROUP_RU_HISTORICAL_RATE.remove_label_values(&[name]);
+    _ = GROUP_RU_CURRENT_RATE.remove_label_values(&[name]);
+    _ = ADMISSION_DELAYED_REQUESTS.remove_label_values(&[name]);
+    _ = ADMISSION_REJECTED_REQUESTS.remove_label_values(&[name]);
+    _ = ADMISSION_DELAY_DURATION.remove_label_values(&[name]);
+    _ = ADMISSION_DELAYED_REQUESTS.remove_label_values(&["background"]);
+    _ = ADMISSION_REJECTED_REQUESTS.remove_label_values(&["background"]);
+    _ = ADMISSION_DELAY_DURATION.remove_label_values(&["background"]);
 }

--- a/components/resource_control/src/resource_group.rs
+++ b/components/resource_control/src/resource_group.rs
@@ -5,10 +5,10 @@ use std::{
     cmp::{max, min},
     collections::HashSet,
     sync::{
-        atomic::{AtomicBool, AtomicU64, Ordering},
+        atomic::{AtomicBool, AtomicI64, AtomicU64, Ordering},
         Arc, Mutex,
     },
-    time::Duration,
+    time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
 use collections::HashMap;
@@ -27,7 +27,12 @@ use tikv_util::{
 };
 use yatp::queue::priority::TaskPriorityProvider;
 
-use crate::{config::Config, metrics::deregister_metrics, resource_limiter::ResourceLimiter};
+use crate::{
+    config::Config,
+    metrics,
+    metrics::{deregister_metrics, TWO_PHASE_THROTTLED_REQUESTS},
+    resource_limiter::{ResourceLimiter, ResourceType},
+};
 
 // a read task cost at least 50us.
 const DEFAULT_PRIORITY_PER_READ_TASK: u64 = 50;
@@ -51,9 +56,259 @@ const HIGH_PRIORITY: u32 = 16;
 // virtual time overflow.
 const RESET_VT_THRESHOLD: u64 = (u64::MAX >> 4) / 2;
 
+/// Duration of each bucket in the RuTracker ring buffer.
+const RU_BUCKET_SECS: u64 = 30;
+
+/// Sliding-window RU consumption tracker for both Tier-1 admission control
+/// and two-phase scheduling phase decisions.
+///
+/// Tracks actual CPU µs consumed (via `consume_penalty`) across reads and
+/// writes in a configurable ring buffer of 30-second buckets. Window size is
+/// set from `historical_usage_window_mins` (× 2 buckets per minute). Using real
+/// RU rather than virtual
+/// time avoids weight-skewing: a high-weight group accumulates VT faster
+/// without necessarily consuming more CPU.
+pub struct RuTracker {
+    /// Ring buffer of completed 30-second bucket totals (oldest at `head`).
+    buckets: Vec<u64>,
+    /// RU accumulated in the currently-open (incomplete) bucket.
+    /// Atomic so that `record_ru_consumption` can add without taking the Mutex.
+    current_bucket: AtomicU64,
+    /// Unix seconds at which the current bucket started.
+    bucket_start_secs: u64,
+    /// Index of the oldest completed bucket.
+    head: usize,
+    /// Number of completed buckets (≤ buckets.len()).
+    completed: usize,
+    /// Cached historical rate (RU/s), updated by `online_adjust_resource_quota`
+    /// every ~10s.
+    cached_historical_rate: f64,
+    /// Consecutive ramp-up epochs where new_limit >= 2x hist. Must reach
+    /// MIN_RAMP_UP_EPOCHS before the limit is fully lifted to INFINITY.
+    ramp_up_epochs: u32,
+}
+
+impl RuTracker {
+    /// Create a new tracker with `num_buckets` 30-second slots.
+    pub fn new(now_secs: u64, num_buckets: usize) -> Self {
+        let num_buckets = num_buckets.max(2); // need at least 2 to warm up
+        Self {
+            buckets: vec![0u64; num_buckets],
+            current_bucket: AtomicU64::new(0),
+            bucket_start_secs: now_secs,
+            head: 0,
+            completed: 0,
+            cached_historical_rate: 0.0,
+            ramp_up_epochs: 0,
+        }
+    }
+
+    pub fn now_secs() -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs()
+    }
+
+    #[inline]
+    fn num_buckets(&self) -> usize {
+        self.buckets.len()
+    }
+
+    /// Record `ru` in the current bucket (lock-free atomic add).
+    pub fn record(&self, ru: u64) {
+        self.current_bucket.fetch_add(ru, Ordering::Relaxed);
+    }
+
+    /// Advance to `now_secs` and record `ru`. Used by tests and callers
+    /// that hold exclusive access.
+    #[cfg(test)]
+    pub fn is_warmed_up(&self) -> bool {
+        self.completed >= 2
+    }
+
+    #[cfg(test)]
+    pub fn record_at(&mut self, ru: u64, now_secs: u64) {
+        self.advance(now_secs);
+        self.current_bucket.fetch_add(ru, Ordering::Relaxed);
+    }
+
+    fn advance(&mut self, now_secs: u64) {
+        let n = self.num_buckets();
+        let elapsed = now_secs.saturating_sub(self.bucket_start_secs);
+        let buckets_to_advance = (elapsed / RU_BUCKET_SECS) as usize;
+        if buckets_to_advance == 0 {
+            return;
+        }
+        if buckets_to_advance >= n {
+            // Gap larger than the window: everything aged out.
+            self.buckets.iter_mut().for_each(|b| *b = 0);
+            self.head = 0;
+            self.completed = 0;
+            self.current_bucket.store(0, Ordering::Relaxed);
+        } else {
+            // Commit the current bucket to the ring, then zero the rest.
+            let write_pos = (self.head + self.completed) % n;
+            self.buckets[write_pos] = self.current_bucket.swap(0, Ordering::Relaxed);
+            if self.completed < n {
+                self.completed += 1;
+            } else {
+                self.head = (self.head + 1) % n;
+            }
+            // Zero out the remaining (buckets_to_advance - 1) slots.
+            for _ in 1..buckets_to_advance {
+                let slot = (self.head + self.completed) % n;
+                self.buckets[slot] = 0;
+                if self.completed < n {
+                    self.completed += 1;
+                } else {
+                    self.head = (self.head + 1) % n;
+                }
+            }
+        }
+        self.bucket_start_secs += buckets_to_advance as u64 * RU_BUCKET_SECS;
+    }
+
+    /// RU/s rate estimated from the current partial bucket and the most recent
+    /// completed bucket. Using both avoids stale readings — the last completed
+    /// bucket alone can be up to 60s old at the end of the current 30s window.
+    ///
+    /// rate = (current_bucket + last_completed) / (elapsed_in_current + 30s)
+    pub fn current_rate(&self, now_secs: u64) -> f64 {
+        let elapsed = now_secs
+            .saturating_sub(self.bucket_start_secs)
+            .min(RU_BUCKET_SECS) as f64;
+        let last_completed = if self.completed > 0 {
+            let newest_slot = (self.head + self.completed - 1) % self.num_buckets();
+            self.buckets[newest_slot]
+        } else {
+            0
+        };
+        let window = elapsed + RU_BUCKET_SECS as f64;
+        (self.current_bucket.load(Ordering::Relaxed) + last_completed) as f64 / window
+    }
+
+    /// Average RU/s rate over all completed buckets (long-term baseline).
+    /// Average RU/s baseline. If the system has been up longer than the full
+    /// historical window, always divide by the full window (not just completed
+    /// buckets). This means a tracker that just started (e.g. spike with no
+    /// prior traffic) has historical=0 and any traffic is immediately detected
+    /// as over baseline, rather than letting new traffic inflate its own
+    /// baseline.
+    pub fn historical_rate(&self, system_start_secs: u64, now_secs: u64) -> f64 {
+        let window_secs = self.num_buckets() as u64 * RU_BUCKET_SECS;
+        let system_uptime = now_secs.saturating_sub(system_start_secs);
+        if system_uptime >= window_secs {
+            // System older than window — use full window as denominator.
+            // Missing buckets count as zero, diluting any fresh traffic.
+            if self.completed == 0 {
+                return 0.0;
+            }
+            let total: u64 = self.buckets.iter().take(self.completed).sum();
+            total as f64 / (self.num_buckets() as f64 * RU_BUCKET_SECS as f64)
+        } else {
+            if self.completed == 0 {
+                return 0.0;
+            }
+            let total: u64 = self.buckets.iter().take(self.completed).sum();
+            // Divide by elapsed system uptime (not just filled buckets) so the
+            // historical rate ramps up smoothly rather than jumping immediately
+            // to the full rate after the first bucket completes.
+            let denom = (system_uptime as f64).max(RU_BUCKET_SECS as f64);
+            total as f64 / denom
+        }
+    }
+
+    /// Returns true if no RU has been recorded: all completed buckets and the
+    /// current bucket are zero. Used to garbage-collect stale ru_trackers
+    /// entries.
+    pub fn is_idle(&self) -> bool {
+        self.current_bucket.load(Ordering::Relaxed) == 0 && self.buckets.iter().all(|&b| b == 0)
+    }
+
+    /// Refresh the cached historical rate. Called periodically from
+    /// `online_adjust_resource_quota` (~every 10s) so the inline hot path
+    /// avoids iterating all buckets.
+    pub fn refresh_cached_historical_rate(&mut self, system_start_secs: u64, now_secs: u64) {
+        self.cached_historical_rate = self.historical_rate(system_start_secs, now_secs);
+    }
+}
+
+/// Encodes a two-phase scheduling priority.
+///
+/// Bit position of the phase bit within the 64-bit encoded priority.
+/// Format: `[4-bit group_priority | 1-bit phase | 59-bit tag]`
+const PRIORITY_TAG_BITS: u32 = 59;
+
+/// Whether a task is within or over its historical RU baseline.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PriorityPhase {
+    /// Within baseline — given scheduling preference over phase-1 tasks.
+    WithinBaseline = 0,
+    /// Over baseline — deprioritised relative to within-baseline tasks.
+    OverBaseline = 1,
+}
+
+/// Format: `[4-bit group_priority | 1-bit phase | 59-bit tag]`
+///
+/// Phase 0 (within baseline) always sorts before phase 1 (over baseline)
+/// within the same group priority tier. Using only 1 bit for phase leaves
+/// 59 bits for the VT tag, matching `RESET_VT_THRESHOLD` (`2^59`).
+fn encode_two_phase_priority(group_priority: u32, phase: PriorityPhase, tag: u64) -> u64 {
+    assert!((1..=16).contains(&group_priority));
+    let tag = tag & ((1u64 << PRIORITY_TAG_BITS) - 1);
+    let phase_bit = (phase as u64) << PRIORITY_TAG_BITS;
+    (!((group_priority - 1) as u64) << 60) | phase_bit | tag
+}
+
+/// Returns true if the encoded priority value represents a phase-1 task.
+#[inline]
+fn is_phase1(priority: u64) -> bool {
+    (priority >> PRIORITY_TAG_BITS) & 1 == 1
+}
 pub enum ResourceConsumeType {
     CpuTime(Duration),
     IoBytes(u64),
+}
+
+/// Result of the Tier-1 admission control check for a single request.
+#[derive(Debug, PartialEq)]
+pub enum AdmissionDecision {
+    /// No throttling needed; let the request proceed immediately.
+    Allow,
+    /// Delay the request by the given duration. The caller **must** call
+    /// [`ResourceGroupManager::release_delay_slot`] once the delay is over
+    /// (or the delayed future is dropped/cancelled).
+    Delay(Duration),
+    /// Reject the request outright (SchedTooBusy). Returned when the number
+    /// of concurrently delayed requests exceeds `admission_max_delayed_count`.
+    Reject,
+}
+
+/// RAII guard that releases an admission-control delay slot on drop.
+/// Ensures the `delayed_req_count` counter is decremented even if the
+/// future is cancelled during the sleep.
+pub struct DelaySlotGuard {
+    mgr: Option<Arc<ResourceGroupManager>>,
+}
+
+impl DelaySlotGuard {
+    fn new(mgr: Arc<ResourceGroupManager>) -> Self {
+        Self { mgr: Some(mgr) }
+    }
+
+    /// Explicitly release the slot and disarm the guard so Drop is a no-op.
+    pub fn release(&mut self) {
+        if let Some(mgr) = self.mgr.take() {
+            mgr.release_delay_slot();
+        }
+    }
+}
+
+impl Drop for DelaySlotGuard {
+    fn drop(&mut self) {
+        self.release();
+    }
 }
 
 /// ResourceGroupManager manages the metadata of each resource group.
@@ -62,13 +317,30 @@ pub struct ResourceGroupManager {
     // the count of all groups, a fast path because call `DashMap::len` is a little slower.
     group_count: AtomicU64,
     registry: RwLock<Vec<Arc<ResourceController>>>,
-    // auto incremental version generator used for mark the background
-    // resource limiter has changed.
-    version_generator: AtomicU64,
     // the shared resource limiter of each priority
     priority_limiters: [Arc<ResourceLimiter>; TaskPriority::PRIORITY_COUNT],
+    bg_limiter: Arc<ResourceLimiter>,
+    // cached: true when at least one group has background settings configured.
+    has_background: AtomicBool,
     // lastest config.
     config: Arc<VersionTrack<Config>>,
+    // Per-group RU consumption trackers for Tier-1 high-priority throttling.
+    // Per-group sliding-window tracker and token-bucket limiter.
+    // Rate on the limiter is set to `fraction × historical_rate` each tick.
+    // The Arc allows handing out limiter references to LimitedFuture wrappers
+    // in the read/write pools without copying the limiter state.
+    ru_trackers: DashMap<String, Mutex<(RuTracker, Arc<ResourceLimiter>)>>,
+    // Number of requests currently held in the admission-control delay phase.
+    delayed_req_count: AtomicI64,
+    // Unix seconds when this manager was created. Used to determine whether
+    // the system has been up long enough that new trackers should be treated
+    // as if they missed the entire historical window (baseline = 0).
+    start_secs: u64,
+    // True when background CPU budget is at the minimum floor (1 core) AND
+    // background consumption is within that floor. Foreground throttling
+    // only engages when this flag is set, ensuring background is fully
+    // squeezed before foreground traffic is touched.
+    bg_cpu_at_floor: AtomicBool,
 }
 
 impl Default for ResourceGroupManager {
@@ -88,13 +360,25 @@ impl ResourceGroupManager {
                 false,
             ))
         });
+        let bg_limiter = Arc::new(ResourceLimiter::new(
+            DEFAULT_RESOURCE_GROUP_NAME.to_owned(),
+            f64::INFINITY,
+            f64::INFINITY,
+            0,
+            true,
+        ));
         let manager = Self {
             resource_groups: Default::default(),
             group_count: AtomicU64::new(0),
             registry: Default::default(),
-            version_generator: AtomicU64::new(0),
+            delayed_req_count: AtomicI64::new(0),
             priority_limiters,
+            bg_limiter,
+            has_background: AtomicBool::new(false),
             config: Arc::new(VersionTrack::new(config)),
+            ru_trackers: Default::default(),
+            start_secs: RuTracker::now_secs(),
+            bg_cpu_at_floor: AtomicBool::new(false),
         };
 
         // init the default resource group by default.
@@ -149,12 +433,7 @@ impl ResourceGroupManager {
             controller.add_resource_group(group_name.clone().into_bytes(), ru_quota, rg.priority);
         });
         info!("add resource group"; "name"=> &rg.name, "ru" => rg.get_r_u_settings().get_r_u().get_settings().get_fill_rate());
-        // try to reuse the quota limit when update resource group settings.
-        let prev_limiter = self
-            .resource_groups
-            .get(&rg.name)
-            .and_then(|g| g.limiter.clone());
-        let limiter = self.build_resource_limiter(&rg, prev_limiter);
+        let limiter = self.build_resource_limiter(&rg);
 
         if self
             .resource_groups
@@ -163,24 +442,37 @@ impl ResourceGroupManager {
         {
             self.group_count.fetch_add(1, Ordering::Relaxed);
         }
+        self.update_has_background();
     }
 
-    fn build_resource_limiter(
-        &self,
-        rg: &PbResourceGroup,
-        old_limiter: Option<Arc<ResourceLimiter>>,
-    ) -> Option<Arc<ResourceLimiter>> {
+    fn update_has_background(&self) {
+        let any_has_bg = self
+            .resource_groups
+            .iter()
+            .any(|g| !g.background_source_types.is_empty());
+        let prev = self.has_background.swap(any_has_bg, Ordering::Release);
+        // When the last background group is removed, reset the shared limiter to
+        // unlimited so that a later re-add does not inherit stale throttled rates.
+        if prev && !any_has_bg {
+            use crate::resource_limiter::ResourceType;
+            self.bg_limiter
+                .get_limiter(ResourceType::Cpu)
+                .set_rate_limit(f64::INFINITY);
+            self.bg_limiter
+                .get_limiter(ResourceType::Io)
+                .set_rate_limit(f64::INFINITY);
+            self.bg_limiter
+                .get_write_io_limiter()
+                .set_rate_limit(f64::INFINITY);
+        }
+        self.registry.read().iter().for_each(|controller| {
+            controller.set_has_background(any_has_bg);
+        });
+    }
+
+    fn build_resource_limiter(&self, rg: &PbResourceGroup) -> Option<Arc<ResourceLimiter>> {
         if !rg.get_background_settings().get_job_types().is_empty() {
-            old_limiter.or_else(|| {
-                let version = self.version_generator.fetch_add(1, Ordering::Relaxed);
-                Some(Arc::new(ResourceLimiter::new(
-                    rg.name.clone(),
-                    f64::INFINITY,
-                    f64::INFINITY,
-                    version,
-                    true,
-                )))
-            })
+            Some(self.bg_limiter.clone())
         } else {
             None
         }
@@ -192,10 +484,11 @@ impl ResourceGroupManager {
             controller.remove_resource_group(group_name.as_bytes());
         });
         if self.resource_groups.remove(&group_name).is_some() {
-            deregister_metrics(name);
             info!("remove resource group"; "name"=> name);
             self.group_count.fetch_sub(1, Ordering::Relaxed);
+            deregister_metrics(&group_name);
         }
+        self.update_has_background();
     }
 
     pub fn retain(&self, mut f: impl FnMut(&String, &PbResourceGroup) -> bool) {
@@ -208,7 +501,6 @@ impl ResourceGroupManager {
             let ret = f(k, &v.group);
             if !ret {
                 removed_names.push(k.clone());
-                deregister_metrics(k);
             }
             ret
         });
@@ -220,6 +512,7 @@ impl ResourceGroupManager {
             });
             self.group_count
                 .fetch_sub(removed_names.len() as u64, Ordering::Relaxed);
+            self.update_has_background();
         }
     }
 
@@ -239,18 +532,47 @@ impl ResourceGroupManager {
     }
 
     pub fn derive_controller(&self, name: String, is_read: bool) -> Arc<ResourceController> {
-        let controller = Arc::new(ResourceController::new(name, is_read));
+        let controller = Arc::new(ResourceController::new(name, is_read, self.config.clone()));
         self.registry.write().push(controller.clone());
         for g in &self.resource_groups {
             let ru_quota = Self::get_ru_setting(&g.value().group, controller.is_read);
             controller.add_resource_group(g.key().clone().into_bytes(), ru_quota, g.group.priority);
         }
+        controller.set_has_background(self.has_background.load(Ordering::Acquire));
         controller
     }
 
     pub fn advance_min_virtual_time(&self) {
+        // Push RU-based phase state into every controller before updating VT,
+        // so get_priority() sees fresh is_over_baseline flags this tick.
+        if self.config.value().enable_fair_scheduling {
+            self.update_group_phases();
+        }
         for controller in self.registry.read().iter() {
             controller.update_min_virtual_time();
+        }
+    }
+
+    /// Iterates all tracked groups and pushes `is_over_baseline` into each
+    /// registered `ResourceController`.  Called every ~1 second from
+    /// `advance_min_virtual_time` when `enable_fair_scheduling` is on.
+    fn update_group_phases(&self) {
+        let now_secs = RuTracker::now_secs();
+        for entry in &self.ru_trackers {
+            let group_bytes = entry.key().as_bytes();
+            let mut guard = entry.value().lock().unwrap();
+            // Roll the ring buffer forward so phase classification uses
+            // up-to-date bucket boundaries, not stale partial data.
+            guard.0.advance(now_secs);
+            let over = guard
+                .1
+                .get_limiter(ResourceType::Cpu)
+                .get_rate_limit()
+                .is_finite();
+            drop(guard);
+            for controller in self.registry.read().iter() {
+                controller.set_group_phase(group_bytes, over);
+            }
         }
     }
 
@@ -271,51 +593,347 @@ impl ResourceGroupManager {
                 ResourceConsumeType::IoBytes(ctx.get_penalty().write_bytes as u64),
             );
         }
+        // RU tracking for foreground admission control is handled by
+        // LimitedFuture (measure-only mode) which calls record_ru_consumption
+        // with actual CPU measured per poll.
     }
 
-    // only enable priority quota limiter when there is at least 1 user-defined
-    // resource group.
-    #[inline]
-    fn enable_priority_limiter(&self) -> bool {
-        // TODO: reenable it once when we fix https://github.com/tikv/tikv/issues/18939
-        // self.get_group_count() > 1
-        false
+    /// Record `ru` units consumed by `group` into the sliding-window tracker
+    /// and consume tokens from the group's rate limiter.
+    pub fn record_ru_consumption(&self, group: &str, ru: u64) {
+        let now = RuTracker::now_secs();
+        // 2 buckets per minute (30s each) to match RU_BUCKET_SECS.
+        let num_buckets = (self.config.value().historical_usage_window_mins.max(2) as usize) * 2;
+        let entry = self.ru_trackers.entry(group.to_owned()).or_insert_with(|| {
+            Mutex::new((
+                RuTracker::new(now, num_buckets),
+                Arc::new(ResourceLimiter::new(
+                    group.to_owned(),
+                    f64::INFINITY,
+                    f64::INFINITY,
+                    0,
+                    false,
+                )),
+            ))
+        });
+        // Lock-free: only atomically adds to current_bucket.
+        // advance() is called separately by online_adjust_resource_quota under the
+        // lock.
+        entry.lock().unwrap().0.record(ru);
     }
 
-    // Always return the background resource limiter if any;
-    // Only return the foregroup limiter when priority is enabled.
+    /// Called by `PriorityLimiterAdjustWorker` every ~1 second with the
+    /// latest process-level CPU utilisation percentage.
+    ///
+    /// Throttle-down: linearly reduces the allowed fraction of historical rate
+    /// for groups that are over their baseline. At `fg_cpu_throttle_threshold`
+    /// (70%) fraction = 1.0 (no throttle), at 90% CPU fraction = 0.8
+    /// (target). Called by the background adjust worker after computing the
+    /// new background CPU budget. `at_floor` should be true when the budget
+    /// has been clamped to the minimum floor AND background consumption
+    /// is within that floor.
+    pub fn set_bg_cpu_at_floor(&self, at_floor: bool) {
+        self.bg_cpu_at_floor.store(at_floor, Ordering::Relaxed);
+    }
+
+    /// Returns true when background CPU is fully throttled (at floor)
+    /// and its consumption is within the floor budget.
+    pub fn is_bg_cpu_at_floor(&self) -> bool {
+        self.bg_cpu_at_floor.load(Ordering::Relaxed)
+    }
+
+    /// Returns true when all foreground groups have unlimited (infinite)
+    /// CPU rate limits, i.e. foreground has fully ramped up.
+    pub fn is_foreground_fully_ramped_up(&self) -> bool {
+        for entry in &self.ru_trackers {
+            let guard = entry.lock().unwrap();
+            if guard
+                .1
+                .get_limiter(ResourceType::Cpu)
+                .get_rate_limit()
+                .is_finite()
+            {
+                return false;
+            }
+        }
+        true
+    }
+
+    /// Only groups whose current rate exceeds their historical rate are
+    /// limited.
+    ///
+    /// Ramp-up: when CPU drops below threshold, recover ×1.1/tick until
+    /// NO_LIMIT is restored.
+    pub fn online_adjust_resource_quota(&self, pct: f64) {
+        const TARGET_CPU: f64 = 90.0;
+        const RAMP_FACTOR: f64 = 1.2;
+        const MIN_RAMP_UP_EPOCHS: u32 = 2;
+
+        let throttle_threshold = self.config.value().fg_cpu_throttle_threshold;
+        let leeway_threshold = throttle_threshold * 0.9;
+        let burst_factor = 1.0 + self.config.value().baseline_burst_pct / 100.0;
+        let now = RuTracker::now_secs();
+
+        // Advance all trackers to `now` and refresh cached historical rates
+        // up front so update_group_phases and the throttling logic below
+        // always see fresh baseline data.
+        for entry in &self.ru_trackers {
+            let mut guard = entry.lock().unwrap();
+            guard.0.advance(now);
+            guard.0.refresh_cached_historical_rate(self.start_secs, now);
+            let name = guard.1.name();
+
+            metrics::GROUP_RU_HISTORICAL_RATE
+                .with_label_values(&[name])
+                .set((guard.0.cached_historical_rate / 1_000_000.0) * 100.0);
+            metrics::GROUP_RU_CURRENT_RATE
+                .with_label_values(&[name])
+                .set((guard.0.current_rate(now) / 1_000_000.0) * 100.0);
+        }
+
+        if pct > throttle_threshold && self.is_bg_cpu_at_floor() {
+            // Linearly scale limit from current rate (at threshold) down to
+            // historical rate (at TARGET_CPU).
+            // pressure: 0.0 at threshold → 1.0 at TARGET_CPU.
+            let pressure =
+                ((pct - throttle_threshold) / (TARGET_CPU - throttle_threshold)).clamp(0.0, 1.0);
+
+            for entry in &self.ru_trackers {
+                let mut guard = entry.lock().unwrap();
+                let hist = guard.0.cached_historical_rate;
+                let current = guard.0.current_rate(now);
+                let burst_target = hist * burst_factor;
+                if hist > 0.0 && current > burst_target {
+                    // rate slides from current (pressure=0) to burst_target (pressure=1).
+                    let rate = current + (burst_target - current) * pressure;
+                    let current_limit = guard.1.get_limiter(ResourceType::Cpu).get_rate_limit();
+                    // Only tighten the limit — never loosen in the throttle branch.
+                    // Ramp-up is the only path that increases limits.
+                    if current_limit.is_infinite() || rate < current_limit {
+                        guard.0.ramp_up_epochs = 0;
+                        guard
+                            .1
+                            .get_limiter(ResourceType::Cpu)
+                            .set_rate_limit(rate.max(1.0));
+                    }
+                }
+            }
+        } else if pct < leeway_threshold {
+            // CPU below start threshold — ramp up by RAMP_FACTOR each tick.
+            // Only lift to INFINITY after MIN_RAMP_UP_EPOCHS consecutive epochs
+            // where the limit has grown past 2x hist, to avoid premature release.
+            for entry in &self.ru_trackers {
+                let mut guard = entry.lock().unwrap();
+                let current_limit = guard.1.get_limiter(ResourceType::Cpu).get_rate_limit();
+                if current_limit.is_finite() {
+                    let hist = guard.0.cached_historical_rate;
+                    let new_limit = current_limit * RAMP_FACTOR;
+                    if hist <= 0.0 || new_limit >= 2.0 * hist {
+                        guard.0.ramp_up_epochs += 1;
+                        if guard.0.ramp_up_epochs >= MIN_RAMP_UP_EPOCHS {
+                            guard.0.ramp_up_epochs = 0;
+                            guard
+                                .1
+                                .get_limiter(ResourceType::Cpu)
+                                .set_rate_limit(f64::INFINITY);
+                        }
+                    } else {
+                        guard.0.ramp_up_epochs = 0;
+                        guard
+                            .1
+                            .get_limiter(ResourceType::Cpu)
+                            .set_rate_limit(new_limit);
+                    }
+                }
+            }
+        }
+
+        // Emit current rate limit per resource group.
+        for entry in &self.ru_trackers {
+            let guard = entry.lock().unwrap();
+            let limit = guard.1.get_limiter(ResourceType::Cpu).get_rate_limit();
+            let val = if limit.is_finite() {
+                (limit / 1_000_000.0) * 100.0
+            } else {
+                0.0
+            };
+            metrics::GROUP_QUOTA_LIMIT_VEC
+                .with_label_values(&[guard.1.name(), "cpu"])
+                .set(val);
+        }
+
+        // Evict idle ru_trackers entries to prevent unbounded growth from
+        // removed or renamed groups. Advance first so stale partial buckets
+        // are flushed before the idle check.
+        self.ru_trackers.retain(|_, entry| {
+            let inner = entry.get_mut().unwrap();
+            inner.0.advance(now);
+            !inner.0.is_idle()
+        });
+    }
+
+    /// Returns the token-bucket debt delay for `group`, or `None` if no
+    /// throttling is active.
+    ///
+    /// Conditions for a non-zero delay (all must hold):
+    ///   1. `enable_read_admission_control` / `enable_write_admission_control`
+    ///      on
+    ///   2. Rate-limit is active (not NO_LIMIT sentinel)
+    ///   3. Tracker has warmed up (≥2 completed 1-min buckets)
+    ///   4. Token-bucket has accumulated debt (group exceeded its allowed rate)
+    pub fn compute_admission_delay(
+        &self,
+        resource_limiter: &ResourceLimiter,
+        is_read: bool,
+    ) -> Option<Duration> {
+        // Always consume tokens so the token-bucket debt stays accurate
+        // for scheduling decisions. Only return the delay when admission
+        // control is enabled (or for background limiters, always).
+        let delay = resource_limiter.admission_delay(is_read);
+        if !resource_limiter.is_background() {
+            let config = self.config.value();
+            let ac_enabled = if is_read {
+                config.enable_read_admission_control
+            } else {
+                config.enable_write_admission_control
+            };
+            if !ac_enabled {
+                return None;
+            }
+        }
+        if delay.is_zero() { None } else { Some(delay) }
+    }
+
+    /// Unified admission-control decision for a request from `group`.
+    ///
+    /// Combines token-bucket rate-limiter debt (`resource_limiter`) with
+    /// RU-baseline overage delay into a single pre-pool sleep duration.
+    /// Covers background, low-priority, and resource-group throttling for
+    /// both reads (`is_read=true`) and writes (`is_read=false`).
+    ///
+    /// Returns:
+    /// - [`AdmissionDecision::Allow`] — no throttling needed.
+    /// - [`AdmissionDecision::Delay(d)`] — caller should sleep `d` then
+    ///   proceed, and **must** call [`release_delay_slot`] afterwards.
+    /// - [`AdmissionDecision::Reject`] — too many requests are already delayed;
+    ///   reject immediately.
+    pub fn admission_decision(
+        &self,
+        is_read: bool,
+        resource_limiter: &ResourceLimiter,
+    ) -> AdmissionDecision {
+        let group = resource_limiter.name();
+        let delay = self
+            .compute_admission_delay(resource_limiter, is_read)
+            .unwrap_or(std::time::Duration::ZERO);
+        if delay.is_zero() {
+            return AdmissionDecision::Allow;
+        }
+        let metric_label = if resource_limiter.is_background() {
+            "background"
+        } else {
+            group
+        };
+        let max = self.config.value().admission_max_delayed_count;
+        let prev = self.delayed_req_count.fetch_add(1, Ordering::Relaxed);
+        metrics::ADMISSION_CURRENTLY_DELAYED.set(prev + 1);
+        if max > 0 && prev >= max as i64 {
+            self.delayed_req_count.fetch_sub(1, Ordering::Relaxed);
+            metrics::ADMISSION_CURRENTLY_DELAYED.set(prev);
+            crate::metrics::ADMISSION_REJECTED_REQUESTS
+                .with_label_values(&[metric_label])
+                .inc();
+            return AdmissionDecision::Reject;
+        }
+        crate::metrics::ADMISSION_DELAYED_REQUESTS
+            .with_label_values(&[metric_label])
+            .inc();
+        crate::metrics::ADMISSION_DELAY_DURATION
+            .with_label_values(&[metric_label])
+            .observe(delay.as_secs_f64());
+        AdmissionDecision::Delay(delay)
+    }
+
+    /// Release a delay slot acquired by [`admission_decision`] returning
+    /// [`AdmissionDecision::Delay`]. Must be called exactly once per `Delay`
+    /// decision, whether the request completes normally or is cancelled.
+    pub fn release_delay_slot(&self) {
+        let prev = self.delayed_req_count.fetch_sub(1, Ordering::Relaxed);
+        metrics::ADMISSION_CURRENTLY_DELAYED.set(prev - 1);
+    }
+
+    /// Returns an RAII guard that calls [`release_delay_slot`] on drop.
+    /// Use this to ensure the slot is released even if the future is
+    /// cancelled during the admission-control sleep.
+    pub fn delay_slot_guard(self: &Arc<Self>) -> DelaySlotGuard {
+        DelaySlotGuard::new(Arc::clone(self))
+    }
+
+    /// Returns the per-group admission-control limiter for `group`, creating
+    /// the entry if it does not yet exist. Used by `with_resource_limiter`
+    /// (measure-only mode) in the read/write pools so `LimitedFuture` can
+    /// build token-bucket debt for pre-pool `admission_decision`.
+    pub fn get_foreground_group_limiter(&self, group: &str) -> Arc<ResourceLimiter> {
+        let now = RuTracker::now_secs();
+        // 2 buckets per minute (30s each) to match RU_BUCKET_SECS.
+        let num_buckets = (self.config.value().historical_usage_window_mins.max(2) as usize) * 2;
+        self.ru_trackers
+            .entry(group.to_owned())
+            .or_insert_with(|| {
+                Mutex::new((
+                    RuTracker::new(now, num_buckets),
+                    Arc::new(ResourceLimiter::new(
+                        group.to_owned(),
+                        f64::INFINITY,
+                        f64::INFINITY,
+                        0,
+                        false,
+                    )),
+                ))
+            })
+            .lock()
+            .unwrap()
+            .1
+            .clone()
+    }
+
+    /// Returns the appropriate `ResourceLimiter` for `with_resource_limiter`:
+    /// - Background tasks → background limiter
+    /// - Foreground tasks (any priority) → per-group limiter from `ru_trackers`
     pub fn get_resource_limiter(
         &self,
         rg: &str,
         request_source: &str,
-        override_priority: u64,
+        _override_priority: u64,
     ) -> Option<Arc<ResourceLimiter>> {
-        let (limiter, group_priority) =
-            self.get_background_resource_limiter_with_priority(rg, request_source);
+        let (limiter, _) = self.get_background_resource_limiter_with_priority(rg, request_source);
         if limiter.is_some() {
             return limiter;
         }
-
-        // if there is only 1 resource group, priority quota limiter is useless so just
-        // return None for better performance.
-        if !self.enable_priority_limiter() {
+        if self.get_group_count() <= 1 {
             return None;
         }
-
-        // request priority has higher priority, 0 means priority is not set.
-        let mut task_priority = override_priority as u32;
-        if task_priority == 0 {
-            task_priority = group_priority;
-        }
-        Some(self.priority_limiters[TaskPriority::from(task_priority) as usize].clone())
+        // Only create a foreground limiter for known groups; unknown or removed
+        // groups fall back to "default" to avoid leaking ru_trackers entries.
+        let group_name = if self.resource_groups.contains_key(rg) {
+            rg
+        } else {
+            DEFAULT_RESOURCE_GROUP_NAME
+        };
+        Some(self.get_foreground_group_limiter(group_name))
     }
 
     // return a ResourceLimiter for background tasks only.
+    // Returns None if request_source does not match a configured background job
+    // type.
     pub fn get_background_resource_limiter(
         &self,
         rg: &str,
         request_source: &str,
     ) -> Option<Arc<ResourceLimiter>> {
+        if request_source.is_empty() {
+            return None;
+        }
         self.get_background_resource_limiter_with_priority(rg, request_source)
             .0
     }
@@ -356,6 +974,14 @@ impl ResourceGroupManager {
     ) -> &[Arc<ResourceLimiter>; TaskPriority::PRIORITY_COUNT] {
         &self.priority_limiters
     }
+
+    pub fn get_background_limiter(&self) -> Arc<ResourceLimiter> {
+        self.bg_limiter.clone()
+    }
+
+    pub fn has_background_groups(&self) -> bool {
+        self.has_background.load(Ordering::Acquire)
+    }
 }
 
 pub(crate) struct ResourceGroup {
@@ -387,8 +1013,8 @@ impl ResourceGroup {
         }
     }
 
-    pub(crate) fn get_ru_quota(&self) -> u64 {
-        assert!(self.group.has_r_u_settings());
+    #[cfg(test)]
+    pub fn get_ru_quota(&self) -> u64 {
         self.group
             .get_r_u_settings()
             .get_r_u()
@@ -442,6 +1068,10 @@ pub struct ResourceController {
     last_rest_vt_time: Cell<Instant>,
     // whether the settings is customized by user
     customized: AtomicBool,
+    // whether any resource group has background settings configured
+    has_background: AtomicBool,
+    // Shared config. Read on the hot path to check enable_fair_scheduling.
+    config: Arc<VersionTrack<Config>>,
 }
 
 // we are ensure to visit the `last_rest_vt_time` by only 1 thread so it's
@@ -450,7 +1080,7 @@ unsafe impl Send for ResourceController {}
 unsafe impl Sync for ResourceController {}
 
 impl ResourceController {
-    fn new(name: String, is_read: bool) -> Self {
+    fn new(name: String, is_read: bool, config: Arc<VersionTrack<Config>>) -> Self {
         Self {
             name,
             is_read,
@@ -459,11 +1089,17 @@ impl ResourceController {
             max_ru_quota: Mutex::new(DEFAULT_MAX_RU_QUOTA),
             last_rest_vt_time: Cell::new(Instant::now_coarse()),
             customized: AtomicBool::new(false),
+            has_background: AtomicBool::new(false),
+            config,
         }
     }
 
     pub fn new_for_test(name: String, is_read: bool) -> Self {
-        let controller = Self::new(name, is_read);
+        let controller = Self::new(
+            name,
+            is_read,
+            Arc::new(VersionTrack::new(Config::default())),
+        );
         // add the "default" resource group.
         controller.add_resource_group(
             DEFAULT_RESOURCE_GROUP_NAME.as_bytes().to_owned(),
@@ -520,6 +1156,9 @@ impl ResourceController {
             weight,
             virtual_time: AtomicU64::new(self.last_min_vt.load(Ordering::Acquire)),
             vt_delta_for_get,
+            // New groups start in phase 0; ResourceGroupManager updates this
+            // each second once the RuTracker has enough history.
+            is_over_baseline: AtomicBool::new(false),
         };
 
         // maybe update existed group
@@ -566,7 +1205,11 @@ impl ResourceController {
     }
 
     pub fn is_customized(&self) -> bool {
-        self.customized.load(Ordering::Acquire)
+        self.customized.load(Ordering::Acquire) || self.has_background.load(Ordering::Acquire)
+    }
+
+    pub fn set_has_background(&self, has_background: bool) {
+        self.has_background.store(has_background, Ordering::Release);
     }
 
     #[inline]
@@ -583,6 +1226,17 @@ impl ResourceController {
 
     pub fn consume(&self, name: &[u8], resource: ResourceConsumeType) {
         self.resource_group(name).consume(resource)
+    }
+
+    /// Updates the two-phase `is_over_baseline` flag for a single group.
+    /// Called each second by `ResourceGroupManager::update_group_phases`.
+    pub fn set_group_phase(&self, group: &[u8], over_baseline: bool) {
+        let consumptions = self.resource_consumptions.read();
+        if let Some(tracker) = consumptions.get(group) {
+            tracker
+                .is_over_baseline
+                .store(over_baseline, Ordering::Relaxed);
+        }
     }
 
     pub fn update_min_virtual_time(&self) {
@@ -636,26 +1290,61 @@ impl ResourceController {
     }
 
     pub fn get_priority(&self, name: &[u8], pri: CommandPri) -> u64 {
-        let level = match pri {
-            CommandPri::Low => 2,
-            CommandPri::Normal => 1,
-            CommandPri::High => 0,
+        let level = Self::command_pri_to_level(pri);
+        self.resource_group(name)
+            .get_priority(level, None, true, self.is_two_phase_enabled())
+    }
+
+    /// Returns the priority for the given task metadata without incrementing
+    /// virtual time. Used for pre-spawn eviction comparison.
+    pub fn peek_priority_of(&self, metadata: &TaskMetadata<'_>, pri: CommandPri) -> u64 {
+        let level = Self::command_pri_to_level(pri);
+        let group = self.resource_group(metadata.group_name());
+        let override_priority = if metadata.override_priority() == 0 {
+            None
+        } else {
+            Some(metadata.override_priority())
         };
-        self.resource_group(name).get_priority(level, None)
+        group.get_priority(level, override_priority, false, self.is_two_phase_enabled())
+    }
+
+    /// Returns true when fair two-phase scheduling is active (read controller
+    /// with enable_fair_scheduling enabled).
+    #[inline]
+    fn is_two_phase_enabled(&self) -> bool {
+        self.is_read && self.config.value().enable_fair_scheduling
+    }
+
+    fn command_pri_to_level(pri: CommandPri) -> usize {
+        match pri {
+            CommandPri::High => 0,
+            CommandPri::Normal => 1,
+            CommandPri::Low => 2,
+        }
     }
 }
 
 impl TaskPriorityProvider for ResourceController {
     fn priority_of(&self, extras: &yatp::queue::Extras) -> u64 {
         let metadata = TaskMetadata::from(extras.metadata());
-        self.resource_group(metadata.group_name()).get_priority(
+        let p = self.resource_group(metadata.group_name()).get_priority(
             extras.current_level() as usize,
             if metadata.override_priority() == 0 {
                 None
             } else {
                 Some(metadata.override_priority())
             },
-        )
+            true,
+            self.is_two_phase_enabled(),
+        );
+        if is_phase1(p)
+            && let Ok(name) = std::str::from_utf8(metadata.group_name())
+        {
+            TWO_PHASE_THROTTLED_REQUESTS
+                .with_label_values(&[name])
+                .inc();
+        }
+        p
     }
 }
 
@@ -676,20 +1365,47 @@ struct GroupPriorityTracker {
     virtual_time: AtomicU64,
     // the constant delta value for each `get_priority` call,
     vt_delta_for_get: u64,
+    // Two-phase scheduling: true when this group's current-minute RU rate
+    // exceeds its historical baseline (set by ResourceGroupManager each second).
+    // Phase 1 tasks are deprioritised relative to phase-0 (within-baseline) tasks.
+    is_over_baseline: AtomicBool,
 }
 
 impl GroupPriorityTracker {
-    fn get_priority(&self, level: usize, override_priority: Option<u32>) -> u64 {
+    /// Computes the scheduling priority for a task at the given level.
+    ///
+    /// When `advance_vt` is true, atomically increments the virtual time
+    /// (used when actually scheduling a task). When false, reads virtual
+    /// time without advancing it (used for priority comparison only).
+    ///
+    /// When `two_phase` is true and `is_over_baseline` is set, the task is
+    /// placed in phase 1 (deprioritised); otherwise it runs in phase 0.
+    /// `is_over_baseline` is updated each second by `ResourceGroupManager`
+    /// from real CPU µs tracked across reads and writes via `consume_penalty`.
+    fn get_priority(
+        &self,
+        level: usize,
+        override_priority: Option<u32>,
+        advance_vt: bool,
+        two_phase: bool,
+    ) -> u64 {
         let task_extra_priority = TASK_EXTRA_FACTOR_BY_LEVEL[level] * 1000 * self.weight;
-        let vt = (if self.vt_delta_for_get > 0 {
-            self.virtual_time
-                .fetch_add(self.vt_delta_for_get, Ordering::Relaxed)
-                + self.vt_delta_for_get
-        } else {
-            self.virtual_time.load(Ordering::Relaxed)
-        }) + task_extra_priority;
         let priority = override_priority.unwrap_or(self.group_priority);
-        concat_priority_vt(priority, vt)
+        let vt_delta = self.vt_delta_for_get;
+
+        let vt = if advance_vt && vt_delta > 0 {
+            self.virtual_time.fetch_add(vt_delta, Ordering::Relaxed) + vt_delta
+        } else {
+            self.virtual_time.load(Ordering::Relaxed) + vt_delta
+        } + task_extra_priority;
+
+        if two_phase && self.is_over_baseline.load(Ordering::Relaxed) {
+            encode_two_phase_priority(priority, PriorityPhase::OverBaseline, vt)
+        } else if two_phase {
+            encode_two_phase_priority(priority, PriorityPhase::WithinBaseline, vt)
+        } else {
+            concat_priority_vt(priority, vt)
+        }
     }
 
     #[inline]
@@ -720,6 +1436,7 @@ impl GroupPriorityTracker {
 
 #[cfg(test)]
 pub(crate) mod tests {
+    use file_system::IoBytes;
     use yatp::queue::Extras;
 
     use super::*;
@@ -1202,6 +1919,150 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn test_encode_two_phase_priority_ordering() {
+        // Phase 0 (reservation) must sort before phase 1 (weight) for the
+        // same group_priority and a larger tag value.
+        let phase0 =
+            encode_two_phase_priority(MEDIUM_PRIORITY, PriorityPhase::WithinBaseline, 9999);
+        let phase1 = encode_two_phase_priority(MEDIUM_PRIORITY, PriorityPhase::OverBaseline, 1);
+        assert!(
+            phase0 < phase1,
+            "phase 0 must be higher priority than phase 1"
+        );
+
+        // Within phase 0, lower tag = higher priority.
+        let p0_low = encode_two_phase_priority(MEDIUM_PRIORITY, PriorityPhase::WithinBaseline, 100);
+        let p0_high =
+            encode_two_phase_priority(MEDIUM_PRIORITY, PriorityPhase::WithinBaseline, 200);
+        assert!(p0_low < p0_high);
+
+        // group_priority still dominates across phases.
+        let high_phase1 =
+            encode_two_phase_priority(HIGH_PRIORITY, PriorityPhase::OverBaseline, u64::MAX >> 8);
+        let low_phase0 = encode_two_phase_priority(LOW_PRIORITY, PriorityPhase::WithinBaseline, 0);
+        assert!(high_phase1 < low_phase0);
+    }
+
+    #[test]
+    fn test_two_phase_scheduling_ru_based() {
+        // Two-phase scheduling driven by real RU (CPU µs) from ResourceGroupManager.
+        let mut cfg = Config::default();
+        cfg.enable_fair_scheduling = true;
+        let mgr = ResourceGroupManager::new(cfg);
+
+        let steady = new_resource_group_ru("steady".into(), 1000, MEDIUM_PRIORITY);
+        let spike = new_resource_group_ru("spike".into(), 1000, MEDIUM_PRIORITY);
+        mgr.add_resource_group(steady);
+        mgr.add_resource_group(spike);
+
+        let ctl = mgr.derive_controller("read".into(), true);
+
+        // Warm up steady's RuTracker: 2 completed 30s buckets with consistent rate.
+        let t0 = RuTracker::now_secs();
+        {
+            let e = mgr
+                .ru_trackers
+                .entry("steady".to_owned())
+                .or_insert_with(|| {
+                    Mutex::new((
+                        RuTracker::new(t0, 30),
+                        Arc::new(ResourceLimiter::new(
+                            "".into(),
+                            f64::INFINITY,
+                            f64::INFINITY,
+                            0,
+                            false,
+                        )),
+                    ))
+                });
+            let mut tr = e.lock().unwrap();
+            tr.0.record_at(6000, t0 + 15);
+            tr.0.record_at(0, t0 + 30); // close bucket 0: 6000 µs
+            tr.0.record_at(6000, t0 + 45);
+            tr.0.record_at(0, t0 + 60); // close bucket 1: 6000 µs → stable baseline
+        }
+        // "spike" has no tracker → is_over_baseline stays false (no history).
+
+        // Push phases into controller.
+        mgr.advance_min_virtual_time();
+
+        // steady: both buckets equal → current_rate == historical_rate → NOT over
+        // baseline. spike: no tracker → also not over baseline.
+        // Neither should be in phase 1 at steady state.
+        {
+            let groups = ctl.resource_consumptions.read();
+            let steady_over = groups
+                .get(b"steady".as_ref())
+                .unwrap()
+                .is_over_baseline
+                .load(Ordering::Relaxed);
+            let spike_over = groups
+                .get(b"spike".as_ref())
+                .unwrap()
+                .is_over_baseline
+                .load(Ordering::Relaxed);
+            assert!(!steady_over, "steady at baseline should be phase 0");
+            assert!(!spike_over, "spike with no history should be phase 0");
+        }
+
+        // Now simulate a spike for "spike": current bucket >> historical.
+        {
+            let e = mgr
+                .ru_trackers
+                .entry("spike".to_owned())
+                .or_insert_with(|| {
+                    Mutex::new((
+                        RuTracker::new(t0, 30),
+                        Arc::new(ResourceLimiter::new(
+                            "".into(),
+                            f64::INFINITY,
+                            f64::INFINITY,
+                            0,
+                            false,
+                        )),
+                    ))
+                });
+            let mut tr = e.lock().unwrap();
+            tr.0.record_at(3000, t0 + 30);
+            tr.0.record_at(0, t0 + 60); // close bucket [t0+30,t0+60): 3000µs baseline
+            tr.0.record_at(12000, t0 + 90); // current open bucket: 12000µs spike (left open)
+        }
+        // Trigger a CPU utilization tick to refresh cached_historical_rate
+        // on all trackers. Set bg_cpu_at_floor so the throttle branch fires
+        // and limits groups that are over baseline.
+        mgr.set_bg_cpu_at_floor(true);
+        mgr.online_adjust_resource_quota(75.0);
+        mgr.advance_min_virtual_time();
+
+        {
+            let groups = ctl.resource_consumptions.read();
+            let spike_over = groups
+                .get(b"spike".as_ref())
+                .unwrap()
+                .is_over_baseline
+                .load(Ordering::Relaxed);
+            assert!(spike_over, "spike bucket1 > bucket0 → should be phase 1");
+        }
+
+        // Phase ordering: steady (phase 0) must sort before spike (phase 1).
+        let groups = ctl.resource_consumptions.read();
+        let steady_pri = groups
+            .get(b"steady".as_ref())
+            .unwrap()
+            .get_priority(1, None, false, true);
+        let spike_pri = groups
+            .get(b"spike".as_ref())
+            .unwrap()
+            .get_priority(1, None, false, true);
+        assert!(!is_phase1(steady_pri), "steady should be phase 0");
+        assert!(is_phase1(spike_pri), "spike should be phase 1");
+        assert!(
+            steady_pri < spike_pri,
+            "phase 0 must schedule before phase 1"
+        );
+    }
+
+    #[test]
     fn test_get_resource_limiter() {
         let mgr = ResourceGroupManager::default();
 
@@ -1219,9 +2080,14 @@ pub(crate) mod tests {
             .clone()
             .unwrap();
 
+        // Only 1 group (default): foreground always returns None.
         assert!(mgr.get_resource_limiter("default", "query", 0).is_none());
         assert!(
             mgr.get_resource_limiter("default", "query", HIGH_PRIORITY as u64)
+                .is_none()
+        );
+        assert!(
+            mgr.get_resource_limiter("default", "query", LOW_PRIORITY as u64)
                 .is_none()
         );
 
@@ -1268,26 +2134,177 @@ pub(crate) mod tests {
             &default_limiter
         ));
 
+        // Background path still takes priority for "stats" source.
         assert!(Arc::ptr_eq(
             &mgr.get_resource_limiter("test1", "stats", 0).unwrap(),
             &default_limiter
         ));
 
-        // test legacy task_type "lightning" can be converted to "import".
-        let lightning_group = new_background_resource_group_ru(
-            "lightning".into(),
-            200,
-            MEDIUM_PRIORITY,
-            vec!["lightning".into()],
+        // Multiple groups: all foreground priorities get the per-group limiter.
+        // The same limiter is returned regardless of priority level.
+        let fg_limiter = mgr
+            .get_resource_limiter("test1", "query", LOW_PRIORITY as u64)
+            .unwrap();
+        assert!(Arc::ptr_eq(
+            &mgr.get_resource_limiter("test1", "query", HIGH_PRIORITY as u64)
+                .unwrap(),
+            &fg_limiter,
+        ));
+        assert!(Arc::ptr_eq(
+            &mgr.get_resource_limiter("test1", "query", 0).unwrap(),
+            &fg_limiter,
+        ));
+    }
+
+    #[test]
+    fn test_ru_tracker() {
+        let t0: u64 = 1_000_000;
+
+        const BUCKETS: usize = 15;
+        let mut tracker = RuTracker::new(t0, BUCKETS);
+        assert!(!tracker.is_warmed_up());
+        // No data at all: current_rate = (0 + 0) / (0 + 60) = 0.
+        assert_eq!(tracker.current_rate(t0), 0.0);
+        assert_eq!(tracker.historical_rate(t0, t0), 0.0);
+
+        // Record 6000 RU in the first 30s bucket.
+        tracker.record_at(6000, t0 + 15);
+
+        // Advance past the first bucket boundary (30s) — completes bucket 0.
+        tracker.record_at(0, t0 + 30);
+        assert_eq!(tracker.completed, 1);
+        // At t0+30: current_bucket=0, elapsed=0, last_completed=6000
+        // rate = (0 + 6000) / (0 + 30) = 200 RU/s
+        assert!((tracker.current_rate(t0 + 30) - 200.0).abs() < 0.01);
+        assert!(!tracker.is_warmed_up()); // needs ≥2 buckets
+
+        // Advance another 30s with 3000 RU — completes bucket 1.
+        tracker.record_at(3000, t0 + 45);
+        tracker.record_at(0, t0 + 60);
+        assert_eq!(tracker.completed, 2);
+        assert!(tracker.is_warmed_up());
+        // At t0+60: current_bucket=0, elapsed=0, last_completed=3000
+        // rate = (0 + 3000) / (0 + 30) = 100 RU/s
+        assert!((tracker.current_rate(t0 + 60) - 100.0).abs() < 0.01);
+        // At t0+75 (15s into next bucket, no new RU): current_bucket=0, elapsed=15
+        // rate = (0 + 3000) / (15 + 30) = 66.67 RU/s
+        assert!((tracker.current_rate(t0 + 75) - 66.67).abs() < 0.1);
+        // historical_rate = (6000+3000) / (2*30) = 150 RU/s
+        assert!((tracker.historical_rate(t0, t0 + 60) - 150.0).abs() < 0.01);
+
+        // Ring buffer: advance 20 more minutes (fully evicts all data).
+        let t_far = t0 + 60 * 20;
+        tracker.record_at(0, t_far);
+        // Gap exceeds window → ring reset, no completed buckets.
+        assert_eq!(tracker.completed, 0);
+        assert_eq!(tracker.current_bucket.load(Ordering::Relaxed), 0);
+
+        // Re-populate after the big gap and fill the entire ring.
+        for i in 1..=BUCKETS {
+            tracker.record_at(100, t_far + (i as u64) * RU_BUCKET_SECS);
+        }
+        assert_eq!(tracker.completed, BUCKETS);
+    }
+
+    #[test]
+    fn test_admission_decision() {
+        let mut cfg = Config::default();
+        cfg.enable_read_admission_control = true;
+        cfg.admission_max_delayed_count = 10; // low limit to test rejection path
+        let mgr = ResourceGroupManager::new(cfg);
+        // Add a second group so the code path is active.
+        mgr.add_resource_group(new_resource_group_ru("spike".into(), 1000, HIGH_PRIORITY));
+        let spike_limiter = mgr.get_foreground_group_limiter("spike");
+
+        // Seed initial RU so the tracker is not idle (prevents eviction by
+        // online_adjust_resource_quota's retain call).
+        let t0 = RuTracker::now_secs();
+        mgr.record_ru_consumption("spike", 1);
+
+        // CPU below threshold → Allow (stays NO_LIMIT, no throttling).
+        mgr.online_adjust_resource_quota(50.0); // below 80%
+        assert_eq!(
+            mgr.admission_decision(true, &spike_limiter),
+            AdmissionDecision::Allow
         );
-        mgr.add_resource_group(lightning_group);
-        assert!(
-            mgr.get_background_resource_limiter("lightning", "lightning")
-                .is_some()
+
+        // CPU above threshold but no warmed-up tracker data → stays NO_LIMIT → Allow.
+        mgr.online_adjust_resource_quota(90.0);
+        assert_eq!(
+            mgr.admission_decision(true, &spike_limiter),
+            AdmissionDecision::Allow
         );
-        assert!(
-            mgr.get_background_resource_limiter("lightning", "import")
-                .is_some()
+
+        // Warm up the tracker: 2 completed buckets. Set up BEFORE calling
+        // online_adjust_resource_quota so historical_rate() is non-zero when the
+        // limiter rate is configured.
+        {
+            let entry = mgr.ru_trackers.get("spike").unwrap();
+            let mut guard = entry.lock().unwrap();
+            guard.0.record_at(6000, t0 + 30);
+            guard.0.record_at(0, t0 + 60); // close bucket 0: 6000 RU (baseline)
+            guard.0.record_at(12000, t0 + 90); // open bucket: 12000 RU spike (left open)
+            // historical ≈ 6000/30 = 200 RU/s (only completed buckets), current
+            // ≈ 400
+        }
+        // Now set CPU — first throttle entry: initializes fraction from spike ratio,
+        // then sets absolute rate = historical × fraction per group.
+        // bg_cpu_at_floor must be true for the throttle branch to fire.
+        mgr.set_bg_cpu_at_floor(true);
+        mgr.online_adjust_resource_quota(90.0);
+        // Consume a burst well above the rate to build token-bucket debt.
+        {
+            let entry = mgr.ru_trackers.get("spike").unwrap();
+            let guard = entry.lock().unwrap();
+            // 10_000 µs consumed against ~133 RU/s rate → several seconds of debt.
+            guard.1.consume(
+                Duration::from_micros(10_000),
+                IoBytes::default(),
+                false,
+                true,
+            );
+        }
+        // Debt is non-zero → Delay.
+        assert!(matches!(
+            mgr.admission_decision(true, &spike_limiter),
+            AdmissionDecision::Delay(_)
+        ));
+        // One slot acquired above; release it.
+        mgr.release_delay_slot();
+
+        // Exhaust the delay slots: acquire 10 (the configured max).
+        for _ in 0..10 {
+            assert!(matches!(
+                mgr.admission_decision(true, &spike_limiter),
+                AdmissionDecision::Delay(_)
+            ));
+        }
+        // 11th request: over the limit → Reject.
+        assert_eq!(
+            mgr.admission_decision(true, &spike_limiter),
+            AdmissionDecision::Reject
+        );
+        // Release all slots.
+        for _ in 0..10 {
+            mgr.release_delay_slot();
+        }
+
+        // Drop CPU into leeway zone (72-80%): multiplier holds, still delays.
+        mgr.online_adjust_resource_quota(75.0);
+        assert!(matches!(
+            mgr.admission_decision(true, &spike_limiter),
+            AdmissionDecision::Delay(_)
+        ));
+
+        // Drop CPU below leeway_start (72%): fraction ramps up ×1.1/tick.
+        // After enough ticks it reaches 5× → NO_LIMIT → rates set to infinity
+        // → token bucket debt clears → Allow.
+        for _ in 0..60 {
+            mgr.online_adjust_resource_quota(50.0);
+        }
+        assert_eq!(
+            mgr.admission_decision(true, &spike_limiter),
+            AdmissionDecision::Allow
         );
     }
 }

--- a/components/resource_control/src/resource_limiter.rs
+++ b/components/resource_control/src/resource_limiter.rs
@@ -37,9 +37,13 @@ impl fmt::Debug for ResourceType {
 }
 
 pub struct ResourceLimiter {
-    _name: String,
+    name: String,
     version: u64,
     limiters: [QuotaLimiter; ResourceType::COUNT],
+    // Dedicated write-only IO limiter for compaction pressure throttling.
+    // Independent from the combined IO limiter; rate is set by do_adjust
+    // based on compaction pressure. Defaults to f64::INFINITY (no throttle).
+    write_io_limiter: QuotaLimiter,
     // whether the resource limiter is a background limiter or priority limiter.
     is_background: bool,
     // the wait duration histogram for prioitry limiter.
@@ -74,23 +78,39 @@ impl ResourceLimiter {
             None
         };
         Self {
-            _name: name,
+            name,
             version,
             limiters: [cpu_limiter, io_limiter],
+            write_io_limiter: QuotaLimiter::new(f64::INFINITY),
             is_background,
             wait_histogram,
         }
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
     }
 
     pub fn is_background(&self) -> bool {
         self.is_background
     }
 
-    pub fn consume(&self, cpu_time: Duration, io_bytes: IoBytes, wait: bool) -> Duration {
+    pub fn consume(
+        &self,
+        cpu_time: Duration,
+        io_bytes: IoBytes,
+        wait: bool,
+        skip_compaction_pressure: bool,
+    ) -> Duration {
         let cpu_dur =
             self.limiters[ResourceType::Cpu as usize].consume(cpu_time.as_micros() as u64, wait);
         let io_dur = self.limiters[ResourceType::Io as usize].consume_io(io_bytes, wait);
-        let wait_dur = cpu_dur.max(io_dur);
+        let write_io_dur = if skip_compaction_pressure {
+            Duration::ZERO
+        } else {
+            self.write_io_limiter.consume(io_bytes.write, wait)
+        };
+        let wait_dur = cpu_dur.max(io_dur).max(write_io_dur);
         if !wait_dur.is_zero()
             && let Some(h) = &self.wait_histogram
         {
@@ -99,8 +119,34 @@ impl ResourceLimiter {
         wait_dur
     }
 
-    pub async fn async_consume(&self, cpu_time: Duration, io_bytes: IoBytes) -> Duration {
-        let dur = self.consume(cpu_time, io_bytes, true);
+    /// Returns the current token-bucket debt the caller should wait before
+    /// entering the thread pool. Reads accumulated debt via `consume(0, ...)`
+    /// which returns the existing debt when the rate limit is finite, without
+    /// adding new token consumption.
+    ///
+    /// For write requests (`is_read = false`), the write-specific IO limiter
+    /// debt is also considered alongside CPU and combined IO debt.
+    ///
+    /// Note: `write_io_limiter` and the combined IO limiter are only rate-set
+    /// for background limiters (via `do_adjust`); for foreground per-group
+    /// limiters their rates remain at `f64::INFINITY`, so their debt is
+    /// always zero and only CPU debt drives the delay in practice.
+    pub fn admission_delay(&self, is_read: bool) -> Duration {
+        self.consume(
+            Duration::ZERO,
+            IoBytes::default(),
+            true,
+            is_read, // skip_compaction_pressure = true for reads (skip write_io_limiter)
+        )
+    }
+
+    pub async fn async_consume(
+        &self,
+        cpu_time: Duration,
+        io_bytes: IoBytes,
+        skip_compaction_pressure: bool,
+    ) -> Duration {
+        let dur = self.consume(cpu_time, io_bytes, true, skip_compaction_pressure);
         if !dur.is_zero() {
             _ = GLOBAL_TIMER_HANDLE
                 .delay(Instant::now() + dur)
@@ -113,6 +159,11 @@ impl ResourceLimiter {
     #[inline]
     pub(crate) fn get_limiter(&self, ty: ResourceType) -> &QuotaLimiter {
         &self.limiters[ty as usize]
+    }
+
+    #[inline]
+    pub(crate) fn get_write_io_limiter(&self) -> &QuotaLimiter {
+        &self.write_io_limiter
     }
 
     pub(crate) fn get_limit_statistics(&self, ty: ResourceType) -> GroupStatistics {

--- a/components/resource_control/src/service.rs
+++ b/components/resource_control/src/service.rs
@@ -1,10 +1,6 @@
 // Copyright 2023 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::{
-    collections::{HashMap, HashSet},
-    sync::Arc,
-    time::Duration,
-};
+use std::{collections::HashSet, sync::Arc, time::Duration};
 
 use futures::{compat::Future01CompatExt, stream, StreamExt};
 use kvproto::{
@@ -17,7 +13,9 @@ use pd_client::{
     RESOURCE_CONTROL_CONTROLLER_CONFIG_PATH,
 };
 use serde::{Deserialize, Serialize};
-use tikv_util::{error, info, timer::GLOBAL_TIMER_HANDLE, warn};
+use tikv_util::{
+    error, info, resource_control::DEFAULT_RESOURCE_GROUP_NAME, timer::GLOBAL_TIMER_HANDLE, warn,
+};
 
 use crate::{resource_limiter::ResourceType, ResourceGroupManager};
 
@@ -187,37 +185,13 @@ impl ResourceManagerService {
 
     // report ru metrics periodically.
     pub async fn report_ru_metrics(&self) {
-        let mut last_group_statistics_map: HashMap<String, ReportStatistic> = HashMap::new();
+        let mut last_bg_statistics: Option<ReportStatistic> = None;
         // load controller config firstly.
         let config = self.load_controller_config().await;
         info!("load controller config"; "config" => ?config);
 
         loop {
-            let background_groups: Vec<_> = self
-                .manager
-                .resource_groups
-                .iter()
-                .filter_map(|kv| {
-                    let g = kv.value();
-                    g.limiter.clone().map(|limiter| {
-                        let io_statistics = limiter.get_limit_statistics(ResourceType::Io);
-                        let cpu_statistics = limiter.get_limit_statistics(ResourceType::Cpu);
-
-                        (
-                            g.group.name.clone(),
-                            ReportStatistic {
-                                // io statistics and cpu statistics should have the same version.
-                                version: io_statistics.version,
-                                read_bytes_consumed: io_statistics.read_consumed,
-                                write_bytes_consumed: io_statistics.write_consumed,
-                                cpu_consumed: cpu_statistics.total_consumed,
-                            },
-                        )
-                    })
-                })
-                .collect();
-
-            if background_groups.is_empty() {
+            if !self.manager.has_background_groups() {
                 let _ = GLOBAL_TIMER_HANDLE
                     .delay(std::time::Instant::now() + BACKGROUND_RU_REPORT_DURATION)
                     .compat()
@@ -225,55 +199,69 @@ impl ResourceManagerService {
                 continue;
             }
 
+            // All background groups share a single limiter; read it once and
+            // report under the fixed label "background".
+            let limiter = self.manager.get_background_limiter();
+            let io_statistics = limiter.get_limit_statistics(ResourceType::Io);
+            let cpu_statistics = limiter.get_limit_statistics(ResourceType::Cpu);
+            let statistic = ReportStatistic {
+                // io statistics and cpu statistics should have the same version.
+                version: io_statistics.version,
+                read_bytes_consumed: io_statistics.read_consumed,
+                write_bytes_consumed: io_statistics.write_consumed,
+                cpu_consumed: cpu_statistics.total_consumed,
+            };
+
+            // Non-existence or version change means this is a brand new limiter,
+            // so no need to sub the old statistics.
+            let (cpu_consumed, io_consumed) = if let Some(last_stats) = last_bg_statistics
+                .as_ref()
+                .filter(|s| s.version == statistic.version)
+            {
+                if statistic == *last_stats {
+                    let _ = GLOBAL_TIMER_HANDLE
+                        .delay(std::time::Instant::now() + BACKGROUND_RU_REPORT_DURATION)
+                        .compat()
+                        .await;
+                    continue;
+                }
+                (
+                    statistic.cpu_consumed - last_stats.cpu_consumed,
+                    (
+                        statistic.read_bytes_consumed - last_stats.read_bytes_consumed,
+                        statistic.write_bytes_consumed - last_stats.write_bytes_consumed,
+                    ),
+                )
+            } else {
+                (
+                    statistic.cpu_consumed,
+                    (
+                        statistic.read_bytes_consumed,
+                        statistic.write_bytes_consumed,
+                    ),
+                )
+            };
+            last_bg_statistics = Some(statistic);
+
             let mut req = TokenBucketsRequest::default();
             let all_reqs = req.mut_requests();
-            for (name, statistic) in background_groups.into_iter() {
-                // Non-existence or version change means this is a brand new limiter, so no need
-                // to sub the old statistics.
-                let (cpu_consumed, io_consumed) = if let Some(last_stats) =
-                    last_group_statistics_map
-                        .get(&name)
-                        .filter(|stats| statistic.version == stats.version)
-                {
-                    if statistic == *last_stats {
-                        continue;
-                    }
-                    (
-                        statistic.cpu_consumed - last_stats.cpu_consumed,
-                        (
-                            statistic.read_bytes_consumed - last_stats.read_bytes_consumed,
-                            statistic.write_bytes_consumed - last_stats.write_bytes_consumed,
-                        ),
-                    )
-                } else {
-                    (
-                        statistic.cpu_consumed,
-                        (
-                            statistic.read_bytes_consumed,
-                            statistic.write_bytes_consumed,
-                        ),
-                    )
-                };
-                // replace the previous statistics.
-                last_group_statistics_map.insert(name.clone(), statistic);
-                // report ru statistics.
-                let mut req = TokenBucketRequest::default();
-                req.set_resource_group_name(name.clone());
-                req.set_is_background(true);
-                let report_consumption = req.mut_consumption_since_last_request();
+            // report ru statistics.
+            let mut bucket_req = TokenBucketRequest::default();
+            bucket_req.set_resource_group_name(DEFAULT_RESOURCE_GROUP_NAME.to_owned());
+            bucket_req.set_is_background(true);
+            let report_consumption = bucket_req.mut_consumption_since_last_request();
 
-                let read_total = config.read_cpu_ms_cost * cpu_consumed as f64
-                    + config.read_cost_per_byte * io_consumed.0 as f64;
-                let write_total = config.write_cost_per_byte * io_consumed.1 as f64;
+            let read_total = config.read_cpu_ms_cost * cpu_consumed as f64
+                + config.read_cost_per_byte * io_consumed.0 as f64;
+            let write_total = config.write_cost_per_byte * io_consumed.1 as f64;
 
-                report_consumption.set_r_r_u(read_total);
-                report_consumption.set_w_r_u(write_total);
-                report_consumption.set_read_bytes(io_consumed.0 as f64);
-                report_consumption.set_write_bytes(io_consumed.1 as f64);
-                report_consumption.set_total_cpu_time_ms(cpu_consumed as f64);
+            report_consumption.set_r_r_u(read_total);
+            report_consumption.set_w_r_u(write_total);
+            report_consumption.set_read_bytes(io_consumed.0 as f64);
+            report_consumption.set_write_bytes(io_consumed.1 as f64);
+            report_consumption.set_total_cpu_time_ms(cpu_consumed as f64);
 
-                all_reqs.push(req);
-            }
+            all_reqs.push(bucket_req);
 
             if !all_reqs.is_empty() {
                 if let Err(e) = self.pd_client.report_ru_metrics(req).await {
@@ -542,7 +530,7 @@ pub mod tests {
         background_worker.spawn_async_task(async move {
             s_clone.report_ru_metrics().await;
         });
-        // Mock consume.
+        // Mock consume on the shared background limiter.
         let bg_limiter = s
             .manager
             .get_background_resource_limiter("background", "br")
@@ -554,27 +542,29 @@ pub mod tests {
                 write: 1000,
             },
             true,
+            false,
         );
         // Wait for report ru metrics.
         std::thread::sleep(Duration::from_millis(100));
-        // Mock update version.
-        let bg = new_resource_group_ru("background".into(), 1000, 15);
-        s.manager.add_resource_group(bg);
 
-        let background_group =
-            new_background_resource_group_ru("background".into(), 500, 8, vec!["lightning".into()]);
+        // Add a second background group; all groups share the same limiter.
+        let background_group = new_background_resource_group_ru(
+            "lightning_group".into(),
+            500,
+            8,
+            vec!["lightning".into()],
+        );
         s.manager.add_resource_group(background_group);
-        let new_bg_limiter = s
-            .manager
-            .get_background_resource_limiter("background", "lightning")
-            .unwrap();
-        new_bg_limiter.consume(
+        // Consuming through either group's limiter goes to the same shared
+        // limiter; the next report will reflect the delta.
+        bg_limiter.consume(
             Duration::from_secs(5),
             IoBytes {
                 read: 2000,
                 write: 2000,
             },
             true,
+            false,
         );
         // Wait for report ru metrics.
         std::thread::sleep(Duration::from_millis(100));

--- a/components/resource_control/src/worker.rs
+++ b/components/resource_control/src/worker.rs
@@ -2,9 +2,11 @@
 
 use std::{
     array,
-    collections::{HashMap, HashSet},
     io::Result as IoResult,
-    sync::Arc,
+    sync::{
+        atomic::{AtomicU32, Ordering},
+        Arc,
+    },
     time::Duration,
 };
 
@@ -12,7 +14,6 @@ use file_system::{fetch_io_bytes, IoBytes, IoType};
 use prometheus::Histogram;
 use strum::EnumCount;
 use tikv_util::{
-    debug,
     resource_control::{TaskPriority, DEFAULT_RESOURCE_GROUP_NAME},
     sys::{cpu_time::ProcessStat, SysQuota},
     time::Instant,
@@ -26,7 +27,7 @@ use crate::{
     resource_limiter::{GroupStatistics, ResourceLimiter, ResourceType},
 };
 
-pub const BACKGROUND_LIMIT_ADJUST_DURATION: Duration = Duration::from_secs(10);
+pub const QUOTA_ADJUST_DURATION: Duration = Duration::from_secs(10);
 
 const MICROS_PER_SEC: f64 = 1_000_000.0;
 // the minimal schedule wait duration due to the overhead of queue.
@@ -92,22 +93,37 @@ impl ResourceStatsProvider for SysQuotaGetter {
 }
 
 pub struct GroupQuotaAdjustWorker<R> {
-    prev_stats_by_group: [HashMap<String, GroupStatistics>; ResourceType::COUNT],
     last_adjust_time: Instant,
     resource_ctl: Arc<ResourceGroupManager>,
-    is_last_time_low_load: [bool; ResourceType::COUNT],
     resource_quota_getter: R,
+    // Shared compaction pressure (0-100+) written by EnginesResourceInfo::update().
+    compaction_pending_bytes_ratio: Arc<AtomicU32>,
+    // Single shared limiter for all background tasks.
+    bg_limiter: Arc<ResourceLimiter>,
+    // Previous statistics snapshot per resource type for delta computation.
+    prev_stats: [GroupStatistics; ResourceType::COUNT],
+    // Whether the previous tick had background groups. Used to detect the
+    // empty->non-empty transition and discard stale accumulated consumption.
+    prev_had_background: bool,
 }
 
 impl GroupQuotaAdjustWorker<SysQuotaGetter> {
-    pub fn new(resource_ctl: Arc<ResourceGroupManager>, io_bandwidth: u64) -> Self {
+    pub fn new(
+        resource_ctl: Arc<ResourceGroupManager>,
+        io_bandwidth: u64,
+        compaction_pending_bytes_ratio: Arc<AtomicU32>,
+    ) -> Self {
         let resource_quota_getter = SysQuotaGetter {
             process_stat: ProcessStat::cur_proc_stat().unwrap(),
             prev_io_stats: [IoBytes::default(); IoType::COUNT],
             prev_io_ts: Instant::now_coarse(),
             io_bandwidth: io_bandwidth as f64,
         };
-        Self::with_quota_getter(resource_ctl, resource_quota_getter)
+        Self::with_quota_getter(
+            resource_ctl,
+            resource_quota_getter,
+            compaction_pending_bytes_ratio,
+        )
     }
 }
 
@@ -115,14 +131,17 @@ impl<R: ResourceStatsProvider> GroupQuotaAdjustWorker<R> {
     pub fn with_quota_getter(
         resource_ctl: Arc<ResourceGroupManager>,
         resource_quota_getter: R,
+        compaction_pending_bytes_ratio: Arc<AtomicU32>,
     ) -> Self {
-        let prev_stats_by_group = array::from_fn(|_| HashMap::default());
+        let bg_limiter = resource_ctl.get_background_limiter();
         Self {
-            prev_stats_by_group,
             last_adjust_time: Instant::now_coarse(),
             resource_ctl,
             resource_quota_getter,
-            is_last_time_low_load: array::from_fn(|_| false),
+            compaction_pending_bytes_ratio,
+            bg_limiter,
+            prev_stats: array::from_fn(|_| GroupStatistics::default()),
+            prev_had_background: false,
         }
     }
 
@@ -137,209 +156,226 @@ impl<R: ResourceStatsProvider> GroupQuotaAdjustWorker<R> {
         }
         self.last_adjust_time = now;
 
-        let mut background_util_limit = self
+        // Fetch CPU stats once so background and foreground use a consistent
+        // snapshot and we avoid double-reading /proc/stat.
+        let cpu_stats = match self
+            .resource_quota_getter
+            .get_current_stats(ResourceType::Cpu)
+        {
+            Ok(s) => s,
+            Err(e) => {
+                warn!("get process total cpu failed; skip adjustment."; "err" => ?e);
+                return;
+            }
+        };
+        let cpu_util = if cpu_stats.total_quota > f64::EPSILON {
+            cpu_stats.current_used / cpu_stats.total_quota * 100.0
+        } else {
+            0.0
+        };
+
+        self.background_adjust_quota(dur_secs, &cpu_stats);
+        self.foreground_adjust_quota(cpu_util);
+    }
+
+    fn foreground_adjust_quota(&mut self, cpu_util: f64) {
+        self.resource_ctl.online_adjust_resource_quota(cpu_util);
+    }
+
+    fn background_adjust_quota(&mut self, dur_secs: f64, cpu_stats: &ResourceUsageStats) {
+        let mut bg_util_limit = self
             .resource_ctl
             .get_resource_group(DEFAULT_RESOURCE_GROUP_NAME)
             .map_or(0, |r| {
                 r.group.get_background_settings().get_utilization_limit()
             });
-        if background_util_limit == 0 {
-            background_util_limit = 100;
+        if bg_util_limit == 0 {
+            bg_util_limit = 100;
         }
+        let (bg_scale_start, fg_cpu_throttle_threshold) = {
+            let config = self.resource_ctl.get_config().value();
+            let start = config.bg_cpu_throttle_threshold.clamp(1.0, 99.0);
+            let end = config.fg_cpu_throttle_threshold.clamp(start, 99.0);
+            (start, end)
+        };
+        // Cap utilization limit to fg_cpu_throttle_threshold. Background tasks should
+        // never consume more than this fraction of total resources. Scale-down
+        // begins at bg_scale_start and reaches min_floor at fg_cpu_throttle_threshold.
+        bg_util_limit = bg_util_limit.min(fg_cpu_throttle_threshold as u64);
 
-        BACKGROUND_TASK_RESOURCE_UTILIZATION_VEC
-            .with_label_values(&["limit"])
-            .set(background_util_limit as i64);
-
-        let mut background_groups: Vec<_> = self
-            .resource_ctl
-            .resource_groups
-            .iter()
-            .filter_map(|kv| {
-                let g = kv.value();
-                g.limiter.as_ref().map(|limiter| GroupStats {
-                    name: g.group.name.clone(),
-                    ru_quota: g.get_ru_quota() as f64,
-                    limiter: limiter.clone(),
-                    stats_per_sec: GroupStatistics::default(),
-                    expect_cost_rate: 0.0,
-                })
-            })
-            .collect();
-        if background_groups.is_empty() {
+        if !self.resource_ctl.has_background_groups() {
+            self.resource_ctl.set_bg_cpu_at_floor(true);
+            self.prev_had_background = false;
             return;
         }
+        if !self.prev_had_background {
+            // Flush consumption that accumulated while the limiter ran unlimited
+            // during the empty period, and drain the CPU delta so the first real
+            // tick sees a clean baseline.
+            self.prev_stats = [
+                self.bg_limiter.get_limit_statistics(ResourceType::Cpu),
+                self.bg_limiter.get_limit_statistics(ResourceType::Io),
+            ];
+            let _ = self
+                .resource_quota_getter
+                .get_current_stats(ResourceType::Cpu);
+            self.prev_had_background = true;
+        }
 
-        self.do_adjust(
+        self.background_adjust_resource_quota(
             ResourceType::Cpu,
             dur_secs,
-            background_util_limit,
-            &mut background_groups,
+            bg_util_limit,
+            bg_scale_start,
+            fg_cpu_throttle_threshold,
+            Some(cpu_stats),
         );
-        self.do_adjust(
+        self.background_adjust_resource_quota(
             ResourceType::Io,
             dur_secs,
-            background_util_limit,
-            &mut background_groups,
+            bg_util_limit,
+            bg_scale_start,
+            fg_cpu_throttle_threshold,
+            None,
         );
-
-        // clean up deleted group stats
-        if self.prev_stats_by_group[0].len() != background_groups.len() {
-            let name_set: HashSet<_> =
-                HashSet::from_iter(background_groups.iter().map(|g| &g.name));
-            for stat_map in &mut self.prev_stats_by_group {
-                stat_map.retain(|k, _v| !name_set.contains(k));
-            }
-        }
+        self.adjust_write_io_by_compaction_pressure();
     }
 
-    fn do_adjust(
+    fn background_adjust_resource_quota(
         &mut self,
         resource_type: ResourceType,
         dur_secs: f64,
         utilization_limit: u64,
-        bg_group_stats: &mut [GroupStats],
+        bg_scale_start: f64,
+        fg_cpu_throttle_threshold: f64,
+        // Pre-fetched stats for CPU (avoids a second /proc/stat read); None for
+        // IO, which always fetches fresh bytes-transferred counters.
+        prefetched_stats: Option<&ResourceUsageStats>,
     ) {
-        let resource_stats = match self.resource_quota_getter.get_current_stats(resource_type) {
-            Ok(r) => r,
-            Err(e) => {
-                warn!("get resource statistics info failed, skip adjust"; "type" => ?resource_type, "err" => ?e);
-                return;
-            }
+        let fetched;
+        let resource_stats = if let Some(s) = prefetched_stats {
+            s
+        } else {
+            fetched = match self.resource_quota_getter.get_current_stats(resource_type) {
+                Ok(r) => r,
+                Err(e) => {
+                    warn!("get resource statistics info failed, skip adjust"; "type" => ?resource_type, "err" => ?e);
+                    return;
+                }
+            };
+            &fetched
         };
-        // if total resource quota is unlimited, set all groups' limit to unlimited.
+        // if total resource quota is unlimited, set background limit to unlimited.
         if resource_stats.total_quota <= f64::EPSILON {
-            for g in bg_group_stats {
-                g.limiter
-                    .get_limiter(resource_type)
-                    .set_rate_limit(f64::INFINITY);
-            }
+            self.bg_limiter
+                .get_limiter(resource_type)
+                .set_rate_limit(f64::INFINITY);
             return;
         }
 
-        let mut total_ru_quota = 0.0;
-        let mut background_consumed_total = 0.0;
-        let mut has_wait = false;
-        for g in bg_group_stats.iter_mut() {
-            total_ru_quota += g.ru_quota;
-            let total_stats = g.limiter.get_limit_statistics(resource_type);
-            let last_stats = self.prev_stats_by_group[resource_type as usize]
-                .insert(g.name.clone(), total_stats)
-                .unwrap_or_default();
-            // version changes means this is a brand new limiter, so no need to sub the old
-            // statistics.
-            let stats_delta = if total_stats.version == last_stats.version {
-                total_stats - last_stats
-            } else {
-                total_stats
-            };
-            BACKGROUND_RESOURCE_CONSUMPTION
-                .with_label_values(&[&g.name, resource_type.as_str()])
-                .inc_by(stats_delta.total_consumed);
-            if resource_type == ResourceType::Cpu {
-                BACKGROUND_TASKS_WAIT_DURATION
-                    .with_label_values(&[&g.name])
-                    .inc_by(stats_delta.total_wait_dur_us);
-            }
-
-            let stats_per_sec = stats_delta / dur_secs;
-            background_consumed_total += stats_per_sec.total_consumed as f64;
-            g.stats_per_sec = stats_per_sec;
-            if stats_per_sec.total_wait_dur_us > 0 {
-                has_wait = true;
-            }
+        // Collect statistics for metrics from the single global limiter.
+        let total_stats = self.bg_limiter.get_limit_statistics(resource_type);
+        let last_stats =
+            std::mem::replace(&mut self.prev_stats[resource_type as usize], total_stats);
+        let stats_delta = total_stats - last_stats;
+        BACKGROUND_RESOURCE_CONSUMPTION
+            .with_label_values(&[resource_type.as_str()])
+            .inc_by(stats_delta.total_consumed);
+        if resource_type == ResourceType::Cpu {
+            BACKGROUND_TASKS_WAIT_DURATION.inc_by(stats_delta.total_wait_dur_us);
         }
+        let background_consumed = (stats_delta / dur_secs).total_consumed as f64;
 
-        let background_util =
-            (background_consumed_total / resource_stats.total_quota * 100.0) as u64;
+        let background_util = (background_consumed / resource_stats.total_quota * 100.0) as u64;
+        let resource_util = resource_stats.current_used / resource_stats.total_quota * 100.0;
         BACKGROUND_TASK_RESOURCE_UTILIZATION_VEC
             .with_label_values(&[resource_type.as_str()])
             .set(background_util as i64);
 
-        // fast path if process cpu is low
-        let is_low_load = resource_stats.current_used <= (resource_stats.total_quota * 0.1);
-        if is_low_load && !has_wait && self.is_last_time_low_load[resource_type as usize] {
-            return;
-        }
-        self.is_last_time_low_load[resource_type as usize] = is_low_load;
-
         let util_limit_percent = (utilization_limit as f64 / 100.0).min(1.0);
-        // the available resource for background tasks is defined as:
-        // (total_resource_quota - foreground_task_used). foreground_task_used
-        // resource is calculated by: (resource_current_total_used -
-        // background_consumed_total). We reserve 20% of the free resources for
-        // foreground tasks in case the fore ground traffics increases.
-        let mut available_resource_rate = ((resource_stats.total_quota
-            - resource_stats.current_used
-            + background_consumed_total)
-            * 0.8)
-            .min(resource_stats.total_quota * util_limit_percent)
-            .max(resource_stats.total_quota * 0.1);
-        let mut total_expected_cost = 0.0;
-        for g in bg_group_stats.iter_mut() {
-            let mut rate_limit = g.limiter.get_limiter(resource_type).get_rate_limit();
-            if rate_limit.is_infinite() {
-                rate_limit = 0.0;
-            }
-            let group_expected_cost = g.stats_per_sec.total_consumed as f64
-                + g.stats_per_sec.total_wait_dur_us as f64 / MICROS_PER_SEC * rate_limit;
-            g.expect_cost_rate = group_expected_cost;
-            total_expected_cost += group_expected_cost;
-        }
-        // sort groups by the expect_cost_rate per ru
-        bg_group_stats.sort_by(|g1, g2| {
-            (g1.expect_cost_rate / g1.ru_quota)
-                .partial_cmp(&(g2.expect_cost_rate / g2.ru_quota))
-                .unwrap()
-        });
+        let target = resource_stats.total_quota * util_limit_percent;
 
-        // quota is enough, group is allowed to got more resource then its share by ru.
-        // e.g. Given a totol resource of 10000, and ("name", ru_quota, expected_rate)
-        // of:  (rg1, 2000, 3000), (rg2, 3000, 1000), (rg3, 5000, 5000)
-        // then after the previous sort, the order is rg2, rg3, rg1 and the handle order
-        // is rg1, rg3, rg2 so the final rate limit assigned is: (rg1, 3000),
-        // (rg3, 5833(7000/6*5)), (rg2, 1166(7000/6*1))
-        if total_expected_cost <= available_resource_rate {
-            for g in bg_group_stats.iter().rev() {
-                let limit = g
-                    .expect_cost_rate
-                    .max(available_resource_rate / total_ru_quota * g.ru_quota);
-                g.limiter.get_limiter(resource_type).set_rate_limit(limit);
-                BACKGROUND_QUOTA_LIMIT_VEC
-                    .with_label_values(&[&g.name, resource_type.as_str()])
-                    .set(limit as i64);
-                available_resource_rate -= limit;
-                total_ru_quota -= g.ru_quota;
+        // Treat infinity as target (initial state before first adjustment).
+        let current_limit = {
+            let l = self.bg_limiter.get_limiter(resource_type).get_rate_limit();
+            if l.is_infinite() { target } else { l }
+        };
+
+        // Minimum: 1 CPU core for CPU, 10% of total for IO.
+        let min_floor = match resource_type {
+            ResourceType::Cpu => MICROS_PER_SEC,
+            ResourceType::Io => resource_stats.total_quota * 0.1,
+        }
+        .min(target);
+
+        let mut new_budget = target;
+        if resource_util > bg_scale_start {
+            // Linearly scale budget from target down to min_floor as utilization
+            // goes from bg_scale_start to fg_cpu_throttle_threshold.
+            let range = (fg_cpu_throttle_threshold - bg_scale_start).max(1.0);
+            let pressure = ((resource_util - bg_scale_start) / range).clamp(0.0, 1.0);
+            new_budget = target * (1.0 - pressure) + min_floor * pressure;
+            // Only tighten: never increase the limit in the throttle branch.
+            if new_budget > current_limit {
+                new_budget = current_limit;
             }
-            return;
+        } else if current_limit > target {
+            // Background limit exceeds its allowed share; reset to target.
+            new_budget = target;
+        } else if current_limit < 0.9 * target && resource_util < 0.9 * bg_scale_start {
+            // System is idle; increase limit incrementally from current limit.
+            new_budget = current_limit * 1.1;
         }
 
-        // quota is not enough, assign by share
-        // e.g. Given a totol resource of 10000, and ("name", ru_quota, expected_rate)
-        // of:  (rg1, 2000, 1000), (rg2, 3000, 5000), (rg3, 5000, 7000)
-        // then after the previous sort, the order is rg1, rg3, rg2, and handle order is
-        // rg1, rg3, rg2 so the final rate limit assigned is: (rg1, 1000), (rg3,
-        // 5250(9000/12*7)), (rg2, 3750(9000/12*5))
-        for g in bg_group_stats {
-            let limit = g
-                .expect_cost_rate
-                .min(available_resource_rate / total_ru_quota * g.ru_quota);
-            g.limiter.get_limiter(resource_type).set_rate_limit(limit);
-            BACKGROUND_QUOTA_LIMIT_VEC
-                .with_label_values(&[&g.name, resource_type.as_str()])
-                .set(limit as i64);
-            available_resource_rate -= limit;
-            total_ru_quota -= g.ru_quota;
+        let new_budget = new_budget.clamp(min_floor, target);
+        self.bg_limiter
+            .get_limiter(resource_type)
+            .set_rate_limit(new_budget);
+        BACKGROUND_QUOTA_LIMIT_VEC
+            .with_label_values(&[resource_type.as_str()])
+            .set(new_budget as i64);
+
+        // Update the "background at floor" flag so foreground throttling
+        // only kicks in after background has been fully squeezed.
+        if resource_type == ResourceType::Cpu {
+            let at_floor = new_budget <= min_floor && background_consumed <= new_budget;
+            self.resource_ctl.set_bg_cpu_at_floor(at_floor);
         }
     }
-}
 
-struct GroupStats {
-    name: String,
-    limiter: Arc<ResourceLimiter>,
-    ru_quota: f64,
-    stats_per_sec: GroupStatistics,
-    expect_cost_rate: f64,
+    /// Adjust the write-only IO limiter based on compaction pressure.
+    /// When pressure >= threshold, linearly scale write IO from ceiling to
+    /// floor over a window of 50% of threshold (i.e. threshold to
+    /// threshold * 1.5). Below threshold, write IO ramps up 10% per tick
+    /// capped at ceiling.
+    fn adjust_write_io_by_compaction_pressure(&self) {
+        let pressure = self.compaction_pending_bytes_ratio.load(Ordering::Relaxed) as f64;
+        let config = self.resource_ctl.get_config().value().clone();
+        let threshold = config.bg_compaction_pressure_threshold.clamp(1.0, 99.0);
+        let ceiling = config.bg_write_io_ceiling.0 as f64; // bytes/s
+        let floor = config.bg_write_io_floor.0 as f64; // bytes/s
+
+        let new_limit = if pressure < threshold {
+            // Below threshold: ramp up current limit by 10%, capped at ceiling.
+            let current_limit = self.bg_limiter.get_write_io_limiter().get_rate_limit();
+            if current_limit.is_infinite() || current_limit >= ceiling {
+                ceiling
+            } else {
+                (current_limit * 1.1).min(ceiling)
+            }
+        } else {
+            // Linear interpolation from ceiling to floor over the window
+            // [threshold, threshold * 1.5]. Beyond that window the rate is
+            // clamped to floor.
+            let window = threshold * 0.5;
+            let pressure_ratio = ((pressure - threshold) / window).clamp(0.0, 1.0);
+            (ceiling * (1.0 - pressure_ratio) + floor * pressure_ratio).max(floor)
+        };
+
+        self.bg_limiter
+            .get_write_io_limiter()
+            .set_rate_limit(new_limit);
+    }
 }
 
 /// PriorityLimiterAdjustWorker automically adjust the quota of each priority
@@ -495,10 +531,6 @@ impl<R: ResourceStatsProvider> PriorityLimiterAdjustWorker<R> {
             limits[i - 1] = limit;
             expect_cpu_time_total -= level_expected[i];
         }
-        debug!("adjsut cpu limiter by priority"; "cpu_quota" => process_cpu_stats.total_quota,
-            "process_cpu" => process_cpu_stats.current_used, "expected_cpu" => ?level_expected,
-            "cpu_costs" => ?cpu_duration, "limits" => ?limits,
-            "limit_cpu_total" => expect_pool_cpu_total, "pool_cpu_cost" => real_cpu_total);
     }
 }
 
@@ -593,7 +625,7 @@ mod tests {
     use std::time::Duration;
 
     use super::*;
-    use crate::{resource_group::tests::*, resource_limiter::QuotaLimiter};
+    use crate::resource_group::tests::*;
 
     struct TestResourceStatsProvider {
         cpu_total: f64,
@@ -631,6 +663,8 @@ mod tests {
     #[test]
     fn test_adjust_resource_limiter() {
         let resource_ctl = Arc::new(ResourceGroupManager::default());
+
+        // Non-background group should not get a limiter.
         let rg1 = new_resource_group_ru("test".into(), 1000, 14);
         resource_ctl.add_resource_group(rg1);
         assert!(
@@ -639,13 +673,23 @@ mod tests {
                 .is_none()
         );
 
+        // 8 CPU cores, 10000 bytes/s IO bandwidth.
         let test_provider = TestResourceStatsProvider::new(8.0, 10000.0);
-        let mut worker =
-            GroupQuotaAdjustWorker::with_quota_getter(resource_ctl.clone(), test_provider);
+        let compaction_pending_bytes_ratio = Arc::new(AtomicU32::new(0));
+        let mut worker = GroupQuotaAdjustWorker::with_quota_getter(
+            resource_ctl.clone(),
+            test_provider,
+            compaction_pending_bytes_ratio,
+        );
 
-        let default_bg =
-            new_background_resource_group_ru("default".into(), 100000, 8, vec!["br".into()]);
+        // Create default background group with 80% utilization limit.
+        let mut default_bg =
+            new_background_resource_group_ru("default".into(), 2000, 8, vec!["br".into()]);
+        default_bg
+            .mut_background_settings()
+            .set_utilization_limit(80);
         resource_ctl.add_resource_group(default_bg);
+
         assert!(
             resource_ctl
                 .get_background_resource_limiter("default", "lightning")
@@ -666,19 +710,6 @@ mod tests {
                 .get_rate_limit()
                 .is_infinite()
         );
-
-        fn reset_quota_limiter(limiter: &QuotaLimiter) {
-            let limit = limiter.get_rate_limit();
-            if limit.is_finite() {
-                limiter.set_rate_limit(f64::INFINITY);
-                limiter.set_rate_limit(limit);
-            }
-        }
-
-        fn reset_limiter(limiter: &Arc<ResourceLimiter>) {
-            reset_quota_limiter(limiter.get_limiter(ResourceType::Cpu));
-            reset_quota_limiter(limiter.get_limiter(ResourceType::Io));
-        }
 
         let reset_quota = |worker: &mut GroupQuotaAdjustWorker<TestResourceStatsProvider>,
                            cpu: f64,
@@ -701,263 +732,197 @@ mod tests {
         }
 
         #[track_caller]
-        fn check_limiter(limiter: &Arc<ResourceLimiter>, cpu: f64, io: IoBytes) {
+        fn check_limiter_rates(limiter: &Arc<ResourceLimiter>, cpu: f64, io: f64) {
             check(
                 limiter.get_limiter(ResourceType::Cpu).get_rate_limit(),
                 cpu * MICROS_PER_SEC,
             );
-            check(
-                limiter.get_limiter(ResourceType::Io).get_rate_limit(),
-                (io.read + io.write) as f64,
-            );
-            reset_limiter(limiter);
+            check(limiter.get_limiter(ResourceType::Io).get_rate_limit(), io);
         }
 
+        // util_limit configured at 80% but capped to fg_cpu_throttle_threshold=70%.
+        // CPU target = 8 * 0.7 = 5.6 cores, IO target = 10000 * 0.7 = 7000
+        // CPU min_floor = 1 core, IO min_floor = 1000
+        // bg_scale_start=60%, fg_cpu_throttle_threshold=70% (scale range: 60→70).
+
+        // No load: initial infinity → treated as target → budget = target.
         reset_quota(&mut worker, 0.0, 0.0, Duration::from_secs(1));
         worker.adjust_quota();
-        check_limiter(
-            &limiter,
-            6.4,
-            IoBytes {
-                read: 4000,
-                write: 4000,
-            },
-        );
+        check_limiter_rates(&limiter, 5.6, 7000.0);
 
+        // Short duration (< 1s): adjustment skipped, limits unchanged.
         reset_quota(&mut worker, 4.0, 2000.0, Duration::from_millis(500));
         worker.adjust_quota();
-        check_limiter(
-            &limiter,
-            6.4,
-            IoBytes {
-                read: 4000,
-                write: 4000,
-            },
-        );
+        check_limiter_rates(&limiter, 5.6, 7000.0);
 
+        // Under target (50% CPU): resource_util < 60%, current == target,
+        // so none of the branches fire → budget = target.
         reset_quota(&mut worker, 4.0, 2000.0, Duration::from_secs(1));
         worker.adjust_quota();
-        check_limiter(
-            &limiter,
-            3.2,
-            IoBytes {
-                read: 3200,
-                write: 3200,
-            },
-        );
+        check_limiter_rates(&limiter, 5.6, 7000.0);
 
-        reset_quota(&mut worker, 6.0, 4000.0, Duration::from_secs(1));
-        limiter.consume(
-            Duration::from_secs(2),
-            IoBytes {
-                read: 1000,
-                write: 1000,
-            },
-            true,
-        );
+        // 80% CPU, 80% IO: resource_util > 60% (bg_scale_start).
+        // pressure = (80-60)/(70-60) = 2.0 clamped to 1.0 → min_floor.
+        // CPU: budget = min_floor = 1.0. IO: budget = min_floor = 1000.
+        reset_quota(&mut worker, 6.4, 8000.0, Duration::from_secs(1));
         worker.adjust_quota();
-        check_limiter(
-            &limiter,
-            3.2,
-            IoBytes {
-                read: 3200,
-                write: 3200,
-            },
-        );
+        check_limiter_rates(&limiter, 1.0, 1000.0);
 
+        // 100% CPU, 95% IO: pressure still clamped 1.0 → min_floor.
         reset_quota(&mut worker, 8.0, 9500.0, Duration::from_secs(1));
         worker.adjust_quota();
-        check_limiter(
-            &limiter,
-            0.8,
-            IoBytes {
-                read: 500,
-                write: 500,
-            },
-        );
+        check_limiter_rates(&limiter, 1.0, 1000.0);
 
-        reset_quota(&mut worker, 7.5, 9500.0, Duration::from_secs(1));
-        limiter.consume(
-            Duration::from_secs(2),
-            IoBytes {
-                read: 1000,
-                write: 1000,
-            },
-            true,
-        );
+        // Still at 100% CPU, 95% IO: same result (deterministic, no decay).
+        reset_quota(&mut worker, 8.0, 9500.0, Duration::from_secs(1));
         worker.adjust_quota();
-        check_limiter(
-            &limiter,
-            2.0,
-            IoBytes {
-                read: 1000,
-                write: 1000,
-            },
-        );
+        check_limiter_rates(&limiter, 1.0, 1000.0);
 
-        reset_quota(&mut worker, 7.5, 9500.0, Duration::from_secs(5));
-        limiter.consume(
-            Duration::from_secs(10),
-            IoBytes {
-                read: 5000,
-                write: 5000,
-            },
-            true,
-        );
+        // 65% CPU, 65% IO: in the scale range (60-70%).
+        // CPU: pressure = 0.5, computed = 3.3. But current_limit=1.0 (min_floor)
+        // and 3.3 > 1.0 → only-tighten clamps to 1.0.
+        // IO: same logic → stays 1000.
+        reset_quota(&mut worker, 5.2, 6500.0, Duration::from_secs(1));
         worker.adjust_quota();
-        check_limiter(
-            &limiter,
-            2.0,
-            IoBytes {
-                read: 1000,
-                write: 1000,
-            },
-        );
+        check_limiter_rates(&limiter, 1.0, 1000.0);
 
-        let default =
-            new_background_resource_group_ru("default".into(), 2000, 8, vec!["br".into()]);
-        resource_ctl.add_resource_group(default);
-        let new_limiter = resource_ctl
-            .get_background_resource_limiter("default", "br")
-            .unwrap();
-        assert_eq!(&*new_limiter as *const _, &*limiter as *const _);
+        // Load drops (50% CPU, 20% IO): resource_util < 54% (0.9*60%), current <
+        // 0.9*target → incremental increase: budget = current * 1.1
+        // CPU: 1.0 * 1.1 = 1.1. IO: 1000 * 1.1 = 1100
+        reset_quota(&mut worker, 4.0, 2000.0, Duration::from_secs(1));
+        worker.adjust_quota();
+        check_limiter_rates(&limiter, 1.1, 1100.0);
 
+        // Adding a second background group does not change the limiter —
+        // all background groups share the single global bg_limiter.
         let bg = new_background_resource_group_ru("background".into(), 1000, 15, vec!["br".into()]);
         resource_ctl.add_resource_group(bg);
-        let bg_limiter = resource_ctl
+        let bg_limiter2 = resource_ctl
             .get_background_resource_limiter("background", "br")
             .unwrap();
+        // Both groups return the same shared limiter.
+        assert!(Arc::ptr_eq(&limiter, &bg_limiter2));
 
-        reset_quota(&mut worker, 5.0, 7000.0, Duration::from_secs(1));
-        worker.adjust_quota();
-        check_limiter(
-            &limiter,
-            1.6,
-            IoBytes {
-                read: 800,
-                write: 800,
-            },
-        );
-        check_limiter(
-            &bg_limiter,
-            0.8,
-            IoBytes {
-                read: 400,
-                write: 400,
-            },
-        );
-
-        reset_quota(&mut worker, 6.0, 5000.0, Duration::from_secs(1));
-        limiter.consume(
-            Duration::from_millis(1200),
-            IoBytes {
-                read: 600,
-                write: 600,
-            },
-            true,
-        );
-        bg_limiter.consume(
-            Duration::from_millis(1800),
-            IoBytes {
-                read: 900,
-                write: 900,
-            },
-            true,
-        );
-        worker.adjust_quota();
-        check_limiter(
-            &limiter,
-            1.2,
-            IoBytes {
-                read: 1800,
-                write: 1800,
-            },
-        );
-        check_limiter(
-            &bg_limiter,
-            2.8,
-            IoBytes {
-                read: 1400,
-                write: 1400,
-            },
-        );
-
-        let bg = new_resource_group_ru("background".into(), 1000, 15);
-        resource_ctl.add_resource_group(bg);
-
-        let new_bg =
-            new_background_resource_group_ru("background".into(), 1000, 15, vec!["br".into()]);
-        resource_ctl.add_resource_group(new_bg);
-        let new_bg_limiter = resource_ctl
-            .get_background_resource_limiter("background", "br")
-            .unwrap();
-        assert_ne!(&*bg_limiter as *const _, &*new_bg_limiter as *const _);
-        assert!(
-            new_bg_limiter
-                .get_limit_statistics(ResourceType::Cpu)
-                .version
-                > bg_limiter.get_limit_statistics(ResourceType::Cpu).version
-        );
-        let cpu_stats = new_bg_limiter.get_limit_statistics(ResourceType::Cpu);
-        assert_eq!(cpu_stats.total_consumed, 0);
-        assert_eq!(cpu_stats.total_wait_dur_us, 0);
-        let io_stats = new_bg_limiter.get_limit_statistics(ResourceType::Io);
-        assert_eq!(io_stats.total_consumed, 0);
-        assert_eq!(io_stats.total_wait_dur_us, 0);
-
+        // No load: current at 1.1M < 0.9*target (5.04M) and util < 63% → incremental.
+        // budget = 1.1 * 1.1 = 1.21
+        // IO: 1100 * 1.1 = 1210
         reset_quota(&mut worker, 0.0, 0.0, Duration::from_secs(1));
         worker.adjust_quota();
-        check_limiter(
-            &limiter,
-            4.27,
-            IoBytes {
-                read: 2667,
-                write: 2667,
-            },
-        );
-        check_limiter(
-            &new_bg_limiter,
-            2.13,
-            IoBytes {
-                read: 1334,
-                write: 1334,
-            },
-        );
+        check_limiter_rates(&limiter, 1.21, 1210.0);
 
-        reset_quota(&mut worker, 6.0, 5000.0, Duration::from_secs(1));
-        limiter.consume(
-            Duration::from_millis(1200),
-            IoBytes {
-                read: 600,
-                write: 600,
-            },
-            true,
-        );
-        new_bg_limiter.consume(
-            Duration::from_millis(1800),
-            IoBytes {
-                read: 900,
-                write: 900,
-            },
-            true,
-        );
-
+        // Over 70% (100% CPU, 95% IO): budget scales down to min_floor.
+        // CPU: pressure = 1.0. budget = min_floor = 1.0
+        // IO: pressure = (95-60)/(70-60) = 3.5 clamped 1.0. budget = min_floor = 1000.
+        reset_quota(&mut worker, 8.0, 9500.0, Duration::from_secs(1));
         worker.adjust_quota();
-        check_limiter(
-            &limiter,
-            2.2,
-            IoBytes {
-                read: 2133,
-                write: 2133,
-            },
+        check_limiter_rates(&limiter, 1.0, 1000.0);
+    }
+
+    #[test]
+    fn test_bg_limiter_with_infinite_ru_groups() {
+        let resource_ctl = Arc::new(ResourceGroupManager::default());
+
+        // 3 foreground groups with large RU quota (no background limiter).
+        for i in 0..3 {
+            let rg = new_resource_group_ru(format!("fg_{i}"), i32::MAX as u64, 8);
+            resource_ctl.add_resource_group(rg);
+        }
+
+        // 1 background group with no explicit utilization limit.
+        // bg_util_limit defaults to 100, capped to 70 by fg_cpu_throttle_threshold.
+        // bg_scale_start=60%, fg_cpu_throttle_threshold=70%.
+        let bg = new_background_resource_group_ru("bg_worker".into(), 5000, 8, vec!["br".into()]);
+        resource_ctl.add_resource_group(bg);
+        let limiter = resource_ctl
+            .get_background_resource_limiter("bg_worker", "br")
+            .unwrap();
+
+        // 8 CPU cores, 10000 bytes/s IO.
+        let test_provider = TestResourceStatsProvider::new(8.0, 10000.0);
+        let compaction_pending_bytes_ratio = Arc::new(AtomicU32::new(0));
+        let mut worker = GroupQuotaAdjustWorker::with_quota_getter(
+            resource_ctl.clone(),
+            test_provider,
+            compaction_pending_bytes_ratio,
         );
-        check_limiter(
-            &new_bg_limiter,
-            1.8,
-            IoBytes {
-                read: 1066,
-                write: 1066,
-            },
+
+        let reset_quota = |worker: &mut GroupQuotaAdjustWorker<TestResourceStatsProvider>,
+                           cpu: f64,
+                           io: f64,
+                           dur: Duration| {
+            worker.resource_quota_getter.cpu_used = cpu;
+            worker.resource_quota_getter.io_used = io;
+            let now = Instant::now_coarse();
+            worker.last_adjust_time = now - dur;
+        };
+
+        #[track_caller]
+        fn check(val: f64, expected: f64) {
+            assert!(
+                expected * 0.99 < val && val < expected * 1.01,
+                "actual: {}, expected: {}",
+                val,
+                expected
+            );
+        }
+
+        // CPU target = 8 * 0.7 = 5.6 cores, IO target = 10000 * 0.7 = 7000
+        // fg groups have no background settings; only bg_worker triggers adjustment.
+
+        // --- Initial: no load → budget = target ---
+        reset_quota(&mut worker, 0.0, 0.0, Duration::from_secs(1));
+        worker.adjust_quota();
+        check(
+            limiter.get_limiter(ResourceType::Cpu).get_rate_limit(),
+            5.6 * MICROS_PER_SEC,
+        );
+        check(
+            limiter.get_limiter(ResourceType::Io).get_rate_limit(),
+            7000.0,
+        );
+
+        // --- Saturate CPU (100%, 80% IO) → budget scales to min_floor ---
+        // CPU: pressure = (100-60)/(70-60) = 4.0 clamped 1.0 → min_floor = 1.0
+        // IO: pressure = (80-60)/(70-60) = 2.0 clamped 1.0 → min_floor = 1000
+        reset_quota(&mut worker, 8.0, 8000.0, Duration::from_secs(1));
+        worker.adjust_quota();
+        check(
+            limiter.get_limiter(ResourceType::Cpu).get_rate_limit(),
+            1.0 * MICROS_PER_SEC,
+        );
+        check(
+            limiter.get_limiter(ResourceType::Io).get_rate_limit(),
+            1000.0,
+        );
+
+        // --- Unsaturate CPU (25%) → budget recovers incrementally ---
+        // CPU: resource_util = 25% < 54% (0.9*60%), current 1.0M < 5.04M → 1.0 * 1.1 =
+        // 1.1 IO: resource_util = 20% < 54%, current 1000 < 6300 → 1000 * 1.1 =
+        // 1100
+        reset_quota(&mut worker, 2.0, 2000.0, Duration::from_secs(1));
+        worker.adjust_quota();
+        check(
+            limiter.get_limiter(ResourceType::Cpu).get_rate_limit(),
+            1.1 * MICROS_PER_SEC,
+        );
+        check(
+            limiter.get_limiter(ResourceType::Io).get_rate_limit(),
+            1100.0,
+        );
+
+        // --- 65% CPU, 65% IO: in scale range (60-70%) ---
+        // CPU: pressure = 0.5, computed = 3.3M. current_limit=1.1M < 3.3M → only
+        // tighten → stays 1.1M. IO: computed = 4000, current=1100 < 4000 →
+        // stays 1100.
+        reset_quota(&mut worker, 5.2, 6500.0, Duration::from_secs(1));
+        worker.adjust_quota();
+        check(
+            limiter.get_limiter(ResourceType::Cpu).get_rate_limit(),
+            1.1 * MICROS_PER_SEC,
+        );
+        check(
+            limiter.get_limiter(ResourceType::Io).get_rate_limit(),
+            1100.0,
         );
     }
 
@@ -1015,7 +980,7 @@ mod tests {
 
         // only default group, always return infinity.
         reset_quota(&mut worker, 6.4);
-        priority_limiters[1].consume(Duration::from_secs(50), IoBytes::default(), true);
+        priority_limiters[1].consume(Duration::from_secs(50), IoBytes::default(), true, false);
         worker.adjust();
         check_limiter(f64::INFINITY, f64::INFINITY, f64::INFINITY);
 
@@ -1025,46 +990,96 @@ mod tests {
         resource_ctl.add_resource_group(rg2);
 
         reset_quota(&mut worker, 6.4);
-        priority_limiters[1].consume(Duration::from_secs(64), IoBytes::default(), true);
+        priority_limiters[1].consume(Duration::from_secs(64), IoBytes::default(), true, false);
         worker.adjust();
         check_limiter(f64::INFINITY, f64::INFINITY, f64::INFINITY);
 
         reset_quota(&mut worker, 6.4);
         for _i in 0..100 {
-            priority_limiters[0].consume(Duration::from_millis(240), IoBytes::default(), true);
-            priority_limiters[1].consume(Duration::from_millis(400), IoBytes::default(), true);
+            priority_limiters[0].consume(
+                Duration::from_millis(240),
+                IoBytes::default(),
+                true,
+                false,
+            );
+            priority_limiters[1].consume(
+                Duration::from_millis(400),
+                IoBytes::default(),
+                true,
+                false,
+            );
         }
         worker.adjust();
         check_limiter(f64::INFINITY, 3.2, 0.8);
 
         reset_quota(&mut worker, 6.4);
         for _i in 0..100 {
-            priority_limiters[0].consume(Duration::from_millis(120), IoBytes::default(), true);
-            priority_limiters[1].consume(Duration::from_millis(200), IoBytes::default(), true);
+            priority_limiters[0].consume(
+                Duration::from_millis(120),
+                IoBytes::default(),
+                true,
+                false,
+            );
+            priority_limiters[1].consume(
+                Duration::from_millis(200),
+                IoBytes::default(),
+                true,
+                false,
+            );
         }
         worker.adjust();
         check_limiter(f64::INFINITY, 1.6, 0.8);
 
         reset_quota(&mut worker, 6.4);
         for _i in 0..100 {
-            priority_limiters[2].consume(Duration::from_millis(200), IoBytes::default(), true);
+            priority_limiters[2].consume(
+                Duration::from_millis(200),
+                IoBytes::default(),
+                true,
+                false,
+            );
         }
         worker.adjust();
         check_limiter(f64::INFINITY, f64::INFINITY, f64::INFINITY);
 
         reset_quota(&mut worker, 8.0);
         for _i in 0..100 {
-            priority_limiters[0].consume(Duration::from_millis(240), IoBytes::default(), true);
-            priority_limiters[1].consume(Duration::from_millis(240), IoBytes::default(), true);
-            priority_limiters[2].consume(Duration::from_millis(320), IoBytes::default(), true);
+            priority_limiters[0].consume(
+                Duration::from_millis(240),
+                IoBytes::default(),
+                true,
+                false,
+            );
+            priority_limiters[1].consume(
+                Duration::from_millis(240),
+                IoBytes::default(),
+                true,
+                false,
+            );
+            priority_limiters[2].consume(
+                Duration::from_millis(320),
+                IoBytes::default(),
+                true,
+                false,
+            );
         }
         worker.adjust();
         check_limiter(f64::INFINITY, 3.2, 0.8);
 
         reset_quota(&mut worker, 6.0);
         for _i in 0..100 {
-            priority_limiters[0].consume(Duration::from_millis(240), IoBytes::default(), true);
-            priority_limiters[2].consume(Duration::from_millis(360), IoBytes::default(), true);
+            priority_limiters[0].consume(
+                Duration::from_millis(240),
+                IoBytes::default(),
+                true,
+                false,
+            );
+            priority_limiters[2].consume(
+                Duration::from_millis(360),
+                IoBytes::default(),
+                true,
+                false,
+            );
         }
         worker.adjust();
         check_limiter(f64::INFINITY, 3.2, 3.2);
@@ -1074,5 +1089,349 @@ mod tests {
         worker.last_adjust_time = Instant::now_coarse() - Duration::from_millis(500);
         worker.adjust();
         check_limiter(f64::INFINITY, 3.2, 3.2);
+    }
+
+    /// Verifies background load-shedding:
+    ///
+    /// - 0–60% CPU   : background full
+    /// - 60–70% CPU  : background linearly throttled to min_floor
+    /// - >70% CPU    : background at min_floor
+    #[test]
+    fn test_tiered_load_shedding() {
+        let resource_ctl = Arc::new(ResourceGroupManager::default());
+
+        let bg = new_background_resource_group_ru("bg".into(), 1000, 8, vec!["br".into()]);
+        resource_ctl.add_resource_group(bg);
+        let bg_limiter = resource_ctl
+            .get_background_resource_limiter("bg", "br")
+            .unwrap();
+
+        let compaction_pending_bytes_ratio = Arc::new(AtomicU32::new(0));
+        let mut bg_worker = GroupQuotaAdjustWorker::with_quota_getter(
+            resource_ctl.clone(),
+            TestResourceStatsProvider::new(8.0, 10000.0),
+            compaction_pending_bytes_ratio,
+        );
+
+        const BG_TARGET: f64 = 5.6;
+        const BG_FLOOR: f64 = 1.0;
+
+        #[track_caller]
+        fn approx(val: f64, expected: f64) {
+            assert!(
+                (val.is_infinite() && expected.is_infinite())
+                    || (expected * 0.99 < val && val < expected * 1.01),
+                "actual: {val}, expected: {expected}"
+            );
+        }
+
+        macro_rules! tick {
+            ($cpu:expr) => {{
+                bg_worker.resource_quota_getter.cpu_used = $cpu;
+                bg_worker.last_adjust_time = Instant::now_coarse() - Duration::from_secs(10);
+                bg_worker.adjust_quota();
+            }};
+        }
+
+        // 50% CPU — below bg_scale_start (60%): bg=full.
+        tick!(4.0);
+        approx(
+            bg_limiter.get_limiter(ResourceType::Cpu).get_rate_limit(),
+            BG_TARGET * MICROS_PER_SEC,
+        );
+
+        // 65% CPU — mid bg range: pressure = 0.5.
+        tick!(5.2);
+        approx(
+            bg_limiter.get_limiter(ResourceType::Cpu).get_rate_limit(),
+            3.3 * MICROS_PER_SEC,
+        );
+
+        // 70% CPU — bg fully throttled.
+        tick!(5.6);
+        approx(
+            bg_limiter.get_limiter(ResourceType::Cpu).get_rate_limit(),
+            BG_FLOOR * MICROS_PER_SEC,
+        );
+
+        // 80% CPU — still at min_floor.
+        tick!(6.4);
+        approx(
+            bg_limiter.get_limiter(ResourceType::Cpu).get_rate_limit(),
+            BG_FLOOR * MICROS_PER_SEC,
+        );
+
+        // Recovery: CPU drops to 50%.
+        tick!(4.0);
+        let bg_rate = bg_limiter.get_limiter(ResourceType::Cpu).get_rate_limit();
+        assert!(
+            bg_rate > BG_FLOOR * MICROS_PER_SEC && bg_rate < BG_TARGET * MICROS_PER_SEC,
+            "bg should be recovering, got {bg_rate}"
+        );
+    }
+
+    #[test]
+    fn test_compaction_pending_bytes_ratio_write_io_throttle() {
+        let resource_ctl = Arc::new(ResourceGroupManager::default());
+
+        // 8 CPU cores, 10000 bytes/s IO bandwidth.
+        let test_provider = TestResourceStatsProvider::new(8.0, 10000.0);
+        let compaction_pending_bytes_ratio = Arc::new(AtomicU32::new(0));
+        let mut worker = GroupQuotaAdjustWorker::with_quota_getter(
+            resource_ctl.clone(),
+            test_provider,
+            compaction_pending_bytes_ratio.clone(),
+        );
+
+        // Create default background group with 80% utilization limit.
+        let mut default_bg =
+            new_background_resource_group_ru("default".into(), 2000, 8, vec!["br".into()]);
+        default_bg
+            .mut_background_settings()
+            .set_utilization_limit(80);
+        resource_ctl.add_resource_group(default_bg);
+
+        let limiter = resource_ctl
+            .get_background_resource_limiter("default", "br")
+            .unwrap();
+
+        let reset_quota = |worker: &mut GroupQuotaAdjustWorker<TestResourceStatsProvider>,
+                           cpu: f64,
+                           io: f64,
+                           dur: Duration| {
+            worker.resource_quota_getter.cpu_used = cpu;
+            worker.resource_quota_getter.io_used = io;
+            let now = Instant::now_coarse();
+            worker.last_adjust_time = now - dur;
+        };
+
+        #[track_caller]
+        fn check(val: f64, expected: f64) {
+            assert!(
+                (val.is_infinite() && expected.is_infinite())
+                    || (expected * 0.99 < val && val < expected * 1.01),
+                "actual: {}, expected: {}",
+                val,
+                expected
+            );
+        }
+
+        // Constants matching config defaults (bg_write_io_ceiling=100GB/s,
+        // bg_write_io_floor=10MB/s).
+        let ceiling = 100.0 * 1024.0 * 1024.0 * 1024.0; // 100 GB/s in bytes/s
+        let floor = 10.0 * 1024.0 * 1024.0; // 10 MB/s in bytes/s
+
+        // First adjustment: establish baseline limits.
+        // util_limit 80% capped to 70%. CPU target = 5.6 cores, IO target = 7000
+        reset_quota(&mut worker, 0.0, 0.0, Duration::from_secs(1));
+        worker.adjust_quota();
+        check(
+            limiter.get_limiter(ResourceType::Cpu).get_rate_limit(),
+            5.6 * MICROS_PER_SEC,
+        );
+        check(
+            limiter.get_limiter(ResourceType::Io).get_rate_limit(),
+            7000.0,
+        );
+
+        // Pressure = 0: below threshold → first call, current is infinite so
+        // set to ceiling.
+        check(limiter.get_write_io_limiter().get_rate_limit(), ceiling);
+
+        // Pressure = 50 (< 70): already at ceiling, stays at ceiling.
+        compaction_pending_bytes_ratio.store(50, Ordering::Relaxed);
+        reset_quota(&mut worker, 0.0, 0.0, Duration::from_secs(1));
+        worker.adjust_quota();
+        check(limiter.get_write_io_limiter().get_rate_limit(), ceiling);
+
+        // CPU and combined IO limits unchanged at target.
+        check(
+            limiter.get_limiter(ResourceType::Cpu).get_rate_limit(),
+            5.6 * MICROS_PER_SEC,
+        );
+        check(
+            limiter.get_limiter(ResourceType::Io).get_rate_limit(),
+            7000.0,
+        );
+
+        // Pressure = 70 (at threshold): pressure_ratio = 0 → budget = ceiling.
+        compaction_pending_bytes_ratio.store(70, Ordering::Relaxed);
+        reset_quota(&mut worker, 0.0, 0.0, Duration::from_secs(1));
+        worker.adjust_quota();
+        check(limiter.get_write_io_limiter().get_rate_limit(), ceiling);
+
+        // CPU and combined IO limits should not be affected by compaction pressure.
+        check(
+            limiter.get_limiter(ResourceType::Cpu).get_rate_limit(),
+            5.6 * MICROS_PER_SEC,
+        );
+
+        // Pressure = 85: window = [70, 105], pressure_ratio = (85-70)/35 ≈ 0.429
+        // budget = ceiling * 0.571 + floor * 0.429
+        compaction_pending_bytes_ratio.store(85, Ordering::Relaxed);
+        reset_quota(&mut worker, 0.0, 0.0, Duration::from_secs(1));
+        worker.adjust_quota();
+        let window = 70.0 * 0.5; // threshold * 0.5 = 35
+        let expected_85 = {
+            let r = ((85.0_f64 - 70.0) / window).clamp(0.0, 1.0);
+            ceiling * (1.0 - r) + floor * r
+        };
+        check(limiter.get_write_io_limiter().get_rate_limit(), expected_85);
+
+        // CPU limit unaffected.
+        check(
+            limiter.get_limiter(ResourceType::Cpu).get_rate_limit(),
+            5.6 * MICROS_PER_SEC,
+        );
+
+        // Pressure = 100: pressure_ratio = (100-70)/35 ≈ 0.857 → well below floor
+        // clamp. budget = ceiling * 0.143 + floor * 0.857
+        compaction_pending_bytes_ratio.store(100, Ordering::Relaxed);
+        reset_quota(&mut worker, 0.0, 0.0, Duration::from_secs(1));
+        worker.adjust_quota();
+        let expected_100 = {
+            let r = ((100.0_f64 - 70.0) / window).clamp(0.0, 1.0);
+            ceiling * (1.0 - r) + floor * r
+        };
+        check(
+            limiter.get_write_io_limiter().get_rate_limit(),
+            expected_100,
+        );
+
+        // CPU limit unaffected.
+        check(
+            limiter.get_limiter(ResourceType::Cpu).get_rate_limit(),
+            5.6 * MICROS_PER_SEC,
+        );
+
+        // Pressure = 106 (>= threshold * 1.5 = 105): pressure_ratio clamped to 1.0 →
+        // floor.
+        compaction_pending_bytes_ratio.store(106, Ordering::Relaxed);
+        reset_quota(&mut worker, 0.0, 0.0, Duration::from_secs(1));
+        worker.adjust_quota();
+        check(limiter.get_write_io_limiter().get_rate_limit(), floor);
+
+        // Pressure drops to 0 (< threshold): ramp up by 10% from floor.
+        // floor * 1.1 = 10 MB/s * 1.1 = 11534336
+        compaction_pending_bytes_ratio.store(0, Ordering::Relaxed);
+        reset_quota(&mut worker, 0.0, 0.0, Duration::from_secs(1));
+        worker.adjust_quota();
+        let ramp1 = floor * 1.1;
+        check(limiter.get_write_io_limiter().get_rate_limit(), ramp1);
+
+        // Pressure stays at 0: another 10% ramp up.
+        reset_quota(&mut worker, 0.0, 0.0, Duration::from_secs(1));
+        worker.adjust_quota();
+        let ramp2 = ramp1 * 1.1;
+        check(limiter.get_write_io_limiter().get_rate_limit(), ramp2);
+
+        // Keep ramping until we hit ceiling.
+        let mut current = ramp2;
+        while current * 1.1 < ceiling {
+            reset_quota(&mut worker, 0.0, 0.0, Duration::from_secs(1));
+            worker.adjust_quota();
+            current = (current * 1.1).min(ceiling);
+            check(limiter.get_write_io_limiter().get_rate_limit(), current);
+        }
+        // One more adjustment should cap at ceiling.
+        reset_quota(&mut worker, 0.0, 0.0, Duration::from_secs(1));
+        worker.adjust_quota();
+        check(limiter.get_write_io_limiter().get_rate_limit(), ceiling);
+    }
+
+    // Verify that with multiple background groups the budget is set globally on
+    // a single shared limiter, not split proportionally across groups.
+    //
+    // Old behaviour: 2 groups with RU 2000 and 1000 would receive 2/3 and 1/3
+    // of the total budget.
+    // New behaviour: both groups return the same Arc<ResourceLimiter> and the
+    // full budget is applied to it once.
+    #[test]
+    fn test_global_budget_not_split_across_groups() {
+        let resource_ctl = Arc::new(ResourceGroupManager::default());
+
+        // 8 CPU cores, 10000 bytes/s IO bandwidth.
+        let test_provider = TestResourceStatsProvider::new(8.0, 10000.0);
+        let compaction_pending_bytes_ratio = Arc::new(AtomicU32::new(0));
+        let mut worker = GroupQuotaAdjustWorker::with_quota_getter(
+            resource_ctl.clone(),
+            test_provider,
+            compaction_pending_bytes_ratio,
+        );
+
+        // Add two background groups with different RU quotas.
+        let mut grp_a =
+            new_background_resource_group_ru("group_a".into(), 2000, 8, vec!["br".into()]);
+        grp_a.mut_background_settings().set_utilization_limit(80);
+        resource_ctl.add_resource_group(grp_a);
+
+        let grp_b = new_background_resource_group_ru("group_b".into(), 1000, 8, vec!["br".into()]);
+        resource_ctl.add_resource_group(grp_b);
+
+        let limiter_a = resource_ctl
+            .get_background_resource_limiter("group_a", "br")
+            .unwrap();
+        let limiter_b = resource_ctl
+            .get_background_resource_limiter("group_b", "br")
+            .unwrap();
+
+        // Both groups must point to the same global limiter.
+        assert!(Arc::ptr_eq(&limiter_a, &limiter_b));
+
+        // util_limit = 80% capped to 70% by bg_resource_threshold.
+        // CPU target = 8 * 0.7 = 5.6 cores, IO target = 10000 * 0.7 = 7000.
+        // Under no load the full target is applied to the single limiter.
+        worker.resource_quota_getter.cpu_used = 0.0;
+        worker.resource_quota_getter.io_used = 0.0;
+        worker.last_adjust_time = Instant::now_coarse() - Duration::from_secs(1);
+        worker.adjust_quota();
+
+        #[track_caller]
+        fn check(val: f64, expected: f64) {
+            assert!(
+                expected * 0.99 < val && val < expected * 1.01,
+                "actual: {val}, expected: {expected}"
+            );
+        }
+
+        // Full budget, not 2/3 of it.
+        check(
+            limiter_a.get_limiter(ResourceType::Cpu).get_rate_limit(),
+            5.6 * MICROS_PER_SEC,
+        );
+        check(
+            limiter_a.get_limiter(ResourceType::Io).get_rate_limit(),
+            7000.0,
+        );
+
+        // limiter_b is the same Arc so it reflects the same rates.
+        check(
+            limiter_b.get_limiter(ResourceType::Cpu).get_rate_limit(),
+            5.6 * MICROS_PER_SEC,
+        );
+        check(
+            limiter_b.get_limiter(ResourceType::Io).get_rate_limit(),
+            7000.0,
+        );
+
+        // Under heavy load (100% CPU) the budget scales down to min_floor for
+        // the single global limiter — not independently per group.
+        worker.resource_quota_getter.cpu_used = 8.0;
+        worker.resource_quota_getter.io_used = 9500.0;
+        worker.last_adjust_time = Instant::now_coarse() - Duration::from_secs(1);
+        worker.adjust_quota();
+
+        // CPU: resource_util=100%, bg_scale_start=60%, fg_cpu_throttle_threshold=70%.
+        // pressure = (100-60)/(70-60) = 4.0 clamped to 1.0 → min_floor = 1.0 core.
+        // IO: resource_util=95%, pressure = (95-60)/(70-60) = 3.5 clamped to 1.0 →
+        // min_floor = 1000.
+        check(
+            limiter_a.get_limiter(ResourceType::Cpu).get_rate_limit(),
+            1.0 * MICROS_PER_SEC,
+        );
+        check(
+            limiter_a.get_limiter(ResourceType::Io).get_rate_limit(),
+            1000.0,
+        );
     }
 }

--- a/components/server/src/common.rs
+++ b/components/server/src/common.rs
@@ -483,6 +483,8 @@ pub struct EnginesResourceInfo {
     raft_engine: Option<RocksEngine>,
     latest_normalized_pending_bytes: AtomicU32,
     normalized_pending_bytes_collector: MovingAvgU32,
+    // Shared compaction pressure (0-100+) read by GroupQuotaAdjustWorker.
+    compaction_pending_bytes_ratio: Arc<AtomicU32>,
 }
 
 impl EnginesResourceInfo {
@@ -493,6 +495,7 @@ impl EnginesResourceInfo {
         tablet_registry: TabletRegistry<RocksEngine>,
         raft_engine: Option<RocksEngine>,
         max_samples_to_preserve: usize,
+        compaction_pending_bytes_ratio: Arc<AtomicU32>,
     ) -> Self {
         // Match DATA_CFS.
         let base_max_compactions = [
@@ -506,6 +509,7 @@ impl EnginesResourceInfo {
             raft_engine,
             latest_normalized_pending_bytes: AtomicU32::new(0),
             normalized_pending_bytes_collector: MovingAvgU32::new(max_samples_to_preserve),
+            compaction_pending_bytes_ratio,
         }
     }
 
@@ -640,10 +644,11 @@ impl EnginesResourceInfo {
         let (_, avg) = self
             .normalized_pending_bytes_collector
             .add(normalized_pending_bytes);
-        self.latest_normalized_pending_bytes.store(
-            std::cmp::max(normalized_pending_bytes, avg),
-            Ordering::Relaxed,
-        );
+        let effective_pressure = std::cmp::max(normalized_pending_bytes, avg);
+        self.latest_normalized_pending_bytes
+            .store(effective_pressure, Ordering::Relaxed);
+        self.compaction_pending_bytes_ratio
+            .store(effective_pressure, Ordering::Relaxed);
     }
 
     #[cfg(any(test, feature = "testexport"))]

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -16,7 +16,10 @@ use std::{
     convert::TryFrom,
     path::{Path, PathBuf},
     str::FromStr,
-    sync::{atomic::AtomicU64, mpsc, Arc, Mutex},
+    sync::{
+        atomic::{AtomicU32, AtomicU64},
+        mpsc, Arc, Mutex,
+    },
     time::Duration,
     u64,
 };
@@ -289,6 +292,7 @@ where
     sst_worker: Option<Box<LazyWorker<String>>>,
     quota_limiter: Arc<QuotaLimiter>,
     resource_manager: Option<Arc<ResourceGroupManager>>,
+    compaction_pending_bytes_ratio: Arc<AtomicU32>,
     causal_ts_provider: Option<Arc<CausalTsProviderImpl>>, // used for rawkv apiv2
     tablet_registry: Option<TabletRegistry<RocksEngine>>,
     br_snap_recovery_mode: bool, // use for br snapshot recovery
@@ -396,6 +400,7 @@ where
             .thread_count(thread_count)
             .create();
 
+        let compaction_pending_bytes_ratio = Arc::new(AtomicU32::new(0));
         let resource_manager = if config.resource_control.enabled {
             let mgr = Arc::new(ResourceGroupManager::new(config.resource_control.clone()));
             let io_bandwidth = config.storage.io_rate_limit.max_bytes_per_sec.0;
@@ -404,6 +409,7 @@ where
                 pd_client.clone(),
                 &background_worker,
                 io_bandwidth,
+                compaction_pending_bytes_ratio.clone(),
             );
             Some(mgr)
         } else {
@@ -491,6 +497,7 @@ where
             sst_worker: None,
             quota_limiter,
             resource_manager,
+            compaction_pending_bytes_ratio,
             causal_ts_provider,
             tablet_registry: None,
             br_snap_recovery_mode: is_recovering_marked,
@@ -619,6 +626,7 @@ where
                 pd_sender.clone(),
                 engines.engine.clone(),
                 resource_ctl,
+                self.resource_manager.clone(),
                 CleanupMethod::Remote(self.core.background_worker.remote()),
                 true,
             ))
@@ -1882,6 +1890,7 @@ where
             reg,
             engines.raft.as_rocks_engine().cloned(),
             180, // max_samples_to_preserve
+            self.compaction_pending_bytes_ratio.clone(),
         ));
 
         (engines, engines_info, ime_engine)
@@ -1919,7 +1928,10 @@ fn pre_start() {
 
 #[cfg(test)]
 mod test {
-    use std::{collections::HashMap, sync::Arc};
+    use std::{
+        collections::HashMap,
+        sync::{atomic::AtomicU32, Arc},
+    };
 
     use engine_rocks::raw::Env;
     use engine_traits::{
@@ -1984,7 +1996,13 @@ mod test {
 
         assert!(old_pending_compaction_bytes > new_pending_compaction_bytes);
 
-        let engines_info = Arc::new(EnginesResourceInfo::new(&config, reg, None, 10));
+        let engines_info = Arc::new(EnginesResourceInfo::new(
+            &config,
+            reg,
+            None,
+            10,
+            Arc::new(AtomicU32::new(0)),
+        ));
 
         let mut cached_latest_tablets = HashMap::default();
         engines_info.update(Instant::now(), &mut cached_latest_tablets);

--- a/components/server/src/server2.rs
+++ b/components/server/src/server2.rs
@@ -17,7 +17,7 @@ use std::{
     path::{Path, PathBuf},
     str::FromStr,
     sync::{
-        atomic::AtomicU64,
+        atomic::{AtomicU32, AtomicU64},
         mpsc::{self, sync_channel},
         Arc,
     },
@@ -266,6 +266,7 @@ struct TikvServer<ER: RaftEngine> {
     sst_worker: Option<Box<LazyWorker<String>>>,
     quota_limiter: Arc<QuotaLimiter>,
     resource_manager: Option<Arc<ResourceGroupManager>>,
+    compaction_pending_bytes_ratio: Arc<AtomicU32>,
     causal_ts_provider: Option<Arc<CausalTsProviderImpl>>, // used for rawkv apiv2
     tablet_registry: Option<TabletRegistry<RocksEngine>>,
     resolved_ts_scheduler: Option<Scheduler<Task>>,
@@ -358,6 +359,7 @@ where
             config.quota.enable_auto_tune,
         ));
 
+        let compaction_pending_bytes_ratio = Arc::new(AtomicU32::new(0));
         let resource_manager = if config.resource_control.enabled {
             let mgr = Arc::new(ResourceGroupManager::new(config.resource_control.clone()));
             let io_bandwidth = config.storage.io_rate_limit.max_bytes_per_sec.0;
@@ -366,6 +368,7 @@ where
                 pd_client.clone(),
                 &background_worker,
                 io_bandwidth,
+                compaction_pending_bytes_ratio.clone(),
             );
             Some(mgr)
         } else {
@@ -422,6 +425,7 @@ where
             sst_worker: None,
             quota_limiter,
             resource_manager,
+            compaction_pending_bytes_ratio,
             causal_ts_provider,
             tablet_registry: None,
             resolved_ts_scheduler: None,
@@ -495,6 +499,7 @@ where
                 pd_sender.clone(),
                 engines.engine.clone(),
                 resource_ctl,
+                self.resource_manager.clone(),
                 CleanupMethod::Remote(self.core.background_worker.remote()),
                 true,
             ))
@@ -1651,6 +1656,7 @@ impl<CER: ConfiguredRaftEngine> TikvServer<CER> {
             registry,
             raft_engine.as_rocks_engine().cloned(),
             180, // max_samples_to_preserve
+            self.compaction_pending_bytes_ratio.clone(),
         ));
 
         let router = RaftRouter::new(node.id(), router);
@@ -1726,7 +1732,10 @@ fn pre_start() {
 
 #[cfg(test)]
 mod test {
-    use std::{collections::HashMap, sync::Arc};
+    use std::{
+        collections::HashMap,
+        sync::{atomic::AtomicU32, Arc},
+    };
 
     use engine_rocks::raw::Env;
     use engine_traits::{
@@ -1790,7 +1799,13 @@ mod test {
 
         assert!(old_pending_compaction_bytes > new_pending_compaction_bytes);
 
-        let engines_info = Arc::new(EnginesResourceInfo::new(&config, reg, None, 10));
+        let engines_info = Arc::new(EnginesResourceInfo::new(
+            &config,
+            reg,
+            None,
+            10,
+            Arc::new(AtomicU32::new(0)),
+        ));
 
         let mut cached_latest_tablets = HashMap::default();
         engines_info.update(Instant::now(), &mut cached_latest_tablets);

--- a/components/sst_importer/src/lib.rs
+++ b/components/sst_importer/src/lib.rs
@@ -5,8 +5,6 @@
 #![feature(error_reporter)]
 
 #[macro_use]
-extern crate lazy_static;
-#[macro_use]
 extern crate serde_derive;
 #[macro_use]
 extern crate tikv_util;

--- a/components/test_raftstore/src/lib.rs
+++ b/components/test_raftstore/src/lib.rs
@@ -4,8 +4,6 @@
 #![feature(trait_alias)]
 
 #[macro_use]
-extern crate lazy_static;
-#[macro_use]
 extern crate tikv_util;
 
 mod cluster;

--- a/components/tikv_alloc/Cargo.toml
+++ b/components/tikv_alloc/Cargo.toml
@@ -36,15 +36,16 @@ optional = true
 features = ["bundled"]
 
 [dependencies.tikv-jemalloc-ctl]
-version = "0.5.0"
+version = "0.6.1"
 optional = true
+features = ["stats"]
 
 [dependencies.tikv-jemalloc-sys]
-version = "0.5.0"
+version = "0.6.1"
 optional = true
 features = ["stats"]
 
 [dependencies.tikv-jemallocator]
-version = "0.5.0"
+version = "0.6.1"
 optional = true
 features = ["unprefixed_malloc_on_supported_platforms", "stats"]

--- a/components/tikv_util/src/lib.rs
+++ b/components/tikv_util/src/lib.rs
@@ -29,10 +29,12 @@ use std::{
     time::Duration,
 };
 
+use lazy_static::lazy_static;
 use nix::{
     sys::wait::{wait, WaitStatus},
     unistd::{fork, ForkResult},
 };
+use serde::Serialize;
 
 use crate::sys::thread::StdThreadBuildWrapper;
 
@@ -580,6 +582,48 @@ pub fn set_vec_capacity<T>(v: &mut Vec<T>, cap: usize) {
         cmp::Ordering::Less => v.shrink_to(cap),
         cmp::Ordering::Greater => v.reserve_exact(cap - v.len()),
         cmp::Ordering::Equal => {}
+    }
+}
+
+// Global server readiness state.
+//
+// This is used to track whether TiKV is fully ready to serve requests after
+// startup. It is queried by the `/ready` API of the status server.
+lazy_static! {
+    pub static ref GLOBAL_SERVER_READINESS: Arc<ServerReadiness> =
+        Arc::new(ServerReadiness::default());
+}
+
+/// Represents the readiness state of the server.
+///
+/// Each field is a flag indicating a condition that must be met for the server
+/// to be considered fully ready to serve.
+#[derive(Serialize, Default)]
+pub struct ServerReadiness {
+    /// Indicates whether the server has connected to PD.
+    pub connected_to_pd: AtomicBool,
+    /// Indicates whether a sufficient number of Raft peers have caught up
+    /// applying logs.
+    pub raft_peers_caught_up: AtomicBool,
+}
+
+impl ServerReadiness {
+    /// Checks if the server is ready.
+    ///
+    /// All conditions must be met for the server to be considered ready.
+    pub fn is_ready(&self) -> bool {
+        self.raft_peers_caught_up.load(Ordering::SeqCst)
+            && self.connected_to_pd.load(Ordering::SeqCst)
+    }
+
+    pub fn to_json(&self) -> String {
+        let json_result = serde_json::to_string_pretty(&self);
+        match json_result {
+            Ok(json) => json,
+            Err(e) => {
+                format!("failed to serialize ServerReadiness: {}", e)
+            }
+        }
     }
 }
 

--- a/deny.toml
+++ b/deny.toml
@@ -110,6 +110,36 @@ ignore = [
     # rand::rng() / thread_rng() during logging, which TiKV does not do.
     # TODO: Upgrade rand to >=0.9.3 or >=0.10.1 when possible.
     "RUSTSEC-2026-0097",
+    # Ignore RUSTSEC-2026-0174 (http-types ASCII invariant violation in
+    # Authorization/WwwAuthenticate headers). http-types is pulled in via
+    # azure_core and is unmaintained with no fix available. TiKV does not
+    # construct Authorization or WwwAuthenticate headers with non-ASCII input.
+    "RUSTSEC-2026-0174",
+    # Ignore RUSTSEC-2026-0186 (unsound issue in memmap2: unchecked pointer
+    # offset in Mmap::advise_range). memmap2 is a transitive dependency with no
+    # fix available on the release branch.
+    "RUSTSEC-2026-0186",
+    # Ignore RUSTSEC-2022-0104 because structopt is only used by tikv-ctl and
+    # does not affect the server runtime. This is safe to ignore.
+    "RUSTSEC-2022-0104",
+    # Ignore RUSTSEC-2026-0190 (unsound `Error::downcast_mut()` in anyhow). The
+    # UB only triggers when context is added via `Error::context` and later
+    # `downcast_mut` is called on the returned error; TiKV does not use that
+    # pattern. No fix available on the release branch's pinned anyhow.
+    "RUSTSEC-2026-0190",
+    # Ignore RUSTSEC-2026-0204 (invalid pointer dereference in the `fmt::Pointer`
+    # impl for crossbeam-epoch's `Atomic`/`Shared`). Only reachable by formatting
+    # a null/invalid `Atomic`/`Shared` via `fmt::Display`, which TiKV does not do.
+    "RUSTSEC-2026-0204",
+    # Ignore RUSTSEC-2026-0194 (quadratic runtime checking a start tag for
+    # duplicate attribute names in quick-xml). quick-xml is pulled in transitively
+    # via the azure SDK and only parses trusted responses; no fix available on the
+    # release branch.
+    "RUSTSEC-2026-0194",
+    # Ignore RUSTSEC-2026-0195 (unbounded namespace-declaration allocation in
+    # quick-xml's `NsReader`, memory-exhaustion DoS). Same transitive azure SDK
+    # dependency parsing trusted responses; no fix available on the release branch.
+    "RUSTSEC-2026-0195",
 ]
 
 # TiKV is licensed under Apache 2.0, according to ASF 3RD PARTY LICENSE POLICY,

--- a/deny.toml
+++ b/deny.toml
@@ -105,6 +105,11 @@ ignore = [
     # in master branch. Because the modification is too large,
     # we decided on the release branch to ignore it.
     "RUSTSEC-2026-0009",
+    # Ignore RUSTSEC-2026-0097 (unsound issue in rand with a custom logger using
+    # rand::rng()). The vulnerability requires a custom logger that calls
+    # rand::rng() / thread_rng() during logging, which TiKV does not do.
+    # TODO: Upgrade rand to >=0.9.3 or >=0.10.1 when possible.
+    "RUSTSEC-2026-0097",
 ]
 
 # TiKV is licensed under Apache 2.0, according to ASF 3RD PARTY LICENSE POLICY,

--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -313,6 +313,25 @@
 ## Set to 0 to disable this feature if you want to panic immediately when encountering such an error.
 # background-error-recovery-window = "1h"
 
+## Test-only transaction anomaly checker. When enabled, every
+## transaction write command is checked for anomalous states where a committed
+## write record and a normal lock coexist for the same key and start_ts. It is
+## disabled by default and has zero overhead when disabled. Do not enable in
+## production.
+[storage.txn-anomaly-checker]
+## Master switch of the checker.
+# enabled = false
+
+## Whether to panic (and freeze the scene) when an anomaly is found.
+# panic-on-hit = true
+
+## Whether to also check whether the snapshot's pre-existing state already
+## satisfies the anomaly predicate.
+# check-pre-state = true
+
+## Directory to write JSON evidence files into. Empty means only logging.
+# evidence-dir = ""
+
 ## Block cache is used by RocksDB to cache uncompressed blocks. Big block cache can speed up read.
 ## It is recommended to turn on shared block cache. Since only the total cache size need to be
 ## set, it is easier to config. In most cases it should be able to auto-balance cache usage

--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -616,9 +616,12 @@
 ## When storage.engine is "partitioned-raft-kv", default value is 0.
 # stats-dump-period = "10m"
 
-## Refer to: https://github.com/facebook/rocksdb/wiki/RocksDB-FAQ
-## If you want to use RocksDB on multi disks or spinning disks, you should set value at least 2MB.
-# compaction-readahead-size = 0
+## RocksDB 8.x compaction no longer relies on the old setup-time file hint path,
+## so TiKV keeps compaction readahead enabled by default instead of forcing it
+## to 0. Refer to: https://github.com/facebook/rocksdb/wiki/RocksDB-FAQ
+## If you want to use RocksDB on multi disks or spinning disks, you should set
+## value at least 2MB.
+# compaction-readahead-size = "2MB"
 
 ## Max buffer size that is used by WritableFileWrite.
 # writable-file-max-buffer-size = "1MB"
@@ -1088,7 +1091,9 @@
 ## Do not set this config the same as `rocksdb.wal-dir`.
 # wal-dir = ""
 
-# compaction-readahead-size = 0
+## Keep compaction readahead enabled by default for the same reason as
+## `rocksdb.compaction-readahead-size`.
+# compaction-readahead-size = "2MB"
 # writable-file-max-buffer-size = "1MB"
 # use-direct-io-for-flush-and-compaction = false
 # enable-pipelined-write = true

--- a/metrics/grafana/common.py
+++ b/metrics/grafana/common.py
@@ -492,7 +492,7 @@ def expr_count_rate(
 
     count(rate(
         tikv_thread_cpu_seconds_total
-        {k8s_cluster="$k8s_cluster",tidb_cluster="$tidb_cluster",instance=~"$instance",name=~"sst_.*"}
+        {k8s_cluster="$k8s_cluster",tidb_cluster="$tidb_cluster",instance=~"$instance",name=~"(sst_|impwkr).*"}
         [$__rate_interval]
     )) by (instance)
     """

--- a/metrics/grafana/tikv_details.dashboard.py
+++ b/metrics/grafana/tikv_details.dashboard.py
@@ -10284,7 +10284,7 @@ def ResourceControl() -> RowPanel:
                     target(
                         expr=expr_sum_rate(
                             "tikv_resource_control_background_task_wait_duration",
-                            by_labels=["instance", "resource_group"],
+                            by_labels=["instance"],
                         ),
                     ),
                 ],
@@ -10298,6 +10298,271 @@ def ResourceControl() -> RowPanel:
                         expr=expr_sum(
                             "tikv_resource_control_priority_quota_limit",
                             by_labels=["instance", "priority"],
+                        ),
+                    ),
+                ],
+            ),
+        ]
+    )
+    layout.row(
+        [
+            graph_panel(
+                title="Analyze read ops per second (total vs block read)",
+                yaxes=yaxes(left_format=UNITS.OPS_PER_SEC),
+                targets=[
+                    target(
+                        expr=expr_sum_rate(
+                            "tikv_analyze_metrics_total",
+                            label_selectors=['metric="read_total_op_count"'],
+                            by_labels=["instance"],
+                        ),
+                        legend_format="total-op/{{instance}}",
+                    ),
+                    target(
+                        expr=expr_sum_rate(
+                            "tikv_analyze_metrics_total",
+                            label_selectors=['metric="read_iops"'],
+                            by_labels=["instance"],
+                        ),
+                        legend_format="block-read/{{instance}}",
+                    ),
+                    target(
+                        expr=expr_sum_rate(
+                            "tikv_coprocessor_rocksdb_perf",
+                            label_selectors=[
+                                'req="analyze_full_sampling"',
+                                'metric="block_read_count"',
+                            ],
+                            by_labels=["instance"],
+                        ),
+                        legend_format="copr-block-read/{{instance}}",
+                    ),
+                ],
+            ),
+            graph_panel(
+                title="Analyze next batch count per second",
+                yaxes=yaxes(left_format=UNITS.OPS_PER_SEC),
+                targets=[
+                    target(
+                        expr=expr_sum_rate(
+                            "tikv_analyze_metrics_total",
+                            label_selectors=['metric="next_batch_count"'],
+                            by_labels=["instance"],
+                        ),
+                        legend_format="{{instance}}",
+                    ),
+                ],
+            ),
+        ]
+    )
+    return layout.row_panel
+
+
+def LoadShedding() -> RowPanel:
+    layout = Layout(title="Load Shedding")
+    # Row 1: RU rates per group
+    layout.row(
+        [
+            graph_panel(
+                title="CPU Utilization % per Resource Group",
+                description="Historical baseline and current CPU utilization % per resource group (100% = 1 core).",
+                yaxes=yaxes(left_format=UNITS.PERCENT_FORMAT),
+                targets=[
+                    target(
+                        expr=expr_sum(
+                            "tikv_resource_control_group_ru_historical_rate",
+                            by_labels=["resource_group"],
+                        ).extra(" > 0"),
+                        legend_format="historical-{{resource_group}}",
+                    ),
+                    target(
+                        expr=expr_sum(
+                            "tikv_resource_control_group_ru_current_rate",
+                            by_labels=["resource_group"],
+                        ).extra(" > 0"),
+                        legend_format="current-{{resource_group}}",
+                    ),
+                ],
+            ),
+            graph_panel(
+                title="Background Resource Utilization",
+                description="Total resource utilization percentage of background tasks.",
+                yaxes=yaxes(left_format=UNITS.PERCENT_FORMAT),
+                targets=[
+                    target(
+                        expr=expr_sum(
+                            "tikv_resource_control_bg_resource_utilization",
+                            by_labels=["type"],
+                        ).extra(" > 0"),
+                    ),
+                ],
+            ),
+        ]
+    )
+    # Row 2: Quota limits
+    layout.row(
+        [
+            graph_panel(
+                title="Resource Group Quota Limit",
+                description="Current rate limit per resource group (0 = unlimited, hidden).",
+                targets=[
+                    target(
+                        expr=expr_sum(
+                            "tikv_resource_control_group_quota_limit",
+                            by_labels=["resource_group", "type"],
+                        ).extra(" > 0"),
+                    ),
+                ],
+            ),
+            graph_panel(
+                title="Background Quota Limit",
+                description="Current quota limit for background resource groups.",
+                targets=[
+                    target(
+                        expr=expr_sum(
+                            "tikv_resource_control_background_quota_limiter",
+                            by_labels=["resource_group", "type"],
+                        ).extra(" > 0"),
+                    ),
+                ],
+            ),
+        ]
+    )
+    # Row 3: Deprioritized/delayed/rejected + currently delayed
+    layout.row(
+        [
+            graph_panel(
+                title="Deprioritized / Delayed / Rejected Requests",
+                description="Rate of deprioritized (phase 1), delayed, and rejected requests.",
+                yaxes=yaxes(left_format=UNITS.OPS_PER_SEC),
+                targets=[
+                    target(
+                        expr=expr_sum_rate(
+                            "tikv_resource_control_two_phase_throttled_requests_total",
+                            by_labels=["resource_group"],
+                        ).extra(" > 0"),
+                        legend_format="deprioritized-{{resource_group}}",
+                    ),
+                    target(
+                        expr=expr_sum_rate(
+                            "tikv_resource_control_admission_delayed_requests_total",
+                            by_labels=["resource_group", "is_background"],
+                        ).extra(" > 0"),
+                        legend_format="delayed-{{resource_group}}-{{is_background}}",
+                    ),
+                    target(
+                        expr=expr_sum_rate(
+                            "tikv_resource_control_admission_rejected_requests_total",
+                            by_labels=["resource_group", "is_background"],
+                        ).extra(" > 0"),
+                        legend_format="rejected-{{resource_group}}-{{is_background}}",
+                    ),
+                ],
+            ),
+            graph_panel(
+                title="Currently Delayed Requests",
+                description="Number of requests currently sitting in admission control delay.",
+                targets=[
+                    target(
+                        expr=expr_sum(
+                            "tikv_resource_control_admission_currently_delayed",
+                        ).extra(" > 0"),
+                    ),
+                ],
+            ),
+        ]
+    )
+    # Row 4: Delay duration + background wait duration
+    layout.row(
+        [
+            graph_panel_histogram_quantiles(
+                title="Admission Delay Duration",
+                description="Delay duration imposed by foreground admission control.",
+                yaxes=yaxes(left_format=UNITS.SECONDS),
+                metric="tikv_resource_control_admission_delay_duration_seconds",
+                label_selectors=['is_background="false"'],
+                by_labels=["resource_group"],
+            ),
+            graph_panel(
+                title="Background Task Wait Duration",
+                description="Total wait duration of background tasks per resource group.",
+                yaxes=yaxes(left_format=UNITS.MICRO_SECONDS),
+                targets=[
+                    target(
+                        expr=expr_sum_rate(
+                            "tikv_resource_control_background_task_wait_duration",
+                            by_labels=["resource_group"],
+                        ).extra(" > 0"),
+                    ),
+                ],
+            ),
+        ]
+    )
+    return layout.row_panel
+
+
+def TikvConfig() -> RowPanel:
+    layout = Layout(title="Config")
+    # RocksDB DB Configuration Table
+    layout.row(
+        [
+            table_panel(
+                title="RocksDB DB Config",
+                description="TiKV RocksDB DB Configuration",
+                targets=[
+                    target(
+                        expr=expr_simple(
+                            "tikv_config_rocksdb_db",
+                        ),
+                    ),
+                ],
+            ),
+        ]
+    )
+    # RocksDB CF Configuration Table
+    layout.row(
+        [
+            table_panel(
+                title="RocksDB CF Config",
+                description="TiKV RocksDB CF Configuration",
+                targets=[
+                    target(
+                        expr=expr_simple(
+                            "tikv_config_rocksdb_cf",
+                        ).extra(
+                            " or (tikv_config_rocksdb unless tikv_config_rocksdb_cf)"
+                        ),
+                    ),
+                ],
+            ),
+        ]
+    )
+    # Flow Control Configuration Table
+    layout.row(
+        [
+            table_panel(
+                title="Flow Control Config",
+                description="TiKV Flow Control Configuration",
+                targets=[
+                    target(
+                        expr=expr_simple(
+                            "tikv_config_flow_control",
+                        ),
+                    ),
+                ],
+            ),
+        ]
+    )
+    # Raftstore Configuration Table
+    layout.row(
+        [
+            table_panel(
+                title="Raftstore Config",
+                description="TiKV Raftstore Configuration",
+                targets=[
+                    target(
+                        expr=expr_simple(
+                            "tikv_config_raftstore",
                         ),
                     ),
                 ],
@@ -10371,6 +10636,7 @@ dashboard = Dashboard(
         Memory(),
         # Infrequently Used
         ResourceControl(),
+        LoadShedding(),
         StatusServer(),
         Encryption(),
         TTL(),

--- a/metrics/grafana/tikv_details.dashboard.py
+++ b/metrics/grafana/tikv_details.dashboard.py
@@ -1383,7 +1383,7 @@ def ThreadCPU() -> RowPanel:
                     target(
                         expr=expr_sum_rate(
                             "tikv_thread_cpu_seconds_total",
-                            label_selectors=['name=~"sst_.*"'],
+                            label_selectors=['name=~"(sst_|impwkr_).*"'],
                         ),
                     ),
                 ],

--- a/metrics/grafana/tikv_details.json
+++ b/metrics/grafana/tikv_details.json
@@ -81157,15 +81157,15 @@
           "targets": [
             {
               "datasource": "${DS_TEST-CLUSTER}",
-              "expr": "sum(rate(\n    tikv_resource_control_background_task_wait_duration\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (instance, resource_group) ",
+              "expr": "sum(rate(\n    tikv_resource_control_background_task_wait_duration\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (instance) ",
               "format": "time_series",
               "hide": false,
               "instant": false,
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "{{instance}}-{{resource_group}}",
+              "legendFormat": "{{instance}}",
               "metric": "",
-              "query": "sum(rate(\n    tikv_resource_control_background_task_wait_duration\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (instance, resource_group) ",
+              "query": "sum(rate(\n    tikv_resource_control_background_task_wait_duration\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (instance) ",
               "refId": "",
               "step": 10,
               "target": ""
@@ -81347,6 +81347,302 @@
             "align": false,
             "alignLevel": 0
           }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "cacheTimeout": null,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": null,
+          "editable": true,
+          "error": false,
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              }
+            }
+          },
+          "fill": 1,
+          "fillGradient": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 7
+          },
+          "height": null,
+          "hideTimeOverride": false,
+          "id": 595,
+          "interval": null,
+          "isNew": true,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": null,
+            "sort": "max",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "maxDataPoints": null,
+          "maxPerRow": null,
+          "minSpan": null,
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true,
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "repeatDirection": null,
+          "seriesOverrides": [],
+          "span": null,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "sum(rate(\n    tikv_analyze_metrics_total\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",metric=\"read_total_op_count\"}\n    [$__rate_interval]\n)) by (instance) ",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "total-op/{{instance}}",
+              "metric": "",
+              "query": "sum(rate(\n    tikv_analyze_metrics_total\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",metric=\"read_total_op_count\"}\n    [$__rate_interval]\n)) by (instance) ",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            },
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "sum(rate(\n    tikv_analyze_metrics_total\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",metric=\"read_iops\"}\n    [$__rate_interval]\n)) by (instance) ",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "block-read/{{instance}}",
+              "metric": "",
+              "query": "sum(rate(\n    tikv_analyze_metrics_total\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",metric=\"read_iops\"}\n    [$__rate_interval]\n)) by (instance) ",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            },
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "sum(rate(\n    tikv_coprocessor_rocksdb_perf\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",req=\"analyze_full_sampling\",metric=\"block_read_count\"}\n    [$__rate_interval]\n)) by (instance) ",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "copr-block-read/{{instance}}",
+              "metric": "",
+              "query": "sum(rate(\n    tikv_coprocessor_rocksdb_perf\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",req=\"analyze_full_sampling\",metric=\"block_read_count\"}\n    [$__rate_interval]\n)) by (instance) ",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Analyze read ops per second (total vs block read)",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "transformations": [],
+          "transparent": false,
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "ops",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": 0
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "cacheTimeout": null,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": null,
+          "editable": true,
+          "error": false,
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              }
+            }
+          },
+          "fill": 1,
+          "fillGradient": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 7
+          },
+          "height": null,
+          "hideTimeOverride": false,
+          "id": 596,
+          "interval": null,
+          "isNew": true,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": null,
+            "sort": "max",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "maxDataPoints": null,
+          "maxPerRow": null,
+          "minSpan": null,
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true,
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "repeatDirection": null,
+          "seriesOverrides": [],
+          "span": null,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "sum(rate(\n    tikv_analyze_metrics_total\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",metric=\"next_batch_count\"}\n    [$__rate_interval]\n)) by (instance) ",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{instance}}",
+              "metric": "",
+              "query": "sum(rate(\n    tikv_analyze_metrics_total\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",metric=\"next_batch_count\"}\n    [$__rate_interval]\n)) by (instance) ",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Analyze next batch count per second",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "transformations": [],
+          "transparent": false,
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "ops",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": 0
+          }
         }
       ],
       "repeat": null,
@@ -81383,7 +81679,1226 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 595,
+      "id": 597,
+      "interval": null,
+      "links": [],
+      "maxDataPoints": 100,
+      "maxPerRow": null,
+      "minSpan": null,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "cacheTimeout": null,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "Historical baseline and current CPU utilization % per resource group (100% = 1 core).",
+          "editable": true,
+          "error": false,
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              }
+            }
+          },
+          "fill": 1,
+          "fillGradient": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 0
+          },
+          "height": null,
+          "hideTimeOverride": false,
+          "id": 598,
+          "interval": null,
+          "isNew": true,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": null,
+            "sort": "max",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "maxDataPoints": null,
+          "maxPerRow": null,
+          "minSpan": null,
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true,
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "repeatDirection": null,
+          "seriesOverrides": [],
+          "span": null,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "sum((\n    tikv_resource_control_group_ru_historical_rate\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    \n)) by (resource_group)  > 0",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "historical-{{resource_group}}",
+              "metric": "",
+              "query": "sum((\n    tikv_resource_control_group_ru_historical_rate\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    \n)) by (resource_group)  > 0",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            },
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "sum((\n    tikv_resource_control_group_ru_current_rate\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    \n)) by (resource_group)  > 0",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "current-{{resource_group}}",
+              "metric": "",
+              "query": "sum((\n    tikv_resource_control_group_ru_current_rate\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    \n)) by (resource_group)  > 0",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "CPU Utilization % per Resource Group",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "transformations": [],
+          "transparent": false,
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "percent",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": 0
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "cacheTimeout": null,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "Total resource utilization percentage of background tasks.",
+          "editable": true,
+          "error": false,
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              }
+            }
+          },
+          "fill": 1,
+          "fillGradient": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 0
+          },
+          "height": null,
+          "hideTimeOverride": false,
+          "id": 599,
+          "interval": null,
+          "isNew": true,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": null,
+            "sort": "max",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "maxDataPoints": null,
+          "maxPerRow": null,
+          "minSpan": null,
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true,
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "repeatDirection": null,
+          "seriesOverrides": [],
+          "span": null,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "sum((\n    tikv_resource_control_bg_resource_utilization\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    \n)) by (type)  > 0",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{type}}",
+              "metric": "",
+              "query": "sum((\n    tikv_resource_control_bg_resource_utilization\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    \n)) by (type)  > 0",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Background Resource Utilization",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "transformations": [],
+          "transparent": false,
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "percent",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": 0
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "cacheTimeout": null,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "Current rate limit per resource group (0 = unlimited, hidden).",
+          "editable": true,
+          "error": false,
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              }
+            }
+          },
+          "fill": 1,
+          "fillGradient": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 7
+          },
+          "height": null,
+          "hideTimeOverride": false,
+          "id": 600,
+          "interval": null,
+          "isNew": true,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": null,
+            "sort": "max",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "maxDataPoints": null,
+          "maxPerRow": null,
+          "minSpan": null,
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true,
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "repeatDirection": null,
+          "seriesOverrides": [],
+          "span": null,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "sum((\n    tikv_resource_control_group_quota_limit\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    \n)) by (resource_group, type)  > 0",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{resource_group}}-{{type}}",
+              "metric": "",
+              "query": "sum((\n    tikv_resource_control_group_quota_limit\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    \n)) by (resource_group, type)  > 0",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Resource Group Quota Limit",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "transformations": [],
+          "transparent": false,
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "none",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": 0
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "cacheTimeout": null,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "Current quota limit for background resource groups.",
+          "editable": true,
+          "error": false,
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              }
+            }
+          },
+          "fill": 1,
+          "fillGradient": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 7
+          },
+          "height": null,
+          "hideTimeOverride": false,
+          "id": 601,
+          "interval": null,
+          "isNew": true,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": null,
+            "sort": "max",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "maxDataPoints": null,
+          "maxPerRow": null,
+          "minSpan": null,
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true,
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "repeatDirection": null,
+          "seriesOverrides": [],
+          "span": null,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "sum((\n    tikv_resource_control_background_quota_limiter\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    \n)) by (resource_group, type)  > 0",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{resource_group}}-{{type}}",
+              "metric": "",
+              "query": "sum((\n    tikv_resource_control_background_quota_limiter\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    \n)) by (resource_group, type)  > 0",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Background Quota Limit",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "transformations": [],
+          "transparent": false,
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "none",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": 0
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "cacheTimeout": null,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "Rate of deprioritized (phase 1), delayed, and rejected requests.",
+          "editable": true,
+          "error": false,
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              }
+            }
+          },
+          "fill": 1,
+          "fillGradient": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 14
+          },
+          "height": null,
+          "hideTimeOverride": false,
+          "id": 602,
+          "interval": null,
+          "isNew": true,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": null,
+            "sort": "max",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "maxDataPoints": null,
+          "maxPerRow": null,
+          "minSpan": null,
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true,
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "repeatDirection": null,
+          "seriesOverrides": [],
+          "span": null,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "sum(rate(\n    tikv_resource_control_two_phase_throttled_requests_total\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (resource_group)  > 0",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "deprioritized-{{resource_group}}",
+              "metric": "",
+              "query": "sum(rate(\n    tikv_resource_control_two_phase_throttled_requests_total\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (resource_group)  > 0",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            },
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "sum(rate(\n    tikv_resource_control_admission_delayed_requests_total\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (resource_group, is_background)  > 0",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "delayed-{{resource_group}}-{{is_background}}",
+              "metric": "",
+              "query": "sum(rate(\n    tikv_resource_control_admission_delayed_requests_total\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (resource_group, is_background)  > 0",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            },
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "sum(rate(\n    tikv_resource_control_admission_rejected_requests_total\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (resource_group, is_background)  > 0",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "rejected-{{resource_group}}-{{is_background}}",
+              "metric": "",
+              "query": "sum(rate(\n    tikv_resource_control_admission_rejected_requests_total\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (resource_group, is_background)  > 0",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Deprioritized / Delayed / Rejected Requests",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "transformations": [],
+          "transparent": false,
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "ops",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": 0
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "cacheTimeout": null,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "Number of requests currently sitting in admission control delay.",
+          "editable": true,
+          "error": false,
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              }
+            }
+          },
+          "fill": 1,
+          "fillGradient": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 14
+          },
+          "height": null,
+          "hideTimeOverride": false,
+          "id": 603,
+          "interval": null,
+          "isNew": true,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": null,
+            "sort": "max",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "maxDataPoints": null,
+          "maxPerRow": null,
+          "minSpan": null,
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true,
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "repeatDirection": null,
+          "seriesOverrides": [],
+          "span": null,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "sum((\n    tikv_resource_control_admission_currently_delayed\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    \n)) by (instance)  > 0",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{instance}}",
+              "metric": "",
+              "query": "sum((\n    tikv_resource_control_admission_currently_delayed\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    \n)) by (instance)  > 0",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Currently Delayed Requests",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "transformations": [],
+          "transparent": false,
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "none",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": 0
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "cacheTimeout": null,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "Delay duration imposed by foreground admission control.",
+          "editable": true,
+          "error": false,
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              }
+            }
+          },
+          "fill": 1,
+          "fillGradient": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 21
+          },
+          "height": null,
+          "hideTimeOverride": false,
+          "id": 604,
+          "interval": null,
+          "isNew": true,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": null,
+            "sort": "max",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "maxDataPoints": null,
+          "maxPerRow": null,
+          "minSpan": null,
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true,
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "repeatDirection": null,
+          "seriesOverrides": [
+            {
+              "alias": "/^count/",
+              "bars": false,
+              "dashLength": 1,
+              "dashes": true,
+              "fill": 2,
+              "fillBelowTo": null,
+              "lines": true,
+              "spaceLength": 1,
+              "transform": "negative-Y",
+              "yaxis": 2,
+              "zindex": -3
+            },
+            {
+              "alias": "/^avg/",
+              "bars": false,
+              "fill": 7,
+              "fillBelowTo": null,
+              "lines": true,
+              "yaxis": 1,
+              "zindex": 0
+            }
+          ],
+          "span": null,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "histogram_quantile(0.9999,(\n    sum(rate(\n    tikv_resource_control_admission_delay_duration_seconds_bucket\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",is_background=\"false\"}\n    [$__rate_interval]\n)) by (resource_group, le, $additional_groupby) \n    \n    \n))  ",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "99.99%-{{resource_group}} {{$additional_groupby}}",
+              "metric": "",
+              "query": "histogram_quantile(0.9999,(\n    sum(rate(\n    tikv_resource_control_admission_delay_duration_seconds_bucket\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",is_background=\"false\"}\n    [$__rate_interval]\n)) by (resource_group, le, $additional_groupby) \n    \n    \n))  ",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            },
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "histogram_quantile(0.99,(\n    sum(rate(\n    tikv_resource_control_admission_delay_duration_seconds_bucket\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",is_background=\"false\"}\n    [$__rate_interval]\n)) by (resource_group, le, $additional_groupby) \n    \n    \n))  ",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "99%-{{resource_group}} {{$additional_groupby}}",
+              "metric": "",
+              "query": "histogram_quantile(0.99,(\n    sum(rate(\n    tikv_resource_control_admission_delay_duration_seconds_bucket\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",is_background=\"false\"}\n    [$__rate_interval]\n)) by (resource_group, le, $additional_groupby) \n    \n    \n))  ",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            },
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "(sum(rate(\n    tikv_resource_control_admission_delay_duration_seconds_sum\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",is_background=\"false\"}\n    [$__rate_interval]\n)) by (resource_group, $additional_groupby)  / sum(rate(\n    tikv_resource_control_admission_delay_duration_seconds_count\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",is_background=\"false\"}\n    [$__rate_interval]\n)) by (resource_group, $additional_groupby) )",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "avg-{{resource_group}} {{$additional_groupby}}",
+              "metric": "",
+              "query": "(sum(rate(\n    tikv_resource_control_admission_delay_duration_seconds_sum\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",is_background=\"false\"}\n    [$__rate_interval]\n)) by (resource_group, $additional_groupby)  / sum(rate(\n    tikv_resource_control_admission_delay_duration_seconds_count\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",is_background=\"false\"}\n    [$__rate_interval]\n)) by (resource_group, $additional_groupby) )",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            },
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "sum(rate(\n    tikv_resource_control_admission_delay_duration_seconds_count\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",is_background=\"false\"}\n    [$__rate_interval]\n)) by (resource_group, $additional_groupby) ",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "count-{{resource_group}} {{$additional_groupby}}",
+              "metric": "",
+              "query": "sum(rate(\n    tikv_resource_control_admission_delay_duration_seconds_count\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",is_background=\"false\"}\n    [$__rate_interval]\n)) by (resource_group, $additional_groupby) ",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Admission Delay Duration",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "transformations": [],
+          "transparent": false,
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "s",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": 0
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "cacheTimeout": null,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "Total wait duration of background tasks per resource group.",
+          "editable": true,
+          "error": false,
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              }
+            }
+          },
+          "fill": 1,
+          "fillGradient": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 21
+          },
+          "height": null,
+          "hideTimeOverride": false,
+          "id": 605,
+          "interval": null,
+          "isNew": true,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": null,
+            "sort": "max",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "maxDataPoints": null,
+          "maxPerRow": null,
+          "minSpan": null,
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true,
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "repeatDirection": null,
+          "seriesOverrides": [],
+          "span": null,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": "${DS_TEST-CLUSTER}",
+              "expr": "sum(rate(\n    tikv_resource_control_background_task_wait_duration\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (resource_group)  > 0",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{resource_group}}",
+              "metric": "",
+              "query": "sum(rate(\n    tikv_resource_control_background_task_wait_duration\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\"}\n    [$__rate_interval]\n)) by (resource_group)  > 0",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Background Task Wait Duration",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "transformations": [],
+          "transparent": false,
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "\u00b5s",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": 0
+          }
+        }
+      ],
+      "repeat": null,
+      "repeatDirection": null,
+      "span": null,
+      "targets": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Load Shedding",
+      "transformations": [],
+      "transparent": false,
+      "type": "row"
+    },
+    {
+      "cacheTimeout": null,
+      "collapsed": true,
+      "datasource": null,
+      "description": null,
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          }
+        }
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "height": null,
+      "hideTimeOverride": false,
+      "id": 606,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -81422,7 +82937,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 596,
+          "id": 607,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -81623,7 +83138,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 597,
+          "id": 608,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -81759,7 +83274,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 598,
+      "id": 609,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -81798,7 +83313,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 599,
+          "id": 610,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -81931,7 +83446,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 600,
+          "id": 611,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -82064,7 +83579,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 601,
+          "id": 612,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -82197,7 +83712,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 602,
+          "id": 613,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -82330,7 +83845,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 603,
+          "id": 614,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -82478,7 +83993,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 604,
+          "id": 615,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -82682,7 +84197,7 @@
       },
       "height": null,
       "hideTimeOverride": false,
-      "id": 605,
+      "id": 616,
       "interval": null,
       "links": [],
       "maxDataPoints": 100,
@@ -82721,7 +84236,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 606,
+          "id": 617,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -82854,7 +84369,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 607,
+          "id": 618,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -82987,7 +84502,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 608,
+          "id": 619,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -83120,7 +84635,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 609,
+          "id": 620,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -83253,7 +84768,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 610,
+          "id": 621,
           "interval": null,
           "isNew": true,
           "legend": {
@@ -83450,7 +84965,7 @@
           },
           "height": null,
           "hideTimeOverride": false,
-          "id": 611,
+          "id": 622,
           "interval": null,
           "links": [],
           "maxDataPoints": 100,

--- a/metrics/grafana/tikv_details.json
+++ b/metrics/grafana/tikv_details.json
@@ -12752,7 +12752,7 @@
           "targets": [
             {
               "datasource": "${DS_TEST-CLUSTER}",
-              "expr": "sum(rate(\n    tikv_thread_cpu_seconds_total\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",name=~\"sst_.*\"}\n    [$__rate_interval]\n)) by (instance) ",
+              "expr": "sum(rate(\n    tikv_thread_cpu_seconds_total\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",name=~\"(sst_|impwkr_).*\"}\n    [$__rate_interval]\n)) by (instance) ",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -12760,7 +12760,7 @@
               "intervalFactor": 1,
               "legendFormat": "{{instance}}",
               "metric": "",
-              "query": "sum(rate(\n    tikv_thread_cpu_seconds_total\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",name=~\"sst_.*\"}\n    [$__rate_interval]\n)) by (instance) ",
+              "query": "sum(rate(\n    tikv_thread_cpu_seconds_total\n    {k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",instance=~\"$instance\",name=~\"(sst_|impwkr_).*\"}\n    [$__rate_interval]\n)) by (instance) ",
               "refId": "",
               "step": 10,
               "target": ""

--- a/metrics/grafana/tikv_details.json.sha256
+++ b/metrics/grafana/tikv_details.json.sha256
@@ -1,1 +1,1 @@
-6eec0ec9db2211fe1c0ef6b2826174572615da78e70f894aa9b417db274d9089  ./metrics/grafana/tikv_details.json
+69af5cde43ce8752864fbb079b122ad4fc0674e0e531e77c1cb9af3b25aeda5c  ./metrics/grafana/tikv_details.json

--- a/metrics/grafana/tikv_details.json.sha256
+++ b/metrics/grafana/tikv_details.json.sha256
@@ -1,1 +1,1 @@
-255d36bd582b388385c70c68790c90257d2f1e92d9d550ab159ea3a6d1a3234c  ./metrics/grafana/tikv_details.json
+6eec0ec9db2211fe1c0ef6b2826174572615da78e70f894aa9b417db274d9089  ./metrics/grafana/tikv_details.json

--- a/scripts/test
+++ b/scripts/test
@@ -22,6 +22,14 @@ CUSTOM_TEST_COMMAND=${CUSTOM_TEST_COMMAND:-"test"}
 # EXTRA_CARGO_ARGS is unecessary now: this can just be given as arguments to ./scripts/test-all or ./scripts/test
 EXTRA_CARGO_ARGS=${EXTRA_CARGO_ARGS:-""}
 
+if [ -f /.dockerenv ]; then
+  if [ -z "$TIKV_ENABLE_FEATURES" ]; then
+    TIKV_ENABLE_FEATURES="docker_test"
+  else
+    TIKV_ENABLE_FEATURES="$TIKV_ENABLE_FEATURES docker_test"
+  fi
+fi
+
 # When SIP is enabled, DYLD_LIBRARY_PATH will not work in subshell, so we have to set it
 # again here. LOCAL_DIR is defined in .travis.yml.
 export DYLD_LIBRARY_PATH="${DYLD_LIBRARY_PATH}:${LOCAL_DIR}/lib"

--- a/scripts/test-all
+++ b/scripts/test-all
@@ -21,5 +21,5 @@ fi
 
 if [[ "$(uname)" = "Linux" ]]; then
     CUSTOM_TEST_COMMAND="" EXTRA_CARGO_ARGS="" ./scripts/test --message-format=json-render-diagnostics -q --no-run |
-        python scripts/check-bins.py --features "${TIKV_ENABLE_FEATURES}" --check-tests
+        python3 scripts/check-bins.py --features "${TIKV_ENABLE_FEATURES}" --check-tests
 fi

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2946,6 +2946,7 @@ pub struct BackupStreamConfig {
     #[online_config(skip)]
     pub initial_scan_rate_limit: ReadableSize,
     pub initial_scan_concurrency: usize,
+    pub s3_multi_part_size: ReadableSize,
 }
 
 impl BackupStreamConfig {
@@ -2979,6 +2980,14 @@ impl BackupStreamConfig {
         if self.initial_scan_rate_limit.0 < 1024 {
             return Err("the `initial_scan_rate_limit` should be at least 1024 bytes".into());
         }
+        if self.s3_multi_part_size.0 > ReadableSize::gb(5).0 {
+            warn!(
+                "backup.s3_multi_part_size cannot larger than 5GB, change it to {:?}",
+                default_cfg.s3_multi_part_size
+            );
+            self.s3_multi_part_size = default_cfg.s3_multi_part_size;
+        }
+
         Ok(())
     }
 }
@@ -3008,6 +3017,7 @@ impl Default for BackupStreamConfig {
             initial_scan_rate_limit: ReadableSize::mb(60),
             initial_scan_concurrency: 6,
             temp_file_memory_quota: cache_size,
+            s3_multi_part_size: ReadableSize::mb(5),
         }
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -6029,8 +6029,9 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "#ifdef MALLOC_CONF"]
     #[cfg(feature = "mem-profiling")]
-    fn test_change_memory_config() {
+    fn test_change_memory_config_ifdef_malloc_conf() {
         let (cfg, _dir) = TikvConfig::with_tmp().unwrap();
         let cfg_controller = ConfigController::new(cfg);
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1260,6 +1260,9 @@ pub struct DbConfig {
     pub enable_statistics: bool,
     #[online_config(skip)]
     pub stats_dump_period: Option<ReadableDuration>,
+    // RocksDB 8.x compaction no longer relies on the old setup-time file hint
+    // path, so keep compaction readahead enabled by default instead of forcing
+    // it to 0 from TiKV config.
     pub compaction_readahead_size: ReadableSize,
     #[doc(hidden)]
     #[serde(skip_serializing)]
@@ -1356,7 +1359,7 @@ impl Default for DbConfig {
             max_open_files: 40960,
             enable_statistics: true,
             stats_dump_period: None,
-            compaction_readahead_size: ReadableSize::kb(0),
+            compaction_readahead_size: ReadableSize::mb(2),
             info_log_max_size: ReadableSize::gb(1),
             info_log_roll_time: ReadableDuration::secs(0),
             info_log_keep_log_file_num: 10,
@@ -1829,6 +1832,9 @@ pub struct RaftDbConfig {
     pub enable_statistics: bool,
     #[online_config(skip)]
     pub stats_dump_period: ReadableDuration,
+    // RocksDB 8.x compaction no longer relies on the old setup-time file hint
+    // path, so keep compaction readahead enabled by default instead of forcing
+    // it to 0 from TiKV config.
     pub compaction_readahead_size: ReadableSize,
     #[doc(hidden)]
     #[serde(skip_serializing)]
@@ -1894,7 +1900,7 @@ impl Default for RaftDbConfig {
             max_open_files: 40960,
             enable_statistics: true,
             stats_dump_period: ReadableDuration::minutes(10),
-            compaction_readahead_size: ReadableSize::kb(0),
+            compaction_readahead_size: ReadableSize::mb(2),
             info_log_max_size: ReadableSize::gb(1),
             info_log_roll_time: ReadableDuration::secs(0),
             info_log_keep_log_file_num: 10,

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -15,7 +15,7 @@ use concurrency_manager::ConcurrencyManager;
 use engine_traits::PerfLevel;
 use futures::{
     channel::{mpsc, oneshot},
-    future::Either,
+    future::{BoxFuture, Either},
     prelude::*,
 };
 use kvproto::{coprocessor as coppb, errorpb, kvrpcpb, kvrpcpb::CommandPri, metapb};
@@ -597,7 +597,7 @@ impl<E: Engine> Endpoint<E> {
                 .map(move |res| {
                     let _ = tx.send(res);
                 });
-        let res = self.read_pool_spawn_with_memory_quota_check(
+        let spawn_fut_result = self.read_pool_spawn_with_memory_quota_check(
             allocated_bytes,
             future,
             priority,
@@ -606,7 +606,7 @@ impl<E: Engine> Endpoint<E> {
             resource_limiter,
         );
         async move {
-            res?;
+            spawn_fut_result?.await?;
             rx.map_err(|_| Error::MaxPendingTasksExceeded).await?
         }
     }
@@ -879,7 +879,7 @@ impl<E: Engine> Endpoint<E> {
                     warn!("coprocessor stream send error"; "error" => %e);
                 });
 
-        self.read_pool_spawn_with_memory_quota_check(
+        let spawn_fut = self.read_pool_spawn_with_memory_quota_check(
             allocated_bytes,
             future,
             priority,
@@ -887,7 +887,18 @@ impl<E: Engine> Endpoint<E> {
             metadata,
             resource_limiter,
         )?;
-        Ok(rx)
+        // Transparent to caller: embed admission delay into the stream itself.
+        // On first poll, drives spawn_fut (sleep if delayed, then submit to
+        // yatp). On error yields one error item. Then chains with rx items.
+        let stream = futures::stream::once(Box::pin(async move {
+            spawn_fut
+                .await
+                .err()
+                .map(|_| Err(Error::MaxPendingTasksExceeded))
+        }))
+        .filter_map(futures::future::ready)
+        .chain(rx);
+        Ok(stream)
     }
 
     /// Parses and handles a stream request. Returns a stream that produce each
@@ -927,7 +938,7 @@ impl<E: Engine> Endpoint<E> {
         task_id: u64,
         metadata: TaskMetadata<'_>,
         resource_limiter: Option<Arc<ResourceLimiter>>,
-    ) -> Result<()>
+    ) -> Result<BoxFuture<'static, Result<()>>>
     where
         F: Future<Output = ()> + Send + 'static,
     {
@@ -938,9 +949,11 @@ impl<E: Engine> Endpoint<E> {
             // Release quota after handle completed.
             drop(owned_quota);
         });
-        self.read_pool
+        Ok(self
+            .read_pool
             .spawn(fut, priority, task_id, metadata, resource_limiter)
-            .map_err(|_| Error::MaxPendingTasksExceeded)
+            .map(|r| r.map_err(|_| Error::MaxPendingTasksExceeded))
+            .boxed())
     }
 }
 

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -710,7 +710,7 @@ macro_rules! impl_write {
                                     writer.write(batch)?;
                                     Ok(writer)
                                 };
-                                with_resource_limiter(f, limiter.clone())
+                                with_resource_limiter(f, limiter.clone(), true, false, None, 0)
                                     .await
                                     .map(|w| (w, limiter))
                             },
@@ -727,7 +727,9 @@ macro_rules! impl_write {
                         Ok(metas)
                     };
 
-                    let metas: Result<_> = with_resource_limiter(finish_fn, resource_limiter).await;
+                    let metas: Result<_> =
+                        with_resource_limiter(finish_fn, resource_limiter, true, false, None, 0)
+                            .await;
                     let metas = match metas {
                         Ok(r) => r,
                         Err(e) => return (Err(e), None),
@@ -1050,6 +1052,10 @@ impl<E: Engine> ImportSst for ImportSstService<E> {
                         .req_type(req.get_request_type()),
                 ),
                 resource_limiter,
+                true,
+                false,
+                None,
+                0,
             )
             .await;
             let mut resp = DownloadResponse::default();
@@ -1175,6 +1181,10 @@ impl<E: Engine> ImportSst for ImportSstService<E> {
                         .req_type(req.get_request_type()),
                 ),
                 resource_limiter,
+                true,
+                false,
+                None,
+                0,
             )
             .await;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,8 +37,6 @@
 #[macro_use(fail_point)]
 extern crate fail;
 #[macro_use]
-extern crate lazy_static;
-#[macro_use]
 extern crate serde_derive;
 #[macro_use]
 extern crate more_asserts;

--- a/src/read_pool.rs
+++ b/src/read_pool.rs
@@ -14,17 +14,18 @@ use std::{
 use file_system::{set_io_type, IoType};
 use futures::{
     channel::oneshot,
-    future::{FutureExt, TryFutureExt},
+    future::{BoxFuture, FutureExt, TryFutureExt},
 };
 use kvproto::{errorpb, kvrpcpb::CommandPri};
 use online_config::{ConfigChange, ConfigManager, ConfigValue, Result as CfgResult};
 use prometheus::{core::Metric, Histogram, IntCounter, IntGauge};
 use resource_control::{
-    with_resource_limiter, ControlledFuture, ResourceController, ResourceLimiter, TaskPriority,
+    with_resource_limiter, AdmissionDecision, ControlledFuture, ResourceController,
+    ResourceGroupManager, ResourceLimiter, TaskPriority,
 };
 use thiserror::Error;
 use tikv_util::{
-    resource_control::TaskMetadata,
+    resource_control::{priority_from_task_meta, TaskMetadata},
     sys::{cpu_time::ProcessStat, SysQuota},
     time::Instant,
     worker::{Runnable, RunnableWithTimer, Scheduler, Worker},
@@ -32,7 +33,10 @@ use tikv_util::{
 };
 use tracker::TrackedFuture;
 use yatp::{
-    metrics::MULTILEVEL_LEVEL_ELAPSED, pool::Remote, queue::Extras, task::future::TaskCell,
+    metrics::MULTILEVEL_LEVEL_ELAPSED,
+    pool::Remote,
+    queue::{Extras, TaskCell as TaskCellTrait},
+    task::future::TaskCell,
 };
 
 use self::metrics::*;
@@ -65,6 +69,7 @@ pub enum ReadPool {
         max_tasks: usize,
         pool_size: usize,
         resource_ctl: Option<Arc<ResourceController>>,
+        resource_manager: Option<Arc<ResourceGroupManager>>,
         time_slice_inspector: Arc<TimeSliceInspector>,
     },
 }
@@ -88,6 +93,7 @@ impl ReadPool {
                 max_tasks,
                 pool_size,
                 resource_ctl,
+                resource_manager,
                 time_slice_inspector,
             } => ReadPoolHandle::Yatp {
                 remote: pool.remote().clone(),
@@ -96,6 +102,7 @@ impl ReadPool {
                 max_tasks: *max_tasks,
                 pool_size: *pool_size,
                 resource_ctl: resource_ctl.clone(),
+                resource_manager: resource_manager.clone(),
                 time_slice_inspector: time_slice_inspector.clone(),
             },
         }
@@ -116,8 +123,68 @@ pub enum ReadPoolHandle {
         max_tasks: usize,
         pool_size: usize,
         resource_ctl: Option<Arc<ResourceController>>,
+        resource_manager: Option<Arc<ResourceGroupManager>>,
         time_slice_inspector: Arc<TimeSliceInspector>,
     },
+}
+
+/// Runs admission control then, if the task is allowed through, enqueues it.
+/// Admission is checked before the capacity/eviction check so that a rejected
+/// or timed-out delayed task never causes an already-queued task to be dropped.
+async fn admission_and_enqueue(
+    resource_manager: Option<Arc<ResourceGroupManager>>,
+    resource_limiter: Option<Arc<ResourceLimiter>>,
+    task_priority: TaskPriority,
+    gauge: IntGauge,
+    max_tasks: usize,
+    remote: Remote<TaskCell>,
+    task_cell: TaskCell,
+    running_tasks: Vec<IntGauge>,
+    resource_ctl: Option<Arc<ResourceController>>,
+    estimated_priority: u64,
+) -> Result<(), ReadPoolError> {
+    // Admission control runs before any eviction so that a rejected or
+    // timed-out delayed task never causes an already-queued task to be dropped.
+    let delay = match (resource_manager.as_deref(), resource_limiter.as_deref()) {
+        (Some(rm), Some(limiter)) => match rm.admission_decision(true, limiter) {
+            AdmissionDecision::Reject => return Err(ReadPoolError::Rejected),
+            AdmissionDecision::Delay(d) => {
+                if task_priority == TaskPriority::High {
+                    warn!("admission delay on high-priority read task";
+                          "group" => limiter.name(),
+                          "delay" => ?d);
+                }
+                Some((d, resource_manager))
+            }
+            AdmissionDecision::Allow => None,
+        },
+        _ => None,
+    };
+    if let Some((d, slot)) = delay {
+        let mut _guard = slot.as_ref().map(|rm| rm.delay_slot_guard());
+        futures_timer::Delay::new(d).await;
+        if let Some(guard) = _guard.as_mut() {
+            guard.release();
+        }
+    }
+    // After admission (and any sleep), check pool capacity and evict if needed.
+    if gauge.get() as usize >= max_tasks {
+        if let Some(ref _resource_ctl) = resource_ctl {
+            if let Some(mut evicted) = remote.try_evict_lowest(estimated_priority) {
+                let evicted_prio = priority_from_task_meta(evicted.mut_extras().metadata());
+                running_tasks[evicted_prio as usize].dec();
+                UNIFIED_READ_POOL_EVICTED_TASKS.inc();
+                drop(evicted);
+            } else {
+                return Err(ReadPoolError::UnifiedReadPoolFull);
+            }
+        } else {
+            return Err(ReadPoolError::UnifiedReadPoolFull);
+        }
+    }
+    gauge.inc();
+    remote.spawn(task_cell);
+    Ok(())
 }
 
 impl ReadPoolHandle {
@@ -128,7 +195,7 @@ impl ReadPoolHandle {
         task_id: u64,
         metadata: TaskMetadata<'_>,
         resource_limiter: Option<Arc<ResourceLimiter>>,
-    ) -> Result<(), ReadPoolError>
+    ) -> BoxFuture<'static, Result<(), ReadPoolError>>
     where
         F: Future<Output = ()> + Send + 'static,
     {
@@ -143,60 +210,82 @@ impl ReadPoolHandle {
                     CommandPri::Normal => read_pool_normal,
                     CommandPri::Low => read_pool_low,
                 };
-
-                pool.spawn(f)?;
+                let res = pool.spawn(f).map_err(ReadPoolError::from);
+                futures::future::ready(res).boxed()
             }
             ReadPoolHandle::Yatp {
                 remote,
                 running_tasks,
                 max_tasks,
                 resource_ctl,
+                resource_manager,
                 ..
             } => {
                 let task_priority = TaskPriority::from(metadata.override_priority());
-                let running_tasks = running_tasks[task_priority as usize].clone();
-                // Note that the running task number limit is not strict.
-                // If several tasks are spawned at the same time while the running task number
-                // is close to the limit, they may all pass this check and the number of running
-                // tasks may exceed the limit.
-                if running_tasks.get() as usize >= *max_tasks {
-                    return Err(ReadPoolError::UnifiedReadPoolFull);
-                }
-                running_tasks.inc();
-                let fixed_level = match priority {
-                    CommandPri::High => Some(0),
-                    CommandPri::Normal => None,
-                    CommandPri::Low => Some(2),
+                let running_task_gauge = running_tasks[task_priority as usize].clone();
+
+                let is_background = resource_limiter.as_ref().is_some_and(|l| l.is_background());
+                let fixed_level = if is_background {
+                    // Background tasks always run at low priority in the pool.
+                    Some(2)
+                } else {
+                    match priority {
+                        CommandPri::High => Some(0),
+                        CommandPri::Normal => None,
+                        CommandPri::Low => Some(2),
+                    }
                 };
                 let group_name = metadata.group_name().to_owned();
+                let estimated_priority = resource_ctl
+                    .as_ref()
+                    .map_or(u64::MAX, |ctl| ctl.peek_priority_of(&metadata, priority));
                 let mut extras = Extras::new_multilevel(task_id, fixed_level);
                 extras.set_metadata(metadata.to_vec());
+                // Clone gauge: one for inc (after admission), one inside the
+                // future for dec (when the task completes).
+                let gauge_for_spawn = running_task_gauge.clone();
                 let task_cell = if let Some(resource_ctl) = resource_ctl {
+                    let inner = ControlledFuture::new(
+                        f.map(move |_| {
+                            running_task_gauge.dec();
+                        }),
+                        resource_ctl.clone(),
+                        group_name.clone(),
+                    );
                     TaskCell::new(
                         TrackedFuture::new(with_resource_limiter(
-                            ControlledFuture::new(
-                                f.map(move |_| {
-                                    running_tasks.dec();
-                                }),
-                                resource_ctl.clone(),
-                                group_name,
-                            ),
-                            resource_limiter,
+                            inner,
+                            resource_limiter.clone(),
+                            true, // skip compaction pressure for foreground jobs
+                            true, // measure-only: build debt, never sleep inside pool
+                            resource_manager.clone(),
+                            0, // read path: no write bytes
                         )),
                         extras,
                     )
                 } else {
                     TaskCell::new(
                         TrackedFuture::new(f.map(move |_| {
-                            running_tasks.dec();
+                            running_task_gauge.dec();
                         })),
                         extras,
                     )
                 };
-                remote.spawn(task_cell);
+                admission_and_enqueue(
+                    resource_manager.clone(),
+                    resource_limiter,
+                    task_priority,
+                    gauge_for_spawn,
+                    *max_tasks,
+                    remote.clone(),
+                    task_cell,
+                    running_tasks.to_vec(),
+                    resource_ctl.clone(),
+                    estimated_priority,
+                )
+                .boxed()
             }
         }
-        Ok(())
     }
 
     pub fn spawn_handle<F, T>(
@@ -212,7 +301,7 @@ impl ReadPoolHandle {
         T: Send + 'static,
     {
         let (tx, rx) = oneshot::channel::<T>();
-        let res = self.spawn(
+        let spawn_fut = self.spawn(
             f.map(move |res| {
                 let _ = tx.send(res);
             }),
@@ -222,7 +311,7 @@ impl ReadPoolHandle {
             resource_limiter,
         );
         async move {
-            res?;
+            spawn_fut.await?;
             rx.map_err(ReadPoolError::from).await
         }
     }
@@ -448,6 +537,7 @@ pub fn build_yatp_read_pool<E: Engine, R: FlowStatsReporter>(
     reporter: R,
     engine: E,
     resource_ctl: Option<Arc<ResourceController>>,
+    resource_manager: Option<Arc<ResourceGroupManager>>,
     cleanup_method: CleanupMethod,
     enable_task_wait_metrics: bool,
 ) -> ReadPool {
@@ -457,6 +547,7 @@ pub fn build_yatp_read_pool<E: Engine, R: FlowStatsReporter>(
         reporter,
         engine,
         resource_ctl,
+        resource_manager,
         cleanup_method,
         unified_read_pool_name,
         enable_task_wait_metrics,
@@ -468,6 +559,7 @@ pub fn build_yatp_read_pool_with_name<E: Engine, R: FlowStatsReporter>(
     reporter: R,
     engine: E,
     resource_ctl: Option<Arc<ResourceController>>,
+    resource_manager: Option<Arc<ResourceGroupManager>>,
     cleanup_method: CleanupMethod,
     unified_read_pool_name: String,
     enable_task_wait_metrics: bool,
@@ -521,6 +613,7 @@ pub fn build_yatp_read_pool_with_name<E: Engine, R: FlowStatsReporter>(
             .saturating_mul(config.max_thread_count),
         pool_size: config.max_thread_count,
         resource_ctl,
+        resource_manager,
         time_slice_inspector,
     }
 }
@@ -881,6 +974,9 @@ pub enum ReadPoolError {
     #[error("Unified read pool is full")]
     UnifiedReadPoolFull,
 
+    #[error("Request rejected by admission control")]
+    Rejected,
+
     #[error("{0}")]
     Canceled(#[from] oneshot::Canceled),
 }
@@ -899,6 +995,11 @@ mod metrics {
             "tikv_unified_read_pool_thread_count",
             "The number of running threads in the unified read pool",
             &["name"]
+        )
+        .unwrap();
+        pub static ref UNIFIED_READ_POOL_EVICTED_TASKS: IntCounter = register_int_counter!(
+            "tikv_unified_read_pool_evicted_tasks",
+            "Number of tasks evicted from the unified read pool by higher-priority tasks"
         )
         .unwrap();
     }
@@ -942,6 +1043,7 @@ mod tests {
             DummyReporter,
             engine,
             None,
+            None,
             CleanupMethod::InPlace,
             name.to_owned(),
             false,
@@ -961,23 +1063,20 @@ mod tests {
         let (task3, _tx3) = gen_task();
         let (task4, _tx4) = gen_task();
 
-        handle
-            .spawn(task1, CommandPri::Normal, 1, TaskMetadata::default(), None)
+        block_on(handle.spawn(task1, CommandPri::Normal, 1, TaskMetadata::default(), None))
             .unwrap();
-        handle
-            .spawn(task2, CommandPri::Normal, 2, TaskMetadata::default(), None)
+        block_on(handle.spawn(task2, CommandPri::Normal, 2, TaskMetadata::default(), None))
             .unwrap();
 
         thread::sleep(Duration::from_millis(300));
-        match handle.spawn(task3, CommandPri::Normal, 3, TaskMetadata::default(), None) {
+        match block_on(handle.spawn(task3, CommandPri::Normal, 3, TaskMetadata::default(), None)) {
             Err(ReadPoolError::UnifiedReadPoolFull) => {}
             _ => panic!("should return full error"),
         }
         tx1.send(()).unwrap();
 
         thread::sleep(Duration::from_millis(300));
-        handle
-            .spawn(task4, CommandPri::Normal, 4, TaskMetadata::default(), None)
+        block_on(handle.spawn(task4, CommandPri::Normal, 4, TaskMetadata::default(), None))
             .unwrap();
         assert_eq!(
             UNIFIED_READ_POOL_RUNNING_TASKS
@@ -1003,6 +1102,7 @@ mod tests {
             DummyReporter,
             engine,
             None,
+            None,
             CleanupMethod::InPlace,
             false,
         );
@@ -1022,15 +1122,13 @@ mod tests {
         let (task4, _tx4) = gen_task();
         let (task5, _tx5) = gen_task();
 
-        handle
-            .spawn(task1, CommandPri::Normal, 1, TaskMetadata::default(), None)
+        block_on(handle.spawn(task1, CommandPri::Normal, 1, TaskMetadata::default(), None))
             .unwrap();
-        handle
-            .spawn(task2, CommandPri::Normal, 2, TaskMetadata::default(), None)
+        block_on(handle.spawn(task2, CommandPri::Normal, 2, TaskMetadata::default(), None))
             .unwrap();
 
         thread::sleep(Duration::from_millis(300));
-        match handle.spawn(task3, CommandPri::Normal, 3, TaskMetadata::default(), None) {
+        match block_on(handle.spawn(task3, CommandPri::Normal, 3, TaskMetadata::default(), None)) {
             Err(ReadPoolError::UnifiedReadPoolFull) => {}
             _ => panic!("should return full error"),
         }
@@ -1038,12 +1136,11 @@ mod tests {
         handle.scale_pool_size(3);
         assert_eq!(handle.get_normal_pool_size(), 3);
 
-        handle
-            .spawn(task4, CommandPri::Normal, 4, TaskMetadata::default(), None)
+        block_on(handle.spawn(task4, CommandPri::Normal, 4, TaskMetadata::default(), None))
             .unwrap();
 
         thread::sleep(Duration::from_millis(300));
-        match handle.spawn(task5, CommandPri::Normal, 5, TaskMetadata::default(), None) {
+        match block_on(handle.spawn(task5, CommandPri::Normal, 5, TaskMetadata::default(), None)) {
             Err(ReadPoolError::UnifiedReadPoolFull) => {}
             _ => panic!("should return full error"),
         }
@@ -1065,6 +1162,7 @@ mod tests {
             DummyReporter,
             engine,
             None,
+            None,
             CleanupMethod::InPlace,
             false,
         );
@@ -1084,15 +1182,13 @@ mod tests {
         let (task4, _tx4) = gen_task();
         let (task5, _tx5) = gen_task();
 
-        handle
-            .spawn(task1, CommandPri::Normal, 1, TaskMetadata::default(), None)
+        block_on(handle.spawn(task1, CommandPri::Normal, 1, TaskMetadata::default(), None))
             .unwrap();
-        handle
-            .spawn(task2, CommandPri::Normal, 2, TaskMetadata::default(), None)
+        block_on(handle.spawn(task2, CommandPri::Normal, 2, TaskMetadata::default(), None))
             .unwrap();
 
         thread::sleep(Duration::from_millis(300));
-        match handle.spawn(task3, CommandPri::Normal, 3, TaskMetadata::default(), None) {
+        match block_on(handle.spawn(task3, CommandPri::Normal, 3, TaskMetadata::default(), None)) {
             Err(ReadPoolError::UnifiedReadPoolFull) => {}
             _ => panic!("should return full error"),
         }
@@ -1113,12 +1209,11 @@ mod tests {
         handle.scale_pool_size(1);
         assert_eq!(handle.get_normal_pool_size(), 1);
 
-        handle
-            .spawn(task4, CommandPri::Normal, 4, TaskMetadata::default(), None)
+        block_on(handle.spawn(task4, CommandPri::Normal, 4, TaskMetadata::default(), None))
             .unwrap();
 
         thread::sleep(Duration::from_millis(300));
-        match handle.spawn(task5, CommandPri::Normal, 5, TaskMetadata::default(), None) {
+        match block_on(handle.spawn(task5, CommandPri::Normal, 5, TaskMetadata::default(), None)) {
             Err(ReadPoolError::UnifiedReadPoolFull) => {}
             _ => panic!("should return full error"),
         }
@@ -1209,6 +1304,7 @@ mod tests {
             DummyReporter,
             engine,
             None,
+            None,
             CleanupMethod::InPlace,
             false,
         );
@@ -1281,12 +1377,12 @@ mod tests {
 
         for control in [false, true] {
             let name = format!("test_yatp_task_poll_duration_metric_{}", control);
-            let resource_manager = if control {
-                let resource_manager = ResourceGroupManager::default();
-                let resource_ctl = resource_manager.derive_controller(name.clone(), true);
-                Some(resource_ctl)
+            let (resource_ctl, resource_manager) = if control {
+                let rm = Arc::new(ResourceGroupManager::default());
+                let ctl = rm.derive_controller(name.clone(), true);
+                (Some(ctl), Some(rm))
             } else {
-                None
+                (None, None)
             };
             let config = UnifiedReadPoolConfig {
                 min_thread_count: 1,
@@ -1301,6 +1397,7 @@ mod tests {
                 &config,
                 DummyReporter,
                 engine,
+                resource_ctl,
                 resource_manager,
                 CleanupMethod::InPlace,
                 name.clone(),
@@ -1321,11 +1418,9 @@ mod tests {
             let (task1, tx1) = gen_task();
             let (task2, tx2) = gen_task();
 
-            handle
-                .spawn(task1, CommandPri::Normal, 1, TaskMetadata::default(), None)
+            block_on(handle.spawn(task1, CommandPri::Normal, 1, TaskMetadata::default(), None))
                 .unwrap();
-            handle
-                .spawn(task2, CommandPri::Normal, 2, TaskMetadata::default(), None)
+            block_on(handle.spawn(task2, CommandPri::Normal, 2, TaskMetadata::default(), None))
                 .unwrap();
 
             tx1.send(()).unwrap();
@@ -1335,5 +1430,184 @@ mod tests {
             assert_eq!(count_metric(&name), 2);
             drop(pool);
         }
+    }
+
+    // Duplicated from resource_control::resource_group::tests which is
+    // #[cfg(test)] pub(crate) and not accessible from this crate.
+    fn new_resource_group_ru(
+        name: String,
+        ru: u64,
+        group_priority: u32,
+    ) -> kvproto::resource_manager::ResourceGroup {
+        use kvproto::resource_manager::{GroupMode, GroupRequestUnitSettings, ResourceGroup};
+        let mut group = ResourceGroup::new();
+        group.set_name(name);
+        group.set_mode(GroupMode::RuMode);
+        group.set_priority(group_priority);
+        let mut ru_setting = GroupRequestUnitSettings::new();
+        ru_setting.mut_r_u().mut_settings().set_fill_rate(ru);
+        group.set_r_u_settings(ru_setting);
+        group
+    }
+
+    #[test]
+    fn test_yatp_eviction() {
+        // Test that when the read pool is full, a higher-priority incoming task
+        // can evict the lowest-priority queued task.
+        //
+        // Strategy: Use 1 worker thread and max_tasks_per_worker=4 (total=4).
+        // Spawn 1 blocking task to occupy the only worker thread, then spawn
+        // 3 low-priority tasks that will sit in the queue. The pool is now
+        // "full" (4 running_tasks). A high-priority task should evict one of
+        // the queued low-priority tasks.
+        //
+        // Note on the two priority systems:
+        // - `override_priority` (in ResourceControlContext) determines the TaskPriority
+        //   bucket (High/Medium/Low) used for running_tasks counters. Both groups use 0
+        //   here, so all tasks are "medium".
+        // - Resource group priority (1 vs 16) is what peek_priority_of uses for the
+        //   eviction comparison. "high_group" (priority=16) produces a numerically
+        //   smaller value than "low_group" (priority=1), meaning it is scheduled first
+        //   and can evict low_group tasks.
+        let resource_manager = Arc::new(ResourceGroupManager::default());
+        let low_group = new_resource_group_ru("low_group".into(), 5000, 1);
+        resource_manager.add_resource_group(low_group);
+        let high_group = new_resource_group_ru("high_group".into(), 5000, 16);
+        resource_manager.add_resource_group(high_group);
+
+        let name = "test-yatp-eviction";
+        let resource_ctl = resource_manager.derive_controller(name.into(), true);
+
+        let config = UnifiedReadPoolConfig {
+            min_thread_count: 1,
+            max_thread_count: 1,
+            max_tasks_per_worker: 4,
+            ..Default::default()
+        };
+
+        let engine = TestEngineBuilder::new().build().unwrap();
+        let pool = build_yatp_read_pool_with_name(
+            &config,
+            DummyReporter,
+            engine,
+            Some(resource_ctl),
+            Some(resource_manager),
+            CleanupMethod::InPlace,
+            name.to_owned(),
+            false,
+        );
+
+        let gen_task = || {
+            let (tx, rx) = oneshot::channel::<()>();
+            let task = async move {
+                let _ = rx.await;
+            };
+            (task, tx)
+        };
+
+        let handle = pool.handle();
+
+        let low_ctx = ResourceControlContext {
+            resource_group_name: "low_group".to_string(),
+            override_priority: 0,
+            ..Default::default()
+        };
+
+        // Task 1: synchronously blocks the only worker thread so that it
+        // cannot pop any further tasks from the global priority queue. An
+        // async-only future (oneshot::channel::await) would return Pending
+        // immediately, letting the worker loop back and drain tasks 2-4 from
+        // the queue before the eviction attempt — causing a race.
+        let (block_tx, block_rx) = std::sync::mpsc::channel::<()>();
+        let task1 = async move {
+            let _ = block_rx.recv();
+        };
+        block_on(handle.spawn(
+            task1,
+            CommandPri::Normal,
+            1,
+            TaskMetadata::from_ctx(&low_ctx),
+            None,
+        ))
+        .unwrap();
+
+        // Wait for task1 to be picked up and block the worker.
+        thread::sleep(Duration::from_millis(300));
+
+        // Tasks 2-4: these will sit in the global queue since the worker is
+        // blocked by task1.
+        let (task2, _tx2) = gen_task();
+        let (task3, _tx3) = gen_task();
+        let (task4, _tx4) = gen_task();
+
+        block_on(handle.spawn(
+            task2,
+            CommandPri::Normal,
+            2,
+            TaskMetadata::from_ctx(&low_ctx),
+            None,
+        ))
+        .unwrap();
+        block_on(handle.spawn(
+            task3,
+            CommandPri::Normal,
+            3,
+            TaskMetadata::from_ctx(&low_ctx),
+            None,
+        ))
+        .unwrap();
+        block_on(handle.spawn(
+            task4,
+            CommandPri::Normal,
+            4,
+            TaskMetadata::from_ctx(&low_ctx),
+            None,
+        ))
+        .unwrap();
+
+        // Verify pool is full: spawning another low-priority task should fail.
+        let (task_low5, _tx_low5) = gen_task();
+        match block_on(handle.spawn(
+            task_low5,
+            CommandPri::Normal,
+            5,
+            TaskMetadata::from_ctx(&low_ctx),
+            None,
+        )) {
+            Err(ReadPoolError::UnifiedReadPoolFull) => {}
+            other => panic!(
+                "expected UnifiedReadPoolFull for low-priority task, got {:?}",
+                other.err()
+            ),
+        }
+
+        // Now spawn a high-priority task — should succeed via eviction of a
+        // queued low-priority task.
+        let (task_high, _tx_high) = gen_task();
+        let high_ctx = ResourceControlContext {
+            resource_group_name: "high_group".to_string(),
+            override_priority: 0,
+            ..Default::default()
+        };
+
+        block_on(handle.spawn(
+            task_high,
+            CommandPri::High,
+            6,
+            TaskMetadata::from_ctx(&high_ctx),
+            None,
+        ))
+        .expect("high-priority task should succeed via eviction");
+
+        // The eviction metric should have been incremented.
+        assert!(
+            UNIFIED_READ_POOL_EVICTED_TASKS.get() >= 1,
+            "eviction counter should be incremented"
+        );
+
+        // Unblock task1 so the worker thread can resume and the pool can
+        // shut down cleanly.
+        let _ = block_tx.send(());
+        thread::sleep(Duration::from_millis(300));
     }
 }

--- a/src/server/gc_worker/compaction_runner.rs
+++ b/src/server/gc_worker/compaction_runner.rs
@@ -294,12 +294,23 @@ impl<S: GcSafePointProvider, R: RegionInfoProvider + 'static, E: KvEngine>
                 tracker.reset_if_needed();
             }
 
-            // Sleep for remaining time in check interval, or start next round immediately
-            if elapsed < check_interval {
-                let remaining_sleep = check_interval - elapsed;
-                if self.sleep_or_stop(remaining_sleep) {
-                    break;
-                }
+            // Sleep for remaining time in check interval, or start next round
+            // immediately. When MVCC-read-aware scoring is enabled, enforce a
+            // minimum gap so the tracker can accumulate meaningful stats after
+            // the reset.
+            const MIN_GAP_BETWEEN_ROUNDS: Duration = Duration::from_secs(20);
+            let remaining_sleep = if elapsed < check_interval {
+                check_interval - elapsed
+            } else {
+                Duration::ZERO
+            };
+            let sleep_duration = if config.auto_compaction.mvcc_read_aware_enabled {
+                remaining_sleep.max(MIN_GAP_BETWEEN_ROUNDS)
+            } else {
+                remaining_sleep
+            };
+            if sleep_duration > Duration::ZERO && self.sleep_or_stop(sleep_duration) {
+                break;
             }
         }
         debug!("compaction-runner stopped");

--- a/src/server/service/diagnostics/sys.rs
+++ b/src/server/service/diagnostics/sys.rs
@@ -682,6 +682,8 @@ mod tests {
 
     #[test]
     #[cfg(target_os = "linux")]
+    // this test verifies that memory quota matches /proc/meminfo which is not true for docker
+    #[cfg(not(feature = "docker_test"))]
     fn test_memory() {
         let mut mem_total_kb: u64 = 0;
         {

--- a/src/server/status_server/mod.rs
+++ b/src/server/status_server/mod.rs
@@ -2147,6 +2147,7 @@ mod tests {
             None,
             GrpcServiceManager::dummy(),
             None,
+            ForcePartitionRangeManager::default(),
         )
         .unwrap();
         let addr = "127.0.0.1:0".to_owned();

--- a/src/server/status_server/mod.rs
+++ b/src/server/status_server/mod.rs
@@ -59,6 +59,7 @@ use tikv_util::{
     logger::set_log_level,
     metrics::{dump, dump_to},
     timer::GLOBAL_TIMER_HANDLE,
+    GLOBAL_SERVER_READINESS,
 };
 use tokio::{
     io::{AsyncRead, AsyncWrite},
@@ -717,6 +718,26 @@ where
         Self::metrics_to_resp(req, should_simplify)
     }
 
+    fn handle_ready_request(req: Request<Body>) -> hyper::Result<Response<Body>> {
+        let verbose = req
+            .uri()
+            .query()
+            .map_or(false, |query| query.contains("verbose"));
+
+        let status_code = if GLOBAL_SERVER_READINESS.is_ready() {
+            StatusCode::OK
+        } else {
+            StatusCode::INTERNAL_SERVER_ERROR
+        };
+
+        let body = if verbose {
+            GLOBAL_SERVER_READINESS.to_json()
+        } else {
+            "".to_string()
+        };
+        Ok(make_response(status_code, body))
+    }
+
     fn start_serve<I, C>(&mut self, builder: HyperBuilder<I>)
     where
         I: Accept<Conn = C, Error = std::io::Error> + Send + 'static,
@@ -789,6 +810,9 @@ where
                                 Self::handle_get_metrics(req, &cfg_controller)
                             }
                             (Method::GET, "/status") => Ok(Response::default()),
+                            (Method::GET, "/ready") => {
+                                Self::handle_ready_request(req)
+                            }
                             (Method::GET, "/debug/pprof/heap_list") => {
                                 Ok(make_response(
                                     StatusCode::GONE,
@@ -1318,7 +1342,12 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::{env, io::Read, path::PathBuf, sync::Arc};
+    use std::{
+        env,
+        io::Read,
+        path::PathBuf,
+        sync::{atomic::Ordering, Arc},
+    };
 
     use collections::HashSet;
     use flate2::read::GzDecoder;
@@ -1337,7 +1366,7 @@ mod tests {
     use service::service_manager::GrpcServiceManager;
     use test_util::new_security_cfg;
     use tikv_kv::RaftExtension;
-    use tikv_util::logger::get_log_level;
+    use tikv_util::{logger::get_log_level, GLOBAL_SERVER_READINESS};
 
     use crate::{
         config::{ConfigController, TikvConfig},
@@ -2106,5 +2135,63 @@ mod tests {
             }
             status_server.stop();
         }
+    }
+
+    #[test]
+    fn test_ready_endpoint() {
+        let mut status_server = StatusServer::new(
+            1,
+            ConfigController::default(),
+            Arc::new(SecurityConfig::default()),
+            MockRouter,
+            None,
+            GrpcServiceManager::dummy(),
+            None,
+        )
+        .unwrap();
+        let addr = "127.0.0.1:0".to_owned();
+        let _ = status_server.start(addr);
+        let client = Client::new();
+        let uri = Uri::builder()
+            .scheme("http")
+            .authority(status_server.listening_addr().to_string().as_str())
+            .path_and_query("/ready?verbose")
+            .build()
+            .unwrap();
+        let uri2 = uri.clone();
+        // Set one readiness condition to true.
+        GLOBAL_SERVER_READINESS
+            .connected_to_pd
+            .store(true, Ordering::Relaxed);
+        let handle = status_server.thread_pool.spawn(async move {
+            let resp = client.get(uri).await.unwrap();
+            assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+
+            let body_bytes = hyper::body::to_bytes(resp.into_body()).await.unwrap();
+            let json: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+            assert_eq!(
+                json["connected_to_pd"], true,
+                "connected_to_pd should be false"
+            );
+            assert_eq!(
+                json["raft_peers_caught_up"], false,
+                "raft_peers_caught_up should be false"
+            );
+        });
+        block_on(handle).unwrap();
+
+        // Set the remaining readiness conditions to true.
+        GLOBAL_SERVER_READINESS
+            .raft_peers_caught_up
+            .store(true, Ordering::Relaxed);
+
+        let client = Client::new();
+        let handle2 = status_server.thread_pool.spawn(async move {
+            let resp = client.get(uri2).await.unwrap();
+            assert_eq!(resp.status(), StatusCode::OK);
+        });
+        block_on(handle2).unwrap();
+
+        status_server.stop();
     }
 }

--- a/src/server/status_server/mod.rs
+++ b/src/server/status_server/mod.rs
@@ -1361,7 +1361,7 @@ mod tests {
     use hyper_openssl::HttpsConnector;
     use online_config::OnlineConfig;
     use openssl::ssl::{SslConnector, SslFiletype, SslMethod};
-    use raftstore::store::region_meta::RegionMeta;
+    use raftstore::store::{region_meta::RegionMeta, ForcePartitionRangeManager};
     use security::SecurityConfig;
     use service::service_manager::GrpcServiceManager;
     use test_util::new_security_cfg;

--- a/src/storage/config.rs
+++ b/src/storage/config.rs
@@ -111,6 +111,40 @@ pub struct Config {
     pub block_cache: BlockCacheConfig,
     #[online_config(submodule)]
     pub io_rate_limit: IoRateLimitConfig,
+    #[online_config(skip)]
+    pub txn_anomaly_checker: TxnAnomalyCheckerConfig,
+}
+
+/// Test-only configuration of the transaction anomaly checker.
+///
+/// The checker inspects the staged writes of every transaction command and
+/// reports (and optionally panics on) anomalous states where a committed
+/// write record and a normal lock coexist for the same key and start_ts.
+/// It is disabled by default; when disabled it has zero overhead.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, OnlineConfig)]
+#[serde(default)]
+#[serde(rename_all = "kebab-case")]
+pub struct TxnAnomalyCheckerConfig {
+    /// Master switch of the checker.
+    pub enabled: bool,
+    /// Whether to panic (and freeze the scene) when an anomaly is found.
+    pub panic_on_hit: bool,
+    /// Whether to also check whether the snapshot's pre-existing state already
+    /// satisfies the anomaly predicate.
+    pub check_pre_state: bool,
+    /// Directory to write JSON evidence files into. Empty means only logging.
+    pub evidence_dir: String,
+}
+
+impl Default for TxnAnomalyCheckerConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            panic_on_hit: true,
+            check_pre_state: true,
+            evidence_dir: String::new(),
+        }
+    }
 }
 
 impl Default for Config {
@@ -140,6 +174,7 @@ impl Default for Config {
             io_rate_limit: IoRateLimitConfig::default(),
             background_error_recovery_window: ReadableDuration::hours(1),
             memory_quota: DEFAULT_TXN_MEMORY_QUOTA_CAPACITY,
+            txn_anomaly_checker: TxnAnomalyCheckerConfig::default(),
         }
     }
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1908,7 +1908,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
         self.sched
             .get_sched_pool()
             // NOTE: we don't support background resource control for raw api.
-            .spawn("", metadata, pri, future)
+            .spawn("", metadata, pri, future, 0)
             .map_err(|_| Error::from(ErrorInner::SchedTooBusy))
     }
 
@@ -3332,12 +3332,15 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
             err.set_server_is_busy(busy_err);
             return FuturesEither::Left(future::err(Error::from(ErrorInner::Kv(err.into()))));
         }
-        FuturesEither::Right(
-            self.read_pool
+
+        let metadata = metadata.deep_clone();
+        let read_pool = self.read_pool.clone();
+        FuturesEither::Right(async move {
+            read_pool
                 .spawn_handle(future, priority, task_id, metadata, resource_limiter)
                 .map_err(|_| Error::from(ErrorInner::SchedTooBusy))
-                .and_then(|res| future::ready(res)),
-        )
+                .await?
+        })
     }
 
     pub fn update_txn_status_cache(

--- a/src/storage/mvcc/reader/reader.rs
+++ b/src/storage/mvcc/reader/reader.rs
@@ -620,7 +620,11 @@ impl<S: EngineSnapshot> MvccReader<S> {
         }
     }
 
-    fn get_txn_commit_record(&mut self, key: &Key, start_ts: TimeStamp) -> Result<TxnCommitRecord> {
+    pub fn get_txn_commit_record(
+        &mut self,
+        key: &Key,
+        start_ts: TimeStamp,
+    ) -> Result<TxnCommitRecord> {
         // It's possible a txn with a small `start_ts` has a greater `commit_ts` than a
         // txn with a greater `start_ts` in pessimistic transaction.
         // I.e., txn_1.commit_ts > txn_2.commit_ts > txn_2.start_ts > txn_1.start_ts.

--- a/src/storage/txn/mod.rs
+++ b/src/storage/txn/mod.rs
@@ -6,6 +6,7 @@ pub mod commands;
 pub mod flow_controller;
 pub mod sched_pool;
 pub mod scheduler;
+pub mod txn_anomaly_checker;
 pub mod txn_status_cache;
 
 mod actions;

--- a/src/storage/txn/sched_pool.rs
+++ b/src/storage/txn/sched_pool.rs
@@ -113,6 +113,7 @@ impl PriorityQueue {
         metadata: TaskMetadata<'_>,
         priority_level: CommandPri,
         f: impl futures::Future<Output = ()> + Send + 'static,
+        write_bytes: u64,
     ) -> Result<(), Full> {
         let fixed_level = match priority_level {
             CommandPri::High => Some(0),
@@ -122,17 +123,22 @@ impl PriorityQueue {
         // TODO: maybe use a better way to generate task_id
         let task_id = rand::random::<u64>();
         let group_name = metadata.group_name().to_owned();
-        let resource_limiter = self.resource_mgr.get_resource_limiter(
-            unsafe { std::str::from_utf8_unchecked(&group_name) },
-            request_source,
-            metadata.override_priority() as u64,
-        );
+        let override_priority = metadata.override_priority() as u64;
         let mut extras = Extras::new_multilevel(task_id, fixed_level);
         extras.set_metadata(metadata.to_vec());
+        let resource_limiter = self.resource_mgr.get_resource_limiter(
+            std::str::from_utf8(&group_name).unwrap_or_default(),
+            request_source,
+            override_priority,
+        );
         self.worker_pool.spawn_with_extras(
             with_resource_limiter(
                 ControlledFuture::new(f, self.resource_ctl.clone(), group_name),
                 resource_limiter,
+                true, // skip compaction pressure for foreground jobs
+                true, // measure-only: build debt, never sleep inside pool
+                Some(self.resource_mgr.clone()),
+                write_bytes,
             ),
             extras,
         )
@@ -221,6 +227,7 @@ impl SchedPool {
         metadata: TaskMetadata<'_>,
         priority_level: CommandPri,
         f: impl futures::Future<Output = ()> + Send + 'static,
+        write_bytes: u64,
     ) -> Result<(), Full> {
         match self.queue_type {
             QueueType::Vanilla => self.vanilla.spawn(priority_level, f),
@@ -232,6 +239,7 @@ impl SchedPool {
                         metadata,
                         priority_level,
                         f,
+                        write_bytes,
                     )
                 } else {
                     fail_point!("single_queue_pool_task");

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -252,6 +252,9 @@ struct TxnSchedulerInner<L: LockManager> {
     // all tasks are executed in this pool
     sched_worker_pool: SchedPool,
 
+    // resource group manager for Tier-1 high-priority throttle on writes.
+    resource_manager: Option<Arc<ResourceGroupManager>>,
+
     // used to control write flow
     running_write_bytes: CachePadded<AtomicUsize>,
 
@@ -466,6 +469,7 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
                 resource_ctl,
                 resource_manager.clone(),
             ),
+            resource_manager: resource_manager.clone(),
             control_mutex: Arc::new(tokio::sync::Mutex::new(false)),
             lock_mgr,
             concurrency_manager,
@@ -523,6 +527,56 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
         });
     }
 
+    /// Returns true if admission control consumed the command (reject or
+    /// delay); the caller should return without further processing.
+    fn apply_admission_control(
+        &self,
+        cmd: &Command,
+    ) -> Option<resource_control::AdmissionDecision> {
+        let rm = self.inner.resource_manager.as_ref()?;
+        let rc_ctx = cmd.resource_control_ctx();
+        let rg = rc_ctx.get_resource_group_name();
+        let request_source = cmd.ctx().request_source.clone();
+        let limiter =
+            rm.get_resource_limiter(rg, &request_source, rc_ctx.get_override_priority())?;
+        Some(rm.admission_decision(false, &limiter))
+    }
+
+    /// Spawns an async task on the sched pool that sleeps for `delay` then
+    /// calls `schedule_command`. The latch is acquired only after the sleep so
+    /// the delay does not block concurrent writers with overlapping keys.
+    fn schedule_after_admission_delay(
+        &self,
+        cmd: Command,
+        callback: StorageCallback,
+        delay: Duration,
+    ) {
+        let tag = cmd.tag();
+        let sched = self.clone();
+        let cb = SchedulerTaskCallback::NormalRequestCallback(callback);
+        let metadata = TaskMetadata::from_ctx(cmd.resource_control_ctx());
+        let priority = cmd.priority();
+        let write_bytes = cmd.write_bytes() as u64;
+        let request_source = cmd.ctx().request_source.clone();
+        let mem_quota = self.inner.memory_quota.clone();
+        let rm = self.inner.resource_manager.as_ref().unwrap().clone();
+        let execution = async move {
+            let mut guard = rm.delay_slot_guard();
+            futures_timer::Delay::new(delay).await;
+            guard.release();
+            let cid = sched.inner.gen_id();
+            if let Ok(task) = Task::allocate(cid, cmd, mem_quota) {
+                sched.schedule_command(task, cb, None);
+            } else {
+                Self::fail_with_busy(tag, cb);
+            }
+        };
+        self.inner
+            .sched_worker_pool
+            .spawn(&request_source, metadata, priority, execution, write_bytes)
+            .unwrap();
+    }
+
     pub(in crate::storage) fn run_cmd(&self, cmd: Command, callback: StorageCallback) {
         let tag = cmd.tag();
         // write flow control
@@ -533,6 +587,19 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
         if cmd.need_flow_control() && self.inner.too_busy(cmd.ctx().region_id) {
             Self::fail_with_busy(tag, callback.into());
             return;
+        }
+        // Admission control before latch acquisition so a delayed command does
+        // not block concurrent writers sharing the same keys.
+        match self.apply_admission_control(&cmd) {
+            Some(resource_control::AdmissionDecision::Reject) => {
+                Self::fail_with_busy(tag, callback.into());
+                return;
+            }
+            Some(resource_control::AdmissionDecision::Delay(delay)) => {
+                self.schedule_after_admission_delay(cmd, callback, delay);
+                return;
+            }
+            _ => {}
         }
         let cid = self.inner.gen_id();
         if let Ok(task) = Task::allocate(cid, cmd, self.inner.memory_quota.clone()) {
@@ -611,52 +678,53 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
         let ctx = cmd.ctx().clone();
         let deadline = cmd.deadline();
         let sched = self.clone();
+        let execution = async move {
+            match unsafe { with_tls_engine(|engine: &mut E| engine.precheck_write_with_ctx(&ctx)) }
+            {
+                // Precheck failed, try to return err early.
+                Err(e) => {
+                    let cb = sched.inner.try_own_and_take_cb(cid);
+                    // The task is not processing or finished currently. It's safe
+                    // to response early here. In the future, the task will be waked up
+                    // and it will finished with DeadlineExceeded error.
+                    // As the cb is taken here, it will not be executed anymore.
+                    if let Some(cb) = cb {
+                        let pr = ProcessResult::Failed {
+                            err: StorageError::from(e),
+                        };
+                        Self::early_response(
+                            cid,
+                            cb,
+                            pr,
+                            tag,
+                            CommandStageKind::precheck_write_err,
+                        );
+                    }
+                }
+                Ok(()) => {
+                    SCHED_STAGE_COUNTER_VEC.get(tag).precheck_write_ok.inc();
+                    // Check deadline in background.
+                    GLOBAL_TIMER_HANDLE
+                        .delay(deadline.to_std_instant())
+                        .compat()
+                        .await
+                        .unwrap();
+                    let cb = sched.inner.try_own_and_take_cb(cid);
+                    if let Some(cb) = cb {
+                        cb.execute(ProcessResult::Failed {
+                            err: StorageErrorInner::DeadlineExceeded.into(),
+                        })
+                    }
+                }
+            }
+        };
         self.get_sched_pool()
             .spawn(
                 &cmd.ctx().request_source,
                 TaskMetadata::from_ctx(cmd.resource_control_ctx()),
                 cmd.priority(),
-                async move {
-                    match unsafe {
-                        with_tls_engine(|engine: &mut E| engine.precheck_write_with_ctx(&ctx))
-                    } {
-                        // Precheck failed, try to return err early.
-                        Err(e) => {
-                            let cb = sched.inner.try_own_and_take_cb(cid);
-                            // The task is not processing or finished currently. It's safe
-                            // to response early here. In the future, the task will be waked up
-                            // and it will finished with DeadlineExceeded error.
-                            // As the cb is taken here, it will not be executed anymore.
-                            if let Some(cb) = cb {
-                                let pr = ProcessResult::Failed {
-                                    err: StorageError::from(e),
-                                };
-                                Self::early_response(
-                                    cid,
-                                    cb,
-                                    pr,
-                                    tag,
-                                    CommandStageKind::precheck_write_err,
-                                );
-                            }
-                        }
-                        Ok(()) => {
-                            SCHED_STAGE_COUNTER_VEC.get(tag).precheck_write_ok.inc();
-                            // Check deadline in background.
-                            GLOBAL_TIMER_HANDLE
-                                .delay(deadline.to_std_instant())
-                                .compat()
-                                .await
-                                .unwrap();
-                            let cb = sched.inner.try_own_and_take_cb(cid);
-                            if let Some(cb) = cb {
-                                cb.execute(ProcessResult::Failed {
-                                    err: StorageErrorInner::DeadlineExceeded.into(),
-                                })
-                            }
-                        }
-                    }
-                },
+                execution,
+                cmd.write_bytes() as u64,
             )
             .unwrap();
     }
@@ -676,9 +744,15 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
                 // when many queuing tasks fail successively.
                 let this = self.clone();
                 self.get_sched_pool()
-                    .spawn(&request_source, metadata, pri, async move {
-                        this.finish_with_err(cid, err, None);
-                    })
+                    .spawn(
+                        &request_source,
+                        metadata,
+                        pri,
+                        async move {
+                            this.finish_with_err(cid, err, None);
+                        },
+                        0,
+                    )
                     .unwrap();
             }
         }
@@ -717,13 +791,14 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
         let sched = self.clone();
         let metadata = TaskMetadata::from_ctx(task.cmd().resource_control_ctx());
         let request_source = task.cmd().ctx().request_source.clone();
+        let request_source_for_spawn = request_source.clone();
         let priority = task.cmd().priority();
+        let write_bytes = task.cmd().write_bytes();
         let execution = async move {
             fail_point!("scheduler_start_execute");
             if sched.check_task_deadline_exceeded(&task, None) {
                 return;
             }
-
             let tag = task.cmd().tag();
             SCHED_STAGE_COUNTER_VEC.get(tag).snapshot.inc();
 
@@ -799,7 +874,13 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
         });
         SCHED_TXN_RUNNING_COMMANDS.inc();
         self.get_sched_pool()
-            .spawn(&request_source, metadata, priority, execution)
+            .spawn(
+                &request_source_for_spawn,
+                metadata,
+                priority,
+                execution,
+                write_bytes as u64,
+            )
             .unwrap();
     }
 
@@ -1133,9 +1214,15 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
         } else {
             let lock_wait_queues = self.inner.lock_wait_queues.clone();
             self.get_sched_pool()
-                .spawn(request_source, metadata, CommandPri::High, async move {
-                    lock_wait_queues.update_lock_wait(new_acquired_locks);
-                })
+                .spawn(
+                    request_source,
+                    metadata,
+                    CommandPri::High,
+                    async move {
+                        lock_wait_queues.update_lock_wait(new_acquired_locks);
+                    },
+                    0,
+                )
                 .unwrap();
         }
     }
@@ -1153,40 +1240,52 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
         let metadata1 = metadata.deep_clone();
         let rsource = request_source.to_string();
         self.get_sched_pool()
-            .spawn(request_source, metadata, CommandPri::High, async move {
-                for (lock_info, released_lock) in legacy_wake_up_list {
-                    let cb = lock_info.key_cb.unwrap().into_inner();
-                    let e = StorageError::from(Error::from(MvccError::from(
-                        MvccErrorInner::WriteConflict {
-                            start_ts: lock_info.parameters.start_ts,
-                            conflict_start_ts: released_lock.start_ts,
-                            conflict_commit_ts: released_lock.commit_ts,
-                            key: released_lock.key.into_raw().unwrap(),
-                            primary: lock_info.parameters.primary,
-                            reason: kvrpcpb::WriteConflictReason::PessimisticRetry,
-                        },
-                    )));
-                    cb(Err(e.into()), false);
-                }
+            .spawn(
+                request_source,
+                metadata,
+                CommandPri::High,
+                async move {
+                    for (lock_info, released_lock) in legacy_wake_up_list {
+                        let cb = lock_info.key_cb.unwrap().into_inner();
+                        let e = StorageError::from(Error::from(MvccError::from(
+                            MvccErrorInner::WriteConflict {
+                                start_ts: lock_info.parameters.start_ts,
+                                conflict_start_ts: released_lock.start_ts,
+                                conflict_commit_ts: released_lock.commit_ts,
+                                key: released_lock.key.into_raw().unwrap(),
+                                primary: lock_info.parameters.primary,
+                                reason: kvrpcpb::WriteConflictReason::PessimisticRetry,
+                            },
+                        )));
+                        cb(Err(e.into()), false);
+                    }
 
-                for f in delayed_wake_up_futures {
-                    let self2 = self1.clone();
-                    let metadata2 = metadata1.clone();
-                    self1
-                        .get_sched_pool()
-                        .spawn(&rsource, metadata2, CommandPri::High, async move {
-                            let res = f.await;
-                            if let Some(resumable_lock_wait_entry) = res {
-                                self2.schedule_awakened_pessimistic_locks(
-                                    None,
-                                    None,
-                                    smallvec![resumable_lock_wait_entry],
-                                );
-                            }
-                        })
-                        .unwrap();
-                }
-            })
+                    for f in delayed_wake_up_futures {
+                        let self2 = self1.clone();
+                        let metadata2 = metadata1.clone();
+                        self1
+                            .get_sched_pool()
+                            .spawn(
+                                &rsource,
+                                metadata2,
+                                CommandPri::High,
+                                async move {
+                                    let res = f.await;
+                                    if let Some(resumable_lock_wait_entry) = res {
+                                        self2.schedule_awakened_pessimistic_locks(
+                                            None,
+                                            None,
+                                            smallvec![resumable_lock_wait_entry],
+                                        );
+                                    }
+                                },
+                                0,
+                            )
+                            .unwrap();
+                    }
+                },
+                0,
+            )
             .unwrap();
     }
 

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -64,7 +64,7 @@ use super::task::Task;
 use crate::{
     server::lock_manager::waiter_manager,
     storage::{
-        config::Config,
+        config::{Config, TxnAnomalyCheckerConfig},
         errors::SharedError,
         get_causal_ts, get_priority_tag, get_raw_key_guard,
         kv::{
@@ -88,6 +88,7 @@ use crate::{
             flow_controller::FlowController,
             latch::{Latches, Lock},
             sched_pool::{tls_collect_query, tls_collect_scan_details, SchedPool},
+            txn_anomaly_checker,
             txn_status_cache::TxnStatusCache,
             Error, ErrorInner, ProcessResult,
         },
@@ -274,6 +275,8 @@ struct TxnSchedulerInner<L: LockManager> {
     in_memory_pessimistic_lock: Arc<AtomicBool>,
 
     enable_async_apply_prewrite: bool,
+
+    txn_anomaly_checker: TxnAnomalyCheckerConfig,
 
     pessimistic_lock_wake_up_delay_duration_ms: Arc<AtomicU64>,
 
@@ -476,6 +479,7 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
             pipelined_pessimistic_lock: dynamic_configs.pipelined_pessimistic_lock,
             in_memory_pessimistic_lock: dynamic_configs.in_memory_pessimistic_lock,
             enable_async_apply_prewrite: config.enable_async_apply_prewrite,
+            txn_anomaly_checker: config.txn_anomaly_checker.clone(),
             pessimistic_lock_wake_up_delay_duration_ms: dynamic_configs.wake_up_delay_duration_ms,
             flow_controller,
             causal_ts_provider,
@@ -492,6 +496,16 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
         SCHED_TXN_MEMORY_QUOTA
             .capacity
             .set(config.memory_quota.0 as i64);
+
+        if config.txn_anomaly_checker.enabled {
+            info!("{}", txn_anomaly_checker::CHECKER_BUILD_MARKER;
+                "version" => env!("CARGO_PKG_VERSION"),
+                "checker_version" => txn_anomaly_checker::CHECKER_VERSION,
+                "panic_on_hit" => config.txn_anomaly_checker.panic_on_hit,
+                "check_pre_state" => config.txn_anomaly_checker.check_pre_state,
+                "evidence_dir" => config.txn_anomaly_checker.evidence_dir.as_str(),
+            );
+        }
 
         slow_log!(
             t.saturating_elapsed(),
@@ -1441,10 +1455,25 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
                 raw_ext,
                 txn_status_cache: txn_scheduler.inner.txn_status_cache.clone(),
             };
+            // Only cloned when the test-only anomaly checker is enabled, so the
+            // default path keeps zero extra cost.
+            let checker_snapshot = if txn_scheduler.inner.txn_anomaly_checker.enabled {
+                Some(snapshot.clone())
+            } else {
+                None
+            };
             let begin_instant = Instant::now();
             let res = unsafe {
                 with_perf_context::<E, _, _>(tag, || task.process_write(snapshot, context))
             };
+            if let (Some(snapshot), Ok(write_result)) = (checker_snapshot, &res) {
+                txn_anomaly_checker::check_write_result(
+                    &snapshot,
+                    tag,
+                    write_result,
+                    &txn_scheduler.inner.txn_anomaly_checker,
+                );
+            }
             let cmd_process_duration = begin_instant.saturating_elapsed();
             sched_details.cmd_process_nanos = cmd_process_duration.as_nanos() as u64;
             sched_details.block_read_nanos = GLOBAL_TRACKERS

--- a/src/storage/txn/txn_anomaly_checker.rs
+++ b/src/storage/txn/txn_anomaly_checker.rs
@@ -1,0 +1,1208 @@
+// Copyright 2026 TiKV Project Authors. Licensed under Apache-2.0.
+
+//! Test-only transaction anomaly checker.
+//!
+//! The checker is hooked into [`super::scheduler`] right after a write command
+//! is processed (i.e. `task.process_write` returns) and before its staged
+//! writes are proposed. For every user key the command touches, it synthesizes
+//! the post-state from "snapshot state + this command's staged modifies" and
+//! verifies that the following anomaly predicate does not hold:
+//!
+//! ```text
+//! CF_WRITE contains a committed record with write.start_ts == S and
+//! write_type in {Put, Delete}
+//! AND CF_LOCK contains a normal (non-pessimistic, non-shared) lock with
+//! lock.ts == S
+//! ```
+//!
+//! Normal 2PC never leaves such a state: commit/rollback put the CF_WRITE
+//! record and the CF_LOCK deletion into the same atomic write batch. When the
+//! predicate is hit, the checker writes an `error!` log (and optionally a JSON
+//! evidence file) carrying enough context to attribute the producer, and
+//! optionally panics to freeze the scene.
+//!
+//! The checker is strictly test-only: it is disabled by default and has zero
+//! overhead when disabled. It never changes transaction semantics; any failure
+//! inside the checker itself is downgraded to a warning log.
+
+use std::{
+    fs,
+    io::Write as _,
+    path::{Path, PathBuf},
+    sync::atomic::{AtomicU64, Ordering},
+};
+
+use collections::HashMap;
+use engine_traits::{CF_LOCK, CF_WRITE};
+use tikv_kv::{Modify, Snapshot, SnapshotExt};
+use tikv_util::Either;
+use txn_types::{Key, Lock, LockType, TimeStamp, Write, WriteRef, WriteType};
+
+use super::commands::WriteResult;
+use crate::storage::{
+    config::TxnAnomalyCheckerConfig,
+    metrics::CommandKind,
+    mvcc::{self, MvccReader, TxnCommitRecord},
+};
+
+/// Marker of the error log and evidence produced when the checker hits. It is
+/// used by the repro testbed to locate hits in TiKV logs.
+pub const CHECKER_HIT_MARKER: &str = "TXN_ANOMALY_CHECKER_HIT";
+/// Marker of the startup log that proves a checker-enabled build is deployed.
+pub const CHECKER_BUILD_MARKER: &str = "TXN_ANOMALY_CHECKER_BUILD";
+/// Version of the checker itself, recorded in evidence files.
+pub const CHECKER_VERSION: &str = "1";
+
+/// Global sequence number to keep evidence file names unique.
+static EVIDENCE_SEQ: AtomicU64 = AtomicU64::new(0);
+
+/// The anomaly is introduced by the staged writes of the command itself.
+const ORIGIN_STAGED: &str = "staged";
+/// The anomaly already exists in the snapshot before this command.
+const ORIGIN_PRE_EXISTING: &str = "pre-existing";
+
+/// A detected violation of the anomaly predicate.
+struct Violation {
+    origin: &'static str,
+    key: Key,
+    start_ts: TimeStamp,
+    commit_ts: TimeStamp,
+    lock: Lock,
+    write_record: Write,
+}
+
+/// Staged modifies of one command, grouped by user key.
+#[derive(Default)]
+struct KeyModifies {
+    /// Committed Put/Delete write record staged by `Put(CF_WRITE)`, with the
+    /// commit_ts decoded from the internal key.
+    staged_write: Option<(TimeStamp, Write)>,
+    /// Normal lock staged by `Put(CF_LOCK)`.
+    staged_lock: Option<Lock>,
+    /// `Delete(CF_LOCK)` staged by the command.
+    staged_delete_lock: bool,
+    /// The CF_LOCK value staged by the command cannot be parsed as a normal
+    /// lock (suspected shared locks). The key is skipped to avoid false
+    /// positives.
+    skip: bool,
+}
+
+/// Commands that must be skipped as a whole: flashback intentionally co-writes
+/// write records and locks; pause/flush/raw commands are not normal 2PC
+/// commands.
+fn is_skipped_tag(tag: CommandKind) -> bool {
+    matches!(
+        tag,
+        CommandKind::flashback_to_version_write
+            | CommandKind::flashback_to_version_rollback_lock
+            | CommandKind::pause
+            | CommandKind::flush
+            | CommandKind::raw_compare_and_swap
+            | CommandKind::raw_atomic_store
+    )
+}
+
+/// Checks the write result of a finished command against the anomaly
+/// predicate. Returns the number of violations found (for tests). Failures of
+/// the checker itself are logged and swallowed.
+pub fn check_write_result<S: Snapshot>(
+    snapshot: &S,
+    tag: CommandKind,
+    write_result: &WriteResult,
+    config: &TxnAnomalyCheckerConfig,
+) -> usize {
+    if !config.enabled || is_skipped_tag(tag) {
+        return 0;
+    }
+    match collect_violations(snapshot, write_result, config) {
+        Ok(violations) if !violations.is_empty() => {
+            report(snapshot, tag, write_result, config, &violations);
+            violations.len()
+        }
+        Ok(_) => 0,
+        Err(e) => {
+            warn!("txn anomaly checker failed, skipped"; "err" => ?e);
+            0
+        }
+    }
+}
+
+fn collect_violations<S: Snapshot>(
+    snapshot: &S,
+    write_result: &WriteResult,
+    config: &TxnAnomalyCheckerConfig,
+) -> mvcc::Result<Vec<Violation>> {
+    // Group staged modifies by user key.
+    let mut keys: HashMap<Key, KeyModifies> = HashMap::default();
+    for m in &write_result.to_be_write.modifies {
+        match m {
+            Modify::Put(cf, k, v) if *cf == CF_WRITE => {
+                let write = match WriteRef::parse(v) {
+                    Ok(w) => w.to_owned(),
+                    Err(e) => {
+                        warn!("txn anomaly checker: cannot parse staged CF_WRITE value, skipped";
+                            "key" => log_wrappers::Value::key(k.as_encoded()), "err" => ?e);
+                        continue;
+                    }
+                };
+                // Rollback/Lock records do not participate in the predicate.
+                if !matches!(write.write_type, WriteType::Put | WriteType::Delete) {
+                    continue;
+                }
+                let commit_ts = k.decode_ts()?;
+                let user_key = k.clone().truncate_ts()?;
+                keys.entry(user_key).or_default().staged_write = Some((commit_ts, write));
+            }
+            Modify::Put(cf, k, v) if *cf == CF_LOCK => {
+                let entry = keys.entry(k.clone()).or_default();
+                match txn_types::parse_lock(v) {
+                    Ok(Either::Left(lock)) => {
+                        // Pessimistic locks are not the subject of the predicate.
+                        if lock.lock_type != LockType::Pessimistic {
+                            entry.staged_lock = Some(lock);
+                        }
+                    }
+                    Ok(Either::Right(_)) => {
+                        warn!("txn anomaly checker: staged CF_LOCK value holds shared locks, skipped";
+                            "key" => log_wrappers::Value::key(k.as_encoded()));
+                        entry.skip = true;
+                    }
+                    Err(e) => {
+                        warn!("txn anomaly checker: cannot parse staged CF_LOCK value, skipped";
+                            "key" => log_wrappers::Value::key(k.as_encoded()), "err" => ?e);
+                        entry.skip = true;
+                    }
+                }
+            }
+            Modify::Delete(cf, k) if *cf == CF_LOCK => {
+                keys.entry(k.clone()).or_default().staged_delete_lock = true;
+            }
+            _ => {}
+        }
+    }
+
+    let mut reader = MvccReader::new(snapshot.clone(), None, false);
+    let mut violations = vec![];
+    for (user_key, staged) in &keys {
+        if staged.skip {
+            continue;
+        }
+        let snapshot_lock = match reader.load_lock(user_key)? {
+            Some(Either::Left(lock)) if lock.lock_type != LockType::Pessimistic => Some(lock),
+            Some(Either::Right(_)) => {
+                warn!("txn anomaly checker: snapshot CF_LOCK value holds shared locks, skipped";
+                    "key" => log_wrappers::Value::key(user_key.as_encoded()));
+                continue;
+            }
+            _ => None,
+        };
+
+        // Pre-state check: the snapshot itself already satisfies the predicate.
+        if config.check_pre_state {
+            if let Some(lock) = &snapshot_lock {
+                if let Some((commit_ts, write)) =
+                    find_committed_record(&mut reader, user_key, lock.ts)?
+                {
+                    violations.push(Violation {
+                        origin: ORIGIN_PRE_EXISTING,
+                        key: user_key.clone(),
+                        start_ts: lock.ts,
+                        commit_ts,
+                        lock: lock.clone(),
+                        write_record: write,
+                    });
+                }
+            }
+        }
+
+        // Forward check: a committed record is staged while a normal lock with
+        // the same start_ts still exists in the post-state.
+        if let Some((commit_ts, write)) = &staged.staged_write {
+            let post_lock = if let Some(lock) = &staged.staged_lock {
+                Some(lock)
+            } else if staged.staged_delete_lock {
+                None
+            } else {
+                snapshot_lock.as_ref()
+            };
+            if let Some(lock) = post_lock {
+                if lock.ts == write.start_ts {
+                    violations.push(Violation {
+                        origin: ORIGIN_STAGED,
+                        key: user_key.clone(),
+                        start_ts: write.start_ts,
+                        commit_ts: *commit_ts,
+                        lock: lock.clone(),
+                        write_record: write.clone(),
+                    });
+                }
+            }
+        }
+
+        // Backward check: a normal lock is staged while the snapshot already
+        // holds a committed record with the same start_ts.
+        if let Some(lock) = &staged.staged_lock {
+            if let Some((commit_ts, write)) = find_committed_record(&mut reader, user_key, lock.ts)?
+            {
+                violations.push(Violation {
+                    origin: ORIGIN_STAGED,
+                    key: user_key.clone(),
+                    start_ts: lock.ts,
+                    commit_ts,
+                    lock: lock.clone(),
+                    write_record: write,
+                });
+            }
+        }
+    }
+    Ok(violations)
+}
+
+/// Finds the committed Put/Delete record of `(key, start_ts)` on the snapshot,
+/// if any. This is the same read path that `rollback_lock` uses to decide the
+/// customer-site panic.
+fn find_committed_record<S: Snapshot>(
+    reader: &mut MvccReader<S>,
+    key: &Key,
+    start_ts: TimeStamp,
+) -> mvcc::Result<Option<(TimeStamp, Write)>> {
+    match reader.get_txn_commit_record(key, start_ts)? {
+        TxnCommitRecord::SingleRecord { commit_ts, write }
+            if matches!(write.write_type, WriteType::Put | WriteType::Delete) =>
+        {
+            Ok(Some((commit_ts, write)))
+        }
+        _ => Ok(None),
+    }
+}
+
+fn report<S: Snapshot>(
+    snapshot: &S,
+    tag: CommandKind,
+    write_result: &WriteResult,
+    config: &TxnAnomalyCheckerConfig,
+    violations: &[Violation],
+) {
+    let first = &violations[0];
+    let ctx = &write_result.ctx;
+    let ext = snapshot.ext();
+    let snap_region_id = ext.get_region_id().unwrap_or(0);
+    let snap_term = ext.get_term().map(|t| t.get()).unwrap_or(0);
+    let modifies_summary = summarize_modifies(&write_result.to_be_write.modifies);
+    let other_keys: Vec<String> = violations[1..]
+        .iter()
+        .map(|v| hex::encode(v.key.as_encoded()))
+        .collect();
+    let now = chrono::Utc::now();
+    let backtrace = std::backtrace::Backtrace::force_capture().to_string();
+
+    error!("{}", CHECKER_HIT_MARKER;
+        "origin" => first.origin,
+        "command" => tag.get_str(),
+        "region_id" => ctx.get_region_id(),
+        "key" => log_wrappers::Value::key(first.key.as_encoded()),
+        "start_ts" => first.start_ts.into_inner(),
+        "commit_ts" => first.commit_ts.into_inner(),
+        "lock" => ?first.lock,
+        "write_record" => ?first.write_record,
+        "modifies" => ?modifies_summary,
+        "other_violated_keys" => ?other_keys,
+    );
+
+    if !config.evidence_dir.is_empty() {
+        let evidence = serde_json::json!({
+            "marker": CHECKER_HIT_MARKER,
+            "checker_version": CHECKER_VERSION,
+            "build_marker": CHECKER_BUILD_MARKER,
+            "origin": first.origin,
+            "command": tag.get_str(),
+            "region_id": ctx.get_region_id(),
+            "region_epoch": format!("{:?}", ctx.get_region_epoch()),
+            "peer": format!("{:?}", ctx.get_peer()),
+            "key": hex::encode(first.key.as_encoded()),
+            "start_ts": first.start_ts.into_inner(),
+            "commit_ts": first.commit_ts.into_inner(),
+            "lock": format!("{:?}", first.lock),
+            "write_record": format!("{:?}", first.write_record),
+            "modifies": modifies_summary,
+            "other_violated_keys": other_keys,
+            "snapshot_region_id": snap_region_id,
+            "snapshot_term": snap_term,
+            "utc": now.to_rfc3339(),
+            "backtrace": backtrace,
+        });
+        match write_evidence_file(&config.evidence_dir, &evidence, now) {
+            Ok(path) => {
+                error!("txn anomaly checker evidence written";
+                    "marker" => CHECKER_HIT_MARKER,
+                    "path" => %path.display(),
+                );
+            }
+            Err(e) => {
+                warn!("txn anomaly checker: failed to write evidence file";
+                    "dir" => config.evidence_dir.as_str(), "err" => ?e);
+                warn!("txn anomaly checker evidence dump"; "evidence" => %evidence);
+            }
+        }
+    }
+
+    if config.panic_on_hit {
+        panic!(
+            "{}: origin={}, command={}, key={:?}, start_ts={}, commit_ts={}",
+            CHECKER_HIT_MARKER,
+            first.origin,
+            tag.get_str(),
+            log_wrappers::Value::key(first.key.as_encoded()),
+            first.start_ts.into_inner(),
+            first.commit_ts.into_inner(),
+        );
+    }
+}
+
+/// Writes the evidence JSON to `<dir>/hit-<utc>-<seq>.json` and fsyncs both
+/// the file and the directory.
+fn write_evidence_file(
+    dir: &str,
+    evidence: &serde_json::Value,
+    now: chrono::DateTime<chrono::Utc>,
+) -> std::io::Result<PathBuf> {
+    fs::create_dir_all(dir)?;
+    let seq = EVIDENCE_SEQ.fetch_add(1, Ordering::Relaxed);
+    let file_name = format!("hit-{}-{}.json", now.format("%Y%m%dT%H%M%S%.6fZ"), seq);
+    let path = Path::new(dir).join(file_name);
+    let mut file = fs::File::create(&path)?;
+    file.write_all(serde_json::to_string_pretty(evidence)?.as_bytes())?;
+    file.sync_all()?;
+    fs::File::open(dir)?.sync_all()?;
+    Ok(path)
+}
+
+/// Builds a compact one-line description for every staged modify.
+fn summarize_modifies(modifies: &[Modify]) -> Vec<String> {
+    modifies
+        .iter()
+        .map(|m| match m {
+            Modify::Put(cf, k, v) => {
+                let mut s = format!("put {} {}", cf, hex::encode(k.as_encoded()));
+                if *cf == CF_LOCK {
+                    if let Ok(Either::Left(lock)) = txn_types::parse_lock(v) {
+                        s += &format!(" lock_ts={} type={:?}", lock.ts.into_inner(), lock.lock_type);
+                    }
+                } else if *cf == CF_WRITE {
+                    if let Ok(w) = WriteRef::parse(v) {
+                        s += &format!(
+                            " start_ts={} type={:?}",
+                            w.start_ts.into_inner(),
+                            w.write_type
+                        );
+                    }
+                }
+                s
+            }
+            Modify::Delete(cf, k) => format!("delete {} {}", cf, hex::encode(k.as_encoded())),
+            Modify::PessimisticLock(k, lock) => format!(
+                "pessimistic_lock {} start_ts={} for_update_ts={}",
+                hex::encode(k.as_encoded()),
+                lock.start_ts.into_inner(),
+                lock.for_update_ts.into_inner()
+            ),
+            Modify::DeleteRange(cf, start, end, notify_only) => format!(
+                "delete_range {} {} {} notify_only={}",
+                cf,
+                hex::encode(start.as_encoded()),
+                hex::encode(end.as_encoded()),
+                notify_only
+            ),
+            Modify::Ingest(_) => "ingest".to_owned(),
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        fs,
+        panic::{catch_unwind, AssertUnwindSafe},
+        path::{Path, PathBuf},
+        sync::{atomic::AtomicU64, mpsc::channel, Arc},
+        thread,
+    };
+
+    use kvproto::kvrpcpb::{
+        ApiVersion, AssertionLevel, Context, PrewriteRequestPessimisticAction::*,
+    };
+    use tikv_kv::WriteData;
+    use txn_types::Mutation;
+
+    use super::*;
+    use crate::storage::{
+        config::Config,
+        kv::Engine,
+        lock_manager::MockLockManager,
+        test_util::{
+            acquire_pessimistic_lock, delete_pessimistic_lock, expect_ok_callback,
+            new_acquire_pessimistic_lock_command,
+        },
+        txn::{
+            commands,
+            commands::{ReleasedLocks, ResponsePolicy},
+            ProcessResult,
+        },
+        types::StorageCallbackType,
+        Storage, TestEngineBuilder, TestStorageBuilderApiV1, TypedCommand,
+    };
+
+    type TestStorage = Storage<crate::storage::kv::RocksEngine, MockLockManager, api_version::ApiV1>;
+
+    /// Schedules a command and waits for its callback result, without
+    /// asserting on it.
+    fn sched_and_wait<T: StorageCallbackType + Send + 'static>(
+        storage: &TestStorage,
+        cmd: TypedCommand<T>,
+    ) -> crate::storage::Result<T> {
+        let (tx, rx) = channel();
+        storage
+            .sched_txn_command(
+                cmd,
+                Box::new(move |res| {
+                    tx.send(res).unwrap();
+                }),
+            )
+            .unwrap();
+        rx.recv().unwrap()
+    }
+
+    fn checker_config(dir: &Path, panic_on_hit: bool) -> TxnAnomalyCheckerConfig {
+        TxnAnomalyCheckerConfig {
+            enabled: true,
+            panic_on_hit,
+            check_pre_state: true,
+            evidence_dir: dir.to_str().unwrap().to_owned(),
+        }
+    }
+
+    fn evidence_files(dir: &Path) -> Vec<PathBuf> {
+        match fs::read_dir(dir) {
+            Ok(entries) => entries
+                .filter_map(|e| e.ok())
+                .map(|e| e.path())
+                .filter(|p| {
+                    p.file_name()
+                        .and_then(|n| n.to_str())
+                        .map_or(false, |n| n.starts_with("hit-"))
+                })
+                .collect(),
+            Err(_) => vec![],
+        }
+    }
+
+    fn read_evidence(dir: &Path) -> serde_json::Value {
+        let files = evidence_files(dir);
+        assert_eq!(files.len(), 1, "expect exactly one evidence file");
+        serde_json::from_str(&fs::read_to_string(&files[0]).unwrap()).unwrap()
+    }
+
+    fn make_write_result(modifies: Vec<Modify>) -> WriteResult {
+        WriteResult::new(
+            Context::default(),
+            WriteData::from_modifies(modifies),
+            1,
+            ProcessResult::Res,
+            vec![],
+            ReleasedLocks::new(),
+            vec![],
+            vec![],
+            ResponsePolicy::OnApplied,
+            vec![],
+        )
+    }
+
+    fn make_lock(key: &Key, ts: TimeStamp, ttl: u64) -> Lock {
+        Lock::new(
+            LockType::Put,
+            key.to_raw().unwrap(),
+            ts,
+            ttl,
+            None,
+            TimeStamp::zero(),
+            1,
+            TimeStamp::zero(),
+            false,
+        )
+    }
+
+    fn seed_lock<E: Engine>(engine: &E, key: &Key, ts: TimeStamp, ttl: u64) {
+        let lock = make_lock(key, ts, ttl);
+        crate::storage::mvcc::tests::write(
+            engine,
+            &Context::default(),
+            vec![Modify::Put(CF_LOCK, key.clone(), lock.to_bytes())],
+        );
+    }
+
+    fn seed_commit_record<E: Engine>(engine: &E, key: &Key, start_ts: TimeStamp, commit_ts: TimeStamp) {
+        let write = Write::new(WriteType::Put, start_ts, Some(b"v".to_vec()));
+        crate::storage::mvcc::tests::write(
+            engine,
+            &Context::default(),
+            vec![Modify::Put(
+                CF_WRITE,
+                key.clone().append_ts(commit_ts),
+                write.as_ref().to_bytes(),
+            )],
+        );
+    }
+
+    /// A staged `Put(CF_WRITE)` without a matching `Delete(CF_LOCK)` must hit.
+    #[test]
+    fn test_staged_forward_hit() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut engine = TestEngineBuilder::new().build().unwrap();
+        let key = Key::from_raw(b"k");
+        seed_lock(&engine, &key, 10.into(), 3000);
+        let snapshot = engine.snapshot(Default::default()).unwrap();
+
+        let write = Write::new(WriteType::Put, 10.into(), Some(b"v".to_vec()));
+        let wr = make_write_result(vec![Modify::Put(
+            CF_WRITE,
+            key.clone().append_ts(20.into()),
+            write.as_ref().to_bytes(),
+        )]);
+        let config = checker_config(dir.path(), false);
+        let hits = check_write_result(&snapshot, CommandKind::commit, &wr, &config);
+        assert_eq!(hits, 1);
+
+        let evidence = read_evidence(dir.path());
+        assert_eq!(evidence["marker"], CHECKER_HIT_MARKER);
+        assert_eq!(evidence["origin"], ORIGIN_STAGED);
+        assert_eq!(evidence["command"], "commit");
+        assert_eq!(evidence["start_ts"], 10);
+        assert_eq!(evidence["commit_ts"], 20);
+        assert_eq!(
+            evidence["key"],
+            hex::encode(key.as_encoded()),
+        );
+    }
+
+    /// A staged normal lock on top of an existing committed record with the
+    /// same start_ts must hit.
+    #[test]
+    fn test_staged_backward_hit() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut engine = TestEngineBuilder::new().build().unwrap();
+        let key = Key::from_raw(b"k");
+        seed_commit_record(&engine, &key, 10.into(), 20.into());
+        let snapshot = engine.snapshot(Default::default()).unwrap();
+
+        let lock = make_lock(&key, 10.into(), 3000);
+        let wr = make_write_result(vec![Modify::Put(CF_LOCK, key.clone(), lock.to_bytes())]);
+        let config = checker_config(dir.path(), false);
+        let hits = check_write_result(&snapshot, CommandKind::prewrite, &wr, &config);
+        assert_eq!(hits, 1);
+        assert_eq!(read_evidence(dir.path())["origin"], ORIGIN_STAGED);
+    }
+
+    /// A staged commit record together with the lock deletion (the normal
+    /// commit shape) must not hit.
+    #[test]
+    fn test_no_hit_when_lock_deleted() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut engine = TestEngineBuilder::new().build().unwrap();
+        let key = Key::from_raw(b"k");
+        seed_lock(&engine, &key, 10.into(), 3000);
+        let snapshot = engine.snapshot(Default::default()).unwrap();
+
+        let write = Write::new(WriteType::Put, 10.into(), Some(b"v".to_vec()));
+        let wr = make_write_result(vec![
+            Modify::Put(CF_WRITE, key.clone().append_ts(20.into()), write.as_ref().to_bytes()),
+            Modify::Delete(CF_LOCK, key.clone()),
+        ]);
+        let config = checker_config(dir.path(), false);
+        assert_eq!(check_write_result(&snapshot, CommandKind::commit, &wr, &config), 0);
+        assert!(evidence_files(dir.path()).is_empty());
+    }
+
+    /// A staged Rollback write record with a remaining lock must not hit
+    /// (rollback records are excluded from the predicate).
+    #[test]
+    fn test_no_hit_for_rollback_record() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut engine = TestEngineBuilder::new().build().unwrap();
+        let key = Key::from_raw(b"k");
+        seed_lock(&engine, &key, 10.into(), 3000);
+        let snapshot = engine.snapshot(Default::default()).unwrap();
+
+        let write = Write::new_rollback(10.into(), true);
+        let wr = make_write_result(vec![Modify::Put(
+            CF_WRITE,
+            key.clone().append_ts(10.into()),
+            write.as_ref().to_bytes(),
+        )]);
+        let config = checker_config(dir.path(), false);
+        assert_eq!(check_write_result(&snapshot, CommandKind::rollback, &wr, &config), 0);
+        assert!(evidence_files(dir.path()).is_empty());
+    }
+
+    /// Disabled checker must be a no-op even on a fabricated anomaly.
+    #[test]
+    fn test_disabled_noop() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut engine = TestEngineBuilder::new().build().unwrap();
+        let key = Key::from_raw(b"k");
+        seed_lock(&engine, &key, 10.into(), 3000);
+        let snapshot = engine.snapshot(Default::default()).unwrap();
+
+        let write = Write::new(WriteType::Put, 10.into(), Some(b"v".to_vec()));
+        let wr = make_write_result(vec![Modify::Put(
+            CF_WRITE,
+            key.clone().append_ts(20.into()),
+            write.as_ref().to_bytes(),
+        )]);
+        let mut config = checker_config(dir.path(), false);
+        config.enabled = false;
+        assert_eq!(check_write_result(&snapshot, CommandKind::commit, &wr, &config), 0);
+        assert!(evidence_files(dir.path()).is_empty());
+    }
+
+    /// `panic-on-hit = true` must panic with the marker after recording.
+    #[test]
+    fn test_panic_on_hit() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut engine = TestEngineBuilder::new().build().unwrap();
+        let key = Key::from_raw(b"k");
+        seed_lock(&engine, &key, 10.into(), 3000);
+        let snapshot = engine.snapshot(Default::default()).unwrap();
+
+        let write = Write::new(WriteType::Put, 10.into(), Some(b"v".to_vec()));
+        let wr = make_write_result(vec![Modify::Put(
+            CF_WRITE,
+            key.clone().append_ts(20.into()),
+            write.as_ref().to_bytes(),
+        )]);
+        let config = checker_config(dir.path(), true);
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            check_write_result(&snapshot, CommandKind::commit, &wr, &config)
+        }));
+        let err = result.expect_err("expect panic on hit");
+        let msg = err
+            .downcast_ref::<String>()
+            .cloned()
+            .or_else(|| err.downcast_ref::<&str>().map(|s| s.to_string()))
+            .unwrap_or_default();
+        assert!(msg.contains(CHECKER_HIT_MARKER), "panic msg: {}", msg);
+        // Evidence is recorded before panicking.
+        assert_eq!(read_evidence(dir.path())["origin"], ORIGIN_STAGED);
+    }
+
+    /// A staged unparseable CF_LOCK value (suspected shared locks) must be
+    /// skipped without a false positive.
+    #[test]
+    fn test_shared_lock_value_skipped() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut engine = TestEngineBuilder::new().build().unwrap();
+        let key = Key::from_raw(b"k");
+        seed_commit_record(&engine, &key, 10.into(), 20.into());
+        let snapshot = engine.snapshot(Default::default()).unwrap();
+
+        let shared = txn_types::SharedLocks::new();
+        let wr = make_write_result(vec![Modify::Put(CF_LOCK, key.clone(), shared.to_bytes())]);
+        let config = checker_config(dir.path(), false);
+        assert_eq!(check_write_result(&snapshot, CommandKind::prewrite, &wr, &config), 0);
+        assert!(evidence_files(dir.path()).is_empty());
+    }
+
+    fn build_checker_storage(dir: &Path) -> TestStorage {
+        let mut config = Config::default();
+        config.set_api_version(ApiVersion::V1);
+        config.txn_anomaly_checker = checker_config(dir, false);
+        TestStorageBuilderApiV1::new(MockLockManager::new())
+            .config(config)
+            .build()
+            .unwrap()
+    }
+
+    #[test]
+    fn test_no_false_positive_optimistic_2pc() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = build_checker_storage(dir.path());
+        let (tx, rx) = channel();
+        let k1 = Key::from_raw(b"k1");
+        let k2 = Key::from_raw(b"k2");
+
+        storage
+            .sched_txn_command(
+                commands::Prewrite::with_defaults(
+                    vec![
+                        Mutation::make_put(k1.clone(), b"v".to_vec()),
+                        Mutation::make_put(k2.clone(), b"v".to_vec()),
+                    ],
+                    b"k1".to_vec(),
+                    10.into(),
+                ),
+                expect_ok_callback(tx.clone(), 0),
+            )
+            .unwrap();
+        rx.recv().unwrap();
+
+        storage
+            .sched_txn_command(
+                commands::Commit::new(vec![k1, k2], 10.into(), 20.into(), Context::default()),
+                expect_ok_callback(tx, 0),
+            )
+            .unwrap();
+        rx.recv().unwrap();
+
+        assert!(evidence_files(dir.path()).is_empty());
+    }
+
+    #[test]
+    fn test_no_false_positive_pessimistic_2pc() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = build_checker_storage(dir.path());
+        let (tx, rx) = channel();
+        let k = Key::from_raw(b"k");
+
+        acquire_pessimistic_lock(&storage, k.clone(), 10, 10);
+        storage
+            .sched_txn_command(
+                commands::PrewritePessimistic::new(
+                    vec![(Mutation::make_put(k.clone(), b"v".to_vec()), DoPessimisticCheck)],
+                    k.to_raw().unwrap(),
+                    10.into(),
+                    3000,
+                    10.into(),
+                    1,
+                    TimeStamp::zero(),
+                    TimeStamp::default(),
+                    None,
+                    false,
+                    AssertionLevel::Off,
+                    vec![],
+                    Context::default(),
+                ),
+                expect_ok_callback(tx.clone(), 0),
+            )
+            .unwrap();
+        rx.recv().unwrap();
+
+        storage
+            .sched_txn_command(
+                commands::Commit::new(vec![k], 10.into(), 20.into(), Context::default()),
+                expect_ok_callback(tx, 0),
+            )
+            .unwrap();
+        rx.recv().unwrap();
+
+        assert!(evidence_files(dir.path()).is_empty());
+    }
+
+    #[test]
+    fn test_no_false_positive_rollback_and_cleanup() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = build_checker_storage(dir.path());
+        let (tx, rx) = channel();
+        let k1 = Key::from_raw(b"k1");
+        let k2 = Key::from_raw(b"k2");
+
+        storage
+            .sched_txn_command(
+                commands::Prewrite::with_defaults(
+                    vec![
+                        Mutation::make_put(k1.clone(), b"v".to_vec()),
+                        Mutation::make_put(k2.clone(), b"v".to_vec()),
+                    ],
+                    b"k1".to_vec(),
+                    10.into(),
+                ),
+                expect_ok_callback(tx.clone(), 0),
+            )
+            .unwrap();
+        rx.recv().unwrap();
+
+        storage
+            .sched_txn_command(
+                commands::Rollback::new(vec![k1], 10.into(), Context::default()),
+                expect_ok_callback(tx.clone(), 0),
+            )
+            .unwrap();
+        rx.recv().unwrap();
+
+        storage
+            .sched_txn_command(
+                commands::Cleanup::new(k2, 10.into(), TimeStamp::zero(), Context::default()),
+                expect_ok_callback(tx, 0),
+            )
+            .unwrap();
+        rx.recv().unwrap();
+
+        assert!(evidence_files(dir.path()).is_empty());
+    }
+
+    #[test]
+    fn test_no_false_positive_pessimistic_rollback() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = build_checker_storage(dir.path());
+        let k = Key::from_raw(b"k");
+
+        acquire_pessimistic_lock(&storage, k.clone(), 10, 10);
+        delete_pessimistic_lock(&storage, k, 10, 10);
+
+        assert!(evidence_files(dir.path()).is_empty());
+    }
+
+    #[test]
+    fn test_no_false_positive_txn_heart_beat() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = build_checker_storage(dir.path());
+        let (tx, rx) = channel();
+        let k = Key::from_raw(b"k");
+
+        storage
+            .sched_txn_command(
+                commands::Prewrite::with_lock_ttl(
+                    vec![Mutation::make_put(k.clone(), b"v".to_vec())],
+                    b"k".to_vec(),
+                    10.into(),
+                    100,
+                ),
+                expect_ok_callback(tx.clone(), 0),
+            )
+            .unwrap();
+        rx.recv().unwrap();
+
+        // A larger advise_ttl rewrites the lock via put_lock.
+        storage
+            .sched_txn_command(
+                commands::TxnHeartBeat::new(k, 10.into(), 110, 0, Context::default()),
+                expect_ok_callback(tx, 0),
+            )
+            .unwrap();
+        rx.recv().unwrap();
+
+        assert!(evidence_files(dir.path()).is_empty());
+    }
+
+    #[test]
+    fn test_no_false_positive_resolve_lock() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = build_checker_storage(dir.path());
+        let (tx, rx) = channel();
+
+        // ResolveLock: commit branch.
+        let k = Key::from_raw(b"k");
+        storage
+            .sched_txn_command(
+                commands::Prewrite::with_defaults(
+                    vec![Mutation::make_put(k.clone(), b"v".to_vec())],
+                    b"k".to_vec(),
+                    10.into(),
+                ),
+                expect_ok_callback(tx.clone(), 0),
+            )
+            .unwrap();
+        rx.recv().unwrap();
+        let mut txn_status = collections::HashMap::default();
+        txn_status.insert(TimeStamp::from(10), TimeStamp::from(20));
+        storage
+            .sched_txn_command(
+                commands::ResolveLockReadPhase::new(txn_status, None, Context::default()),
+                expect_ok_callback(tx.clone(), 0),
+            )
+            .unwrap();
+        rx.recv().unwrap();
+
+        // ResolveLock: rollback branch.
+        storage
+            .sched_txn_command(
+                commands::Prewrite::with_defaults(
+                    vec![Mutation::make_put(k.clone(), b"v".to_vec())],
+                    b"k".to_vec(),
+                    30.into(),
+                ),
+                expect_ok_callback(tx.clone(), 0),
+            )
+            .unwrap();
+        rx.recv().unwrap();
+        let mut txn_status = collections::HashMap::default();
+        txn_status.insert(TimeStamp::from(30), TimeStamp::zero());
+        storage
+            .sched_txn_command(
+                commands::ResolveLockReadPhase::new(txn_status, None, Context::default()),
+                expect_ok_callback(tx.clone(), 0),
+            )
+            .unwrap();
+        rx.recv().unwrap();
+
+        // ResolveLockLite: rollback and commit branches.
+        let k1 = Key::from_raw(b"k1");
+        let k2 = Key::from_raw(b"k2");
+        storage
+            .sched_txn_command(
+                commands::Prewrite::with_defaults(
+                    vec![
+                        Mutation::make_put(k1.clone(), b"v".to_vec()),
+                        Mutation::make_put(k2.clone(), b"v".to_vec()),
+                    ],
+                    b"k1".to_vec(),
+                    40.into(),
+                ),
+                expect_ok_callback(tx.clone(), 0),
+            )
+            .unwrap();
+        rx.recv().unwrap();
+        storage
+            .sched_txn_command(
+                commands::ResolveLockLite::new(
+                    40.into(),
+                    TimeStamp::zero(),
+                    vec![k1],
+                    Context::default(),
+                ),
+                expect_ok_callback(tx.clone(), 0),
+            )
+            .unwrap();
+        rx.recv().unwrap();
+        storage
+            .sched_txn_command(
+                commands::ResolveLockLite::new(40.into(), 50.into(), vec![k2], Context::default()),
+                expect_ok_callback(tx, 0),
+            )
+            .unwrap();
+        rx.recv().unwrap();
+
+        assert!(evidence_files(dir.path()).is_empty());
+    }
+
+    #[test]
+    fn test_no_false_positive_check_txn_status() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = build_checker_storage(dir.path());
+        let (tx, rx) = channel();
+
+        // rollback_if_not_exist on a missing txn writes a rollback record.
+        let k0 = Key::from_raw(b"k0");
+        storage
+            .sched_txn_command(
+                commands::CheckTxnStatus::new(
+                    k0,
+                    9.into(),
+                    11.into(),
+                    11.into(),
+                    true,
+                    false,
+                    false,
+                    true,
+                    Context::default(),
+                ),
+                expect_ok_callback(tx.clone(), 0),
+            )
+            .unwrap();
+        rx.recv().unwrap();
+
+        // min_commit_ts push rewrites the lock via put_lock.
+        let k = Key::from_raw(b"k");
+        storage
+            .sched_txn_command(
+                commands::Prewrite::new(
+                    vec![Mutation::make_put(k.clone(), b"v".to_vec())],
+                    b"k".to_vec(),
+                    10.into(),
+                    10_000_000,
+                    false,
+                    1,
+                    12.into(),
+                    TimeStamp::default(),
+                    None,
+                    false,
+                    AssertionLevel::Off,
+                    Context::default(),
+                ),
+                expect_ok_callback(tx.clone(), 0),
+            )
+            .unwrap();
+        rx.recv().unwrap();
+        storage
+            .sched_txn_command(
+                commands::CheckTxnStatus::new(
+                    k,
+                    10.into(),
+                    15.into(),
+                    15.into(),
+                    false,
+                    false,
+                    false,
+                    true,
+                    Context::default(),
+                ),
+                expect_ok_callback(tx, 0),
+            )
+            .unwrap();
+        rx.recv().unwrap();
+
+        assert!(evidence_files(dir.path()).is_empty());
+    }
+
+    /// Pre-seed an anomalous state directly into the engine, then let a normal
+    /// command touch the key. The checker must report a pre-existing hit
+    /// before the command itself would run into the customer-site panic.
+    #[test]
+    fn test_hit_pre_existing() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = build_checker_storage(dir.path());
+        let (tx, rx) = channel();
+        let k = Key::from_raw(b"k");
+
+        // Prewrite with a non-zero min_commit_ts and a large TTL, so that the
+        // later check_txn_status neither expires the lock (which would run
+        // into the original panic) nor skips the put_lock rewrite (which
+        // keeps the key in the command's modifies).
+        storage
+            .sched_txn_command(
+                commands::Prewrite::new(
+                    vec![Mutation::make_put(k.clone(), b"v".to_vec())],
+                    b"k".to_vec(),
+                    10.into(),
+                    10_000_000,
+                    false,
+                    1,
+                    12.into(),
+                    TimeStamp::default(),
+                    None,
+                    false,
+                    AssertionLevel::Off,
+                    Context::default(),
+                ),
+                expect_ok_callback(tx.clone(), 0),
+            )
+            .unwrap();
+        rx.recv().unwrap();
+
+        // Inject the anomalous committed record directly, bypassing the txn
+        // layer, to simulate a state produced before the checker was deployed.
+        let write = Write::new(WriteType::Put, 10.into(), Some(b"v".to_vec()));
+        let mut region_modifies = collections::HashMap::default();
+        region_modifies.insert(
+            0_u64,
+            vec![Modify::Put(
+                CF_WRITE,
+                k.clone().append_ts(20.into()),
+                write.as_ref().to_bytes(),
+            )],
+        );
+        storage
+            .get_engine()
+            .modify_on_kv_engine(region_modifies)
+            .unwrap();
+
+        storage
+            .sched_txn_command(
+                commands::CheckTxnStatus::new(
+                    k.clone(),
+                    10.into(),
+                    15.into(),
+                    15.into(),
+                    false,
+                    false,
+                    false,
+                    true,
+                    Context::default(),
+                ),
+                expect_ok_callback(tx, 0),
+            )
+            .unwrap();
+        rx.recv().unwrap();
+
+        let evidence = read_evidence(dir.path());
+        assert_eq!(evidence["origin"], ORIGIN_PRE_EXISTING);
+        assert_eq!(evidence["command"], "check_txn_status");
+        assert_eq!(evidence["start_ts"], 10);
+        assert_eq!(evidence["commit_ts"], 20);
+        assert_eq!(evidence["key"], hex::encode(k.as_encoded()));
+    }
+
+    /// A small concurrent pessimistic "REPLACE"-like workload on one hot key
+    /// must not produce any false positive.
+    #[test]
+    fn test_no_false_positive_concurrent_replace() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = build_checker_storage(dir.path());
+        let k = Key::from_raw(b"hot");
+        // Globally increasing ts allocator, like a tiny TSO.
+        let ts_alloc = Arc::new(AtomicU64::new(1000));
+
+        let mut handles = vec![];
+        for _ in 0..4 {
+            let storage = storage.clone();
+            let k = k.clone();
+            let ts_alloc = ts_alloc.clone();
+            handles.push(thread::spawn(move || {
+                for i in 0..10 {
+                    let value = format!("v{}", i).into_bytes();
+                    // A REPLACE-like pessimistic write. On write conflict (a
+                    // faster thread committed a larger ts first), roll back
+                    // and retry with a fresh ts, like TiDB does.
+                    for attempt in 0..100 {
+                        assert!(attempt < 99, "too many retries");
+                        let start_ts = ts_alloc.fetch_add(2, Ordering::Relaxed);
+                        let res = sched_and_wait(
+                            &storage,
+                            new_acquire_pessimistic_lock_command(
+                                vec![(k.clone(), false)],
+                                start_ts,
+                                start_ts,
+                                false,
+                                false,
+                            ),
+                        );
+                        if res.is_err() {
+                            continue;
+                        }
+                        let res = sched_and_wait(
+                            &storage,
+                            commands::PrewritePessimistic::new(
+                                vec![(
+                                    Mutation::make_put(k.clone(), value.clone()),
+                                    DoPessimisticCheck,
+                                )],
+                                k.to_raw().unwrap(),
+                                start_ts.into(),
+                                3000,
+                                start_ts.into(),
+                                1,
+                                TimeStamp::zero(),
+                                TimeStamp::default(),
+                                None,
+                                false,
+                                AssertionLevel::Off,
+                                vec![],
+                                Context::default(),
+                            ),
+                        );
+                        if res.is_err() {
+                            // Clean up the pessimistic lock of the abandoned
+                            // attempt before retrying.
+                            delete_pessimistic_lock(&storage, k.clone(), start_ts, start_ts);
+                            continue;
+                        }
+                        sched_and_wait(
+                            &storage,
+                            commands::Commit::new(
+                                vec![k.clone()],
+                                start_ts.into(),
+                                (start_ts + 1).into(),
+                                Context::default(),
+                            ),
+                        )
+                        .unwrap();
+                        break;
+                    }
+                }
+            }));
+        }
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        assert!(evidence_files(dir.path()).is_empty());
+    }
+}

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -69,6 +69,7 @@ snmalloc = ["tikv/snmalloc"]
 mem-profiling = ["tikv/mem-profiling"]
 sse = ["tikv/sse"]
 portable = ["tikv/portable"]
+docker_test = []  # Feature flag for Docker-specific tests
 
 [dependencies]
 api_version = { workspace = true }

--- a/tests/integrations/backup/mod.rs
+++ b/tests/integrations/backup/mod.rs
@@ -494,6 +494,8 @@ fn test_backup_raw_meta() {
 }
 
 #[test]
+// this test relies on file permissions which are ignored when run in docker under the root
+#[cfg(not(feature = "docker_test"))]
 fn test_invalid_external_storage() {
     let mut suite = TestSuite::new(1, 144 * 1024 * 1024, ApiVersion::V1);
     // Put some data.

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -910,6 +910,17 @@ fn test_serde_custom_tikv_config() {
     value.resource_control = ResourceControlConfig {
         enabled: false,
         priority_ctl_strategy: PriorityCtlStrategy::Aggressive,
+        bg_cpu_throttle_threshold: 60.0,
+        fg_cpu_throttle_threshold: 70.0,
+        bg_compaction_pressure_threshold: 70.0,
+        bg_write_io_ceiling: ReadableSize::gb(100),
+        bg_write_io_floor: ReadableSize::mb(10),
+        enable_fair_scheduling: false,
+        enable_read_admission_control: false,
+        enable_write_admission_control: false,
+        historical_usage_window_mins: 15,
+        baseline_burst_pct: 20.0,
+        admission_max_delayed_count: 10_000,
     };
 
     let custom = read_file_in_project_dir("integrations/config/test-custom.toml");
@@ -942,6 +953,13 @@ fn test_readpool_default_config() {
     let mut expected = TikvConfig::default();
     expected.readpool.unified.max_thread_count = 1;
     assert_eq!(cfg, expected);
+}
+
+#[test]
+fn test_compaction_readahead_default_config() {
+    let cfg = TikvConfig::default();
+    assert_eq!(cfg.rocksdb.compaction_readahead_size, ReadableSize::mb(2));
+    assert_eq!(cfg.raftdb.compaction_readahead_size, ReadableSize::mb(2));
 }
 
 #[test]

--- a/tests/integrations/config/test-custom.toml
+++ b/tests/integrations/config/test-custom.toml
@@ -689,3 +689,14 @@ split.split-contained-score = 0.5
 [resource-control]
 enabled = false
 priority-ctl-strategy = "aggressive"
+bg-cpu-throttle-threshold = 60.0
+fg-cpu-throttle-threshold = 70.0
+bg-compaction-pressure-threshold = 70.0
+bg-write-io-ceiling = "100GB"
+bg-write-io-floor = "10MB"
+enable-fair-scheduling = false
+enable-read-admission-control = false
+enable-write-admission-control = false
+historical-usage-window-mins = 15
+baseline-burst-pct = 20.0
+admission-max-delayed-count = 10000


### PR DESCRIPTION
Do not merge. This PR exists to obtain a pull ref for a one-off internal dev build.

- Base: head of #19715 (release-8.5-20260608-v8.5.6)
- Adds a single commit: an optional, disabled-by-default txn anomaly checker in the storage scheduler (`[storage.txn-anomaly-checker]`), used only for internal reproduction testing. Zero overhead and no behavior change when disabled.