### PR TITLE
tikv-ctl: fix bad-ssts manifest dump with a specified manifest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4501,7 +4501,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git#1c17b59dcb506302ed4684b3628c4a7165e0b86d"
+source = "git+https://github.com/HunDunDM/rust-rocksdb?branch=hundundm/single-sst-pick#124bfc0f6858b7e5d89886f5bcd7fdadc76a113a"
 dependencies = [
  "bindgen 0.65.1",
  "bzip2-sys",
@@ -4520,7 +4520,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/tikv/rust-rocksdb.git#1c17b59dcb506302ed4684b3628c4a7165e0b86d"
+source = "git+https://github.com/HunDunDM/rust-rocksdb?branch=hundundm/single-sst-pick#124bfc0f6858b7e5d89886f5bcd7fdadc76a113a"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -6718,7 +6718,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git#1c17b59dcb506302ed4684b3628c4a7165e0b86d"
+source = "git+https://github.com/HunDunDM/rust-rocksdb?branch=hundundm/single-sst-pick#124bfc0f6858b7e5d89886f5bcd7fdadc76a113a"
 dependencies = [
  "libc 0.2.176",
  "librocksdb_sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4501,7 +4501,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git#124bfc0f6858b7e5d89886f5bcd7fdadc76a113a"
+source = "git+https://github.com/tikv/rust-rocksdb.git#cdb577c128b8e7d6a5b67c47bd499b149b1069a7"
 dependencies = [
  "bindgen 0.65.1",
  "bzip2-sys",
@@ -4520,7 +4520,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/tikv/rust-rocksdb.git#124bfc0f6858b7e5d89886f5bcd7fdadc76a113a"
+source = "git+https://github.com/tikv/rust-rocksdb.git#cdb577c128b8e7d6a5b67c47bd499b149b1069a7"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -6718,7 +6718,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git#124bfc0f6858b7e5d89886f5bcd7fdadc76a113a"
+source = "git+https://github.com/tikv/rust-rocksdb.git#cdb577c128b8e7d6a5b67c47bd499b149b1069a7"
 dependencies = [
  "libc 0.2.176",
  "librocksdb_sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4501,7 +4501,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/HunDunDM/rust-rocksdb?branch=hundundm/single-sst-pick#124bfc0f6858b7e5d89886f5bcd7fdadc76a113a"
+source = "git+https://github.com/tikv/rust-rocksdb.git#124bfc0f6858b7e5d89886f5bcd7fdadc76a113a"
 dependencies = [
  "bindgen 0.65.1",
  "bzip2-sys",
@@ -4520,7 +4520,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/HunDunDM/rust-rocksdb?branch=hundundm/single-sst-pick#124bfc0f6858b7e5d89886f5bcd7fdadc76a113a"
+source = "git+https://github.com/tikv/rust-rocksdb.git#124bfc0f6858b7e5d89886f5bcd7fdadc76a113a"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -6718,7 +6718,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/HunDunDM/rust-rocksdb?branch=hundundm/single-sst-pick#124bfc0f6858b7e5d89886f5bcd7fdadc76a113a"
+source = "git+https://github.com/tikv/rust-rocksdb.git#124bfc0f6858b7e5d89886f5bcd7fdadc76a113a"
 dependencies = [
  "libc 0.2.176",
  "librocksdb_sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -231,8 +231,6 @@ sysinfo = { git = "https://github.com/tikv/sysinfo", branch = "0.26-fix-cpu" }
 # After the PR to rust-rocksdb is merged, remember to comment this out and run `cargo update -p rocksdb`.
 # [patch.'https://github.com/tikv/rust-rocksdb']
 # rocksdb = { git = "https://github.com/your_github_id/rust-rocksdb", branch = "your_branch" }
-[patch.'https://github.com/tikv/rust-rocksdb']
-rocksdb = { git = "https://github.com/HunDunDM/rust-rocksdb", branch = "hundundm/single-sst-pick" }
 
 [workspace]
 # See https://github.com/rust-lang/rfcs/blob/master/text/2957-cargo-features2.md

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -231,6 +231,8 @@ sysinfo = { git = "https://github.com/tikv/sysinfo", branch = "0.26-fix-cpu" }
 # After the PR to rust-rocksdb is merged, remember to comment this out and run `cargo update -p rocksdb`.
 # [patch.'https://github.com/tikv/rust-rocksdb']
 # rocksdb = { git = "https://github.com/your_github_id/rust-rocksdb", branch = "your_branch" }
+[patch.'https://github.com/tikv/rust-rocksdb']
+rocksdb = { git = "https://github.com/HunDunDM/rust-rocksdb", branch = "hundundm/single-sst-pick" }
 
 [workspace]
 # See https://github.com/rust-lang/rfcs/blob/master/text/2957-cargo-features2.md

--- a/cmd/tikv-ctl/src/main.rs
+++ b/cmd/tikv-ctl/src/main.rs
@@ -1285,6 +1285,24 @@ fn run_sst_dump_command(args: Vec<String>, cfg: &TikvConfig) {
     engine_rocks::raw::run_sst_dump_tool(&args, &build_rocks_opts(cfg));
 }
 
+fn build_bad_sst_manifest_dump_args(
+    db: &str,
+    sst_file_number: &str,
+    manifest: Option<&str>,
+) -> Vec<String> {
+    let mut args = vec![
+        "ldb".to_string(),
+        "--hex".to_string(),
+        "manifest_dump".to_string(),
+        format!("--db={}", db),
+        format!("--sst_file_number={}", sst_file_number),
+    ];
+    if let Some(manifest_path) = manifest {
+        args.push(format!("--path={}", manifest_path));
+    }
+    args
+}
+
 fn print_bad_ssts(data_dir: &str, manifest: Option<&str>, pd_client: RpcClient, cfg: &TikvConfig) {
     let db = &cfg.infer_kv_engine_path(Some(data_dir)).unwrap();
     println!(
@@ -1359,16 +1377,7 @@ fn print_bad_ssts(data_dir: &str, manifest: Option<&str>, pd_client: RpcClient, 
                 }
             }
         };
-        let mut args1 = vec![
-            "ldb".to_string(),
-            "--hex".to_string(),
-            "manifest_dump".to_string(),
-        ];
-        args1.push(format!("--db={}", db));
-        args1.push(format!("--sst_file_number={}", sst_file_number));
-        if let Some(manifest_path) = manifest {
-            args1.push(format!("--manifest={}", manifest_path));
-        }
+        let args1 = build_bad_sst_manifest_dump_args(db, sst_file_number, manifest);
 
         let stdout = BufferRedirect::stdout().unwrap();
         let stderr = BufferRedirect::stderr().unwrap();
@@ -1549,4 +1558,50 @@ fn validate_storage_data_dir(config: &mut TikvConfig, data_dir: Option<String>) 
         return false;
     }
     true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_bad_sst_manifest_dump_args;
+
+    #[test]
+    fn test_build_bad_sst_manifest_dump_args_with_manifest() {
+        let args = build_bad_sst_manifest_dump_args(
+            "/path/to/db",
+            "57155",
+            Some("/path/to/db/MANIFEST-000001"),
+        );
+
+        assert_eq!(
+            args,
+            vec![
+                "ldb",
+                "--hex",
+                "manifest_dump",
+                "--db=/path/to/db",
+                "--sst_file_number=57155",
+                "--path=/path/to/db/MANIFEST-000001",
+            ]
+        );
+        assert!(args.iter().any(|arg| arg.starts_with("--path=")));
+        assert!(!args.iter().any(|arg| arg.starts_with("--manifest=")));
+    }
+
+    #[test]
+    fn test_build_bad_sst_manifest_dump_args_without_manifest() {
+        let args = build_bad_sst_manifest_dump_args("/path/to/db", "57155", None);
+
+        assert_eq!(
+            args,
+            vec![
+                "ldb",
+                "--hex",
+                "manifest_dump",
+                "--db=/path/to/db",
+                "--sst_file_number=57155",
+            ]
+        );
+        assert!(!args.iter().any(|arg| arg.starts_with("--path=")));
+        assert!(!args.iter().any(|arg| arg.starts_with("--manifest=")));
+    }
 }

--- a/cmd/tikv-ctl/src/main.rs
+++ b/cmd/tikv-ctl/src/main.rs
@@ -1303,6 +1303,39 @@ fn build_bad_sst_manifest_dump_args(
     args
 }
 
+fn read_redirected_output(
+    stderr: BufferRedirect,
+    stdout: BufferRedirect,
+) -> io::Result<(String, String)> {
+    // Stop both redirects before reporting an error. Otherwise the diagnostic
+    // itself is written back into the temporary redirect and never reaches the
+    // terminal.
+    let mut stderr = stderr.into_inner();
+    let mut stdout = stdout.into_inner();
+    let mut stderr_bytes = Vec::new();
+    let mut stdout_bytes = Vec::new();
+    stderr.read_to_end(&mut stderr_bytes)?;
+    stdout.read_to_end(&mut stdout_bytes)?;
+    Ok((
+        String::from_utf8_lossy(&stderr_bytes).into_owned(),
+        String::from_utf8_lossy(&stdout_bytes).into_owned(),
+    ))
+}
+
+fn child_process_failure(result: Result<i32, String>, command: &[String]) -> Option<String> {
+    match result {
+        Ok(0) => None,
+        Ok(status) => Some(format!(
+            "child process returned status code {status}, failed to run {}",
+            command.join(" ")
+        )),
+        Err(e) => Some(format!(
+            "failed to run child process {}: {e}",
+            command.join(" ")
+        )),
+    }
+}
+
 fn print_bad_ssts(data_dir: &str, manifest: Option<&str>, pd_client: RpcClient, cfg: &TikvConfig) {
     let db = &cfg.infer_kv_engine_path(Some(data_dir)).unwrap();
     println!(
@@ -1342,15 +1375,13 @@ fn print_bad_ssts(data_dir: &str, manifest: Option<&str>, pd_client: RpcClient, 
         }
     }
 
-    drop(stdout);
-    let mut stderr_buf = stderr.into_inner();
-    let mut buffer = Vec::new();
-    stderr_buf.read_to_end(&mut buffer).unwrap();
-    let corruptions = unsafe { String::from_utf8_unchecked(buffer) };
+    let (corruptions, _) = read_redirected_output(stderr, stdout)
+        .unwrap_or_else(|e| panic!("failed to read sst_dump output: {e}"));
 
     let r = Regex::new(r"/\w*\.sst").unwrap();
     let column_r = Regex::new(r"--------------- (.*) --------------\n(.*)").unwrap();
     let sst_stat_r = Regex::new(r".*\n\d+:\d+\[\d+ .. \d+\]\['(\w*)' seq:\d+, type:\d+ .. '(\w*)' seq:\d+, type:\d+\] at level \d+").unwrap();
+    let mut has_analysis_error = false;
     for line in corruptions.lines() {
         println!("--------------------------------------------------------");
         // The corruption format may like this:
@@ -1362,6 +1393,7 @@ fn print_bad_ssts(data_dir: &str, manifest: Option<&str>, pd_client: RpcClient, 
         let sst_file_number = match r.captures(line) {
             None => {
                 println!("skip bad line format");
+                has_analysis_error = true;
                 continue;
             }
             Some(parts) => {
@@ -1373,6 +1405,7 @@ fn print_bad_ssts(data_dir: &str, manifest: Option<&str>, pd_client: RpcClient, 
                         .unwrap()
                 } else {
                     println!("skip bad line format");
+                    has_analysis_error = true;
                     continue;
                 }
             }
@@ -1381,28 +1414,23 @@ fn print_bad_ssts(data_dir: &str, manifest: Option<&str>, pd_client: RpcClient, 
 
         let stdout = BufferRedirect::stdout().unwrap();
         let stderr = BufferRedirect::stderr().unwrap();
-        match run_and_wait_child_process(|| engine_rocks::raw::run_ldb_tool(&args1, &opts)).unwrap()
-        {
-            0 => {}
-            status => {
-                let mut err = String::new();
-                let mut stderr_buf = stderr.into_inner();
-                drop(stdout);
-                stderr_buf.read_to_string(&mut err).unwrap();
+        let result = run_and_wait_child_process(|| engine_rocks::raw::run_ldb_tool(&args1, &opts));
+        let (err, output) = match read_redirected_output(stderr, stdout) {
+            Ok(output) => output,
+            Err(e) => {
                 println!(
-                    "ldb process return status code {}, failed to run {}:\n{}",
-                    status,
-                    args1.join(" "),
-                    err
+                    "failed to read ldb output after running {}: {e}",
+                    args1.join(" ")
                 );
+                has_analysis_error = true;
                 continue;
             }
         };
-
-        let mut stdout_buf = stdout.into_inner();
-        drop(stderr);
-        let mut output = String::new();
-        stdout_buf.read_to_string(&mut output).unwrap();
+        if let Some(failure) = child_process_failure(result, &args1) {
+            println!("{failure}\nldb stderr:\n{err}\nldb stdout:\n{output}");
+            has_analysis_error = true;
+            continue;
+        }
 
         println!("\nsst meta:");
         // The output may like this:
@@ -1419,6 +1447,7 @@ fn print_bad_ssts(data_dir: &str, manifest: Option<&str>, pd_client: RpcClient, 
             let matches = match sst_stat_r.captures(&output) {
                 None => {
                     println!("sst start key format is not correct: {}", output);
+                    has_analysis_error = true;
                     continue;
                 }
                 Some(v) => v,
@@ -1461,14 +1490,30 @@ fn print_bad_ssts(data_dir: &str, manifest: Option<&str>, pd_client: RpcClient, 
         } else {
             // it is expected when the sst is output of a compaction and the sst isn't added
             // to manifest yet.
-            println!(
-                "sst {} is not found in manifest: {}",
-                sst_file_number, output
-            );
+            if err.is_empty() {
+                println!(
+                    "sst {} is not found in manifest: {}",
+                    sst_file_number, output
+                );
+            } else if err.contains("NotFound") {
+                // RocksDB's manifest_dump writes NotFound to stderr but still
+                // exits with status code 0.
+                println!("sst {} is not found in manifest: {}", sst_file_number, err);
+            } else {
+                has_analysis_error = true;
+                println!(
+                    "failed to get sst {} metadata from manifest:\n{}",
+                    sst_file_number, err
+                );
+            }
         }
     }
     println!("--------------------------------------------------------");
-    println!("corruption analysis has completed");
+    if has_analysis_error {
+        println!("corruption analysis has completed with errors");
+    } else {
+        println!("corruption analysis has completed");
+    }
 }
 
 fn print_overlap_region_and_suggestions(
@@ -1515,16 +1560,11 @@ fn print_overlap_region_and_suggestions(
     }
 }
 
-fn flush_std_buffer_to_log(
-    msg: &str,
-    mut err_buffer: BufferRedirect,
-    mut out_buffer: BufferRedirect,
-) {
-    let mut err = String::new();
-    let mut out = String::new();
-    err_buffer.read_to_string(&mut err).unwrap();
-    out_buffer.read_to_string(&mut out).unwrap();
-    println!("{}, err redirect:{}, out redirect:{}", msg, err, out);
+fn flush_std_buffer_to_log(msg: &str, err_buffer: BufferRedirect, out_buffer: BufferRedirect) {
+    match read_redirected_output(err_buffer, out_buffer) {
+        Ok((err, out)) => println!("{msg}, err redirect:{err}, out redirect:{out}"),
+        Err(e) => println!("{msg}, failed to read redirected output: {e}"),
+    }
 }
 
 fn read_cluster_id(config: &TikvConfig) -> Result<u64, String> {
@@ -1562,7 +1602,7 @@ fn validate_storage_data_dir(config: &mut TikvConfig, data_dir: Option<String>) 
 
 #[cfg(test)]
 mod tests {
-    use super::build_bad_sst_manifest_dump_args;
+    use super::{build_bad_sst_manifest_dump_args, child_process_failure};
 
     #[test]
     fn test_build_bad_sst_manifest_dump_args_with_manifest() {
@@ -1603,5 +1643,20 @@ mod tests {
         );
         assert!(!args.iter().any(|arg| arg.starts_with("--path=")));
         assert!(!args.iter().any(|arg| arg.starts_with("--manifest=")));
+    }
+
+    #[test]
+    fn test_child_process_failure() {
+        let command = vec!["ldb".to_string(), "manifest_dump".to_string()];
+
+        assert_eq!(child_process_failure(Ok(0), &command), None);
+        assert_eq!(
+            child_process_failure(Ok(2), &command).unwrap(),
+            "child process returned status code 2, failed to run ldb manifest_dump"
+        );
+        assert_eq!(
+            child_process_failure(Err("terminated by SIGSEGV".to_string()), &command).unwrap(),
+            "failed to run child process ldb manifest_dump: terminated by SIGSEGV"
+        );
     }
 }

--- a/components/tikv_util/src/lib.rs
+++ b/components/tikv_util/src/lib.rs
@@ -31,7 +31,7 @@ use std::{
 
 use lazy_static::lazy_static;
 use nix::{
-    sys::wait::{WaitStatus, wait},
+    sys::wait::{WaitStatus, waitpid},
     unistd::{ForkResult, fork},
 };
 use serde::Serialize;
@@ -638,10 +638,17 @@ pub fn check_environment_variables() {
 /// Create a child process and wait to get its exit code.
 pub fn run_and_wait_child_process(child: impl Fn()) -> Result<i32, String> {
     match unsafe { fork() } {
-        Ok(ForkResult::Parent { .. }) => match wait().unwrap() {
-            WaitStatus::Exited(_, status) => Ok(status),
-            v => Err(format!("{:?}", v)),
-        },
+        Ok(ForkResult::Parent { child }) => {
+            let status = waitpid(child, None)
+                .map_err(|e| format!("failed to wait for child process {child}: {e}"))?;
+            match status {
+                WaitStatus::Exited(_, status) => Ok(status),
+                WaitStatus::Signaled(pid, signal, core_dumped) => Err(format!(
+                    "child process {pid} was terminated by signal {signal:?}, core dumped: {core_dumped}"
+                )),
+                status => Err(format!("unexpected child process status: {status:?}")),
+            }
+        }
         Ok(ForkResult::Child) => {
             child();
             std::process::exit(0);
@@ -782,6 +789,16 @@ mod tests {
         let mut panic = String::new();
         stderr.read_to_string(&mut panic).unwrap();
         assert!(!panic.is_empty());
+    }
+
+    #[test]
+    fn test_run_and_wait_child_process_reports_signal() {
+        let err = run_and_wait_child_process(|| unsafe {
+            libc::raise(libc::SIGTERM);
+        })
+        .unwrap_err();
+
+        assert!(err.contains("SIGTERM"), "{err}");
     }
 
     #[test]


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: close #19873 

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Update rust-rocksdb to include the RocksDB manifest dump support for selecting a single SST file.

Translate the manifest path supplied through `tikv-ctl bad-ssts --manifest` to the `--path` argument expected by RocksDB's `manifest_dump` command. Previously, TiKV forwarded it as the unsupported `--manifest` argument, causing the command to fail before printing the corrupted SST metadata.

Add unit tests covering argument construction with and without an explicitly specified manifest path.
```

### Related changes

- [x] [tikv/rocksdb#432](https://github.com/tikv/rocksdb/pull/432)
- [x] [tikv/rust-rocksdb#854](https://github.com/tikv/rust-rocksdb/pull/854)
- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Fix an issue that caused `tikv-ctl bad-ssts --manifest` to fail because it forwarded an unsupported argument to RocksDB.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bad-SST manifest analysis and diagnostics, including clearer handling of corrupted metadata and command failures.
  * Correctly reports child-process termination by signals, including the specific signal involved.
  * Ensures analysis completion status accurately reflects detected errors.

* **Tests**
  * Added coverage for manifest handling, command failure reporting, and signal-terminated processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->