### PR TITLE
coprocessor: merge batched full-sampling results

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4422,7 +4422,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git#a15c348f8713e5c492b6dfb41224c464b5824979"
+source = "git+https://github.com/0xTars/kvproto.git?rev=a15dd9ca8aa82a741da9379a5a1d61bf6de119eb#a15dd9ca8aa82a741da9379a5a1d61bf6de119eb"
 dependencies = [
  "bytes",
  "futures 0.3.15",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -381,7 +381,8 @@ grpcio-health = { version = "0.10.4", default-features = false, features = [
   "protobuf-codec",
 ] }
 tipb = { git = "https://github.com/pingcap/tipb.git" }
-kvproto = { git = "https://github.com/pingcap/kvproto.git" }
+# TODO: revert to pingcap/kvproto once https://github.com/pingcap/kvproto/pull/1511 merges.
+kvproto = { git = "https://github.com/0xTars/kvproto.git", rev = "a15dd9ca8aa82a741da9379a5a1d61bf6de119eb" }
 yatp = { git = "https://github.com/tikv/yatp.git", branch = "master" }
 tokio-timer = { git = "https://github.com/tikv/tokio", branch = "tokio-timer-hotfix" }
 tokio-executor = { git = "https://github.com/tikv/tokio", branch = "tokio-timer-hotfix" }

--- a/components/tikv_alloc/src/trace.rs
+++ b/components/tikv_alloc/src/trace.rs
@@ -263,6 +263,19 @@ impl<T: Default> MemoryTraceGuard<T> {
         }
         std::mem::take(&mut self.item)
     }
+
+    /// Adjusts the traced size to `size`, e.g. after replacing the item with
+    /// one of a different size. Does nothing if the guard traces no memory.
+    pub fn retrace(&mut self, size: usize) {
+        if let Some(node) = &self.node {
+            if size > self.size {
+                node.trace(TraceEvent::Add(size - self.size));
+            } else if size < self.size {
+                node.trace(TraceEvent::Sub(self.size - size));
+            }
+            self.size = size;
+        }
+    }
 }
 
 impl<T: Default> Drop for MemoryTraceGuard<T> {
@@ -342,6 +355,24 @@ mod tests {
             .sub_trace(Id::Name("mid2"))
             .trace(TraceEvent::Add(100));
         assert_eq!(111, trace.sum());
+    }
+
+    #[test]
+    fn test_trace_guard_retrace() {
+        let trace = mem_trace!(root);
+        let mut guard = trace.trace_guard(vec![0u8; 4], 4);
+        assert_eq!(trace.sum(), 4);
+        guard.retrace(10);
+        assert_eq!(trace.sum(), 10);
+        guard.retrace(2);
+        assert_eq!(trace.sum(), 2);
+        drop(guard);
+        assert_eq!(trace.sum(), 0);
+
+        // A guard without a trace node ignores retrace.
+        let mut guard = crate::trace::MemoryTraceGuard::from(vec![0u8; 4]);
+        guard.retrace(10);
+        drop(guard);
     }
 
     #[test]

--- a/components/tracker/src/lib.rs
+++ b/components/tracker/src/lib.rs
@@ -144,6 +144,58 @@ impl Tracker {
     }
 }
 
+/// Attributes a tracked future's poll time to the slab tracker addressed by
+/// a token: busy poll time accumulates into
+/// [`RequestMetrics::future_process_nanos`] and the gaps between polls, plus
+/// the wait before the first poll when that poll begins, accumulate into
+/// [`RequestMetrics::future_suspend_nanos`], which
+/// [`Tracker::merge_time_detail`] folds into the request's `TimeDetailV2`.
+/// Unlike `TlsFutureTracker` in the storage layer it keeps no thread local
+/// state, so it can track a future handed to a foreign executor; an invalid
+/// or removed token makes it a no-op. An instance dropped before its first poll
+/// has no poll callback and therefore cannot flush that initial wait.
+#[derive(Debug)]
+pub struct TokenFutureTracker {
+    token: TrackerToken,
+    poll_began: Option<Instant>,
+    last_finished: Instant,
+    suspend_nanos: u64,
+}
+
+impl TokenFutureTracker {
+    /// Creates a poll-time tracker for the slab tracker addressed by `token`.
+    pub fn new(token: TrackerToken) -> Self {
+        Self {
+            token,
+            poll_began: None,
+            last_finished: Instant::now(),
+            suspend_nanos: 0,
+        }
+    }
+}
+
+impl FutureTrack for TokenFutureTracker {
+    fn on_poll_begin(&mut self) {
+        let now = Instant::now();
+        self.suspend_nanos += now.saturating_duration_since(self.last_finished).as_nanos() as u64;
+        self.poll_began = Some(now);
+    }
+
+    fn on_poll_finish(&mut self) {
+        let now = Instant::now();
+        let process_nanos = self
+            .poll_began
+            .take()
+            .map_or(0, |at| now.saturating_duration_since(at).as_nanos() as u64);
+        let suspend_nanos = std::mem::take(&mut self.suspend_nanos);
+        GLOBAL_TRACKERS.with_tracker(self.token, |tracker| {
+            tracker.metrics.future_process_nanos += process_nanos;
+            tracker.metrics.future_suspend_nanos += suspend_nanos;
+        });
+        self.last_finished = now;
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct RequestInfo {
     pub region_id: u64,
@@ -286,6 +338,54 @@ mod tests {
             cid: 0,
             is_external_req: false,
         }
+    }
+
+    #[test]
+    fn test_token_future_tracker_attributes_poll_time() {
+        use std::{
+            future::{Future, poll_fn},
+            pin::pin,
+            task::{Context, Poll, Waker},
+            time::Duration,
+        };
+
+        // Spinning self-measures, so assertions hold under arbitrary
+        // scheduling load, unlike sleeps.
+        fn spin(d: Duration) {
+            let begin = Instant::now();
+            while begin.elapsed() < d {}
+        }
+
+        let token = GLOBAL_TRACKERS.insert(Tracker::new(new_req_info()));
+        let mut polled = false;
+        let fut = track(
+            poll_fn(move |_cx| {
+                spin(Duration::from_millis(2));
+                if polled {
+                    Poll::Ready(())
+                } else {
+                    polled = true;
+                    Poll::Pending
+                }
+            }),
+            TokenFutureTracker::new(token),
+        );
+        let mut fut = pin!(fut);
+        let mut cx = Context::from_waker(Waker::noop());
+
+        spin(Duration::from_millis(2));
+        assert!(fut.as_mut().poll(&mut cx).is_pending());
+        spin(Duration::from_millis(2));
+        assert!(fut.as_mut().poll(&mut cx).is_ready());
+
+        let mut detail = pb::TimeDetailV2::default();
+        GLOBAL_TRACKERS.with_tracker(token, |tracker| tracker.merge_time_detail(&mut detail));
+        GLOBAL_TRACKERS.remove(token);
+
+        // Two polls spun >= 2ms each; a >= 2ms gap preceded each poll.
+        let expected = Duration::from_millis(4).as_nanos() as u64;
+        assert!(detail.get_process_wall_time_ns() >= expected);
+        assert!(detail.get_process_suspend_wall_time_ns() >= expected);
     }
 
     #[test]

--- a/doc/maintenance-guides/src/coprocessor.md
+++ b/doc/maintenance-guides/src/coprocessor.md
@@ -57,6 +57,82 @@ It is a read-heavy hot path and directly impacts query latency.
 - Cache-match version, flashback allowance, and lock-bypass/access sets are all
   correctness-sensitive metadata, not optional optimization flags.
 
+### Handler outcomes and batched-task merging
+
+- `RequestHandler::handle_request` returns a `HandlerOutcome`; today only
+  full-sampling analyze opts into the `Mergeable` outcome
+  (`statistics/analyze_context.rs`).
+- Merging happens only when the client allows it
+  (`Request.allow_batch_task_data_merge`), the request carries batched
+  tasks, and the top task kept an error-free mergeable result. Results of
+  one request must have the same concrete type; the endpoint relies on this
+  handler invariant rather than checking it at runtime. Merging and batch
+  responses preserve request-task order even when handlers complete out of
+  order, including for legacy callers whose task IDs are not unique.
+- Wire contract: the top response carries its result merged with every
+  eligible successful batched task. Each merged task is acknowledged by a
+  data-less batch response with `data_merged_into_response` set and keeps its
+  execution details; failed or non-mergeable tasks keep normal batch
+  responses so the client can retry or consume them independently. Clients
+  that never set the request field keep receiving one response per task.
+- Scheduling invariant: a unary read pool task is enqueued only when its
+  future is first polled, while its deadline starts at parse time.
+  `endpoint.rs::collect_batch_task_outputs` therefore drives the top task
+  and the batched tasks concurrently (as `futures::join!` did before
+  batched merging existed); awaiting the top task first would leave every
+  batched task unscheduled behind it and could expire their deadlines
+  before they run.
+- Serialization and merging are CPU work that must keep the protections
+  handlers run under (read pool scheduling, resource metering tag,
+  deadline, coprocessor semaphore, execution tracking), not run on the gRPC
+  event loop. A request that cannot take part in merging — no batched
+  tasks, client did not allow merging — serializes its `Mergeable` outcome
+  inside its own read pool task (`handle_unary_request_impl`, inside the
+  deadline/track/concurrency wrappers). When merging can happen, results
+  stay unserialized until every output is collected, then
+  `merge_batch_task_responses` runs as a read pool task under the request's
+  deadline, resource tag, resource limiter and the coprocessor semaphore
+  (`BatchMergeFinalizer`). The semaphore permit is taken before the first
+  merge step — merging never uses `limit_concurrency`'s permit-free fast
+  path, whose accounting cannot stop the merge's coarse first chunk — with
+  the wait bounded by the deadline (expiry before the permit is retry-safe:
+  nothing is consumed yet). If the pool rejects or drops the merge task,
+  the finalizer sheds the request with a retryable server-busy error,
+  exactly like an ordinary admission failure: the collected results are
+  dropped, the client retries every task, and merge work never runs on the
+  caller's executor (reserve finalizer capacity instead of inlining if
+  re-scans must be avoided). Collected outputs remain in a handoff slot
+  owned by the caller until the pool task starts. Both read-pool admission
+  and the subsequent queue/response wait use the request's remaining
+  deadline. If either wait expires before the pool task claims the slot,
+  the caller removes and drops the outputs; a queued task that later
+  observes an empty slot exits without merging. Once the pool task has
+  claimed the slot, the caller cannot cancel that running work; the
+  worker's own semaphore and commit deadline checks prevent an expired
+  result from being committed. If the pool already committed and sent the
+  response before a delayed caller poll, the receiver is checked once
+  after the timer fires and that completed response wins; a missing sender
+  without a response is treated as a retryable admission failure. Its poll
+  time is attributed to the request tracker (`TokenFutureTracker`), which
+  folds it into the top task's `TimeDetailV2` process and suspend time.
+  A finalizer dropped before its first pool poll has no poll callback, so
+  that admission wait is not reported in `TimeDetailV2`.
+  Outputs that finish early are buffered until the merge runs, so peak
+  memory is the collected unserialized results.
+- The batched response is committed — per-task data and acknowledgments
+  attached, response bytes accounted, memory retraced — only after a
+  deadline check that follows the synchronous top-result encoding. If the
+  merge task's deadline expires (including during that encoding), or
+  serializing a result after consuming any batched result fails, the
+  endpoint returns a plain error with neither partial data, task
+  acknowledgments nor response-byte charges, so a retry cannot lose,
+  double-count or overcharge data.
+- The canonical contracts (merge order, downcast safety, memory and metrics
+  accounting) live on `HandlerOutcome`/`MergeableResult` in
+  `src/coprocessor/mod.rs` and on `collect_batch_task_outputs`/
+  `merge_batch_task_responses`/`BatchMergeFinalizer` in
+  `src/coprocessor/endpoint.rs`.
+
 ## Start Here
 
 - `src/coprocessor/mod.rs`
@@ -97,6 +173,8 @@ It is a read-heavy hot path and directly impacts query latency.
 - Memory quota and concurrency limiters must remain cheap and correct.
 - Streaming and unary response handling must preserve stats and partial-progress
   semantics.
+- Merged batched responses must keep the wire contract described in
+  "Handler outcomes and batched-task merging".
 
 ## Observability And Operational Signals
 

--- a/src/coprocessor/cache.rs
+++ b/src/coprocessor/cache.rs
@@ -28,12 +28,12 @@ impl CachedRequestHandler {
 
 #[async_trait]
 impl RequestHandler for CachedRequestHandler {
-    async fn handle_request(&mut self) -> Result<MemoryTraceGuard<Response>> {
+    async fn handle_request(&mut self) -> Result<MemoryTraceGuard<HandlerOutcome>> {
         let mut resp = Response::default();
         resp.set_is_cache_hit(true);
         if let Some(v) = self.data_version {
             resp.set_cache_last_version(v);
         }
-        Ok(resp.into())
+        Ok(HandlerOutcome::Ready(resp).into())
     }
 }

--- a/src/coprocessor/checksum.rs
+++ b/src/coprocessor/checksum.rs
@@ -56,7 +56,7 @@ impl<S: Snapshot> ChecksumContext<S> {
 
 #[async_trait]
 impl<S: Snapshot> RequestHandler for ChecksumContext<S> {
-    async fn handle_request(&mut self) -> Result<MemoryTraceGuard<Response>> {
+    async fn handle_request(&mut self) -> Result<MemoryTraceGuard<HandlerOutcome>> {
         let algorithm = self.req.get_algorithm();
         if algorithm != ChecksumAlgorithm::Crc64Xor {
             return Err(box_err!("unknown checksum algorithm {:?}", algorithm));
@@ -94,7 +94,7 @@ impl<S: Snapshot> RequestHandler for ChecksumContext<S> {
 
         let mut resp = Response::default();
         resp.set_data(data);
-        Ok(resp.into())
+        Ok(HandlerOutcome::Ready(resp).into())
     }
 
     fn collect_scan_statistics(&mut self, dest: &mut Statistics) {

--- a/src/coprocessor/dag/mod.rs
+++ b/src/coprocessor/dag/mod.rs
@@ -21,7 +21,7 @@ use tipb::{DagRequest, SelectResponse, StreamResponse};
 
 pub use self::storage_impl::TikvStorage;
 use crate::{
-    coprocessor::{Deadline, RequestHandler, Result, metrics::*},
+    coprocessor::{Deadline, HandlerOutcome, RequestHandler, Result, metrics::*},
     storage::{Statistics, Store},
     tikv_util::quota_limiter::QuotaLimiter,
 };
@@ -198,9 +198,10 @@ impl BatchDagHandler {
 
 #[async_trait]
 impl RequestHandler for BatchDagHandler {
-    async fn handle_request(&mut self) -> Result<MemoryTraceGuard<Response>> {
+    async fn handle_request(&mut self) -> Result<MemoryTraceGuard<HandlerOutcome>> {
         let result = self.runner.handle_request().await;
-        handle_qe_response(result, self.runner.can_be_cached(), self.data_version).map(|x| x.into())
+        handle_qe_response(result, self.runner.can_be_cached(), self.data_version)
+            .map(|x| HandlerOutcome::Ready(x).into())
     }
 
     async fn handle_streaming_request(&mut self) -> Result<(Option<Response>, bool)> {

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -66,6 +66,46 @@ use crate::{
 /// execution.
 const LIGHT_TASK_THRESHOLD: Duration = Duration::from_millis(5);
 
+/// Serializes a `Mergeable` outcome's result into its response data,
+/// resizing the guard's memory trace to the serialized data. A `Ready`
+/// outcome is returned unchanged. The response size is not recorded here:
+/// the caller records it once the data is in the response, exactly as for
+/// a `Ready` outcome.
+fn serialize_handler_outcome(
+    outcome: MemoryTraceGuard<HandlerOutcome>,
+) -> Result<MemoryTraceGuard<coppb::Response>> {
+    let mergeable = matches!(&*outcome, HandlerOutcome::Mergeable { .. });
+    let mut serialize_err = None;
+    let mut resp = outcome.map(|outcome| match outcome {
+        HandlerOutcome::Ready(response) => response,
+        HandlerOutcome::Mergeable {
+            mut partial_response,
+            result,
+        } => {
+            debug_assert!(partial_response.get_data().is_empty());
+            match result.into_data() {
+                Ok(data) => {
+                    partial_response.set_data(data);
+                    partial_response
+                }
+                Err(e) => {
+                    serialize_err = Some(e);
+                    coppb::Response::default()
+                }
+            }
+        }
+    });
+    if let Some(e) = serialize_err {
+        // Dropping the placeholder response releases the guard's trace.
+        return Err(e);
+    }
+    if mergeable {
+        let data_len = resp.get_data().len();
+        resp.retrace(data_len);
+    }
+    Ok(resp)
+}
+
 /// A pool to build and run Coprocessor request handlers.
 #[derive(Clone)]
 pub struct Endpoint<E: Engine> {
@@ -479,6 +519,10 @@ impl<E: Engine> Endpoint<E> {
     /// snapshot and the given `handler_builder`. Finally, it calls the unary
     /// request interface of the `RequestHandler` to process the request and
     /// produce a result.
+    ///
+    /// A `Mergeable` outcome is serialized into its response right here —
+    /// inside the deadline, tracking, concurrency and resource protections
+    /// of the request, like any `Ready` response's data.
     async fn handle_unary_request_impl(
         semaphore: Option<Arc<Semaphore>>,
         mut tracker: Box<Tracker<E>>,
@@ -533,13 +577,18 @@ impl<E: Engine> Endpoint<E> {
         tracker.on_begin_all_items();
 
         let deadline = tracker.req_ctx.deadline;
-        let handle_request_future = check_deadline(handler.handle_request(), deadline);
-        let handle_request_future = track(handle_request_future, tracker.as_mut());
+        let handle_request_future = handler.handle_request();
+        let process_future = async move {
+            let outcome = handle_request_future.await?;
+            serialize_handler_outcome(outcome)
+        };
+        let process_future = check_deadline(process_future, deadline);
+        let process_future = track(process_future, tracker.as_mut());
 
         let deadline_res = if let Some(semaphore) = &semaphore {
-            limit_concurrency(handle_request_future, semaphore, LIGHT_TASK_THRESHOLD).await
+            limit_concurrency(process_future, semaphore, LIGHT_TASK_THRESHOLD).await
         } else {
-            handle_request_future.await
+            process_future.await
         };
         let result = deadline_res.map_err(Error::from).and_then(|res| res);
 
@@ -552,10 +601,7 @@ impl<E: Engine> Endpoint<E> {
         handler.collect_scan_statistics(&mut storage_stats);
         tracker.collect_storage_statistics(storage_stats);
         let mut resp = match result {
-            Ok(output) => {
-                let resp = output.map(|outcome| match outcome {
-                    HandlerOutcome::Ready(resp) => resp,
-                });
+            Ok(resp) => {
                 let resp_size = resp.data.len() as u64;
                 COPR_RESP_SIZE.inc_by(resp_size);
                 record_network_out_bytes(resp_size);
@@ -1360,6 +1406,129 @@ mod tests {
                 .unwrap()
                 .map(|x| HandlerOutcome::Ready(x).into())
         }
+    }
+
+    /// A mergeable result that concatenates task values.
+    #[derive(Default)]
+    struct ConcatMergeable {
+        values: Vec<u8>,
+        fail_serialize: bool,
+    }
+
+    impl MergeableResult for ConcatMergeable {
+        fn merge(&mut self, other: Box<dyn MergeableResult>) {
+            let other = (other as Box<dyn std::any::Any>)
+                .downcast::<ConcatMergeable>()
+                .unwrap();
+            self.values.extend(other.values);
+        }
+
+        fn into_data(mut self: Box<Self>) -> Result<Vec<u8>> {
+            if self.fail_serialize {
+                return Err(box_err!("cannot serialize"));
+            }
+            // This fixture obeys `MergeableResult`'s order-independent
+            // contract even when merge order changes.
+            self.values.sort_unstable();
+            Ok(self.values)
+        }
+    }
+
+    fn mergeable_outcome(values: Vec<u8>, fail_serialize: bool) -> HandlerOutcome {
+        HandlerOutcome::Mergeable {
+            partial_response: coppb::Response::default(),
+            result: Box::new(ConcatMergeable {
+                values,
+                fail_serialize,
+            }),
+        }
+    }
+
+    /// A unary `RequestHandler` that produces a `Mergeable` outcome.
+    struct MergeableFixture {
+        values: Vec<u8>,
+        fail_serialize: bool,
+    }
+
+    #[async_trait]
+    impl RequestHandler for MergeableFixture {
+        async fn handle_request(&mut self) -> Result<MemoryTraceGuard<HandlerOutcome>> {
+            Ok(mergeable_outcome(mem::take(&mut self.values), self.fail_serialize).into())
+        }
+    }
+
+    #[test]
+    fn test_serialize_handler_outcome() {
+        // A mergeable outcome is serialized into a ready response and the
+        // guard's trace is resized to the serialized data.
+        let trace = tikv_alloc::mem_trace!(test_serialize_outcome);
+        let output = trace.trace_guard(mergeable_outcome(vec![3, 1, 2], false), 0);
+        let resp = serialize_handler_outcome(output).unwrap();
+        assert_eq!(resp.get_data(), &[1, 2, 3]);
+        assert_eq!(trace.sum(), 3);
+        drop(resp);
+        assert_eq!(trace.sum(), 0);
+
+        // A serialization failure surfaces as the handler's error and
+        // releases the trace.
+        let output = trace.trace_guard(mergeable_outcome(vec![1], true), 5);
+        serialize_handler_outcome(output).unwrap_err();
+        assert_eq!(trace.sum(), 0);
+
+        // A ready outcome passes through with its traced size untouched.
+        let mut ready = coppb::Response::default();
+        ready.set_data(vec![7]);
+        let output = trace.trace_guard(HandlerOutcome::Ready(ready), 5);
+        let resp = serialize_handler_outcome(output).unwrap();
+        assert_eq!(resp.get_data(), &[7]);
+        assert_eq!(trace.sum(), 5);
+    }
+
+    #[test]
+    fn test_handle_unary_request_serialize_outcome() {
+        let engine = TestEngineBuilder::new().build().unwrap();
+        let read_pool = ReadPool::from(build_read_pool_for_test(
+            &CoprReadPoolConfig::default_for_test(),
+            engine,
+        ));
+        let cm = ConcurrencyManager::new_for_test(1.into());
+        let copr = Endpoint::<RocksEngine>::new(
+            &Config::default(),
+            read_pool.handle(),
+            cm,
+            ResourceTagFactory::new_for_test(),
+            Arc::new(QuotaLimiter::default()),
+            None,
+        );
+
+        // The handler's mergeable result is serialized inside the request's
+        // own read pool task and returned as ordinary response data.
+        let handler_builder = Box::new(|_, _: &_| {
+            Ok(MergeableFixture {
+                values: vec![3, 1, 2],
+                fail_serialize: false,
+            }
+            .into_boxed())
+        });
+        let resp = block_on(
+            copr.handle_unary_request(ParseCopRequestResult::default_for_test(handler_builder)),
+        )
+        .unwrap();
+        assert_eq!(resp.get_data(), &[1, 2, 3]);
+
+        // An in-place serialization failure surfaces like a handler error.
+        let handler_builder = Box::new(|_, _: &_| {
+            Ok(MergeableFixture {
+                values: vec![1],
+                fail_serialize: true,
+            }
+            .into_boxed())
+        });
+        let resp = block_on(
+            copr.handle_unary_request(ParseCopRequestResult::default_for_test(handler_builder)),
+        )
+        .unwrap();
+        assert!(!resp.get_other_error().is_empty());
     }
 
     /// A streaming `RequestHandler` that always produces a fixture.

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -552,7 +552,10 @@ impl<E: Engine> Endpoint<E> {
         handler.collect_scan_statistics(&mut storage_stats);
         tracker.collect_storage_statistics(storage_stats);
         let mut resp = match result {
-            Ok(resp) => {
+            Ok(output) => {
+                let resp = output.map(|outcome| match outcome {
+                    HandlerOutcome::Ready(resp) => resp,
+                });
                 let resp_size = resp.data.len() as u64;
                 COPR_RESP_SIZE.inc_by(resp_size);
                 record_network_out_bytes(resp_size);
@@ -1338,7 +1341,7 @@ mod tests {
 
     #[async_trait]
     impl RequestHandler for UnaryFixture {
-        async fn handle_request(&mut self) -> Result<MemoryTraceGuard<coppb::Response>> {
+        async fn handle_request(&mut self) -> Result<MemoryTraceGuard<HandlerOutcome>> {
             if self.yieldable {
                 // We split the task into small executions of 100 milliseconds.
                 for _ in 0..self.handle_duration.as_millis() as u64 / 100 {
@@ -1352,7 +1355,10 @@ mod tests {
                 thread::sleep(self.handle_duration);
             }
 
-            self.result.take().unwrap().map(|x| x.into())
+            self.result
+                .take()
+                .unwrap()
+                .map(|x| HandlerOutcome::Ready(x).into())
         }
     }
 

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -2,11 +2,12 @@
 
 use std::{
     borrow::Cow, fmt::Display, future::Future, iter::FromIterator, marker::PhantomData, mem,
-    sync::Arc, time::Duration,
+    sync::Arc, task::Poll, time::Duration,
 };
 
 use ::tracker::{
-    GLOBAL_TRACKERS, RequestInfo, RequestType, set_tls_tracker_token, track, with_tls_tracker,
+    GLOBAL_TRACKERS, RequestInfo, RequestType, TokenFutureTracker, TrackerToken,
+    get_tls_tracker_token, set_tls_tracker_token, track, with_tls_tracker,
 };
 use anyhow::anyhow;
 use api_version::{KvFormat, dispatch_api_version};
@@ -23,8 +24,8 @@ use online_config::ConfigManager;
 use protobuf::{CodedInputStream, Message};
 use resource_control::{ResourceGroupManager, ResourceLimiter, TaskMetadata};
 use resource_metering::{
-    FutureExt, ResourceTagFactory, StreamExt, record_logical_read_bytes, record_network_in_bytes,
-    record_network_out_bytes,
+    FutureExt, ResourceMeteringTag, ResourceTagFactory, StreamExt, record_logical_read_bytes,
+    record_network_in_bytes, record_network_out_bytes,
 };
 use tidb_query_common::{
     error::StorageError,
@@ -34,7 +35,7 @@ use tidb_query_common::{
 use tikv_alloc::trace::MemoryTraceGuard;
 use tikv_kv::{ExtraRegionOverride, SnapshotExt};
 use tikv_util::{
-    deadline::set_deadline_exceeded_busy_error,
+    deadline::{Deadline, set_deadline_exceeded_busy_error},
     future::async_timeout,
     memory::{MemoryQuota, OwnedAllocated},
     quota_limiter::QuotaLimiter,
@@ -66,18 +67,43 @@ use crate::{
 /// execution.
 const LIGHT_TASK_THRESHOLD: Duration = Duration::from_millis(5);
 
+fn response_has_error(resp: &coppb::Response) -> bool {
+    resp.has_region_error() || resp.has_locked() || !resp.get_other_error().is_empty()
+}
+
+/// Records the size of response data attributed to the request tracked by
+/// `tracker`. The token is passed explicitly because response data may be
+/// serialized outside the request's own read pool task (see
+/// `BatchMergeFinalizer`), where the thread local tracker belongs to
+/// another request.
+fn record_coprocessor_response_size(resp_size: u64, tracker: TrackerToken) {
+    COPR_RESP_SIZE.inc_by(resp_size);
+    record_network_out_bytes(resp_size);
+    GLOBAL_TRACKERS.with_tracker(tracker, |tracker| {
+        tracker.metrics.coprocessor_response_bytes = tracker
+            .metrics
+            .coprocessor_response_bytes
+            .saturating_add(resp_size);
+    });
+}
+
+fn batch_response_has_error(resp: &coppb::StoreBatchTaskResponse) -> bool {
+    resp.has_region_error() || resp.has_locked() || !resp.get_other_error().is_empty()
+}
+
+type HandlerOutput = MemoryTraceGuard<HandlerOutcome>;
+
 /// Serializes a `Mergeable` outcome's result into its response data,
 /// resizing the guard's memory trace to the serialized data. A `Ready`
 /// outcome is returned unchanged. The response size is not recorded here:
 /// the caller records it once the data is in the response, exactly as for
 /// a `Ready` outcome.
-fn serialize_handler_outcome(
-    outcome: MemoryTraceGuard<HandlerOutcome>,
-) -> Result<MemoryTraceGuard<coppb::Response>> {
-    let mergeable = matches!(&*outcome, HandlerOutcome::Mergeable { .. });
+fn serialize_handler_outcome(outcome: HandlerOutput) -> Result<HandlerOutput> {
+    if !matches!(&*outcome, HandlerOutcome::Mergeable { .. }) {
+        return Ok(outcome);
+    }
     let mut serialize_err = None;
-    let mut resp = outcome.map(|outcome| match outcome {
-        HandlerOutcome::Ready(response) => response,
+    let mut outcome = outcome.map(|outcome| match outcome {
         HandlerOutcome::Mergeable {
             mut partial_response,
             result,
@@ -86,24 +112,356 @@ fn serialize_handler_outcome(
             match result.into_data() {
                 Ok(data) => {
                     partial_response.set_data(data);
-                    partial_response
+                    HandlerOutcome::Ready(partial_response)
                 }
                 Err(e) => {
                     serialize_err = Some(e);
-                    coppb::Response::default()
+                    HandlerOutcome::default()
                 }
             }
         }
+        ready => ready,
     });
     if let Some(e) = serialize_err {
-        // Dropping the placeholder response releases the guard's trace.
+        // Dropping the placeholder outcome releases the guard's trace.
         return Err(e);
     }
-    if mergeable {
-        let data_len = resp.get_data().len();
-        resp.retrace(data_len);
+    let data_len = outcome.response().get_data().len();
+    outcome.retrace(data_len);
+    Ok(outcome)
+}
+
+/// Completes after one poll, waking its task immediately. Placed between
+/// two chunks of synchronous work it gives wrappers like `check_deadline`
+/// and `limit_concurrency` a poll boundary to act on.
+fn yield_once() -> impl Future<Output = ()> {
+    let mut yielded = false;
+    future::poll_fn(move |cx| {
+        if yielded {
+            Poll::Ready(())
+        } else {
+            yielded = true;
+            cx.waker().wake_by_ref();
+            Poll::Pending
+        }
+    })
+}
+
+/// The output of handling one batched task of the request: the task's
+/// response plus, when the handler produced a `Mergeable` outcome, its
+/// still-unserialized result.
+///
+/// When `mergeable_result` is `Some`, `response` carries no data; the
+/// task's data lives in the result until `merge_batch_task_responses`
+/// either merges it into the top response or serializes it into
+/// `response`. Unlike `HandlerOutput` this carries no memory trace guard:
+/// the task's guard is consumed in `process_batch_tasks` and the
+/// serialized data is re-accounted by the top task's guard.
+struct BatchTaskOutput {
+    response: coppb::StoreBatchTaskResponse,
+    mergeable_result: Option<Box<dyn MergeableResult>>,
+}
+
+/// Drives the top task and the batched tasks concurrently until all of
+/// them complete, collecting the batched outputs in stream order.
+///
+/// Polling `batch_outputs` alongside `top_output` matters: a batched task
+/// is enqueued into the read pool only when its future is first polled
+/// (see `handle_unary_request`), while its deadline starts at parse time.
+/// Awaiting the top task first would leave every batched task unscheduled
+/// behind an arbitrarily slow top task and could expire their deadlines
+/// before they run at all.
+async fn collect_batch_task_outputs(
+    top_output: impl Future<Output = HandlerOutput>,
+    batch_outputs: impl Stream<Item = BatchTaskOutput>,
+) -> (HandlerOutput, Vec<BatchTaskOutput>) {
+    let mut completed_outputs = Vec::new();
+    let batch_outputs = batch_outputs.fuse();
+    futures::pin_mut!(top_output, batch_outputs);
+    let output = loop {
+        match future::select(top_output.as_mut(), batch_outputs.next()).await {
+            Either::Left((output, _)) => break output,
+            Either::Right((Some(batch_output), _)) => completed_outputs.push(batch_output),
+            Either::Right((None, _)) => break top_output.await,
+        }
+    };
+    while let Some(batch_output) = batch_outputs.next().await {
+        completed_outputs.push(batch_output);
     }
-    Ok(resp)
+    (output, completed_outputs)
+}
+
+/// Merges and serializes the collected outputs into the final response.
+/// `tracker` is the top task's token, which owns the response bytes
+/// committed here; the batched tasks' trackers are already gone.
+///
+/// When the top task kept an error-free mergeable result, each compatible
+/// successful batched result is merged into it and dropped. Only its
+/// data-less acknowledgment and execution details remain. Other results
+/// are serialized into their own batch responses. Batch responses follow
+/// the order in which `batch_outputs` yields them.
+///
+/// This is the CPU-heavy step of a batched request outside its handlers,
+/// so the endpoint runs it in the read pool (see `BatchMergeFinalizer`).
+/// The deadline is checked and the task yields between per-task steps, and
+/// the response is committed — acknowledgments and per-task data
+/// attached, response bytes accounted, memory retraced — only after a
+/// final deadline check that follows the synchronous top-result encoding.
+/// On any deadline failure the whole response degrades to a plain error
+/// without data, acknowledgments or batch responses, charging nothing:
+/// consumed results cannot be recovered, and the top error makes the
+/// client retry every task, so nothing is lost or double-counted.
+async fn merge_batch_task_responses(
+    mut output: HandlerOutput,
+    batch_outputs: Vec<BatchTaskOutput>,
+    tracker: TrackerToken,
+    deadline: Deadline,
+) -> MemoryTraceGuard<coppb::Response> {
+    let merge_batch_results = matches!(
+        &*output,
+        HandlerOutcome::Mergeable {
+            partial_response,
+            ..
+        } if !response_has_error(partial_response)
+    );
+    let mut merged_batch_result = false;
+    let mut batch_responses = Vec::with_capacity(batch_outputs.len());
+
+    for mut batch_output in batch_outputs {
+        if deadline.check().is_err() {
+            return make_error_response(Error::DeadlineExceeded).into();
+        }
+        let can_merge = merge_batch_results
+            && !batch_response_has_error(&batch_output.response)
+            && batch_output.mergeable_result.is_some();
+        if can_merge {
+            debug_assert!(batch_output.response.get_data().is_empty());
+            let HandlerOutcome::Mergeable { result: merged, .. } = &mut *output else {
+                unreachable!("batch merging requires a mergeable top result");
+            };
+            merged.merge(batch_output.mergeable_result.take().unwrap());
+            batch_output.response.set_data_merged_into_response(true);
+            merged_batch_result = true;
+        }
+        batch_responses.push(resolve_batch_task_output(batch_output));
+        yield_once().await;
+    }
+
+    if deadline.check().is_err() {
+        return make_error_response(Error::DeadlineExceeded).into();
+    }
+    build_batched_response(
+        output,
+        batch_responses,
+        tracker,
+        Some(deadline),
+        merged_batch_result,
+    )
+}
+
+/// Serializes an unmerged mergeable result into its batch response,
+/// confining a failure to the task. The serialized bytes are accounted
+/// only when the whole batched response is committed
+/// (`build_batched_response`), never for a response that is not returned.
+fn resolve_batch_task_output(mut output: BatchTaskOutput) -> coppb::StoreBatchTaskResponse {
+    if let Some(mergeable) = output.mergeable_result {
+        match mergeable.into_data() {
+            Ok(data) => output.response.set_data(data),
+            Err(e) => make_error_batch_response(&mut output.response, e),
+        }
+    }
+    output.response
+}
+
+/// Builds the top task's final response: serializes a still-unserialized
+/// top result into its response data, attaches the batch responses, and
+/// resizes the guard's memory trace to the serialized data.
+///
+/// `commit_deadline` is set on the finalizer path, where results are
+/// serialized here and nothing is accounted yet: encoding the top result
+/// is synchronous and unbounded by the per-step deadline checks, so the
+/// deadline is re-checked after it, and only then is the response
+/// committed — batch responses attached and every byte the response
+/// carries accounted at once. An encode that outlived the deadline yields
+/// the plain retryable error and charges nothing. Without a
+/// `commit_deadline` (the unmerged path), every piece was serialized and
+/// accounted inside its own pipeline task already, so the responses are
+/// only attached.
+fn build_batched_response(
+    output: HandlerOutput,
+    batch_responses: Vec<coppb::StoreBatchTaskResponse>,
+    tracker: TrackerToken,
+    commit_deadline: Option<Deadline>,
+    merged_batch_result: bool,
+) -> MemoryTraceGuard<coppb::Response> {
+    let batch_data_len: u64 = batch_responses
+        .iter()
+        .map(|resp| resp.get_data().len() as u64)
+        .sum();
+    let mut resp = output.map(|outcome| {
+        let mut response = match outcome {
+            HandlerOutcome::Ready(response) => response,
+            HandlerOutcome::Mergeable {
+                mut partial_response,
+                result,
+            } => {
+                debug_assert!(partial_response.get_data().is_empty());
+                match result.into_data() {
+                    Ok(data) => {
+                        partial_response.set_data(data);
+                        partial_response
+                    }
+                    // Once a child result has been merged it cannot be
+                    // recovered for an individual response. No acknowledgments
+                    // or partial data are returned, so a retry cannot lose or
+                    // double-count results.
+                    Err(e) if merged_batch_result => return make_error_response(e),
+                    Err(e) => make_error_response(e),
+                }
+            }
+        };
+        if let Some(deadline) = commit_deadline {
+            if deadline.check().is_err() {
+                return make_error_response(Error::DeadlineExceeded);
+            }
+            record_coprocessor_response_size(
+                response.get_data().len() as u64 + batch_data_len,
+                tracker,
+            );
+        }
+        response.set_batch_responses(batch_responses.into());
+        response
+    });
+    let data_len = resp
+        .get_batch_responses()
+        .iter()
+        .fold(resp.get_data().len(), |len, batch_resp| {
+            len.saturating_add(batch_resp.get_data().len())
+        });
+    resp.retrace(data_len);
+    resp
+}
+
+/// Runs `merge_batch_task_responses` of one batched request as a read pool
+/// task, restoring the protections its handlers ran under: read pool
+/// scheduling and resource control, the request's resource tag, its
+/// deadline, the coprocessor semaphore, and execution time tracking.
+///
+/// Merging is always heavy work, so the semaphore permit is taken before
+/// the first merge step instead of through `limit_concurrency`'s
+/// permit-free fast path, whose per-poll bookkeeping cannot stop the
+/// merge's coarse first chunk. The wait is bounded by the deadline;
+/// nothing is consumed while waiting, so the expiry error is retry-safe.
+/// The collected results stay in a cancelable handoff slot until the pool
+/// task starts. If admission or queueing outlives the deadline, the caller
+/// removes and drops them; a task left in the pool sees an empty slot and
+/// exits without merging. Pool rejection or loss instead sheds the request
+/// with a retryable busy error, exactly like an ordinary admission failure.
+/// Merge work never runs on the caller's executor. The finalizer is built from
+/// the top task's request before parsing consumes it (see
+/// `Endpoint::batch_merge_finalizer`).
+struct BatchMergeFinalizer {
+    read_pool: ReadPoolHandle,
+    semaphore: Option<Arc<Semaphore>>,
+    resource_tag: ResourceMeteringTag,
+    priority: CommandPri,
+    metadata: TaskMetadata<'static>,
+    resource_limiter: Option<Arc<ResourceLimiter>>,
+    deadline: Deadline,
+    task_id: u64,
+}
+
+impl BatchMergeFinalizer {
+    async fn finalize(
+        self,
+        output: HandlerOutput,
+        batch_outputs: Vec<BatchTaskOutput>,
+        tracker: TrackerToken,
+    ) -> MemoryTraceGuard<coppb::Response> {
+        let Self {
+            read_pool,
+            semaphore,
+            resource_tag,
+            priority,
+            metadata,
+            resource_limiter,
+            deadline,
+            task_id,
+        } = self;
+        // The handlers' own trackers are consumed by now, so the merge
+        // attributes its poll time to the request tracker, which
+        // `merge_time_detail` folds into the top task's process and suspend
+        // time. Created here so the wait for a pool slot counts as suspend.
+        let poll_tracker = TokenFutureTracker::new(tracker);
+        let work = track(
+            async move {
+                let _permit = match &semaphore {
+                    Some(semaphore) => {
+                        match async_timeout(semaphore.acquire(), deadline.remaining_duration())
+                            .await
+                        {
+                            Ok(permit) => Some(permit.expect("the semaphore never be closed")),
+                            Err(_) => {
+                                return make_error_response(Error::DeadlineExceeded).into();
+                            }
+                        }
+                    }
+                    None => None,
+                };
+                merge_batch_task_responses(output, batch_outputs, tracker, deadline).await
+            },
+            poll_tracker,
+        )
+        .in_resource_metering_tag(resource_tag);
+        // The collectors stay outside the pool task until the task is polled.
+        // This lets the caller drop them on an admission or queue timeout even
+        // though the read pool has no task-cancellation handle.
+        let work_slot = Arc::new(std::sync::Mutex::new(Some(work)));
+        let pool_work_slot = Arc::clone(&work_slot);
+        let (tx, rx) = oneshot::channel();
+        let pool_work = async move {
+            let work = pool_work_slot.lock().unwrap().take();
+            if let Some(work) = work {
+                let _ = tx.send(work.await);
+            }
+        };
+        // The merge works on memory the request already owns and accounts,
+        // so unlike `read_pool_spawn_with_memory_quota_check` this spawn
+        // does not reserve additional quota.
+        let spawned = read_pool.spawn(pool_work, priority, task_id, metadata, resource_limiter);
+        match async_timeout(spawned, deadline.remaining_duration()).await {
+            Ok(Ok(())) => {}
+            Ok(Err(_)) => {
+                drop(work_slot.lock().unwrap().take());
+                return make_error_response(Error::MaxPendingTasksExceeded).into();
+            }
+            Err(_) => {
+                drop(work_slot.lock().unwrap().take());
+                return make_error_response(Error::DeadlineExceeded).into();
+            }
+        }
+        let mut rx = rx;
+        match async_timeout(&mut rx, deadline.remaining_duration()).await {
+            Ok(Ok(resp)) => resp,
+            Ok(Err(_)) => {
+                drop(work_slot.lock().unwrap().take());
+                make_error_response(Error::MaxPendingTasksExceeded).into()
+            }
+            Err(_) => match rx.try_recv() {
+                // The response committed before this caller was polled again.
+                // It is preserved instead of racing an already-ready timer.
+                Ok(Some(resp)) => resp,
+                Ok(None) => {
+                    drop(work_slot.lock().unwrap().take());
+                    make_error_response(Error::DeadlineExceeded).into()
+                }
+                Err(_) => {
+                    drop(work_slot.lock().unwrap().take());
+                    make_error_response(Error::MaxPendingTasksExceeded).into()
+                }
+            },
+        }
+    }
 }
 
 /// A pool to build and run Coprocessor request handlers.
@@ -520,14 +878,18 @@ impl<E: Engine> Endpoint<E> {
     /// request interface of the `RequestHandler` to process the request and
     /// produce a result.
     ///
-    /// A `Mergeable` outcome is serialized into its response right here —
-    /// inside the deadline, tracking, concurrency and resource protections
-    /// of the request, like any `Ready` response's data.
+    /// When `serialize_outcome` is set, a `Mergeable` outcome is serialized
+    /// into its response right here — inside the deadline, tracking,
+    /// concurrency and resource protections of the request, like any `Ready`
+    /// response's data. Callers clear it only when the endpoint merges
+    /// batched results, in which case the result stays unserialized until
+    /// `merge_batch_task_responses`.
     async fn handle_unary_request_impl(
         semaphore: Option<Arc<Semaphore>>,
         mut tracker: Box<Tracker<E>>,
         handler_builder: RequestHandlerBuilder<E::IMSnap>,
-    ) -> Result<MemoryTraceGuard<coppb::Response>> {
+        serialize_outcome: bool,
+    ) -> Result<HandlerOutput> {
         with_tls_tracker(|tracker1| {
             record_network_in_bytes(tracker1.metrics.grpc_req_size);
         });
@@ -580,7 +942,11 @@ impl<E: Engine> Endpoint<E> {
         let handle_request_future = handler.handle_request();
         let process_future = async move {
             let outcome = handle_request_future.await?;
-            serialize_handler_outcome(outcome)
+            if serialize_outcome {
+                serialize_handler_outcome(outcome)
+            } else {
+                Ok(outcome)
+            }
         };
         let process_future = check_deadline(process_future, deadline);
         let process_future = track(process_future, tracker.as_mut());
@@ -600,18 +966,22 @@ impl<E: Engine> Endpoint<E> {
         let mut storage_stats = Statistics::default();
         handler.collect_scan_statistics(&mut storage_stats);
         tracker.collect_storage_statistics(storage_stats);
-        let mut resp = match result {
-            Ok(resp) => {
-                let resp_size = resp.data.len() as u64;
-                COPR_RESP_SIZE.inc_by(resp_size);
-                record_network_out_bytes(resp_size);
-                with_tls_tracker(|tracker| {
-                    tracker.metrics.coprocessor_response_bytes = tracker
-                        .metrics
-                        .coprocessor_response_bytes
-                        .saturating_add(resp_size);
-                });
-                resp
+        let mut resp: HandlerOutput = match result {
+            Ok(outcome) => {
+                // On the merge path (`serialize_outcome` cleared) nothing
+                // is recorded here at all: even a `Ready` outcome's data —
+                // a cache hit, say — is accounted only if and when the
+                // batched response is committed
+                // (`build_batched_response`), so bytes are neither charged
+                // twice nor charged for a response that is never returned.
+                // A `Mergeable` outcome carries no data yet either way.
+                if serialize_outcome {
+                    record_coprocessor_response_size(
+                        outcome.response().get_data().len() as u64,
+                        get_tls_tracker_token(),
+                    );
+                }
+                outcome
             }
             Err(e) => {
                 if let Error::DefaultNotFound(errmsg) = &e {
@@ -620,15 +990,16 @@ impl<E: Engine> Endpoint<E> {
                         "reqCtx" => ?&tracker.req_ctx,
                     );
                 }
-                make_error_response(e).into()
+                HandlerOutcome::Ready(make_error_response(e)).into()
             }
         };
         let (exec_details, exec_details_v2) = tracker.get_exec_details();
         tracker.on_finish_all_items();
         record_logical_read_bytes(exec_details_v2.get_scan_detail_v2().processed_versions_size);
-        resp.set_exec_details(exec_details);
-        resp.set_exec_details_v2(exec_details_v2);
-        resp.set_latest_buckets_version(buckets_version);
+        let response = resp.response_mut();
+        response.set_exec_details(exec_details);
+        response.set_exec_details_v2(exec_details_v2);
+        response.set_latest_buckets_version(buckets_version);
         Ok(resp)
     }
 
@@ -636,10 +1007,16 @@ impl<E: Engine> Endpoint<E> {
     ///
     /// Returns `Err(err)` if the read pool is full. Returns `Ok(future)` in
     /// other cases. The future inside may be an error however.
+    ///
+    /// Note that the read pool task is enqueued only once the returned
+    /// future is first polled, while the request's deadline is already
+    /// counting down; the caller must not sit on the future.
+    /// `serialize_outcome` is described on `handle_unary_request_impl`.
     fn handle_unary_request(
         &self,
         r: ParseCopRequestResult<E::IMSnap>,
-    ) -> impl Future<Output = Result<MemoryTraceGuard<coppb::Response>>> {
+        serialize_outcome: bool,
+    ) -> impl Future<Output = Result<HandlerOutput>> {
         let req_ctx = r.req_ctx;
         let priority = req_ctx.context.get_priority();
         let task_id = req_ctx.build_task_id();
@@ -672,12 +1049,16 @@ impl<E: Engine> Endpoint<E> {
         allocated_bytes += tracker.approximate_mem_size();
 
         let (tx, rx) = oneshot::channel();
-        let future =
-            Self::handle_unary_request_impl(self.semaphore.clone(), tracker, r.handler_builder)
-                .in_resource_metering_tag(resource_tag)
-                .map(move |res| {
-                    let _ = tx.send(res);
-                });
+        let future = Self::handle_unary_request_impl(
+            self.semaphore.clone(),
+            tracker,
+            r.handler_builder,
+            serialize_outcome,
+        )
+        .in_resource_metering_tag(resource_tag)
+        .map(move |res| {
+            let _ = tx.send(res);
+        });
         let spawn_fut_result = self.read_pool_spawn_with_memory_quota_check(
             allocated_bytes,
             future,
@@ -717,53 +1098,101 @@ impl<E: Engine> Endpoint<E> {
             return Either::Left(async move { resp.into() });
         }
 
-        let result_of_batch = self.process_batch_tasks(&mut req, &peer);
+        // Merging batched results into the top response can happen only when
+        // the client allows it and there are batched tasks; every other
+        // request serializes its outcome inside its own read pool task (see
+        // `handle_unary_request_impl`).
+        let merge_batch_tasks =
+            req.get_allow_batch_task_data_merge() && !req.get_tasks().is_empty();
+        let finalize_context = merge_batch_tasks.then(|| req.get_context().clone());
+        let batch_outputs = self.process_batch_tasks(&mut req, &peer);
         set_tls_tracker_token(tracker);
         with_tls_tracker(|tracker| {
             tracker.metrics.grpc_req_size = req.compute_size() as u64;
         });
+        let mut top_deadline = None;
+        let mut top_task_id = 0;
         let result_of_future = self
             .parse_request_and_check_memory_locks(req, peer, false)
-            .map(|r| self.handle_unary_request(r));
+            .map(|r| {
+                top_deadline = Some(r.req_ctx.deadline);
+                top_task_id = r.req_ctx.build_task_id();
+                self.handle_unary_request(r, !merge_batch_tasks)
+            });
         with_tls_tracker(|tracker| {
             tracker.metrics.grpc_process_nanos =
                 tracker.req_info.begin.saturating_elapsed().as_nanos() as u64;
         });
+        let batch_finalizer = finalize_context.map(|ctx| {
+            self.batch_merge_finalizer(
+                ctx,
+                // Parsing the top request may have failed; the batched
+                // results are then finalized under a fresh default deadline.
+                top_deadline.unwrap_or_else(|| Deadline::from_now(self.max_handle_duration)),
+                top_task_id,
+            )
+        });
         let fut = async move {
-            let res = match result_of_future {
-                Err(e) => {
-                    let mut res = make_error_response(e);
-                    let batch_res = result_of_batch.await;
-                    res.set_batch_responses(batch_res.into());
-                    res.into()
-                }
-                Ok(handle_fut) => {
-                    let (handle_res, batch_res) = futures::join!(handle_fut, result_of_batch);
-                    let mut res = handle_res.unwrap_or_else(|e| make_error_response(e).into());
-                    res.set_batch_responses(batch_res.into());
-                    GLOBAL_TRACKERS.with_tracker(tracker, |tracker| {
-                        let exec_detail_v2 = res.mut_exec_details_v2();
-                        tracker.write_scan_detail(exec_detail_v2.mut_scan_detail_v2());
-                        tracker.merge_time_detail(exec_detail_v2.mut_time_detail_v2());
-                    });
-                    res
+            let collect_top_details = result_of_future.is_ok();
+            let top_output = async move {
+                match result_of_future {
+                    Err(e) => HandlerOutcome::Ready(make_error_response(e)).into(),
+                    Ok(handle_fut) => handle_fut
+                        .await
+                        .unwrap_or_else(|e| HandlerOutcome::Ready(make_error_response(e)).into()),
                 }
             };
+            let (output, batch_outputs) =
+                collect_batch_task_outputs(top_output, batch_outputs).await;
+            let mut res = match batch_finalizer {
+                Some(finalizer) => finalizer.finalize(output, batch_outputs, tracker).await,
+                // No merging can happen: every outcome was serialized inside
+                // its own read pool task (see `handle_unary_request_impl`),
+                // so the ready responses only need to be attached. A
+                // leftover mergeable result is still resolved defensively.
+                None => {
+                    debug_assert!(!matches!(&*output, HandlerOutcome::Mergeable { .. }));
+                    let batch_responses = batch_outputs
+                        .into_iter()
+                        .map(resolve_batch_task_output)
+                        .collect();
+                    build_batched_response(output, batch_responses, tracker, None, false)
+                }
+            };
+            if collect_top_details {
+                GLOBAL_TRACKERS.with_tracker(tracker, |tracker| {
+                    let exec_detail_v2 = res.mut_exec_details_v2();
+                    tracker.write_scan_detail(exec_detail_v2.mut_scan_detail_v2());
+                    tracker.merge_time_detail(exec_detail_v2.mut_time_detail_v2());
+                });
+            }
+            // Finalizing may serialize response data (see
+            // `HandlerOutcome::Mergeable`), which was not yet recorded when
+            // the response details were produced.
+            GLOBAL_TRACKERS.with_tracker(tracker, |tracker| {
+                res.mut_exec_details_v2()
+                    .mut_ru_v2()
+                    .set_coprocessor_response_bytes(tracker.metrics.coprocessor_response_bytes);
+            });
             GLOBAL_TRACKERS.remove(tracker);
             res
         };
         Either::Right(fut)
     }
 
-    // process_batch_tasks process the input batched coprocessor tasks if any,
-    // prepare all the requests and schedule them into the read pool, then
-    // collect all the responses and convert them into the `StoreBatchResponse`
-    // type.
-    pub fn process_batch_tasks(
+    // All batched coprocessor tasks are prepared and their outputs are streamed
+    // in request order. FuturesOrdered still polls the tasks concurrently when
+    // the stream is polled, so the caller must poll it promptly (see
+    // `collect_batch_task_outputs`).
+    fn process_batch_tasks(
         &self,
         req: &mut coppb::Request,
         peer: &Option<String>,
-    ) -> impl Future<Output = Vec<coppb::StoreBatchTaskResponse>> {
+    ) -> impl Stream<Item = BatchTaskOutput> {
+        // Without merging, every task serializes its result inside its own
+        // read pool task; with it, results stay unserialized for
+        // `merge_batch_task_responses`.
+        let serialize_outcome = !req.get_allow_batch_task_data_merge();
         let mut batch_futs = Vec::with_capacity(req.tasks.len());
         let batch_reqs: Vec<(coppb::Request, u64)> = req
             .take_tasks()
@@ -793,11 +1222,22 @@ impl<E: Engine> Endpoint<E> {
                 Ok(r) => {
                     let cur_tracker = GLOBAL_TRACKERS.insert(::tracker::Tracker::new(request_info));
                     set_tls_tracker_token(cur_tracker);
-                    let fut = self.handle_unary_request(r);
+                    let fut = self.handle_unary_request(r, serialize_outcome);
                     let fut = async move {
                         let res = fut.await;
+                        let mut mergeable_result = None;
                         match res {
-                            Ok(mut resp) => {
+                            Ok(mut output) => {
+                                let mut resp = match output.consume() {
+                                    HandlerOutcome::Ready(response) => response,
+                                    HandlerOutcome::Mergeable {
+                                        partial_response,
+                                        result,
+                                    } => {
+                                        mergeable_result = Some(result);
+                                        partial_response
+                                    }
+                                };
                                 response.set_data(resp.take_data());
                                 if let Some(err) = resp.region_error.take() {
                                     response.set_region_error(err);
@@ -819,18 +1259,50 @@ impl<E: Engine> Endpoint<E> {
                             }
                         }
                         GLOBAL_TRACKERS.remove(cur_tracker);
-                        response
+                        BatchTaskOutput {
+                            response,
+                            mergeable_result,
+                        }
                     };
 
                     batch_futs.push(future::Either::Left(fut));
                 }
                 Err(e) => batch_futs.push(future::Either::Right(async move {
                     make_error_batch_response(&mut response, e);
-                    response
+                    BatchTaskOutput {
+                        response,
+                        mergeable_result: None,
+                    }
                 })),
             }
         }
-        stream::FuturesOrdered::from_iter(batch_futs).collect()
+        stream::FuturesOrdered::from_iter(batch_futs)
+    }
+
+    /// Builds the runner of the deferred merge/serialization of a batched
+    /// request (see `BatchMergeFinalizer`) from the top request's context.
+    fn batch_merge_finalizer(
+        &self,
+        ctx: kvrpcpb::Context,
+        deadline: Deadline,
+        task_id: u64,
+    ) -> BatchMergeFinalizer {
+        BatchMergeFinalizer {
+            read_pool: self.read_pool.clone(),
+            semaphore: self.semaphore.clone(),
+            resource_tag: self.resource_tag_factory.new_tag(&ctx),
+            priority: ctx.get_priority(),
+            metadata: TaskMetadata::from_ctx(ctx.get_resource_control_context()).deep_clone(),
+            resource_limiter: self.resource_ctl.as_ref().and_then(|r| {
+                r.get_resource_limiter(
+                    ctx.get_resource_control_context().get_resource_group_name(),
+                    ctx.get_request_source(),
+                    ctx.get_resource_control_context().get_override_priority(),
+                )
+            }),
+            deadline,
+            task_id,
+        }
     }
 
     /// The real implementation of handling a stream request.
@@ -1328,23 +1800,37 @@ mod tests {
         thread, vec,
     };
 
+    use file_system::IoBytes;
     use futures::executor::{block_on, block_on_stream};
     use kvproto::kvrpcpb::{IsolationLevel, LockInfo};
     use protobuf::Message;
     use raft::StateRole;
-    use raftstore::coprocessor::region_info_accessor::MockRegionInfoProvider;
+    use raftstore::{
+        coprocessor::region_info_accessor::MockRegionInfoProvider,
+        store::{ReadStats, WriteStats},
+    };
     use tidb_query_common::storage::Storage;
     use tikv_kv::{MockEngine, MockEngineBuilder, destroy_tls_engine, set_tls_engine};
+    use tikv_util::yatp_pool::CleanupMethod;
     use tipb::{Executor, Expr};
     use txn_types::{Key, LockType};
 
     use super::*;
     use crate::{
-        config::CoprReadPoolConfig,
+        config::{CoprReadPoolConfig, UnifiedReadPoolConfig},
         coprocessor::readpool_impl::build_read_pool_for_test,
-        read_pool::ReadPool,
-        storage::{Store, TestEngineBuilder, kv::RocksEngine},
+        read_pool::{ReadPool, build_yatp_read_pool},
+        storage::{FlowStatsReporter, Store, TestEngineBuilder, kv::RocksEngine},
     };
+
+    #[derive(Clone)]
+    struct DummyFlowStatsReporter;
+
+    impl FlowStatsReporter for DummyFlowStatsReporter {
+        fn report_read_stats(&self, _read_stats: ReadStats) {}
+
+        fn report_write_stats(&self, _write_stats: WriteStats) {}
+    }
 
     /// A unary `RequestHandler` that always produces a fixture.
     struct UnaryFixture {
@@ -1408,11 +1894,22 @@ mod tests {
         }
     }
 
+    /// Resolves the output of `handle_unary_request` into its response,
+    /// which must be ready.
+    fn unwrap_ready(output: HandlerOutput) -> MemoryTraceGuard<coppb::Response> {
+        output.map(|outcome| match outcome {
+            HandlerOutcome::Ready(response) => response,
+            HandlerOutcome::Mergeable { .. } => panic!("expected a ready response"),
+        })
+    }
+
     /// A mergeable result that concatenates task values.
     #[derive(Default)]
     struct ConcatMergeable {
         values: Vec<u8>,
         fail_serialize: bool,
+        serialize_delay: Duration,
+        merge_count: Option<Arc<atomic::AtomicUsize>>,
     }
 
     impl MergeableResult for ConcatMergeable {
@@ -1421,14 +1918,20 @@ mod tests {
                 .downcast::<ConcatMergeable>()
                 .unwrap();
             self.values.extend(other.values);
+            if let Some(merge_count) = &self.merge_count {
+                merge_count.fetch_add(1, atomic::Ordering::SeqCst);
+            }
         }
 
         fn into_data(mut self: Box<Self>) -> Result<Vec<u8>> {
             if self.fail_serialize {
                 return Err(box_err!("cannot serialize"));
             }
-            // This fixture obeys `MergeableResult`'s order-independent
-            // contract even when merge order changes.
+            if !self.serialize_delay.is_zero() {
+                thread::sleep(self.serialize_delay);
+            }
+            // This test double's output stays canonical so finalizer tests can
+            // vary completion timing without changing their expected payload.
             self.values.sort_unstable();
             Ok(self.values)
         }
@@ -1440,7 +1943,44 @@ mod tests {
             result: Box::new(ConcatMergeable {
                 values,
                 fail_serialize,
+                ..Default::default()
             }),
+        }
+    }
+
+    fn slow_mergeable_outcome(values: Vec<u8>, serialize_delay: Duration) -> HandlerOutcome {
+        HandlerOutcome::Mergeable {
+            partial_response: coppb::Response::default(),
+            result: Box::new(ConcatMergeable {
+                values,
+                serialize_delay,
+                ..Default::default()
+            }),
+        }
+    }
+
+    fn observed_mergeable_outcome(
+        values: Vec<u8>,
+        merge_count: Arc<atomic::AtomicUsize>,
+    ) -> HandlerOutcome {
+        HandlerOutcome::Mergeable {
+            partial_response: coppb::Response::default(),
+            result: Box::new(ConcatMergeable {
+                values,
+                merge_count: Some(merge_count),
+                ..Default::default()
+            }),
+        }
+    }
+
+    fn mergeable_batch_output(values: Vec<u8>, fail_serialize: bool) -> BatchTaskOutput {
+        BatchTaskOutput {
+            response: coppb::StoreBatchTaskResponse::default(),
+            mergeable_result: Some(Box::new(ConcatMergeable {
+                values,
+                fail_serialize,
+                ..Default::default()
+            })),
         }
     }
 
@@ -1457,16 +1997,334 @@ mod tests {
         }
     }
 
+    fn merge_batch_task_responses_for_test(
+        output: HandlerOutput,
+        batch_outputs: Vec<BatchTaskOutput>,
+    ) -> MemoryTraceGuard<coppb::Response> {
+        block_on(merge_batch_task_responses(
+            output,
+            batch_outputs,
+            ::tracker::INVALID_TRACKER_TOKEN,
+            Deadline::from_now(Duration::from_secs(60)),
+        ))
+    }
+
+    /// Sets every detail counter to `value`, so tests catch a task's
+    /// details being dropped or mixed up while attaching.
+    fn filled_exec_details_v2(value: u64) -> kvrpcpb::ExecDetailsV2 {
+        let mut details = kvrpcpb::ExecDetailsV2::default();
+        let scan = details.mut_scan_detail_v2();
+        scan.processed_versions = value;
+        scan.processed_versions_size = value;
+        scan.total_versions = value;
+        scan.rocksdb_delete_skipped_count = value;
+        scan.rocksdb_key_skipped_count = value;
+        scan.rocksdb_block_cache_hit_count = value;
+        scan.rocksdb_block_read_count = value;
+        scan.rocksdb_block_read_byte = value;
+        scan.rocksdb_block_read_nanos = value;
+        scan.get_snapshot_nanos = value;
+        scan.read_index_propose_wait_nanos = value;
+        scan.read_index_confirm_wait_nanos = value;
+        scan.read_pool_schedule_wait_nanos = value;
+        let time = details.mut_time_detail_v2();
+        time.wait_wall_time_ns = value;
+        time.process_wall_time_ns = value;
+        time.process_suspend_wall_time_ns = value;
+        time.kv_read_wall_time_ns = value;
+        details
+    }
+
+    #[test]
+    fn test_collect_batch_task_outputs_polls_batch_tasks_concurrently() {
+        // The top task must not gate the batched tasks: their read pool
+        // tasks are enqueued only when the stream is polled while their
+        // deadlines are already counting down. Here the top task completes
+        // only after the batched task ran, so awaiting the top task first
+        // would hang forever.
+        let (tx, rx) = oneshot::channel::<()>();
+        let top = async move {
+            rx.await.unwrap();
+            HandlerOutput::from(HandlerOutcome::Ready(coppb::Response::default()))
+        };
+        let mut tx = Some(tx);
+        let batch_outputs = stream::iter([2u8, 3]).then(move |value| {
+            if let Some(tx) = tx.take() {
+                tx.send(()).unwrap();
+            }
+            future::ready(mergeable_batch_output(vec![value], false))
+        });
+        let (output, batch_outputs) = block_on(collect_batch_task_outputs(top, batch_outputs));
+        assert!(matches!(&*output, HandlerOutcome::Ready(_)));
+        // Outputs are collected in the order supplied by the stream.
+        let values: Vec<_> = batch_outputs
+            .into_iter()
+            .map(|output| output.mergeable_result.unwrap().into_data().unwrap())
+            .collect();
+        assert_eq!(values, vec![vec![2], vec![3]]);
+    }
+
+    #[test]
+    fn test_merge_batch_task_responses_merge() {
+        // Successful mergeable results are merged into the top result and
+        // acknowledged data-less, keeping request order and their own
+        // execution details. The serialized merged data becomes traced by
+        // the guard's memory trace.
+        let merge_count = Arc::new(atomic::AtomicUsize::new(0));
+        let mut outcome = observed_mergeable_outcome(vec![1], merge_count.clone());
+        outcome
+            .response_mut()
+            .set_exec_details_v2(filled_exec_details_v2(1));
+        let mut batch_outputs = vec![
+            mergeable_batch_output(vec![3], false),
+            mergeable_batch_output(vec![2], false),
+        ];
+        batch_outputs[0]
+            .response
+            .set_exec_details_v2(filled_exec_details_v2(100));
+        batch_outputs[1]
+            .response
+            .set_exec_details_v2(filled_exec_details_v2(10));
+
+        let trace = tikv_alloc::mem_trace!(test_merge_batch_responses);
+        let output = trace.trace_guard(outcome, 0);
+        let resp = merge_batch_task_responses_for_test(output, batch_outputs);
+        assert_eq!(merge_count.load(atomic::Ordering::SeqCst), 2);
+        assert_eq!(resp.get_data(), &[1, 2, 3]);
+        assert!(!response_has_error(&resp));
+        assert_eq!(resp.get_exec_details_v2(), &filled_exec_details_v2(1));
+        let batch_resps = resp.get_batch_responses();
+        assert_eq!(batch_resps.len(), 2);
+        for (batch_resp, value) in batch_resps.iter().zip([100, 10]) {
+            assert!(batch_resp.get_data_merged_into_response());
+            assert!(batch_resp.get_data().is_empty());
+            assert_eq!(
+                batch_resp.get_exec_details_v2(),
+                &filled_exec_details_v2(value)
+            );
+        }
+        assert_eq!(trace.sum(), 3);
+        drop(resp);
+        assert_eq!(trace.sum(), 0);
+    }
+
+    #[test]
+    fn test_merge_batch_task_responses_top_error_blocks_merge() {
+        // A failed top task blocks merging even when every batched
+        // task kept a mergeable result.
+        let mut outcome = mergeable_outcome(vec![1], false);
+        outcome
+            .response_mut()
+            .set_other_error("top failed".to_owned());
+        let resp = merge_batch_task_responses_for_test(
+            outcome.into(),
+            vec![mergeable_batch_output(vec![2], false)],
+        );
+        assert_eq!(resp.get_other_error(), "top failed");
+        assert_eq!(resp.get_data(), &[1]);
+        let batch_resps = resp.get_batch_responses();
+        assert_eq!(batch_resps.len(), 1);
+        assert!(!batch_resps[0].get_data_merged_into_response());
+        assert_eq!(batch_resps[0].get_data(), &[2]);
+    }
+
+    #[test]
+    fn test_merge_batch_task_responses_deadline() {
+        // An exceeded deadline degrades the whole response to a plain error
+        // without data, acknowledgments or batch responses: the top error
+        // makes the client retry every task, so nothing is lost or
+        // double-counted. The consumed results release their traces.
+        let deadline = Deadline::from_now(Duration::ZERO);
+        thread::sleep(Duration::from_millis(200));
+        let trace = tikv_alloc::mem_trace!(test_merge_deadline);
+        let output = trace.trace_guard(mergeable_outcome(vec![1], false), 5);
+        let resp = block_on(merge_batch_task_responses(
+            output,
+            vec![mergeable_batch_output(vec![2], false)],
+            ::tracker::INVALID_TRACKER_TOKEN,
+            deadline,
+        ));
+        assert!(resp.has_region_error());
+        assert!(resp.get_data().is_empty());
+        assert!(resp.get_batch_responses().is_empty());
+        assert_eq!(trace.sum(), 0);
+    }
+
+    #[test]
+    fn test_merge_batch_task_responses_commit_deadline() {
+        // Encoding the top result is synchronous and unbounded by the
+        // per-step deadline checks: a deadline that expires during it must
+        // degrade the response to a plain error that carries and charges
+        // nothing, so the client retries every task. (Under extreme load
+        // the earlier checks may fire instead; the assertions hold either
+        // way.)
+        let token = GLOBAL_TRACKERS.insert(::tracker::Tracker::new(RequestInfo::new(
+            &kvrpcpb::Context::default(),
+            RequestType::Unknown,
+            0,
+        )));
+        let trace = tikv_alloc::mem_trace!(test_commit_deadline);
+        let output = trace.trace_guard(slow_mergeable_outcome(vec![1], Duration::from_secs(1)), 5);
+        let resp = block_on(merge_batch_task_responses(
+            output,
+            vec![mergeable_batch_output(vec![2], false)],
+            token,
+            Deadline::from_now(Duration::from_millis(500)),
+        ));
+        assert!(resp.has_region_error());
+        assert!(resp.get_data().is_empty());
+        assert!(resp.get_batch_responses().is_empty());
+        assert_eq!(trace.sum(), 0);
+        let mut response_bytes = 0;
+        GLOBAL_TRACKERS.with_tracker(token, |tracker| {
+            response_bytes = tracker.metrics.coprocessor_response_bytes;
+        });
+        GLOBAL_TRACKERS.remove(token);
+        assert_eq!(response_bytes, 0);
+    }
+
+    #[test]
+    fn test_merge_batch_task_responses_commit_accounting() {
+        // Response bytes are accounted once at commit, covering everything
+        // the response carries: the merged top data and unmerged tasks'
+        // own data together.
+        let token = GLOBAL_TRACKERS.insert(::tracker::Tracker::new(RequestInfo::new(
+            &kvrpcpb::Context::default(),
+            RequestType::Unknown,
+            0,
+        )));
+        let mut failed = mergeable_batch_output(vec![9], false);
+        failed.response.set_other_error("boom".to_owned());
+        let resp = block_on(merge_batch_task_responses(
+            mergeable_outcome(vec![1], false).into(),
+            vec![mergeable_batch_output(vec![2], false), failed],
+            token,
+            Deadline::from_now(Duration::from_secs(60)),
+        ));
+        assert_eq!(resp.get_data(), &[1, 2]);
+        let mut response_bytes = 0;
+        GLOBAL_TRACKERS.with_tracker(token, |tracker| {
+            response_bytes = tracker.metrics.coprocessor_response_bytes;
+        });
+        GLOBAL_TRACKERS.remove(token);
+        let batch_data_len: u64 = resp
+            .get_batch_responses()
+            .iter()
+            .map(|resp| resp.get_data().len() as u64)
+            .sum();
+        assert_eq!(
+            response_bytes,
+            resp.get_data().len() as u64 + batch_data_len
+        );
+    }
+
+    #[test]
+    fn test_batched_response_memory_trace() {
+        let trace = tikv_alloc::mem_trace!(test_batched_response_memory_trace);
+        let output = trace.trace_guard(mergeable_outcome(vec![1], false), 0);
+        let mut child = mergeable_batch_output(vec![2, 3, 4], false);
+        child.response.set_other_error("keep separate".to_owned());
+
+        let resp = merge_batch_task_responses_for_test(output, vec![child]);
+        assert_eq!(resp.get_data(), &[1]);
+        assert_eq!(resp.get_batch_responses()[0].get_data(), &[2, 3, 4]);
+        assert_eq!(trace.sum(), 4);
+        drop(resp);
+        assert_eq!(trace.sum(), 0);
+    }
+
+    #[test]
+    fn test_merge_batch_task_responses_partial_merge() {
+        // A failed task stays separate while successful mergeable tasks are
+        // merged and acknowledged. Errors and details remain on their tasks.
+        let mut outcome = mergeable_outcome(vec![1], false);
+        outcome
+            .response_mut()
+            .set_exec_details_v2(filled_exec_details_v2(1));
+        let mut failed = mergeable_batch_output(vec![3], false);
+        failed.response.set_other_error("boom".to_owned());
+        failed
+            .response
+            .set_exec_details_v2(filled_exec_details_v2(100));
+        let mut batch_outputs = vec![mergeable_batch_output(vec![2], false), failed];
+        batch_outputs[0]
+            .response
+            .set_exec_details_v2(filled_exec_details_v2(10));
+
+        let resp = merge_batch_task_responses_for_test(outcome.into(), batch_outputs);
+        assert_eq!(resp.get_data(), &[1, 2]);
+        assert_eq!(resp.get_exec_details_v2(), &filled_exec_details_v2(1));
+        let batch_resps = resp.get_batch_responses();
+        assert_eq!(batch_resps.len(), 2);
+        assert!(batch_resps[0].get_data_merged_into_response());
+        assert!(batch_resps[0].get_data().is_empty());
+        assert_eq!(
+            batch_resps[0].get_exec_details_v2(),
+            &filled_exec_details_v2(10)
+        );
+        assert!(!batch_resps[1].get_data_merged_into_response());
+        assert_eq!(batch_resps[1].get_data(), &[3]);
+        assert_eq!(batch_resps[1].get_other_error(), "boom");
+        assert_eq!(
+            batch_resps[1].get_exec_details_v2(),
+            &filled_exec_details_v2(100)
+        );
+    }
+
+    #[test]
+    fn test_merge_batch_task_responses_serialize_errors_confined() {
+        // When the top result cannot carry merged data, a task whose result
+        // cannot be serialized turns into that task's error; the other
+        // tasks are unaffected.
+        let batch_outputs = vec![
+            mergeable_batch_output(vec![2], true),
+            mergeable_batch_output(vec![3], false),
+        ];
+        let resp = merge_batch_task_responses_for_test(
+            HandlerOutcome::Ready(coppb::Response::default()).into(),
+            batch_outputs,
+        );
+        assert!(!response_has_error(&resp));
+        let batch_resps = resp.get_batch_responses();
+        assert_eq!(batch_resps.len(), 2);
+        assert!(!batch_resps[0].get_other_error().is_empty());
+        assert!(batch_resps[0].get_data().is_empty());
+        assert_eq!(batch_resps[1].get_data(), &[3]);
+
+        // A top task whose result cannot be serialized turns into an error
+        // response that still carries the batch responses.
+        let resp = merge_batch_task_responses_for_test(
+            mergeable_outcome(vec![1], true).into(),
+            vec![BatchTaskOutput {
+                response: coppb::StoreBatchTaskResponse::default(),
+                mergeable_result: None,
+            }],
+        );
+        assert!(!resp.get_other_error().is_empty());
+        assert_eq!(resp.get_batch_responses().len(), 1);
+
+        // When the merged result cannot be serialized, the tasks' results
+        // are already consumed: the whole response degrades to an error
+        // without acknowledging the tasks as merged.
+        let resp = merge_batch_task_responses_for_test(
+            mergeable_outcome(vec![1], true).into(),
+            vec![mergeable_batch_output(vec![2], false)],
+        );
+        assert!(!resp.get_other_error().is_empty());
+        assert!(resp.get_batch_responses().is_empty());
+    }
+
     #[test]
     fn test_serialize_handler_outcome() {
         // A mergeable outcome is serialized into a ready response and the
         // guard's trace is resized to the serialized data.
         let trace = tikv_alloc::mem_trace!(test_serialize_outcome);
         let output = trace.trace_guard(mergeable_outcome(vec![3, 1, 2], false), 0);
-        let resp = serialize_handler_outcome(output).unwrap();
-        assert_eq!(resp.get_data(), &[1, 2, 3]);
+        let output = serialize_handler_outcome(output).unwrap();
+        assert!(matches!(&*output, HandlerOutcome::Ready(_)));
+        assert_eq!(output.response().get_data(), &[1, 2, 3]);
         assert_eq!(trace.sum(), 3);
-        drop(resp);
+        drop(output);
         assert_eq!(trace.sum(), 0);
 
         // A serialization failure surfaces as the handler's error and
@@ -1479,8 +2337,8 @@ mod tests {
         let mut ready = coppb::Response::default();
         ready.set_data(vec![7]);
         let output = trace.trace_guard(HandlerOutcome::Ready(ready), 5);
-        let resp = serialize_handler_outcome(output).unwrap();
-        assert_eq!(resp.get_data(), &[7]);
+        let output = serialize_handler_outcome(output).unwrap();
+        assert_eq!(output.response().get_data(), &[7]);
         assert_eq!(trace.sum(), 5);
     }
 
@@ -1501,8 +2359,8 @@ mod tests {
             None,
         );
 
-        // The handler's mergeable result is serialized inside the request's
-        // own read pool task and returned as ordinary response data.
+        // With `serialize_outcome`, a `Mergeable` outcome is serialized into
+        // its response inside the request's own read pool task.
         let handler_builder = Box::new(|_, _: &_| {
             Ok(MergeableFixture {
                 values: vec![3, 1, 2],
@@ -1510,11 +2368,29 @@ mod tests {
             }
             .into_boxed())
         });
-        let resp = block_on(
-            copr.handle_unary_request(ParseCopRequestResult::default_for_test(handler_builder)),
-        )
-        .unwrap();
+        let resp = unwrap_ready(
+            block_on(copr.handle_unary_request(
+                ParseCopRequestResult::default_for_test(handler_builder),
+                true,
+            ))
+            .unwrap(),
+        );
         assert_eq!(resp.get_data(), &[1, 2, 3]);
+
+        // Without it, the result stays unserialized for batched merging.
+        let handler_builder = Box::new(|_, _: &_| {
+            Ok(MergeableFixture {
+                values: vec![1],
+                fail_serialize: false,
+            }
+            .into_boxed())
+        });
+        let output = block_on(copr.handle_unary_request(
+            ParseCopRequestResult::default_for_test(handler_builder),
+            false,
+        ))
+        .unwrap();
+        assert!(matches!(&*output, HandlerOutcome::Mergeable { .. }));
 
         // An in-place serialization failure surfaces like a handler error.
         let handler_builder = Box::new(|_, _: &_| {
@@ -1524,11 +2400,487 @@ mod tests {
             }
             .into_boxed())
         });
-        let resp = block_on(
-            copr.handle_unary_request(ParseCopRequestResult::default_for_test(handler_builder)),
-        )
-        .unwrap();
+        let resp = unwrap_ready(
+            block_on(copr.handle_unary_request(
+                ParseCopRequestResult::default_for_test(handler_builder),
+                true,
+            ))
+            .unwrap(),
+        );
         assert!(!resp.get_other_error().is_empty());
+    }
+
+    #[test]
+    fn test_batch_merge_finalizer() {
+        let engine = TestEngineBuilder::new().build().unwrap();
+        let read_pool = ReadPool::from(build_read_pool_for_test(
+            &CoprReadPoolConfig::default_for_test(),
+            engine,
+        ));
+        let cm = ConcurrencyManager::new_for_test(1.into());
+        let copr = Endpoint::<RocksEngine>::new(
+            &Config::default(),
+            read_pool.handle(),
+            cm,
+            ResourceTagFactory::new_for_test(),
+            Arc::new(QuotaLimiter::default()),
+            None,
+        );
+
+        // The finalizer runs the merge as a read pool task and hands the
+        // response back to the caller.
+        let finalizer = copr.batch_merge_finalizer(
+            kvrpcpb::Context::default(),
+            Deadline::from_now(Duration::from_secs(60)),
+            0,
+        );
+        let resp = block_on(finalizer.finalize(
+            mergeable_outcome(vec![1], false).into(),
+            vec![mergeable_batch_output(vec![2], false)],
+            ::tracker::INVALID_TRACKER_TOKEN,
+        ));
+        assert_eq!(resp.get_data(), &[1, 2]);
+        let batch_resps = resp.get_batch_responses();
+        assert_eq!(batch_resps.len(), 1);
+        assert!(batch_resps[0].get_data_merged_into_response());
+        assert!(batch_resps[0].get_data().is_empty());
+
+        // The merge's poll time lands on the request tracker, where
+        // `merge_time_detail` folds it into the top task's process time.
+        let token = GLOBAL_TRACKERS.insert(::tracker::Tracker::new(RequestInfo::new(
+            &kvrpcpb::Context::default(),
+            RequestType::Unknown,
+            0,
+        )));
+        let finalizer = copr.batch_merge_finalizer(
+            kvrpcpb::Context::default(),
+            Deadline::from_now(Duration::from_secs(60)),
+            0,
+        );
+        let resp = block_on(finalizer.finalize(
+            mergeable_outcome(vec![1], false).into(),
+            vec![mergeable_batch_output(vec![2], false)],
+            token,
+        ));
+        assert_eq!(resp.get_data(), &[1, 2]);
+        let mut process_nanos = 0;
+        GLOBAL_TRACKERS.with_tracker(token, |tracker| {
+            process_nanos = tracker.metrics.future_process_nanos;
+        });
+        GLOBAL_TRACKERS.remove(token);
+        assert!(process_nanos > 0);
+    }
+
+    #[test]
+    fn test_batch_merge_finalizer_semaphore() {
+        let engine = TestEngineBuilder::new().build().unwrap();
+        let read_pool = ReadPool::from(build_read_pool_for_test(
+            &CoprReadPoolConfig::default_for_test(),
+            engine,
+        ));
+        let cm = ConcurrencyManager::new_for_test(1.into());
+        let copr = Endpoint::<RocksEngine>::new(
+            &Config::default(),
+            read_pool.handle(),
+            cm,
+            ResourceTagFactory::new_for_test(),
+            Arc::new(QuotaLimiter::default()),
+            None,
+        );
+
+        // The permit is taken before the first merge step: an exhausted
+        // semaphore stops the merge before it consumes anything, and the
+        // deadline-bounded wait degrades to a plain error that makes the
+        // client retry every task.
+        let mut finalizer = copr.batch_merge_finalizer(
+            kvrpcpb::Context::default(),
+            Deadline::from_now(Duration::ZERO),
+            0,
+        );
+        finalizer.semaphore = Some(Arc::new(Semaphore::new(0)));
+        let resp = block_on(finalizer.finalize(
+            mergeable_outcome(vec![1], false).into(),
+            vec![mergeable_batch_output(vec![2], false)],
+            ::tracker::INVALID_TRACKER_TOKEN,
+        ));
+        assert!(resp.has_region_error());
+        assert!(resp.get_data().is_empty());
+        assert!(resp.get_batch_responses().is_empty());
+
+        // With a permit available the merge proceeds normally.
+        let mut finalizer = copr.batch_merge_finalizer(
+            kvrpcpb::Context::default(),
+            Deadline::from_now(Duration::from_secs(60)),
+            0,
+        );
+        finalizer.semaphore = Some(Arc::new(Semaphore::new(1)));
+        let resp = block_on(finalizer.finalize(
+            mergeable_outcome(vec![1], false).into(),
+            vec![mergeable_batch_output(vec![2], false)],
+            ::tracker::INVALID_TRACKER_TOKEN,
+        ));
+        assert_eq!(resp.get_data(), &[1, 2]);
+    }
+
+    #[test]
+    fn test_batch_merge_finalizer_pool_rejection() {
+        // A zero-task pool rejects every spawn outright. The running-task
+        // gauges are shared between the unnamed test pools, so occupying a
+        // one-slot pool instead would race with concurrently running tests.
+        let engine = TestEngineBuilder::new().build().unwrap();
+        let read_pool = ReadPool::from(build_read_pool_for_test(
+            &CoprReadPoolConfig {
+                max_tasks_per_worker_normal: 0,
+                ..CoprReadPoolConfig::default_for_test()
+            },
+            engine,
+        ));
+        let handle = read_pool.handle();
+        let cm = ConcurrencyManager::new_for_test(1.into());
+        let copr = Endpoint::<RocksEngine>::new(
+            &Config::default(),
+            handle.clone(),
+            cm,
+            ResourceTagFactory::new_for_test(),
+            Arc::new(QuotaLimiter::default()),
+            None,
+        );
+
+        // The finalizer's spawn is rejected: the request is shed with a
+        // retryable busy error carrying no data, acknowledgments or batch
+        // responses, exactly like an ordinary admission failure, and the
+        // collected results are dropped for the client to retry.
+        assert!(
+            block_on(handle.spawn(
+                async {},
+                CommandPri::Normal,
+                1,
+                TaskMetadata::default(),
+                None
+            ))
+            .is_err()
+        );
+
+        let finalizer = copr.batch_merge_finalizer(
+            kvrpcpb::Context::default(),
+            Deadline::from_now(Duration::from_secs(60)),
+            0,
+        );
+        let trace = tikv_alloc::mem_trace!(test_pool_rejection);
+        let output = trace.trace_guard(mergeable_outcome(vec![1], false), 5);
+        let resp = block_on(finalizer.finalize(
+            output,
+            vec![mergeable_batch_output(vec![2], false)],
+            ::tracker::INVALID_TRACKER_TOKEN,
+        ));
+        assert!(resp.has_region_error());
+        assert!(resp.get_region_error().has_server_is_busy());
+        assert!(resp.get_data().is_empty());
+        assert!(resp.get_batch_responses().is_empty());
+        assert_eq!(trace.sum(), 0);
+    }
+
+    fn build_unified_read_pool(resource_manager: Option<Arc<ResourceGroupManager>>) -> ReadPool {
+        build_yatp_read_pool(
+            &UnifiedReadPoolConfig {
+                min_thread_count: 1,
+                max_thread_count: 1,
+                max_tasks_per_worker: 8,
+                ..Default::default()
+            },
+            DummyFlowStatsReporter,
+            TestEngineBuilder::new().build().unwrap(),
+            None,
+            resource_manager,
+            CleanupMethod::InPlace,
+            false,
+        )
+    }
+
+    fn build_single_thread_read_pool() -> ReadPool {
+        ReadPool::from(build_read_pool_for_test(
+            &CoprReadPoolConfig {
+                high_concurrency: 1,
+                normal_concurrency: 1,
+                low_concurrency: 1,
+                ..CoprReadPoolConfig::default_for_test()
+            },
+            TestEngineBuilder::new().build().unwrap(),
+        ))
+    }
+
+    fn batch_merge_finalizer_for_test(
+        read_pool: ReadPoolHandle,
+        resource_limiter: Option<Arc<ResourceLimiter>>,
+        deadline: Deadline,
+    ) -> BatchMergeFinalizer {
+        BatchMergeFinalizer {
+            read_pool,
+            semaphore: None,
+            resource_tag: ResourceTagFactory::new_for_test().new_tag(&kvrpcpb::Context::default()),
+            priority: CommandPri::Normal,
+            metadata: TaskMetadata::default(),
+            resource_limiter,
+            deadline,
+            task_id: 0,
+        }
+    }
+
+    #[test]
+    fn test_batch_merge_finalizer_admission_respects_deadline() {
+        let resource_manager = Arc::new(ResourceGroupManager::default());
+        let pool = build_unified_read_pool(Some(resource_manager));
+        let limiter = Arc::new(ResourceLimiter::new(
+            "batch-merge-finalizer".to_owned(),
+            10_000.0,
+            f64::INFINITY,
+            0,
+            true,
+        ));
+        let mut admission_delay = Duration::ZERO;
+        for _ in 0..1_000 {
+            limiter.consume(
+                Duration::from_micros(1_000),
+                IoBytes::default(),
+                false,
+                true,
+            );
+            admission_delay = limiter.admission_delay(true);
+            if admission_delay >= Duration::from_millis(200) {
+                break;
+            }
+        }
+        assert!(admission_delay >= Duration::from_millis(100));
+
+        let trace = tikv_alloc::mem_trace!(test_batch_merge_finalizer_admission_deadline);
+        let output = trace.trace_guard(mergeable_outcome(vec![1], false), 5);
+        let finalizer = batch_merge_finalizer_for_test(
+            pool.handle(),
+            Some(limiter),
+            Deadline::from_now(Duration::from_millis(20)),
+        );
+        let started_at = Instant::now();
+        let resp = block_on(finalizer.finalize(
+            output,
+            vec![mergeable_batch_output(vec![2], false)],
+            ::tracker::INVALID_TRACKER_TOKEN,
+        ));
+
+        assert!(started_at.saturating_elapsed() < Duration::from_millis(100));
+        assert!(resp.has_region_error());
+        assert!(resp.get_region_error().has_server_is_busy());
+        assert_eq!(
+            resp.get_region_error().get_server_is_busy().get_reason(),
+            "deadline is exceeded"
+        );
+        assert!(resp.get_data().is_empty());
+        assert!(resp.get_batch_responses().is_empty());
+        assert_eq!(trace.sum(), 0);
+    }
+
+    #[test]
+    fn test_batch_merge_finalizer_queue_respects_deadline() {
+        let pool = build_single_thread_read_pool();
+        let handle = pool.handle();
+        let (started_tx, started_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        block_on(handle.spawn(
+            async move {
+                started_tx.send(()).unwrap();
+                release_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+            },
+            CommandPri::Normal,
+            1,
+            TaskMetadata::default(),
+            None,
+        ))
+        .unwrap();
+        started_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+
+        let trace = tikv_alloc::mem_trace!(test_batch_merge_finalizer_queue_deadline);
+        let output = trace.trace_guard(mergeable_outcome(vec![1], false), 5);
+        let finalizer = batch_merge_finalizer_for_test(
+            handle,
+            None,
+            Deadline::from_now(Duration::from_millis(20)),
+        );
+        let started_at = Instant::now();
+        let resp = block_on(finalizer.finalize(
+            output,
+            vec![mergeable_batch_output(vec![2], false)],
+            ::tracker::INVALID_TRACKER_TOKEN,
+        ));
+        release_tx.send(()).unwrap();
+
+        assert!(started_at.saturating_elapsed() < Duration::from_secs(1));
+        assert!(resp.has_region_error());
+        assert!(resp.get_region_error().has_server_is_busy());
+        assert_eq!(
+            resp.get_region_error().get_server_is_busy().get_reason(),
+            "deadline is exceeded"
+        );
+        assert!(resp.get_data().is_empty());
+        assert!(resp.get_batch_responses().is_empty());
+        assert_eq!(trace.sum(), 0);
+    }
+
+    #[test]
+    fn test_batch_merge_finalizer_preserves_completed_response() {
+        let pool = build_single_thread_read_pool();
+        let token = GLOBAL_TRACKERS.insert(::tracker::Tracker::new(RequestInfo::new(
+            &kvrpcpb::Context::default(),
+            RequestType::Unknown,
+            0,
+        )));
+        let finalizer = batch_merge_finalizer_for_test(
+            pool.handle(),
+            None,
+            Deadline::from_now(Duration::from_millis(150)),
+        );
+        let mut finalize = Box::pin(finalizer.finalize(
+            slow_mergeable_outcome(vec![1], Duration::from_millis(20)).into(),
+            vec![mergeable_batch_output(vec![2], false)],
+            token,
+        ));
+
+        // The caller stays unpolled after the response completes and the
+        // deadline expires. A completed response must still win when the caller
+        // resumes.
+        let state = block_on(futures::future::poll_fn(|cx| {
+            Poll::Ready(finalize.as_mut().poll(cx))
+        }));
+        assert!(state.is_pending());
+        thread::sleep(Duration::from_millis(200));
+        let resp = block_on(finalize);
+
+        assert_eq!(resp.get_data(), &[1, 2]);
+        assert_eq!(tracked_response_bytes(token), 2);
+        drop(resp);
+        GLOBAL_TRACKERS.remove(token);
+    }
+
+    fn tracked_response_bytes(token: ::tracker::TrackerToken) -> u64 {
+        let mut bytes = 0;
+        GLOBAL_TRACKERS.with_tracker(token, |tracker| {
+            bytes = tracker.metrics.coprocessor_response_bytes;
+        });
+        bytes
+    }
+
+    #[test]
+    fn test_merge_path_ready_bytes_committed_once() {
+        // A `Ready` outcome on the merge path — a cache hit, say — is not
+        // recorded in its handler pipeline; the commit accounts everything
+        // the response carries exactly once, so its bytes are neither
+        // charged twice nor charged when the response is never returned.
+        let engine = TestEngineBuilder::new().build().unwrap();
+        let read_pool = ReadPool::from(build_read_pool_for_test(
+            &CoprReadPoolConfig::default_for_test(),
+            engine,
+        ));
+        let cm = ConcurrencyManager::new_for_test(1.into());
+        let copr = Endpoint::<RocksEngine>::new(
+            &Config::default(),
+            read_pool.handle(),
+            cm,
+            ResourceTagFactory::new_for_test(),
+            Arc::new(QuotaLimiter::default()),
+            None,
+        );
+        let token = GLOBAL_TRACKERS.insert(::tracker::Tracker::new(RequestInfo::new(
+            &kvrpcpb::Context::default(),
+            RequestType::Unknown,
+            0,
+        )));
+        set_tls_tracker_token(token);
+
+        let mut ready = coppb::Response::default();
+        ready.set_data(vec![1, 2, 3]);
+        let handler_builder =
+            Box::new(move |_, _: &_| Ok(UnaryFixture::new(Ok(ready)).into_boxed()));
+        let output = block_on(copr.handle_unary_request(
+            ParseCopRequestResult::default_for_test(handler_builder),
+            false,
+        ))
+        .unwrap();
+        assert_eq!(tracked_response_bytes(token), 0);
+
+        // The ready top data and the unmerged task's own data are accounted
+        // together at commit.
+        let finalizer = copr.batch_merge_finalizer(
+            kvrpcpb::Context::default(),
+            Deadline::from_now(Duration::from_secs(60)),
+            0,
+        );
+        let resp = block_on(finalizer.finalize(
+            output,
+            vec![mergeable_batch_output(vec![9], false)],
+            token,
+        ));
+        assert_eq!(resp.get_data(), &[1, 2, 3]);
+        assert_eq!(resp.get_batch_responses()[0].get_data(), &[9]);
+        assert_eq!(tracked_response_bytes(token), 4);
+        GLOBAL_TRACKERS.remove(token);
+        set_tls_tracker_token(::tracker::INVALID_TRACKER_TOKEN);
+    }
+
+    #[test]
+    fn test_merge_path_aborts_charge_nothing() {
+        // Shedding on pool rejection and deadline expiry both return before
+        // the commit, so nothing is charged for a response that is never
+        // returned.
+        let engine = TestEngineBuilder::new().build().unwrap();
+        let read_pool = ReadPool::from(build_read_pool_for_test(
+            &CoprReadPoolConfig {
+                max_tasks_per_worker_normal: 0,
+                ..CoprReadPoolConfig::default_for_test()
+            },
+            engine,
+        ));
+        let cm = ConcurrencyManager::new_for_test(1.into());
+        let copr = Endpoint::<RocksEngine>::new(
+            &Config::default(),
+            read_pool.handle(),
+            cm,
+            ResourceTagFactory::new_for_test(),
+            Arc::new(QuotaLimiter::default()),
+            None,
+        );
+        let token = GLOBAL_TRACKERS.insert(::tracker::Tracker::new(RequestInfo::new(
+            &kvrpcpb::Context::default(),
+            RequestType::Unknown,
+            0,
+        )));
+        let ready_output = || {
+            let mut ready = coppb::Response::default();
+            ready.set_data(vec![1, 2, 3]);
+            HandlerOutput::from(HandlerOutcome::Ready(ready))
+        };
+
+        let finalizer = copr.batch_merge_finalizer(
+            kvrpcpb::Context::default(),
+            Deadline::from_now(Duration::from_secs(60)),
+            0,
+        );
+        let resp = block_on(finalizer.finalize(
+            ready_output(),
+            vec![mergeable_batch_output(vec![9], false)],
+            token,
+        ));
+        assert!(resp.get_region_error().has_server_is_busy());
+        assert_eq!(tracked_response_bytes(token), 0);
+
+        let deadline = Deadline::from_now(Duration::ZERO);
+        thread::sleep(Duration::from_millis(200));
+        let resp = block_on(merge_batch_task_responses(
+            ready_output(),
+            vec![mergeable_batch_output(vec![9], false)],
+            token,
+            deadline,
+        ));
+        assert!(resp.has_region_error());
+        assert_eq!(tracked_response_bytes(token), 0);
+        GLOBAL_TRACKERS.remove(token);
     }
 
     /// A streaming `RequestHandler` that always produces a fixture.
@@ -1639,10 +2991,13 @@ mod tests {
         // a normal request
         let handler_builder =
             Box::new(|_, _: &_| Ok(UnaryFixture::new(Ok(coppb::Response::default())).into_boxed()));
-        let resp = block_on(
-            copr.handle_unary_request(ParseCopRequestResult::default_for_test(handler_builder)),
-        )
-        .unwrap();
+        let resp = unwrap_ready(
+            block_on(copr.handle_unary_request(
+                ParseCopRequestResult::default_for_test(handler_builder),
+                true,
+            ))
+            .unwrap(),
+        );
         assert!(resp.get_other_error().is_empty());
 
         // an outdated request
@@ -1659,11 +3014,14 @@ mod tests {
             PerfLevel::EnableCount,
             false,
         );
-        block_on(copr.handle_unary_request(ParseCopRequestResult {
-            req_ctx: outdated_req_ctx,
-            req_tag: ReqTag::test,
-            handler_builder,
-        }))
+        block_on(copr.handle_unary_request(
+            ParseCopRequestResult {
+                req_ctx: outdated_req_ctx,
+                req_tag: ReqTag::test,
+                handler_builder,
+            },
+            true,
+        ))
         .unwrap_err();
     }
 
@@ -1812,8 +3170,10 @@ mod tests {
                         .into_boxed(),
                 )
             });
-            let future =
-                copr.handle_unary_request(ParseCopRequestResult::default_for_test(handler_builder));
+            let future = copr.handle_unary_request(
+                ParseCopRequestResult::default_for_test(handler_builder),
+                true,
+            );
             let tx = tx.clone();
             thread::spawn(move || {
                 tx.send(block_on(future)).unwrap();
@@ -1826,7 +3186,7 @@ mod tests {
             rx.recv().unwrap().unwrap_err();
         }
         for i in 0..2 {
-            let resp = rx.recv().unwrap().unwrap();
+            let resp = unwrap_ready(rx.recv().unwrap().unwrap());
             assert_eq!(resp.get_data(), [1, 2, i]);
             assert!(!resp.has_region_error());
         }
@@ -1851,10 +3211,13 @@ mod tests {
 
         let handler_builder =
             Box::new(|_, _: &_| Ok(UnaryFixture::new(Err(box_err!("foo"))).into_boxed()));
-        let resp = block_on(
-            copr.handle_unary_request(ParseCopRequestResult::default_for_test(handler_builder)),
-        )
-        .unwrap();
+        let resp = unwrap_ready(
+            block_on(copr.handle_unary_request(
+                ParseCopRequestResult::default_for_test(handler_builder),
+                true,
+            ))
+            .unwrap(),
+        );
         assert_eq!(resp.get_data().len(), 0);
         assert!(!resp.get_other_error().is_empty());
     }
@@ -1895,10 +3258,13 @@ mod tests {
             response.set_data(vec![1, 2, 3, 4]);
             Ok(UnaryFixture::new(Ok(response)).into_boxed())
         });
-        let resp = block_on(
-            copr.handle_unary_request(ParseCopRequestResult::default_for_test(handler_builder)),
-        )
-        .unwrap();
+        let resp = unwrap_ready(
+            block_on(copr.handle_unary_request(
+                ParseCopRequestResult::default_for_test(handler_builder),
+                true,
+            ))
+            .unwrap(),
+        );
 
         assert_eq!(
             resp.get_exec_details_v2()
@@ -2199,13 +3565,20 @@ mod tests {
                         .into_boxed(),
                 )
             });
-            let resp_future_1 = copr.handle_unary_request(ParseCopRequestResult {
-                req_tag: ReqTag::test,
-                req_ctx: req_with_exec_detail.clone(),
-                handler_builder,
-            });
+            let resp_future_1 = copr.handle_unary_request(
+                ParseCopRequestResult {
+                    req_tag: ReqTag::test,
+                    req_ctx: req_with_exec_detail.clone(),
+                    handler_builder,
+                },
+                true,
+            );
             let sender = tx.clone();
-            thread::spawn(move || sender.send(vec![block_on(resp_future_1).unwrap()]).unwrap());
+            thread::spawn(move || {
+                sender
+                    .send(vec![unwrap_ready(block_on(resp_future_1).unwrap())])
+                    .unwrap()
+            });
             // Sleep a while to make sure that thread is spawn and snapshot is taken.
             thread::sleep(SNAPSHOT_DURATION);
 
@@ -2216,13 +3589,20 @@ mod tests {
                         .into_boxed(),
                 )
             });
-            let resp_future_2 = copr.handle_unary_request(ParseCopRequestResult {
-                req_tag: ReqTag::test,
-                req_ctx: req_with_exec_detail.clone(),
-                handler_builder,
-            });
+            let resp_future_2 = copr.handle_unary_request(
+                ParseCopRequestResult {
+                    req_tag: ReqTag::test,
+                    req_ctx: req_with_exec_detail.clone(),
+                    handler_builder,
+                },
+                true,
+            );
             let sender = tx.clone();
-            thread::spawn(move || sender.send(vec![block_on(resp_future_2).unwrap()]).unwrap());
+            thread::spawn(move || {
+                sender
+                    .send(vec![unwrap_ready(block_on(resp_future_2).unwrap())])
+                    .unwrap()
+            });
             thread::sleep(SNAPSHOT_DURATION);
 
             // Response 1
@@ -2325,13 +3705,20 @@ mod tests {
                 )
                 .into_boxed())
             });
-            let resp_future_1 = copr.handle_unary_request(ParseCopRequestResult {
-                req_tag: ReqTag::test,
-                req_ctx: req_with_exec_detail.clone(),
-                handler_builder,
-            });
+            let resp_future_1 = copr.handle_unary_request(
+                ParseCopRequestResult {
+                    req_tag: ReqTag::test,
+                    req_ctx: req_with_exec_detail.clone(),
+                    handler_builder,
+                },
+                true,
+            );
             let sender = tx.clone();
-            thread::spawn(move || sender.send(vec![block_on(resp_future_1).unwrap()]).unwrap());
+            thread::spawn(move || {
+                sender
+                    .send(vec![unwrap_ready(block_on(resp_future_1).unwrap())])
+                    .unwrap()
+            });
             // Sleep a while to make sure that thread is spawn and snapshot is taken.
             thread::sleep(SNAPSHOT_DURATION);
 
@@ -2342,13 +3729,20 @@ mod tests {
                         .into_boxed(),
                 )
             });
-            let resp_future_2 = copr.handle_unary_request(ParseCopRequestResult {
-                req_tag: ReqTag::test,
-                req_ctx: req_with_exec_detail.clone(),
-                handler_builder,
-            });
+            let resp_future_2 = copr.handle_unary_request(
+                ParseCopRequestResult {
+                    req_tag: ReqTag::test,
+                    req_ctx: req_with_exec_detail.clone(),
+                    handler_builder,
+                },
+                true,
+            );
             let sender = tx.clone();
-            thread::spawn(move || sender.send(vec![block_on(resp_future_2).unwrap()]).unwrap());
+            thread::spawn(move || {
+                sender
+                    .send(vec![unwrap_ready(block_on(resp_future_2).unwrap())])
+                    .unwrap()
+            });
             thread::sleep(SNAPSHOT_DURATION);
 
             // Response 1
@@ -2408,13 +3802,20 @@ mod tests {
                         .into_boxed(),
                 )
             });
-            let resp_future_1 = copr.handle_unary_request(ParseCopRequestResult {
-                req_tag: ReqTag::test,
-                req_ctx: req_with_exec_detail.clone(),
-                handler_builder,
-            });
+            let resp_future_1 = copr.handle_unary_request(
+                ParseCopRequestResult {
+                    req_tag: ReqTag::test,
+                    req_ctx: req_with_exec_detail.clone(),
+                    handler_builder,
+                },
+                true,
+            );
             let sender = tx.clone();
-            thread::spawn(move || sender.send(vec![block_on(resp_future_1).unwrap()]).unwrap());
+            thread::spawn(move || {
+                sender
+                    .send(vec![unwrap_ready(block_on(resp_future_1).unwrap())])
+                    .unwrap()
+            });
             // Sleep a while to make sure that thread is spawn and snapshot is taken.
             thread::sleep(SNAPSHOT_DURATION);
 
@@ -2592,12 +3993,17 @@ mod tests {
             inner.deadline = Deadline::from_now(Duration::from_millis(500));
             let config: ReqContext = inner.into();
 
-            let resp = block_on(copr.handle_unary_request(ParseCopRequestResult {
-                req_tag: ReqTag::test,
-                req_ctx: config,
-                handler_builder,
-            }))
-            .unwrap();
+            let resp = unwrap_ready(
+                block_on(copr.handle_unary_request(
+                    ParseCopRequestResult {
+                        req_tag: ReqTag::test,
+                        req_ctx: config,
+                        handler_builder,
+                    },
+                    true,
+                ))
+                .unwrap(),
+            );
             assert_eq!(resp.get_data().len(), 0);
             let region_err = resp.get_region_error();
             assert_eq!(
@@ -2619,12 +4025,17 @@ mod tests {
             inner.deadline = Deadline::from_now(Duration::from_millis(500));
             let config: ReqContext = inner.into();
 
-            let resp = block_on(copr.handle_unary_request(ParseCopRequestResult {
-                req_tag: ReqTag::test,
-                req_ctx: config,
-                handler_builder,
-            }))
-            .unwrap();
+            let resp = unwrap_ready(
+                block_on(copr.handle_unary_request(
+                    ParseCopRequestResult {
+                        req_tag: ReqTag::test,
+                        req_ctx: config,
+                        handler_builder,
+                    },
+                    true,
+                ))
+                .unwrap(),
+            );
             assert_eq!(resp.get_data().len(), 0);
             let region_err = resp.get_region_error();
             assert_eq!(
@@ -2818,12 +4229,17 @@ mod tests {
             inner.deadline = Deadline::from_now(Duration::from_millis(500));
             let config: ReqContext = inner.into();
 
-            let resp = block_on(copr.handle_unary_request(ParseCopRequestResult {
-                req_tag: ReqTag::test,
-                req_ctx: config,
-                handler_builder,
-            }))
-            .unwrap();
+            let resp = unwrap_ready(
+                block_on(copr.handle_unary_request(
+                    ParseCopRequestResult {
+                        req_tag: ReqTag::test,
+                        req_ctx: config,
+                        handler_builder,
+                    },
+                    true,
+                ))
+                .unwrap(),
+            );
             assert!(!resp.has_region_error(), "{:?}", resp);
         }
 
@@ -2838,11 +4254,14 @@ mod tests {
             inner.deadline = Deadline::from_now(Duration::from_millis(500));
             let config: ReqContext = inner.into();
 
-            let res = block_on(copr.handle_unary_request(ParseCopRequestResult {
-                req_tag: ReqTag::test,
-                req_ctx: config,
-                handler_builder,
-            }));
+            let res = block_on(copr.handle_unary_request(
+                ParseCopRequestResult {
+                    req_tag: ReqTag::test,
+                    req_ctx: config,
+                    handler_builder,
+                },
+                true,
+            ));
             assert!(res.is_err(), "{:?}", res);
             let resp = make_error_response(res.unwrap_err());
             assert_eq!(resp.get_data().len(), 0);

--- a/src/coprocessor/mod.rs
+++ b/src/coprocessor/mod.rs
@@ -62,11 +62,23 @@ pub const REQ_FLAG_TIDB_SYSSESSION: u64 = 2048;
 
 type HandlerStreamStepResult = Result<(Option<coppb::Response>, bool)>;
 
+/// The outcome of handling a unary request.
+pub enum HandlerOutcome {
+    Ready(coppb::Response),
+}
+
+// `MemoryTraceGuard<T>` requires `T: Default`.
+impl Default for HandlerOutcome {
+    fn default() -> Self {
+        Self::Ready(coppb::Response::default())
+    }
+}
+
 /// An interface for all kind of Coprocessor request handlers.
 #[async_trait]
 pub trait RequestHandler: Send {
-    /// Processes current request and produces a response.
-    async fn handle_request(&mut self) -> Result<MemoryTraceGuard<coppb::Response>> {
+    /// Processes current request and produces an outcome.
+    async fn handle_request(&mut self) -> Result<MemoryTraceGuard<HandlerOutcome>> {
         panic!("unary request is not supported for this handler");
     }
 

--- a/src/coprocessor/mod.rs
+++ b/src/coprocessor/mod.rs
@@ -35,7 +35,7 @@ pub mod readpool_impl;
 mod statistics;
 mod tracker;
 
-use std::{ops::Deref, sync::Arc};
+use std::{any::Any, ops::Deref, sync::Arc};
 
 use async_trait::async_trait;
 pub use checksum::checksum_crc64_xor;
@@ -61,6 +61,19 @@ pub const REQ_TYPE_CHECKSUM: i64 = 105;
 pub const REQ_FLAG_TIDB_SYSSESSION: u64 = 2048;
 
 type HandlerStreamStepResult = Result<(Option<coppb::Response>, bool)>;
+
+/// A task result that can be combined with results of the same request and
+/// serialized after merging.
+pub trait MergeableResult: Any + Send {
+    /// Merges another result of the same concrete type. Callers may choose any
+    /// merge order, so implementations must produce the same logical result
+    /// independent of that order.
+    fn merge(&mut self, other: Box<dyn MergeableResult>);
+
+    /// Serializes the result into response data. The result should keep any
+    /// memory it holds tracked until it is merged away or serialized.
+    fn into_data(self: Box<Self>) -> Result<Vec<u8>>;
+}
 
 /// The outcome of handling a unary request.
 pub enum HandlerOutcome {

--- a/src/coprocessor/mod.rs
+++ b/src/coprocessor/mod.rs
@@ -75,15 +75,42 @@ pub trait MergeableResult: Any + Send {
     fn into_data(self: Box<Self>) -> Result<Vec<u8>>;
 }
 
-/// The outcome of handling a unary request.
+/// The outcome of handling a unary request: either a response that is ready
+/// to be returned, or a partial response whose data is kept unserialized
+/// until the endpoint serializes it at the end of the request pipeline (see
+/// `endpoint::serialize_handler_outcome`).
 pub enum HandlerOutcome {
+    /// A response that is fully serialized and ready to return.
     Ready(coppb::Response),
+    /// A partial response paired with an unserialized mergeable data result.
+    Mergeable {
+        /// The response carrying everything but the data (errors, cache
+        /// hints, ...); its data is produced from `result`.
+        partial_response: coppb::Response,
+        /// The type-erased result that compatible child results merge into.
+        result: Box<dyn MergeableResult>,
+    },
 }
 
 // `MemoryTraceGuard<T>` requires `T: Default`.
 impl Default for HandlerOutcome {
     fn default() -> Self {
         Self::Ready(coppb::Response::default())
+    }
+}
+
+impl HandlerOutcome {
+    /// The response as produced so far: the ready response, or the partial
+    /// response of a `Mergeable` outcome, whose data stays empty until the
+    /// result is serialized.
+    pub fn response(&self) -> &coppb::Response {
+        match self {
+            Self::Ready(response)
+            | Self::Mergeable {
+                partial_response: response,
+                ..
+            } => response,
+        }
     }
 }
 

--- a/src/coprocessor/mod.rs
+++ b/src/coprocessor/mod.rs
@@ -62,30 +62,47 @@ pub const REQ_FLAG_TIDB_SYSSESSION: u64 = 2048;
 
 type HandlerStreamStepResult = Result<(Option<coppb::Response>, bool)>;
 
-/// A task result that can be combined with results of the same request and
-/// serialized after merging.
+/// A task result that a `RequestHandler` returns unserialized (see
+/// `HandlerOutcome::Mergeable`), so that the endpoint can merge the results
+/// of a batched request's tasks (one per region) and serialize the merged
+/// result only once.
 pub trait MergeableResult: Any + Send {
-    /// Merges another result of the same concrete type. Callers may choose any
-    /// merge order, so implementations must produce the same logical result
-    /// independent of that order.
+    /// Merges the result of another task of the same request into this one.
+    /// Results of one request must have the same concrete type; the endpoint
+    /// relies on this invariant, so implementations may downcast `other`
+    /// accordingly. Eligible batched results are merged in request-task order,
+    /// even when their handlers complete out of order.
     fn merge(&mut self, other: Box<dyn MergeableResult>);
 
     /// Serializes the result into response data. The result should keep any
-    /// memory it holds tracked until it is merged away or serialized.
+    /// memory it holds tracked (e.g. reported to a memory trace) until it is
+    /// merged away or serialized.
     fn into_data(self: Box<Self>) -> Result<Vec<u8>>;
 }
 
 /// The outcome of handling a unary request: either a response that is ready
-/// to be returned, or a partial response whose data is kept unserialized
-/// until the endpoint serializes it at the end of the request pipeline (see
-/// `endpoint::serialize_handler_outcome`).
+/// to be returned, or a partial response whose data is kept unserialized so
+/// that the endpoint can merge the results of a batched request's tasks
+/// before serializing the merged result once. Any request type can opt into
+/// the latter by returning `Mergeable` from its handler.
+///
+/// The merged shape is negotiated explicitly: when the client allows it
+/// (`Request::allow_batch_task_data_merge`) and the top task produces an
+/// error-free mergeable result, each compatible successful batched task is
+/// merged into it and acknowledged by a response without data
+/// (`StoreBatchTaskResponse::data_merged_into_response`) that keeps the
+/// task's execution details. Failed or non-mergeable tasks keep their normal
+/// responses, so the client can consume the merged successes and apply its
+/// usual retry or error handling to the rest. If the client does not allow
+/// merging or the top task cannot carry merged data, every result is
+/// serialized into its own response as usual.
 pub enum HandlerOutcome {
     /// A response that is fully serialized and ready to return.
     Ready(coppb::Response),
     /// A partial response paired with an unserialized mergeable data result.
     Mergeable {
         /// The response carrying everything but the data (errors, cache
-        /// hints, ...); its data is produced from `result`.
+        /// hints, ...); its data is produced from the merged result.
         partial_response: coppb::Response,
         /// The type-erased result that compatible child results merge into.
         result: Box<dyn MergeableResult>,
@@ -112,12 +129,24 @@ impl HandlerOutcome {
             } => response,
         }
     }
+
+    /// Mutable variant of [`HandlerOutcome::response`].
+    pub fn response_mut(&mut self) -> &mut coppb::Response {
+        match self {
+            Self::Ready(response)
+            | Self::Mergeable {
+                partial_response: response,
+                ..
+            } => response,
+        }
+    }
 }
 
 /// An interface for all kind of Coprocessor request handlers.
 #[async_trait]
 pub trait RequestHandler: Send {
-    /// Processes current request and produces an outcome.
+    /// Processes current request and produces an outcome: a ready response,
+    /// or a result kept unserialized for merging. See `HandlerOutcome`.
     async fn handle_request(&mut self) -> Result<MemoryTraceGuard<HandlerOutcome>> {
         panic!("unary request is not supported for this handler");
     }

--- a/src/coprocessor/statistics/analyze.rs
+++ b/src/coprocessor/statistics/analyze.rs
@@ -1,10 +1,11 @@
 // Copyright 2017 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::{cmp::Reverse, collections::BinaryHeap, hash::Hasher, mem, sync::Arc};
+use std::{any::Any, cmp::Reverse, collections::BinaryHeap, hash::Hasher, mem, sync::Arc};
 
 use api_version::KvFormat;
 use kvproto::coprocessor::KeyRange;
 use mur3::Hasher128;
+use protobuf::Message;
 use rand::{Rng, rngs::StdRng};
 use tidb_query_datatype::{
     FieldTypeAccessor,
@@ -239,8 +240,12 @@ impl<S: Snapshot, F: KvFormat> RowSampleBuilder<S, F> {
     }
 }
 
-trait RowSampleCollector: Send {
+trait RowSampleCollector: Any + Send {
     fn mut_base(&mut self) -> &mut BaseRowSampleCollector;
+    /// Merges another collector into this one. Both collectors are built from
+    /// the same analyze request, so they always have the same concrete type
+    /// and implementations may downcast `other` infallibly.
+    fn merge_collector(&mut self, other: Box<dyn RowSampleCollector>);
     fn collect_column_group(
         &mut self,
         columns_val: &[Vec<u8>],
@@ -291,6 +296,19 @@ impl Default for BaseRowSampleCollector {
     }
 }
 
+fn row_sample_memory_usage(row: &[Vec<u8>]) -> usize {
+    row.iter().map(Vec::capacity).sum()
+}
+
+fn bernoulli_samples_memory_usage(samples: &[Vec<Vec<u8>>]) -> usize {
+    samples.iter().map(|row| row_sample_memory_usage(row)).sum()
+}
+
+fn release_reported_memory_usage(base: &mut BaseRowSampleCollector) {
+    base.memory_usage = 0;
+    base.report_memory_usage(true);
+}
+
 impl BaseRowSampleCollector {
     fn new(max_fm_sketch_size: usize, col_and_group_len: usize) -> BaseRowSampleCollector {
         BaseRowSampleCollector {
@@ -301,6 +319,24 @@ impl BaseRowSampleCollector {
             total_sizes: vec![0; col_and_group_len],
             memory_usage: 0,
             reported_memory_usage: 0,
+        }
+    }
+
+    fn merge_from(&mut self, other: &mut BaseRowSampleCollector) {
+        // Collectors of one request share the layout derived from the shared
+        // request; a mismatch would silently truncate the zips below.
+        debug_assert_eq!(self.null_count.len(), other.null_count.len());
+        debug_assert_eq!(self.total_sizes.len(), other.total_sizes.len());
+        debug_assert_eq!(self.fm_sketches.len(), other.fm_sketches.len());
+        self.count += other.count;
+        for (dst, src) in self.null_count.iter_mut().zip(&other.null_count) {
+            *dst += src;
+        }
+        for (dst, src) in self.total_sizes.iter_mut().zip(&other.total_sizes) {
+            *dst += src;
+        }
+        for (sketch, other_sketch) in self.fm_sketches.iter_mut().zip(&other.fm_sketches) {
+            sketch.merge(other_sketch);
         }
     }
 
@@ -420,6 +456,21 @@ impl RowSampleCollector for BernoulliRowSampleCollector {
     fn mut_base(&mut self) -> &mut BaseRowSampleCollector {
         &mut self.base
     }
+
+    fn merge_collector(&mut self, other: Box<dyn RowSampleCollector>) {
+        // Collectors of one request always have the same concrete type.
+        let mut other = (other as Box<dyn Any>)
+            .downcast::<BernoulliRowSampleCollector>()
+            .unwrap();
+        let sample_memory_usage = bernoulli_samples_memory_usage(&other.samples);
+        self.samples.append(&mut other.samples);
+        self.base.memory_usage += sample_memory_usage;
+        self.base.report_memory_usage(false);
+
+        release_reported_memory_usage(&mut other.base);
+        self.base.merge_from(&mut other.base);
+    }
+
     fn collect_column_group(
         &mut self,
         columns_val: &[Vec<u8>],
@@ -491,12 +542,45 @@ impl ReservoirRowSampleCollector {
             max_sample_size,
         }
     }
+
+    fn should_keep_weight(&self, weight: i64) -> bool {
+        if self.max_sample_size == 0 {
+            return false;
+        }
+        self.samples.len() < self.max_sample_size || self.samples.peek().unwrap().0.0 < weight
+    }
+
+    fn push_weighted_sample(&mut self, weight: i64, sample: Vec<Vec<u8>>) {
+        if self.samples.len() >= self.max_sample_size {
+            let (_, evicted) = self.samples.pop().unwrap().0;
+            self.base.memory_usage -= row_sample_memory_usage(&evicted);
+        }
+        self.base.memory_usage += row_sample_memory_usage(&sample);
+        self.samples.push(Reverse((weight, sample)));
+    }
 }
 
 impl RowSampleCollector for ReservoirRowSampleCollector {
     fn mut_base(&mut self) -> &mut BaseRowSampleCollector {
         &mut self.base
     }
+
+    fn merge_collector(&mut self, other: Box<dyn RowSampleCollector>) {
+        // Collectors of one request always have the same concrete type.
+        let mut other = (other as Box<dyn Any>)
+            .downcast::<ReservoirRowSampleCollector>()
+            .unwrap();
+        for Reverse((weight, sample)) in mem::take(&mut other.samples) {
+            if self.should_keep_weight(weight) {
+                self.push_weighted_sample(weight, sample);
+            }
+        }
+        self.base.report_memory_usage(false);
+
+        release_reported_memory_usage(&mut other.base);
+        self.base.merge_from(&mut other.base);
+    }
+
     fn collect_column_group(
         &mut self,
         columns_val: &[Vec<u8>],
@@ -524,25 +608,10 @@ impl RowSampleCollector for ReservoirRowSampleCollector {
     }
 
     fn sampling(&mut self, data: &[Vec<u8>]) {
-        // We should tolerate the abnormal case => `self.max_sample_size == 0`.
-        if self.max_sample_size == 0 {
-            return;
-        }
-        let mut need_push = false;
         let cur_rng = self.base.rng.gen_range(0, i64::MAX);
-        if self.samples.len() < self.max_sample_size {
-            need_push = true;
-        } else if self.samples.peek().unwrap().0.0 < cur_rng {
-            need_push = true;
-            let (_, evicted) = self.samples.pop().unwrap().0;
-            self.base.memory_usage -= evicted.iter().map(|x| x.capacity()).sum::<usize>();
-        }
-
-        if need_push {
-            let sample = data.to_vec();
-            self.base.memory_usage += sample.iter().map(|x| x.capacity()).sum::<usize>();
+        if self.should_keep_weight(cur_rng) {
+            self.push_weighted_sample(cur_rng, data.to_vec());
             self.base.report_memory_usage(false);
-            self.samples.push(Reverse((cur_rng, sample)));
         }
     }
 
@@ -843,6 +912,23 @@ impl AnalyzeSamplingResult {
     }
 }
 
+impl MergeableResult for AnalyzeSamplingResult {
+    fn merge(&mut self, other: Box<dyn MergeableResult>) {
+        // Results of one request have the same concrete type by the
+        // `MergeableResult::merge` contract, so the downcast cannot fail.
+        let other = (other as Box<dyn std::any::Any>)
+            .downcast::<AnalyzeSamplingResult>()
+            .unwrap();
+        self.row_sample_collector
+            .merge_collector(other.row_sample_collector);
+    }
+
+    fn into_data(self: Box<Self>) -> Result<Vec<u8>> {
+        let resp: tipb::AnalyzeColumnsResp = (*self).into();
+        Ok(box_try!(resp.write_to_bytes()))
+    }
+}
+
 impl From<AnalyzeSamplingResult> for tipb::AnalyzeColumnsResp {
     fn from(mut result: AnalyzeSamplingResult) -> tipb::AnalyzeColumnsResp {
         let pb_collector = result.row_sample_collector.to_proto();
@@ -1100,6 +1186,107 @@ mod tests {
             }
             assert_eq!(collector.samples.len(), 0);
         }
+    }
+
+    fn sorted_hashset(sketch: &tipb::FmSketch) -> Vec<u64> {
+        let mut hashes = sketch.get_hashset().to_vec();
+        hashes.sort_unstable();
+        hashes
+    }
+
+    fn test_sampling_result(
+        count: u64,
+        null_count: i64,
+        total_size: i64,
+        sample_weights: &[i64],
+        ndv_hashes: &[u64],
+    ) -> AnalyzeSamplingResult {
+        let mut collector = ReservoirRowSampleCollector::new(2, 1000, 1);
+        collector.base.count = count;
+        collector.base.null_count[0] = null_count;
+        collector.base.total_sizes[0] = total_size;
+        for hash in ndv_hashes {
+            collector.base.fm_sketches[0].insert_hash_value(*hash);
+        }
+        for weight in sample_weights {
+            collector.push_weighted_sample(*weight, vec![vec![*weight as u8]]);
+        }
+        AnalyzeSamplingResult::new(Box::new(collector))
+    }
+
+    #[test]
+    fn test_analyze_sampling_result_merge() {
+        let a = 10;
+        let b = 20;
+        let c = 30;
+        let mut result = test_sampling_result(2, 1, 10, &[1, 3], &[a, b]);
+        result.merge(Box::new(test_sampling_result(2, 2, 20, &[4], &[a, c])));
+
+        let resp: tipb::AnalyzeColumnsResp = result.into();
+        let collector = resp.get_row_collector();
+        assert_eq!(collector.get_count(), 4);
+        assert_eq!(collector.get_null_counts(), &[3]);
+        assert_eq!(collector.get_total_size(), &[30]);
+
+        let mut sample_weights: Vec<_> = collector
+            .get_samples()
+            .iter()
+            .map(|sample| sample.get_weight())
+            .collect();
+        sample_weights.sort_unstable();
+        assert_eq!(sample_weights, vec![3, 4]);
+        assert_eq!(sorted_hashset(&collector.get_fm_sketch()[0]), vec![a, b, c]);
+    }
+
+    fn test_bernoulli_sampling_result(
+        count: u64,
+        null_count: i64,
+        total_size: i64,
+        samples: &[u8],
+        ndv_hashes: &[u64],
+    ) -> AnalyzeSamplingResult {
+        let mut collector = BernoulliRowSampleCollector::new(1.0, 1000, 1);
+        collector.base.count = count;
+        collector.base.null_count[0] = null_count;
+        collector.base.total_sizes[0] = total_size;
+        for hash in ndv_hashes {
+            collector.base.fm_sketches[0].insert_hash_value(*hash);
+        }
+        for sample in samples {
+            collector.samples.push(vec![vec![*sample]]);
+            collector.base.memory_usage += 1;
+        }
+        AnalyzeSamplingResult::new(Box::new(collector))
+    }
+
+    #[test]
+    fn test_analyze_bernoulli_sampling_result_merge() {
+        // Bernoulli samples are concatenated instead of reduced.
+        let a = 10;
+        let b = 20;
+        let c = 30;
+        let mut result = test_bernoulli_sampling_result(2, 1, 10, &[1, 3], &[a, b]);
+        result.merge(Box::new(test_bernoulli_sampling_result(
+            2,
+            2,
+            20,
+            &[4],
+            &[a, c],
+        )));
+
+        let resp: tipb::AnalyzeColumnsResp = result.into();
+        let collector = resp.get_row_collector();
+        assert_eq!(collector.get_count(), 4);
+        assert_eq!(collector.get_null_counts(), &[3]);
+        assert_eq!(collector.get_total_size(), &[30]);
+        let mut samples: Vec<_> = collector
+            .get_samples()
+            .iter()
+            .map(|sample| sample.get_row()[0][0])
+            .collect();
+        samples.sort_unstable();
+        assert_eq!(samples, vec![1, 3, 4]);
+        assert_eq!(sorted_hashset(&collector.get_fm_sketch()[0]), vec![a, b, c]);
     }
 }
 

--- a/src/coprocessor/statistics/analyze_context.rs
+++ b/src/coprocessor/statistics/analyze_context.rs
@@ -221,7 +221,7 @@ impl<S: Snapshot, F: KvFormat> AnalyzeContext<S, F> {
 
 #[async_trait]
 impl<S: Snapshot, F: KvFormat> RequestHandler for AnalyzeContext<S, F> {
-    async fn handle_request(&mut self) -> Result<MemoryTraceGuard<Response>> {
+    async fn handle_request(&mut self) -> Result<MemoryTraceGuard<HandlerOutcome>> {
         let ret = match self.req.get_tp() {
             AnalyzeType::TypeIndex | AnalyzeType::TypeCommonHandle => {
                 let req = self.req.take_idx_req();
@@ -298,12 +298,12 @@ impl<S: Snapshot, F: KvFormat> RequestHandler for AnalyzeContext<S, F> {
                 let memory_size = data.capacity();
                 let mut resp = Response::default();
                 resp.set_data(data);
-                Ok(MEMTRACE_ANALYZE.trace_guard(resp, memory_size))
+                Ok(MEMTRACE_ANALYZE.trace_guard(HandlerOutcome::Ready(resp), memory_size))
             }
             Err(Error::Other(e)) => {
                 let mut resp = Response::default();
                 resp.set_other_error(e);
-                Ok(resp.into())
+                Ok(HandlerOutcome::Ready(resp).into())
             }
             Err(e) => Err(e),
         }

--- a/src/coprocessor/statistics/analyze_context.rs
+++ b/src/coprocessor/statistics/analyze_context.rs
@@ -22,7 +22,8 @@ use crate::{
         MEMTRACE_ANALYZE,
         dag::TikvStorage,
         statistics::analyze::{
-            AnalyzeIndexResult, AnalyzeMixedResult, RowSampleBuilder, SampleBuilder,
+            AnalyzeIndexResult, AnalyzeMixedResult, AnalyzeSamplingResult, RowSampleBuilder,
+            SampleBuilder,
         },
         *,
     },
@@ -120,13 +121,10 @@ impl<S: Snapshot, F: KvFormat> AnalyzeContext<S, F> {
         Ok(res_data)
     }
 
-    async fn handle_full_sampling(builder: &mut RowSampleBuilder<S, F>) -> Result<Vec<u8>> {
-        let sample_res = builder.collect_column_stats().await?;
-        let res_data = {
-            let res: tipb::AnalyzeColumnsResp = sample_res.into();
-            box_try!(res.write_to_bytes())
-        };
-        Ok(res_data)
+    async fn handle_full_sampling(
+        builder: &mut RowSampleBuilder<S, F>,
+    ) -> Result<AnalyzeSamplingResult> {
+        builder.collect_column_stats().await
     }
 
     // handle_index is used to handle `AnalyzeIndexReq`,
@@ -222,6 +220,11 @@ impl<S: Snapshot, F: KvFormat> AnalyzeContext<S, F> {
 #[async_trait]
 impl<S: Snapshot, F: KvFormat> RequestHandler for AnalyzeContext<S, F> {
     async fn handle_request(&mut self) -> Result<MemoryTraceGuard<HandlerOutcome>> {
+        let ready = |data| {
+            let mut response = Response::default();
+            response.set_data(data);
+            HandlerOutcome::Ready(response)
+        };
         let ret = match self.req.get_tp() {
             AnalyzeType::TypeIndex | AnalyzeType::TypeCommonHandle => {
                 let req = self.req.take_idx_req();
@@ -245,7 +248,7 @@ impl<S: Snapshot, F: KvFormat> RequestHandler for AnalyzeContext<S, F> {
                 )
                 .await;
                 scanner.collect_storage_stats(&mut self.storage_stats);
-                res
+                res.map(ready)
             }
 
             AnalyzeType::TypeColumn => {
@@ -255,7 +258,7 @@ impl<S: Snapshot, F: KvFormat> RequestHandler for AnalyzeContext<S, F> {
                 let mut builder = SampleBuilder::<_, F>::new(col_req, None, storage, ranges)?;
                 let res = AnalyzeContext::handle_column(&mut builder).await;
                 builder.data.collect_storage_stats(&mut self.storage_stats);
-                res
+                res.map(ready)
             }
 
             // Type mixed is analyze common handle and columns by scan table rows once.
@@ -268,14 +271,13 @@ impl<S: Snapshot, F: KvFormat> RequestHandler for AnalyzeContext<S, F> {
                     SampleBuilder::<_, F>::new(col_req, Some(idx_req), storage, ranges)?;
                 let res = AnalyzeContext::handle_mixed(&mut builder).await;
                 builder.data.collect_storage_stats(&mut self.storage_stats);
-                res
+                res.map(ready)
             }
 
             AnalyzeType::TypeFullSampling => {
                 let col_req = self.req.take_col_req();
                 let storage = self.storage.take().unwrap();
                 let ranges = std::mem::take(&mut self.ranges);
-
                 let mut builder = RowSampleBuilder::<_, F>::new(
                     col_req,
                     storage,
@@ -283,10 +285,12 @@ impl<S: Snapshot, F: KvFormat> RequestHandler for AnalyzeContext<S, F> {
                     self.quota_limiter.clone(),
                     self.is_auto_analyze,
                 )?;
-
                 let res = AnalyzeContext::handle_full_sampling(&mut builder).await;
                 builder.merge_storage_stats_into(&mut self.storage_stats);
-                res
+                res.map(|sampling_result| HandlerOutcome::Mergeable {
+                    partial_response: Response::default(),
+                    result: Box::new(sampling_result),
+                })
             }
 
             AnalyzeType::TypeSampleIndex => Err(Error::Other(
@@ -294,11 +298,9 @@ impl<S: Snapshot, F: KvFormat> RequestHandler for AnalyzeContext<S, F> {
             )),
         };
         match ret {
-            Ok(data) => {
-                let memory_size = data.capacity();
-                let mut resp = Response::default();
-                resp.set_data(data);
-                Ok(MEMTRACE_ANALYZE.trace_guard(HandlerOutcome::Ready(resp), memory_size))
+            Ok(outcome) => {
+                let memory_size = outcome.response().get_data().len();
+                Ok(MEMTRACE_ANALYZE.trace_guard(outcome, memory_size))
             }
             Err(Error::Other(e)) => {
                 let mut resp = Response::default();

--- a/src/coprocessor/statistics/fmsketch.rs
+++ b/src/coprocessor/statistics/fmsketch.rs
@@ -79,6 +79,16 @@ impl FmSketch {
             self.mask = mask;
         }
     }
+
+    pub(crate) fn merge(&mut self, other: &FmSketch) {
+        if self.mask < other.mask {
+            self.mask = other.mask;
+            self.hash_set.retain(|&x| x & self.mask == 0);
+        }
+        for hash in &other.hash_set {
+            self.insert_hash_value(*hash);
+        }
+    }
 }
 
 impl From<FmSketch> for tipb::FmSketch {
@@ -185,5 +195,29 @@ mod tests {
         assert_eq!(sketch.hash_set.len(), max_size);
         sketch.insert_hash_value(4);
         assert_eq!(sketch.hash_set.len(), max_size);
+    }
+
+    #[test]
+    fn test_merge() {
+        // Sketches over halves of the data merge into the same sketch as one
+        // built over all of it, whether the mask grows on the left (small
+        // max_size forces levels) or the right side.
+        let data = TestData::default();
+        let max_size = 100;
+        let whole = build_fmsketch(&data.samples, max_size).unwrap();
+        let (left, right) = data.samples.split_at(data.samples.len() / 2);
+        let mut merged = build_fmsketch(left, max_size).unwrap();
+        merged.merge(&build_fmsketch(right, max_size).unwrap());
+        assert_eq!(merged.mask, whole.mask);
+        assert_eq!(merged.ndv(), whole.ndv());
+
+        // Merging a leveled-up sketch (bigger mask) prunes the receiver.
+        let small = build_fmsketch(&data.samples, 2).unwrap();
+        let mut receiver = FmSketch::new(2);
+        receiver.insert_hash_value(1);
+        assert_eq!(receiver.mask, 0);
+        receiver.merge(&small);
+        assert!(receiver.mask >= small.mask);
+        assert!(receiver.hash_set.iter().all(|h| h & receiver.mask == 0));
     }
 }

--- a/tests/integrations/coprocessor/test_analyze.rs
+++ b/tests/integrations/coprocessor/test_analyze.rs
@@ -383,40 +383,44 @@ fn test_batched_full_sampling_responses() {
     let second_split_key = Key::from_raw(&product.get_record_range(8, 8).start);
     cluster.must_split(&second_region, second_split_key.as_encoded());
 
-    let mut col_req = AnalyzeColumnsReq::default();
-    col_req.set_columns_info(product.columns_info().into());
-    // A sample rate of one keeps every row, so each response is
-    // deterministic.
-    col_req.set_sample_rate(1.0);
-    col_req.set_sketch_size(1000);
-    let mut analyze_req = AnalyzeReq::default();
-    analyze_req.set_tp(AnalyzeType::TypeFullSampling);
-    analyze_req.set_col_req(col_req);
+    let mut build_req = |allow_merge: bool| -> Request {
+        let mut col_req = AnalyzeColumnsReq::default();
+        col_req.set_columns_info(product.columns_info().into());
+        // A sample rate of one keeps every row, so the merged sample set is
+        // deterministic.
+        col_req.set_sample_rate(1.0);
+        col_req.set_sketch_size(1000);
+        let mut analyze_req = AnalyzeReq::default();
+        analyze_req.set_tp(AnalyzeType::TypeFullSampling);
+        analyze_req.set_col_req(col_req);
 
-    let top_range = product.get_record_range(1, 2);
-    let top_region = cluster.get_region(Key::from_raw(&top_range.start).as_encoded());
-    let mut top_ctx = Context::default();
-    top_ctx.set_region_id(top_region.get_id());
-    top_ctx.set_region_epoch(top_region.get_region_epoch().clone());
-    top_ctx.set_peer(cluster.leader_of_region(top_region.get_id()).unwrap());
+        let top_range = product.get_record_range(1, 2);
+        let top_region = cluster.get_region(Key::from_raw(&top_range.start).as_encoded());
+        let mut top_ctx = Context::default();
+        top_ctx.set_region_id(top_region.get_id());
+        top_ctx.set_region_epoch(top_region.get_region_epoch().clone());
+        top_ctx.set_peer(cluster.leader_of_region(top_region.get_id()).unwrap());
 
-    let mut req = Request::default();
-    req.set_tp(REQ_TYPE_ANALYZE);
-    req.set_data(analyze_req.write_to_bytes().unwrap());
-    req.set_ranges(vec![top_range].into());
-    req.set_start_ts(100);
-    req.set_context(top_ctx);
-    for (task_id, (start, end)) in [(1, (4, 5)), (2, (9, 10))] {
-        let range = product.get_record_range(start, end);
-        let batch_region = cluster.get_region(Key::from_raw(&range.start).as_encoded());
-        let mut task = StoreBatchTask::new();
-        task.set_region_id(batch_region.get_id());
-        task.set_region_epoch(batch_region.get_region_epoch().clone());
-        task.set_peer(cluster.leader_of_region(batch_region.get_id()).unwrap());
-        task.set_ranges(vec![range].into());
-        task.set_task_id(task_id);
-        req.tasks.push(task);
-    }
+        let mut req = Request::default();
+        req.set_tp(REQ_TYPE_ANALYZE);
+        req.set_data(analyze_req.write_to_bytes().unwrap());
+        req.set_ranges(vec![top_range].into());
+        req.set_start_ts(100);
+        req.set_context(top_ctx);
+        req.set_allow_batch_task_data_merge(allow_merge);
+        for (task_id, (start, end)) in [(1, (4, 5)), (2, (9, 10))] {
+            let range = product.get_record_range(start, end);
+            let batch_region = cluster.get_region(Key::from_raw(&range.start).as_encoded());
+            let mut task = StoreBatchTask::new();
+            task.set_region_id(batch_region.get_id());
+            task.set_region_epoch(batch_region.get_region_epoch().clone());
+            task.set_peer(cluster.leader_of_region(batch_region.get_id()).unwrap());
+            task.set_ranges(vec![range].into());
+            task.set_task_id(task_id);
+            req.tasks.push(task);
+        }
+        req
+    };
 
     let parse_collector = |data: &[u8]| -> tipb::RowSampleCollector {
         let mut resp = AnalyzeColumnsResp::default();
@@ -424,15 +428,63 @@ fn test_batched_full_sampling_responses() {
         resp.take_row_collector()
     };
 
-    // Existing clients receive one full-sampling result per region.
-    let mut resp = handle_request(&endpoint, req);
+    // When the client allows merging, the response carries the merged result
+    // of all three regions and every batched task is acknowledged without
+    // data of its own.
+    let mut resp = handle_request(&endpoint, build_req(true));
     assert!(!resp.has_region_error(), "{:?}", resp);
     assert!(resp.get_other_error().is_empty(), "{:?}", resp);
-    assert_eq!(parse_collector(resp.get_data()).get_count(), 2);
-    let batch_resps = resp.take_batch_responses();
+    let collector = parse_collector(resp.get_data());
+    assert_eq!(collector.get_count(), 6);
+    assert_eq!(collector.get_samples().len(), 6);
+    let mut batch_resps = resp.take_batch_responses().into_vec();
+    batch_resps.sort_unstable_by_key(|resp| resp.get_task_id());
     assert_eq!(batch_resps.len(), 2);
     for (batch_resp, task_id) in batch_resps.iter().zip([1, 2]) {
         assert_eq!(batch_resp.get_task_id(), task_id);
+        assert!(batch_resp.get_data_merged_into_response());
+        assert!(batch_resp.get_data().is_empty());
+        assert_eq!(
+            batch_resp
+                .get_exec_details_v2()
+                .get_scan_detail_v2()
+                .get_processed_versions(),
+            2
+        );
+    }
+
+    // A failed task remains separate for retry while successful tasks are
+    // still merged and acknowledged.
+    let mut req = build_req(true);
+    req.tasks[1].mut_region_epoch().set_version(0);
+    let mut resp = handle_request(&endpoint, req);
+    assert!(!resp.has_region_error(), "{:?}", resp);
+    assert!(resp.get_other_error().is_empty(), "{:?}", resp);
+    let collector = parse_collector(resp.get_data());
+    assert_eq!(collector.get_count(), 4);
+    assert_eq!(collector.get_samples().len(), 4);
+    let mut batch_resps = resp.take_batch_responses().into_vec();
+    batch_resps.sort_unstable_by_key(|resp| resp.get_task_id());
+    assert_eq!(batch_resps.len(), 2);
+    assert_eq!(batch_resps[0].get_task_id(), 1);
+    assert!(batch_resps[0].get_data_merged_into_response());
+    assert!(batch_resps[0].get_data().is_empty());
+    assert_eq!(batch_resps[1].get_task_id(), 2);
+    assert!(!batch_resps[1].get_data_merged_into_response());
+    assert!(batch_resps[1].has_region_error());
+
+    // Without the client's consent every task keeps its own serialized
+    // result.
+    let mut resp = handle_request(&endpoint, build_req(false));
+    assert!(!resp.has_region_error(), "{:?}", resp);
+    assert!(resp.get_other_error().is_empty(), "{:?}", resp);
+    assert_eq!(parse_collector(resp.get_data()).get_count(), 2);
+    let mut batch_resps = resp.take_batch_responses().into_vec();
+    batch_resps.sort_unstable_by_key(|resp| resp.get_task_id());
+    assert_eq!(batch_resps.len(), 2);
+    for (batch_resp, task_id) in batch_resps.iter().zip([1, 2]) {
+        assert_eq!(batch_resp.get_task_id(), task_id);
+        assert!(!batch_resp.get_data_merged_into_response());
         assert_eq!(parse_collector(batch_resp.get_data()).get_count(), 2);
     }
 }

--- a/tests/integrations/coprocessor/test_analyze.rs
+++ b/tests/integrations/coprocessor/test_analyze.rs
@@ -1,15 +1,17 @@
 // Copyright 2017 TiKV Project Authors. Licensed under Apache-2.0.
 
 use kvproto::{
-    coprocessor::{KeyRange, Request},
+    coprocessor::{KeyRange, Request, StoreBatchTask},
     kvrpcpb::{Context, IsolationLevel},
 };
 use protobuf::Message;
 use test_coprocessor::*;
+use test_storage::*;
 use tipb::{
     AnalyzeColumnGroup, AnalyzeColumnsReq, AnalyzeColumnsResp, AnalyzeIndexReq, AnalyzeIndexResp,
     AnalyzeReq, AnalyzeType,
 };
+use txn_types::Key;
 
 pub const REQ_TYPE_ANALYZE: i64 = 104;
 
@@ -354,4 +356,83 @@ fn test_invalid_range() {
     req.set_ranges(vec![key_range].into());
     let resp = handle_request(&endpoint, req);
     assert!(!resp.get_other_error().is_empty());
+}
+
+#[test]
+fn test_batched_full_sampling_responses() {
+    let data = vec![
+        (1, Some("name:0"), 2),
+        (2, Some("name:4"), 3),
+        (4, Some("name:3"), 1),
+        (5, Some("name:1"), 4),
+        (9, Some("name:8"), 7),
+        (10, Some("name:6"), 8),
+    ];
+    let product = ProductTable::new();
+    let (mut cluster, raft_engine, ctx) = new_raft_engine(1, "");
+    let (_, endpoint, _) =
+        init_data_with_engine_and_commit(ctx, raft_engine, &product, &data, true);
+
+    // The region is split into [1, 2], [4, 5], [9, 10].
+    let region =
+        cluster.get_region(Key::from_raw(&product.get_record_range(1, 1).start).as_encoded());
+    let split_key = Key::from_raw(&product.get_record_range(3, 3).start);
+    cluster.must_split(&region, split_key.as_encoded());
+    let second_region =
+        cluster.get_region(Key::from_raw(&product.get_record_range(4, 4).start).as_encoded());
+    let second_split_key = Key::from_raw(&product.get_record_range(8, 8).start);
+    cluster.must_split(&second_region, second_split_key.as_encoded());
+
+    let mut col_req = AnalyzeColumnsReq::default();
+    col_req.set_columns_info(product.columns_info().into());
+    // A sample rate of one keeps every row, so each response is
+    // deterministic.
+    col_req.set_sample_rate(1.0);
+    col_req.set_sketch_size(1000);
+    let mut analyze_req = AnalyzeReq::default();
+    analyze_req.set_tp(AnalyzeType::TypeFullSampling);
+    analyze_req.set_col_req(col_req);
+
+    let top_range = product.get_record_range(1, 2);
+    let top_region = cluster.get_region(Key::from_raw(&top_range.start).as_encoded());
+    let mut top_ctx = Context::default();
+    top_ctx.set_region_id(top_region.get_id());
+    top_ctx.set_region_epoch(top_region.get_region_epoch().clone());
+    top_ctx.set_peer(cluster.leader_of_region(top_region.get_id()).unwrap());
+
+    let mut req = Request::default();
+    req.set_tp(REQ_TYPE_ANALYZE);
+    req.set_data(analyze_req.write_to_bytes().unwrap());
+    req.set_ranges(vec![top_range].into());
+    req.set_start_ts(100);
+    req.set_context(top_ctx);
+    for (task_id, (start, end)) in [(1, (4, 5)), (2, (9, 10))] {
+        let range = product.get_record_range(start, end);
+        let batch_region = cluster.get_region(Key::from_raw(&range.start).as_encoded());
+        let mut task = StoreBatchTask::new();
+        task.set_region_id(batch_region.get_id());
+        task.set_region_epoch(batch_region.get_region_epoch().clone());
+        task.set_peer(cluster.leader_of_region(batch_region.get_id()).unwrap());
+        task.set_ranges(vec![range].into());
+        task.set_task_id(task_id);
+        req.tasks.push(task);
+    }
+
+    let parse_collector = |data: &[u8]| -> tipb::RowSampleCollector {
+        let mut resp = AnalyzeColumnsResp::default();
+        resp.merge_from_bytes(data).unwrap();
+        resp.take_row_collector()
+    };
+
+    // Existing clients receive one full-sampling result per region.
+    let mut resp = handle_request(&endpoint, req);
+    assert!(!resp.has_region_error(), "{:?}", resp);
+    assert!(resp.get_other_error().is_empty(), "{:?}", resp);
+    assert_eq!(parse_collector(resp.get_data()).get_count(), 2);
+    let batch_resps = resp.take_batch_responses();
+    assert_eq!(batch_resps.len(), 2);
+    for (batch_resp, task_id) in batch_resps.iter().zip([1, 2]) {
+        assert_eq!(batch_resp.get_task_id(), task_id);
+        assert_eq!(parse_collector(batch_resp.get_data()).get_count(), 2);
+    }
 }

--- a/tests/integrations/coprocessor/test_select.rs
+++ b/tests/integrations/coprocessor/test_select.rs
@@ -2245,6 +2245,8 @@ fn test_batch_request() {
                 let batch_leader = cluster.leader_of_region(batch_region.get_id()).unwrap();
                 let batch_key_ranges =
                     vec![product.get_record_range(handle_range.start, handle_range.end)];
+                // `task_id` stays at its protobuf default to exercise legacy
+                // positional response association.
                 let mut store_batch_task = StoreBatchTask::new();
                 store_batch_task.set_region_id(batch_region.get_id());
                 store_batch_task.set_region_epoch(batch_region.get_region_epoch().clone());
@@ -2326,6 +2328,9 @@ fn test_batch_request() {
 
     for (ranges, results, invalid_epoch, key_is_locked) in cases.iter() {
         let mut req = prepare_req(&mut cluster, ranges);
+        // Legacy clients may leave every task ID at its protobuf default.
+        // Their responses must therefore remain associated by request order.
+        assert!(req.get_tasks().iter().all(|task| task.get_task_id() == 0));
         if *invalid_epoch {
             req.context
                 .as_mut()
@@ -2357,6 +2362,12 @@ fn test_batch_request() {
         }
         let mut resp = handle_request(&endpoint, req);
         let mut batch_results = resp.take_batch_responses().to_vec();
+        assert_eq!(batch_results.len(), results.len() - 1);
+        assert!(
+            batch_results
+                .iter()
+                .all(|response| response.get_task_id() == 0)
+        );
         for (i, result) in results.iter().enumerate() {
             if i == 0 {
                 verify_response(result, &resp);


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: ref #19872

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

This replaces #19854 because its source branch cannot be updated.

When the client opts in through the kvproto negotiation, full-sampling Analyze tasks in one `StoreBatchTasks` request may merge their data into the top-level response. TiKV preserves a per-task acknowledgment and execution details for every merged child.

The final merge runs through the read pool. Admission and queue wait consume the request's remaining deadline. If that wait expires before the pool task claims the handoff slot, the caller drops the unclaimed collectors; after the worker claims the slot, it releases them as its own deadline checks unwind. A response completed before a delayed caller poll keeps the established success behavior. Network/RU response-byte tracing is committed once from the final top-level payload plus the child payloads that are actually attached. Final send/publication versus caller-timeout atomicity remains deferred and is not claimed fixed here.

```commit-message
Merge batched full-sampling Analyze results while preserving per-task
acknowledgments and execution details.

Bound finalizer admission and queue wait by the request deadline, and
trace the final constructed response payload exactly once.
```

### Related changes

- [x] Protocol change: pingcap/kvproto#1511
- [x] Client accounting change: tikv/client-go#2032
- [x] TiDB caller change: pingcap/tidb#70055
- [x] Cross-repository design proposal: pingcap/tidb#70059
- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
  - `cargo test -p tikv --lib coprocessor::endpoint::tests` (41 passed)
  - focused finalizer deadline and response-tracing regressions, including repeated fixed-pool queue/admission/late-poll cases
- [x] Integration test
  - batched full-sampling Analyze integration
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Reduce full-sampling Analyze response overhead by safely merging batched task results.
```
