### PR TITLE
storage: pass raw forward key ranges to resource metering tags

### DIFF
--- a/components/raftstore/src/store/worker/metrics.rs
+++ b/components/raftstore/src/store/worker/metrics.rs
@@ -151,14 +151,14 @@ lazy_static! {
     )
     .unwrap();
     pub static ref SNAP_COUNTER: SnapCounter = auto_flush_from!(SNAP_COUNTER_VEC, SnapCounter);
-    pub static ref CHECK_SPILT_COUNTER_VEC: IntCounterVec = register_int_counter_vec!(
+    pub static ref CHECK_SPLIT_COUNTER_VEC: IntCounterVec = register_int_counter_vec!(
         "tikv_raftstore_check_split_total",
         "Total number of raftstore split check.",
         &["type"]
     )
     .unwrap();
-    pub static ref CHECK_SPILT_COUNTER: CheckSplitCounter =
-        auto_flush_from!(CHECK_SPILT_COUNTER_VEC, CheckSplitCounter);
+    pub static ref CHECK_SPLIT_COUNTER: CheckSplitCounter =
+        auto_flush_from!(CHECK_SPLIT_COUNTER_VEC, CheckSplitCounter);
     pub static ref SNAP_HISTOGRAM_VEC: HistogramVec = register_histogram_vec!(
         "tikv_raftstore_snapshot_duration_seconds",
         "Bucketed histogram of raftstore snapshot process duration",
@@ -185,7 +185,7 @@ lazy_static! {
         "Total number of snapshots that are waiting to be applied",
     )
     .unwrap();
-    pub static ref CHECK_SPILT_HISTOGRAM: Histogram = register_histogram!(
+    pub static ref CHECK_SPLIT_HISTOGRAM: Histogram = register_histogram!(
         "tikv_raftstore_check_split_duration_seconds",
         "Bucketed histogram of raftstore split check duration",
         exponential_buckets(0.00001, 2.0, 26).unwrap()

--- a/components/raftstore/src/store/worker/pd.rs
+++ b/components/raftstore/src/store/worker/pd.rs
@@ -3662,7 +3662,7 @@ mod tests {
                             store_id: 0,
                             region_id: 1,
                             peer_id: 0,
-                            key_ranges: vec![],
+                            raw_key_ranges: vec![],
                             extra_attachment: Arc::new(b"a".to_vec()),
                         }),
                         RawRecord {

--- a/components/raftstore/src/store/worker/split_check.rs
+++ b/components/raftstore/src/store/worker/split_check.rs
@@ -650,7 +650,7 @@ impl<EK: KvEngine, S: StoreHandle> Runner<EK, S> {
             "end_key" => log_wrappers::Value::key(&end_key),
             "policy" => ?policy,
         );
-        CHECK_SPILT_COUNTER.all.inc();
+        CHECK_SPLIT_COUNTER.all.inc();
         let mut host = self
             .coprocessor
             .new_split_checker_host(region, tablet, reason, policy);
@@ -762,14 +762,14 @@ impl<EK: KvEngine, S: StoreHandle> Runner<EK, S> {
             };
             self.router
                 .ask_split(region_id, region_epoch, split_keys, source.into());
-            CHECK_SPILT_COUNTER.success.inc();
+            CHECK_SPLIT_COUNTER.success.inc();
         } else {
             debug!(
                 "no need to send, split key not found";
                 "region_id" => region_id,
             );
 
-            CHECK_SPILT_COUNTER.ignore.inc();
+            CHECK_SPLIT_COUNTER.ignore.inc();
         }
     }
 
@@ -787,7 +787,7 @@ impl<EK: KvEngine, S: StoreHandle> Runner<EK, S> {
         end_key: &[u8],
         bucket_ranges: Option<Vec<BucketRange>>,
     ) -> Result<Vec<Vec<u8>>> {
-        let timer = CHECK_SPILT_HISTOGRAM.start_coarse_timer();
+        let timer = CHECK_SPLIT_HISTOGRAM.start_coarse_timer();
         let mut buckets = Vec::new();
         let mut bucket = Bucket::default();
         let empty_bucket = vec![];

--- a/components/raftstore/src/store/worker/split_controller.rs
+++ b/components/raftstore/src/store/worker/split_controller.rs
@@ -709,7 +709,7 @@ impl AutoSplitController {
                     .and_modify(|(cpu_time, _)| *cpu_time += record.cpu_time as f64)
                     .or_insert_with(|| (record.cpu_time as f64, None));
                 // Calculate the (Region ID, Key Range) -> CPU Time.
-                tag.key_ranges.iter().for_each(|key_range| {
+                tag.raw_key_ranges.iter().for_each(|key_range| {
                     region_key_range_cpu_time_map
                         .entry((tag.region_id, key_range))
                         .and_modify(|cpu_time| *cpu_time += record.cpu_time)
@@ -1435,7 +1435,7 @@ mod tests {
                 store_id: 0,
                 region_id,
                 peer_id: 0,
-                key_ranges: vec![(key_range.start_key.clone(), key_range.end_key.clone())],
+                raw_key_ranges: vec![(key_range.start_key.clone(), key_range.end_key.clone())],
                 extra_attachment: Arc::new(vec![]),
             });
             raw_records.records.insert(
@@ -1873,21 +1873,21 @@ mod tests {
             store_id: 0,
             region_id: 1,
             peer_id: 0,
-            key_ranges: vec![(b"a".to_vec(), b"b".to_vec())],
+            raw_key_ranges: vec![(b"a".to_vec(), b"b".to_vec())],
             extra_attachment: Arc::new(vec![]),
         });
         let cd_key_range_tag = Arc::new(TagInfos {
             store_id: 0,
             region_id: 1,
             peer_id: 0,
-            key_ranges: vec![(b"c".to_vec(), b"d".to_vec())],
+            raw_key_ranges: vec![(b"c".to_vec(), b"d".to_vec())],
             extra_attachment: Arc::new(vec![]),
         });
         let multiple_key_ranges_tag = Arc::new(TagInfos {
             store_id: 0,
             region_id: 1,
             peer_id: 0,
-            key_ranges: vec![
+            raw_key_ranges: vec![
                 (b"a".to_vec(), b"b".to_vec()),
                 (b"c".to_vec(), b"d".to_vec()),
             ],
@@ -1897,7 +1897,7 @@ mod tests {
             store_id: 0,
             region_id: 1,
             peer_id: 0,
-            key_ranges: vec![],
+            raw_key_ranges: vec![],
             extra_attachment: Arc::new(vec![]),
         });
 

--- a/components/resource_metering/src/lib.rs
+++ b/components/resource_metering/src/lib.rs
@@ -219,6 +219,10 @@ impl ResourceTagFactory {
     }
 
     /// Creates a tag with raw key ranges for a read request.
+    ///
+    /// Transactional storage and coprocessor pass forward raw `[start, end)`
+    /// ranges. RawKV callers may pass request bytes as-is and are not a
+    /// reliable CPU hottest-range input.
     pub fn new_tag_with_key_ranges(
         &self,
         context: &kvproto::kvrpcpb::Context,
@@ -324,7 +328,9 @@ pub struct TagInfos {
     pub region_id: u64,
     pub peer_id: u64,
     /// Forward `[start, end)` ranges in raw key form. An empty end is
-    /// unbounded. Only read requests contain ranges.
+    /// unbounded. Transactional storage and coprocessor producers guarantee
+    /// this contract; RawKV producers are best-effort and are not a reliable
+    /// input for CPU hottest-range split. Only read requests contain ranges.
     pub raw_key_ranges: Vec<(Vec<u8>, Vec<u8>)>,
     pub extra_attachment: Arc<Vec<u8>>,
 }

--- a/components/resource_metering/src/lib.rs
+++ b/components/resource_metering/src/lib.rs
@@ -416,7 +416,7 @@ mod tests {
                     store_id: 1,
                     region_id: 2,
                     peer_id: 3,
-                    key_ranges: vec![],
+                    raw_key_ranges: vec![],
                     extra_attachment: Arc::new(b"block-read-only".to_vec()),
                 }),
                 resource_tag_factory,

--- a/components/resource_metering/src/lib.rs
+++ b/components/resource_metering/src/lib.rs
@@ -192,13 +192,13 @@ impl ResourceTagFactory {
         }
     }
 
-    // create a new tag with key ranges for a read request.
+    /// Creates a tag with raw key ranges for a read request.
     pub fn new_tag_with_key_ranges(
         &self,
         context: &kvproto::kvrpcpb::Context,
-        key_ranges: Vec<(Vec<u8>, Vec<u8>)>,
+        raw_key_ranges: Vec<(Vec<u8>, Vec<u8>)>,
     ) -> ResourceMeteringTag {
-        let tag_infos = TagInfos::from_rpc_context_with_key_ranges(context, key_ranges);
+        let tag_infos = TagInfos::from_rpc_context_with_key_ranges(context, raw_key_ranges);
         ResourceMeteringTag {
             infos: Arc::new(tag_infos),
             resource_tag_factory: self.clone(),
@@ -297,8 +297,9 @@ pub struct TagInfos {
     pub store_id: u64,
     pub region_id: u64,
     pub peer_id: u64,
-    // Only a read request contains the key ranges.
-    pub key_ranges: Vec<(Vec<u8>, Vec<u8>)>,
+    /// Forward `[start, end)` ranges in raw key form. An empty end is
+    /// unbounded. Only read requests contain ranges.
+    pub raw_key_ranges: Vec<(Vec<u8>, Vec<u8>)>,
     pub extra_attachment: Arc<Vec<u8>>,
 }
 
@@ -309,22 +310,22 @@ impl TagInfos {
             store_id: peer.get_store_id(),
             peer_id: peer.get_id(),
             region_id: context.get_region_id(),
-            key_ranges: vec![],
+            raw_key_ranges: vec![],
             extra_attachment: Arc::new(Vec::from(context.get_resource_group_tag())),
         }
     }
 
-    // create a TagInfos with start and end keys for a read request.
+    /// Creates tag information with raw key ranges for a read request.
     pub fn from_rpc_context_with_key_ranges(
         context: &kvproto::kvrpcpb::Context,
-        key_ranges: Vec<(Vec<u8>, Vec<u8>)>,
+        raw_key_ranges: Vec<(Vec<u8>, Vec<u8>)>,
     ) -> Self {
         let peer = context.get_peer();
         Self {
             store_id: peer.get_store_id(),
             peer_id: peer.get_id(),
             region_id: context.get_region_id(),
-            key_ranges,
+            raw_key_ranges,
             extra_attachment: Arc::new(Vec::from(context.get_resource_group_tag())),
         }
     }
@@ -332,7 +333,7 @@ impl TagInfos {
 
 impl HeapSize for TagInfos {
     fn approximate_heap_size(&self) -> usize {
-        self.key_ranges.approximate_heap_size() + self.extra_attachment.approximate_heap_size()
+        self.raw_key_ranges.approximate_heap_size() + self.extra_attachment.approximate_heap_size()
     }
 }
 
@@ -351,7 +352,7 @@ mod tests {
                     store_id: 1,
                     region_id: 2,
                     peer_id: 3,
-                    key_ranges: vec![],
+                    raw_key_ranges: vec![],
                     extra_attachment: Arc::new(b"12345".to_vec()),
                 }),
                 resource_tag_factory,

--- a/components/resource_metering/src/model.rs
+++ b/components/resource_metering/src/model.rs
@@ -864,21 +864,21 @@ mod tests {
             store_id: 0,
             region_id: 0,
             peer_id: 0,
-            key_ranges: vec![],
+            raw_key_ranges: vec![],
             extra_attachment: Arc::new(b"a".to_vec()),
         });
         let tag2 = Arc::new(TagInfos {
             store_id: 0,
             region_id: 0,
             peer_id: 0,
-            key_ranges: vec![],
+            raw_key_ranges: vec![],
             extra_attachment: Arc::new(b"b".to_vec()),
         });
         let tag3 = Arc::new(TagInfos {
             store_id: 0,
             region_id: 0,
             peer_id: 0,
-            key_ranges: vec![],
+            raw_key_ranges: vec![],
             extra_attachment: Arc::new(b"c".to_vec()),
         });
         let mut records = Records::default();
@@ -939,21 +939,21 @@ mod tests {
             store_id: 0,
             region_id: 0,
             peer_id: 0,
-            key_ranges: vec![],
+            raw_key_ranges: vec![],
             extra_attachment: Arc::new(b"a".to_vec()),
         });
         let tag2 = Arc::new(TagInfos {
             store_id: 0,
             region_id: 0,
             peer_id: 0,
-            key_ranges: vec![],
+            raw_key_ranges: vec![],
             extra_attachment: Arc::new(b"b".to_vec()),
         });
         let tag3 = Arc::new(TagInfos {
             store_id: 0,
             region_id: 0,
             peer_id: 0,
-            key_ranges: vec![],
+            raw_key_ranges: vec![],
             extra_attachment: Arc::new(b"c".to_vec()),
         });
         let mut records = HashMap::default();
@@ -1046,21 +1046,21 @@ mod tests {
             store_id: 0,
             region_id: 0,
             peer_id: 0,
-            key_ranges: vec![],
+            raw_key_ranges: vec![],
             extra_attachment: Arc::new(b"a".to_vec()),
         });
         let tag2 = Arc::new(TagInfos {
             store_id: 0,
             region_id: 0,
             peer_id: 0,
-            key_ranges: vec![],
+            raw_key_ranges: vec![],
             extra_attachment: Arc::new(b"b".to_vec()),
         });
         let tag3 = Arc::new(TagInfos {
             store_id: 0,
             region_id: 0,
             peer_id: 0,
-            key_ranges: vec![],
+            raw_key_ranges: vec![],
             extra_attachment: Arc::new(b"c".to_vec()),
         });
 
@@ -1134,21 +1134,21 @@ mod tests {
             store_id: 0,
             region_id: 0,
             peer_id: 0,
-            key_ranges: vec![],
+            raw_key_ranges: vec![],
             extra_attachment: Arc::new(b"a".to_vec()),
         });
         let tag2 = Arc::new(TagInfos {
             store_id: 0,
             region_id: 0,
             peer_id: 0,
-            key_ranges: vec![],
+            raw_key_ranges: vec![],
             extra_attachment: Arc::new(b"b".to_vec()),
         });
         let tag3 = Arc::new(TagInfos {
             store_id: 0,
             region_id: 0,
             peer_id: 0,
-            key_ranges: vec![],
+            raw_key_ranges: vec![],
             extra_attachment: Arc::new(b"c".to_vec()),
         });
         // tag4's extra tag is equal to tag1's
@@ -1156,7 +1156,7 @@ mod tests {
             store_id: 0,
             region_id: 2,
             peer_id: 0,
-            key_ranges: vec![],
+            raw_key_ranges: vec![],
             extra_attachment: Arc::new(b"a".to_vec()),
         });
         // tag5's extra tag is equal to tag1's
@@ -1164,7 +1164,7 @@ mod tests {
             store_id: 0,
             region_id: 3,
             peer_id: 0,
-            key_ranges: vec![],
+            raw_key_ranges: vec![],
             extra_attachment: Arc::new(b"a".to_vec()),
         });
         // tag6's extra tag is equal to tag2's
@@ -1172,7 +1172,7 @@ mod tests {
             store_id: 0,
             region_id: 5,
             peer_id: 0,
-            key_ranges: vec![],
+            raw_key_ranges: vec![],
             extra_attachment: Arc::new(b"b".to_vec()),
         });
         let mut records = HashMap::default();
@@ -1315,21 +1315,21 @@ mod tests {
             store_id: 0,
             region_id: 1,
             peer_id: 0,
-            key_ranges: vec![],
+            raw_key_ranges: vec![],
             extra_attachment: Arc::new(b"a".to_vec()),
         });
         let tag2 = Arc::new(TagInfos {
             store_id: 0,
             region_id: 2,
             peer_id: 0,
-            key_ranges: vec![],
+            raw_key_ranges: vec![],
             extra_attachment: Arc::new(b"b".to_vec()),
         });
         let tag3 = Arc::new(TagInfos {
             store_id: 0,
             region_id: 3,
             peer_id: 0,
-            key_ranges: vec![],
+            raw_key_ranges: vec![],
             extra_attachment: Arc::new(b"c".to_vec()),
         });
         // tag4's region_id is equal to tag1's
@@ -1337,7 +1337,7 @@ mod tests {
             store_id: 1,
             region_id: 1,
             peer_id: 0,
-            key_ranges: vec![],
+            raw_key_ranges: vec![],
             extra_attachment: Arc::new(b"a".to_vec()),
         });
         // tag5's region_id is equal to tag1's
@@ -1345,7 +1345,7 @@ mod tests {
             store_id: 2,
             region_id: 1,
             peer_id: 0,
-            key_ranges: vec![],
+            raw_key_ranges: vec![],
             extra_attachment: Arc::new(b"a".to_vec()),
         });
         // tag6's region_id is equal to tag2's
@@ -1353,7 +1353,7 @@ mod tests {
             store_id: 3,
             region_id: 2,
             peer_id: 0,
-            key_ranges: vec![],
+            raw_key_ranges: vec![],
             extra_attachment: Arc::new(b"b".to_vec()),
         });
         let mut records = HashMap::default();
@@ -1481,21 +1481,21 @@ mod tests {
             store_id: 0,
             region_id: 0,
             peer_id: 0,
-            key_ranges: vec![],
+            raw_key_ranges: vec![],
             extra_attachment: Arc::new(b"a".to_vec()),
         });
         let tag2 = Arc::new(TagInfos {
             store_id: 0,
             region_id: 0,
             peer_id: 0,
-            key_ranges: vec![],
+            raw_key_ranges: vec![],
             extra_attachment: Arc::new(b"b".to_vec()),
         });
         let tag3 = Arc::new(TagInfos {
             store_id: 0,
             region_id: 0,
             peer_id: 0,
-            key_ranges: vec![],
+            raw_key_ranges: vec![],
             extra_attachment: Arc::new(b"c".to_vec()),
         });
         let mut records = HashMap::default();
@@ -1565,14 +1565,14 @@ mod tests {
             store_id: 0,
             region_id: 0,
             peer_id: 0,
-            key_ranges: vec![],
+            raw_key_ranges: vec![],
             extra_attachment: Arc::new(b"d".to_vec()),
         });
         let tag5 = Arc::new(TagInfos {
             store_id: 0,
             region_id: 0,
             peer_id: 0,
-            key_ranges: vec![],
+            raw_key_ranges: vec![],
             extra_attachment: Arc::new(b"ad".to_vec()),
         });
         let mut records = rs.records.clone();

--- a/components/resource_metering/src/recorder/mod.rs
+++ b/components/resource_metering/src/recorder/mod.rs
@@ -378,7 +378,7 @@ mod tests {
                 store_id: 0,
                 region_id: 0,
                 peer_id: 0,
-                key_ranges: vec![],
+                raw_key_ranges: vec![],
                 extra_attachment: [1].to_vec().into(),
             });
             records.records.entry(tag).or_default().cpu_time = 2;

--- a/components/resource_metering/src/recorder/sub_recorder/cpu.rs
+++ b/components/resource_metering/src/recorder/sub_recorder/cpu.rs
@@ -155,7 +155,7 @@ mod tests {
             store_id: 0,
             region_id: 0,
             peer_id: 0,
-            key_ranges: vec![],
+            raw_key_ranges: vec![],
             extra_attachment: Arc::new(b"abc".to_vec()),
         });
         let store = LocalStorage {

--- a/components/resource_metering/src/reporter/mod.rs
+++ b/components/resource_metering/src/reporter/mod.rs
@@ -309,7 +309,7 @@ mod tests {
                 store_id: 0,
                 region_id: 0,
                 peer_id: 0,
-                key_ranges: vec![],
+                raw_key_ranges: vec![],
                 extra_attachment: Arc::new(b"12345".to_vec()),
             }),
             RawRecord {
@@ -360,7 +360,7 @@ mod tests {
                 store_id: 0,
                 region_id: 0,
                 peer_id: 0,
-                key_ranges: vec![],
+                raw_key_ranges: vec![],
                 extra_attachment: Arc::new(b"12345".to_vec()),
             }),
             RawRecord {
@@ -429,7 +429,7 @@ mod tests {
                 store_id: 0,
                 region_id: 1,
                 peer_id: 0,
-                key_ranges: vec![],
+                raw_key_ranges: vec![],
                 extra_attachment: Arc::new(b"12345".to_vec()),
             }),
             RawRecord {

--- a/doc/maintenance-guides/src/storage.md
+++ b/doc/maintenance-guides/src/storage.md
@@ -60,7 +60,8 @@ High-risk contracts:
 - raw KV API version and TTL rules from `config.rs`
 - transactional resource-metering ranges use raw keys normalized to forward
   `[lower, upper)` bounds; malformed encoded bounds omit range attribution
-  instead of widening the range
+  instead of widening the range. Empty point keys omit the range. RawKV
+  ranges are best-effort and are not a reliable CPU hottest-range input
 
 ## Start Here
 

--- a/doc/maintenance-guides/src/storage.md
+++ b/doc/maintenance-guides/src/storage.md
@@ -58,6 +58,9 @@ High-risk contracts:
 - `ProcessResult` and callback completion semantics
 - `TxnStatusCache` and max-ts related assumptions
 - raw KV API version and TTL rules from `config.rs`
+- transactional resource-metering ranges use raw keys normalized to forward
+  `[lower, upper)` bounds; malformed encoded bounds omit range attribution
+  instead of widening the range
 
 ## Start Here
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -643,7 +643,9 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
         let priority_tag = get_priority_tag(priority);
         let resource_tag = self.resource_tag_factory.new_tag_with_key_ranges(
             &ctx,
-            vec![(key.as_encoded().to_vec(), key.as_encoded().to_vec())],
+            key.to_raw()
+                .map(|raw| vec![(raw.clone(), raw)])
+                .unwrap_or_default(),
         );
         let concurrency_manager = self.concurrency_manager.clone();
         let api_version = self.api_version;
@@ -858,10 +860,10 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
         // representative.
         let rand_index = rand::thread_rng().gen_range(0, requests.len());
         let rand_ctx = requests[rand_index].get_context();
-        let rand_key = requests[rand_index].get_key().to_vec();
+        let raw_rand_key = requests[rand_index].get_key().to_vec();
         let resource_tag = self
             .resource_tag_factory
-            .new_tag_with_key_ranges(rand_ctx, vec![(rand_key.clone(), rand_key)]);
+            .new_tag_with_key_ranges(rand_ctx, vec![(raw_rand_key.clone(), raw_rand_key)]);
         // Unset the TLS tracker because the future below does not belong to any
         // specific request
         clear_tls_tracker_token();
@@ -1067,13 +1069,13 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
         let priority_tag = get_priority_tag(priority);
         keys.sort();
         keys.dedup();
-        let key_ranges = keys
+        let raw_key_ranges = keys
             .iter()
-            .map(|k| (k.as_encoded().to_vec(), k.as_encoded().to_vec()))
+            .filter_map(|key| key.to_raw().ok().map(|raw| (raw.clone(), raw)))
             .collect();
         let resource_tag = self
             .resource_tag_factory
-            .new_tag_with_key_ranges(&ctx, key_ranges);
+            .new_tag_with_key_ranges(&ctx, raw_key_ranges);
         let concurrency_manager = self.concurrency_manager.clone();
         let api_version = self.api_version;
         let busy_threshold = Duration::from_millis(ctx.busy_threshold_ms as u64);
@@ -1280,13 +1282,13 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
             )
         });
         let priority_tag = get_priority_tag(priority);
-        let key_ranges = keys
+        let raw_key_ranges = keys
             .iter()
-            .map(|k| (k.as_encoded().to_vec(), k.as_encoded().to_vec()))
+            .filter_map(|key| key.to_raw().ok().map(|raw| (raw.clone(), raw)))
             .collect();
         let resource_tag = self
             .resource_tag_factory
-            .new_tag_with_key_ranges(&ctx, key_ranges);
+            .new_tag_with_key_ranges(&ctx, raw_key_ranges);
         let concurrency_manager = self.concurrency_manager.clone();
         let api_version = self.api_version;
         let busy_threshold = Duration::from_millis(ctx.busy_threshold_ms as u64);
@@ -1508,13 +1510,21 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
         let priority_tag = get_priority_tag(priority);
         let resource_tag = self.resource_tag_factory.new_tag_with_key_ranges(
             &ctx,
-            vec![(
-                start_key.as_encoded().to_vec(),
-                match &end_key {
-                    Some(k) => k.as_encoded().to_vec(),
-                    None => vec![],
-                },
-            )],
+            start_key
+                .to_raw()
+                .map(|start| {
+                    let end = end_key
+                        .as_ref()
+                        .and_then(|key| key.to_raw().ok())
+                        .unwrap_or_default();
+                    // Normalize to [lower, upper) regardless of scan direction.
+                    if reverse_scan {
+                        vec![(end, start)]
+                    } else {
+                        vec![(start, end)]
+                    }
+                })
+                .unwrap_or_default(),
         );
         let concurrency_manager = self.concurrency_manager.clone();
         let api_version = self.api_version;
@@ -1700,16 +1710,18 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
         let priority_tag = get_priority_tag(priority);
         let resource_tag = self.resource_tag_factory.new_tag_with_key_ranges(
             &ctx,
-            vec![(
-                match &start_key {
-                    Some(k) => k.as_encoded().to_vec(),
-                    None => vec![],
-                },
-                match &end_key {
-                    Some(k) => k.as_encoded().to_vec(),
-                    None => vec![],
-                },
-            )],
+            start_key
+                .as_ref()
+                .map(|key| key.to_raw())
+                .transpose()
+                .and_then(|start| {
+                    end_key
+                        .as_ref()
+                        .map(|key| key.to_raw())
+                        .transpose()
+                        .map(|end| vec![(start.unwrap_or_default(), end.unwrap_or_default())])
+                })
+                .unwrap_or_default(),
         );
         let concurrency_manager = self.concurrency_manager.clone();
         // Do not allow replica read for scan_lock.

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -169,6 +169,28 @@ macro_rules! check_key_size {
 /// To be convenience for test cases unrelated to RawKV.
 pub type StorageApiV1<E, L> = Storage<E, L, ApiV1>;
 
+// Converts transactional scan bounds to the forward raw range used by load
+// split attribution. A malformed bound drops attribution for this request;
+// it must not be treated as an unbounded end.
+fn txn_raw_key_range(
+    start_key: Option<&Key>,
+    end_key: Option<&Key>,
+    reverse_scan: bool,
+) -> Option<(Vec<u8>, Vec<u8>)> {
+    // Keep the existing scan-lock behavior: without a start bound there is no
+    // concrete range to attribute to a hottest-key split.
+    let start_key = start_key?.to_raw().ok()?;
+    let end_key = match end_key {
+        Some(key) => key.to_raw().ok()?,
+        None => Vec::new(),
+    };
+    Some(if reverse_scan {
+        (end_key, start_key)
+    } else {
+        (start_key, end_key)
+    })
+}
+
 /// [`Storage`](Storage) implements transactional KV APIs and raw KV APIs on a
 /// given [`Engine`]. An [`Engine`] provides low level KV functionality.
 /// [`Engine`] has multiple implementations. When a TiKV server is running, a
@@ -1515,23 +1537,12 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
             )
         });
         let priority_tag = get_priority_tag(priority);
+        let raw_key_ranges = txn_raw_key_range(Some(&start_key), end_key.as_ref(), reverse_scan)
+            .into_iter()
+            .collect();
         let resource_tag = self.resource_tag_factory.new_tag_with_key_ranges(
             &ctx,
-            start_key
-                .to_raw()
-                .map(|start| {
-                    let end = end_key
-                        .as_ref()
-                        .and_then(|key| key.to_raw().ok())
-                        .unwrap_or_default();
-                    // Normalize to [lower, upper) regardless of scan direction.
-                    if reverse_scan {
-                        vec![(end, start)]
-                    } else {
-                        vec![(start, end)]
-                    }
-                })
-                .unwrap_or_default(),
+            raw_key_ranges,
         );
         let concurrency_manager = self.concurrency_manager.clone();
         let api_version = self.api_version;
@@ -1715,20 +1726,12 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
             )
         });
         let priority_tag = get_priority_tag(priority);
+        let raw_key_ranges = txn_raw_key_range(start_key.as_ref(), end_key.as_ref(), false)
+            .into_iter()
+            .collect();
         let resource_tag = self.resource_tag_factory.new_tag_with_key_ranges(
             &ctx,
-            start_key
-                .as_ref()
-                .map(|key| key.to_raw())
-                .transpose()
-                .and_then(|start| {
-                    end_key
-                        .as_ref()
-                        .map(|key| key.to_raw())
-                        .transpose()
-                        .map(|end| vec![(start.unwrap_or_default(), end.unwrap_or_default())])
-                })
-                .unwrap_or_default(),
+            raw_key_ranges,
         );
         let concurrency_manager = self.concurrency_manager.clone();
         // Do not allow replica read for scan_lock.
@@ -7563,6 +7566,38 @@ mod tests {
             (b"c3".to_vec(), vec![]),
         ]);
         assert!(!<StorageApiV1<RocksEngine, MockLockManager>>::check_key_ranges(&ranges, true));
+    }
+
+    #[test]
+    fn test_txn_raw_key_range_drops_malformed_bound() {
+        let start_key = Key::from_raw(b"a");
+        let end_key = Key::from_raw(b"z");
+        assert_eq!(
+            txn_raw_key_range(Some(&start_key), Some(&end_key), false),
+            Some((b"a".to_vec(), b"z".to_vec()))
+        );
+
+        let malformed_end_key = Key::from_encoded(vec![0xff]);
+        assert_eq!(
+            txn_raw_key_range(Some(&start_key), Some(&malformed_end_key), false),
+            None,
+            "a malformed end key must not widen attribution to an unbounded range"
+        );
+        assert_eq!(
+            txn_raw_key_range(Some(&end_key), Some(&start_key), true),
+            Some((b"a".to_vec(), b"z".to_vec()))
+        );
+        assert_eq!(
+            txn_raw_key_range(Some(&end_key), None, true),
+            Some((Vec::new(), b"z".to_vec()))
+        );
+        assert_eq!(txn_raw_key_range(None, None, false), None);
+
+        let malformed_start_key = Key::from_encoded(vec![0xff]);
+        assert_eq!(
+            txn_raw_key_range(Some(&malformed_start_key), Some(&end_key), false),
+            None
+        );
     }
 
     #[test]

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -169,17 +169,38 @@ macro_rules! check_key_size {
 /// To be convenience for test cases unrelated to RawKV.
 pub type StorageApiV1<E, L> = Storage<E, L, ApiV1>;
 
+// Converts a transactional point key to the raw range used by load-split
+// attribution. An empty raw key is omitted so it is not treated as an
+// unbounded `[start, end)` by CPU hottest-range fallback.
+fn txn_raw_point_range_bytes(raw: Vec<u8>) -> Option<(Vec<u8>, Vec<u8>)> {
+    if raw.is_empty() {
+        None
+    } else {
+        Some((raw.clone(), raw))
+    }
+}
+
+fn txn_raw_point_range(key: &Key) -> Option<(Vec<u8>, Vec<u8>)> {
+    txn_raw_point_range_bytes(key.to_raw().ok()?)
+}
+
 // Converts transactional scan bounds to the forward raw range used by load
 // split attribution. A malformed bound drops attribution for this request;
-// it must not be treated as an unbounded end.
+// it must not be treated as an unbounded end. Missing start and end together
+// are omitted so `("", "")` is not expanded to the whole Region. A missing
+// start with a present end is recorded as `("", end)`.
 fn txn_raw_key_range(
     start_key: Option<&Key>,
     end_key: Option<&Key>,
     reverse_scan: bool,
 ) -> Option<(Vec<u8>, Vec<u8>)> {
-    // Keep the existing scan-lock behavior: without a start bound there is no
-    // concrete range to attribute to a hottest-key split.
-    let start_key = start_key?.to_raw().ok()?;
+    if start_key.is_none() && end_key.is_none() {
+        return None;
+    }
+    let start_key = match start_key {
+        Some(key) => key.to_raw().ok()?,
+        None => Vec::new(),
+    };
     let end_key = match end_key {
         Some(key) => key.to_raw().ok()?,
         None => Vec::new(),
@@ -666,12 +687,9 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
             )
         });
         let priority_tag = get_priority_tag(priority);
-        let resource_tag = self.resource_tag_factory.new_tag_with_key_ranges(
-            &ctx,
-            key.to_raw()
-                .map(|raw| vec![(raw.clone(), raw)])
-                .unwrap_or_default(),
-        );
+        let resource_tag = self
+            .resource_tag_factory
+            .new_tag_with_key_ranges(&ctx, txn_raw_point_range(&key).into_iter().collect());
         let concurrency_manager = self.concurrency_manager.clone();
         let api_version = self.api_version;
         let busy_threshold = Duration::from_millis(ctx.busy_threshold_ms as u64);
@@ -887,9 +905,12 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
         let rand_index = rand::thread_rng().gen_range(0, requests.len());
         let rand_ctx = requests[rand_index].get_context();
         let raw_rand_key = requests[rand_index].get_key().to_vec();
-        let resource_tag = self
-            .resource_tag_factory
-            .new_tag_with_key_ranges(rand_ctx, vec![(raw_rand_key.clone(), raw_rand_key)]);
+        let resource_tag = self.resource_tag_factory.new_tag_with_key_ranges(
+            rand_ctx,
+            txn_raw_point_range_bytes(raw_rand_key)
+                .into_iter()
+                .collect(),
+        );
         // Unset the TLS tracker because the future below does not belong to any
         // specific request
         clear_tls_tracker_token();
@@ -1096,10 +1117,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
         let priority_tag = get_priority_tag(priority);
         keys.sort();
         keys.dedup();
-        let raw_key_ranges = keys
-            .iter()
-            .filter_map(|key| key.to_raw().ok().map(|raw| (raw.clone(), raw)))
-            .collect();
+        let raw_key_ranges = keys.iter().filter_map(txn_raw_point_range).collect();
         let resource_tag = self
             .resource_tag_factory
             .new_tag_with_key_ranges(&ctx, raw_key_ranges);
@@ -1310,10 +1328,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
             )
         });
         let priority_tag = get_priority_tag(priority);
-        let raw_key_ranges = keys
-            .iter()
-            .filter_map(|key| key.to_raw().ok().map(|raw| (raw.clone(), raw)))
-            .collect();
+        let raw_key_ranges = keys.iter().filter_map(txn_raw_point_range).collect();
         let resource_tag = self
             .resource_tag_factory
             .new_tag_with_key_ranges(&ctx, raw_key_ranges);
@@ -1540,10 +1555,9 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
         let raw_key_ranges = txn_raw_key_range(Some(&start_key), end_key.as_ref(), reverse_scan)
             .into_iter()
             .collect();
-        let resource_tag = self.resource_tag_factory.new_tag_with_key_ranges(
-            &ctx,
-            raw_key_ranges,
-        );
+        let resource_tag = self
+            .resource_tag_factory
+            .new_tag_with_key_ranges(&ctx, raw_key_ranges);
         let concurrency_manager = self.concurrency_manager.clone();
         let api_version = self.api_version;
         let busy_threshold = Duration::from_millis(ctx.busy_threshold_ms as u64);
@@ -1729,10 +1743,9 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
         let raw_key_ranges = txn_raw_key_range(start_key.as_ref(), end_key.as_ref(), false)
             .into_iter()
             .collect();
-        let resource_tag = self.resource_tag_factory.new_tag_with_key_ranges(
-            &ctx,
-            raw_key_ranges,
-        );
+        let resource_tag = self
+            .resource_tag_factory
+            .new_tag_with_key_ranges(&ctx, raw_key_ranges);
         let concurrency_manager = self.concurrency_manager.clone();
         // Do not allow replica read for scan_lock.
         ctx.set_replica_read(false);
@@ -7592,12 +7605,35 @@ mod tests {
             Some((Vec::new(), b"z".to_vec()))
         );
         assert_eq!(txn_raw_key_range(None, None, false), None);
+        assert_eq!(
+            txn_raw_key_range(None, Some(&end_key), false),
+            Some((Vec::new(), b"z".to_vec())),
+            "scan_lock without a start bound must still record [region_start, end)"
+        );
 
         let malformed_start_key = Key::from_encoded(vec![0xff]);
         assert_eq!(
             txn_raw_key_range(Some(&malformed_start_key), Some(&end_key), false),
             None
         );
+    }
+
+    #[test]
+    fn test_txn_raw_point_range_omits_empty_key() {
+        assert_eq!(
+            txn_raw_point_range(&Key::from_raw(b"a")),
+            Some((b"a".to_vec(), b"a".to_vec()))
+        );
+        assert_eq!(
+            txn_raw_point_range(&Key::from_raw(b"")),
+            None,
+            "an empty point key must not be recorded as an unbounded range"
+        );
+        assert_eq!(
+            txn_raw_point_range_bytes(b"a".to_vec()),
+            Some((b"a".to_vec(), b"a".to_vec()))
+        );
+        assert_eq!(txn_raw_point_range_bytes(Vec::new()), None);
     }
 
     #[test]


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: close #19877

What's Changed:

```commit-message
storage: pass raw forward key ranges to resource metering tags

Resource-metering tags mixed key encodings: storage passed memcomparable
encoded keys while coprocessor passed raw keys. The load-based split consumer
(split_check key-range mode) assumes raw keys and re-encodes them, so CPU
hottest-range half split silently failed for kv get/scan hotspots. Reverse
scans additionally produced inverted (upper, lower) ranges, and an unbounded
reverse scan produced (upper, "") which points at the wrong side.

Pass raw keys from all transactional storage entry points, normalize scan
ranges to forward [lower, upper) regardless of direction, and rename the field
to raw_key_ranges so the expected encoding is part of the type surface.
Raw-API entry points already pass raw keys.

raftstore: fix CHECK_SPLIT metric identifier spelling

Rename the CHECK_SPILT_* statics to CHECK_SPLIT_*. Identifier-only change;
the registered metric names are unchanged.
```

Behavior notes:

- Only the resource-metering tag construction changes; ReadStats sampling for
  QPS-based split keys continues to use encoded keys and is untouched.
- `Key::to_raw()` failures fall back to a tag without ranges, keeping CPU
  accounting per Region intact.
- The cloud-engine fork already runs this normalization; this keeps the two
  codebases aligned.

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`
- [ ] Need to cherry-pick to the release branch

### Check List

Tests

- [x] Existing resource_metering and split_controller unit tests cover the
  renamed field; behavior is exercised by
  `cargo test -p raftstore --lib -- split_controller::tests::test_collect_cpu_stats`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

### Release note

- **Improvements**
  - Resource metering now records raw key ranges for read, scan, and lock-scan operations, including ranges with only an end boundary.
  - Empty point keys are excluded from range attribution, and documentation clarifies RawKV range limitations.
  - Auto-split handling routes single-key splits through the current peer and avoids repeated CPU-triggered attempts during cooldown periods.

- **Bug Fixes**
  - Corrected split-check metric names and reporting for consistent counters and timing measurements.
  - Empty auto-split candidate lists are no longer scheduled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->