### PR TITLE
config: auto-tune grpc concurrency for mixed read/write workloads

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3857,6 +3857,32 @@ impl TikvConfig {
         config::canonicalize_sub_path(data_dir, DEFAULT_ROCKSDB_SUB_DIR)
     }
 
+    fn kv_read_pool_concurrency(&self) -> usize {
+        if self.readpool.storage.use_unified_pool() {
+            self.readpool.unified.max_thread_count
+        } else {
+            self.readpool.storage.normal_concurrency
+        }
+    }
+
+    fn min_grpc_concurrency_for_mixed_workload(&self) -> usize {
+        // Keep enough gRPC worker threads to avoid bottlenecking mixed read/write
+        // traffic at the service edge.
+        let write_path_floor = self.storage.scheduler_worker_pool_size.saturating_add(2);
+        cmp::max(write_path_floor, self.kv_read_pool_concurrency())
+    }
+
+    fn adjust_grpc_concurrency_for_mixed_workload(&mut self) {
+        let min_grpc_concurrency = self.min_grpc_concurrency_for_mixed_workload();
+        if self.server.grpc_concurrency < min_grpc_concurrency {
+            warn!(
+                "server.grpc-concurrency {} is too small for current storage/readpool settings, set to {} instead",
+                self.server.grpc_concurrency, min_grpc_concurrency
+            );
+            self.server.grpc_concurrency = min_grpc_concurrency;
+        }
+    }
+
     pub fn validate(&mut self) -> Result<(), Box<dyn Error>> {
         // Setting up data paths.
         if self.cfg_path.is_empty() {
@@ -4174,6 +4200,7 @@ impl TikvConfig {
         self.log.validate()?;
         self.readpool.validate()?;
         self.storage.validate()?;
+        self.adjust_grpc_concurrency_for_mixed_workload();
         self.rocksdb.validate()?;
         self.raftdb.validate()?;
         self.raft_engine.validate()?;
@@ -7076,6 +7103,32 @@ mod tests {
             invalid_cfg.validate().unwrap_err().to_string(),
             "Titan is unavailable for feature TTL"
         );
+    }
+
+    #[test]
+    fn test_adjust_grpc_concurrency_for_mixed_workload() {
+        let mut cfg = TikvConfig::default();
+        cfg.readpool.storage.use_unified_pool = Some(false);
+        cfg.readpool.coprocessor.use_unified_pool = Some(false);
+        cfg.readpool.storage.normal_concurrency = 8;
+        cfg.storage.scheduler_worker_pool_size = 8;
+        cfg.server.grpc_concurrency = 4;
+
+        cfg.validate().unwrap();
+        assert_eq!(cfg.server.grpc_concurrency, 10);
+    }
+
+    #[test]
+    fn test_keep_grpc_concurrency_if_enough_for_mixed_workload() {
+        let mut cfg = TikvConfig::default();
+        cfg.readpool.storage.use_unified_pool = Some(false);
+        cfg.readpool.coprocessor.use_unified_pool = Some(false);
+        cfg.readpool.storage.normal_concurrency = 8;
+        cfg.storage.scheduler_worker_pool_size = 8;
+        cfg.server.grpc_concurrency = 12;
+
+        cfg.validate().unwrap();
+        assert_eq!(cfg.server.grpc_concurrency, 12);
     }
 
     #[test]


### PR DESCRIPTION
Adjust server.grpc-concurrency during TikvConfig validation so mixed read/write workloads are less likely to be bottlenecked by gRPC worker under-provisioning.

The minimum grpc worker floor is derived from storage scheduler worker capacity and KV read pool concurrency, and grpc concurrency is raised with a warning when configured lower than the floor.

Also add config unit tests for both auto-adjust and no-adjust paths.

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #xxx

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message

```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note

```
