### PR TITLE
raftstore: bound TermCache to known log indexes

### DIFF
--- a/components/raftstore/src/store/entry_storage.rs
+++ b/components/raftstore/src/store/entry_storage.rs
@@ -413,6 +413,10 @@ impl Drop for EntryCache {
 /// term information.
 struct TermCache {
     cache: VecDeque<(u64, u64)>, // (term, start_index)
+    // The greatest index covered by the last cached term. The final cache
+    // entry has no following start_index from which an end can be inferred,
+    // so it must not be considered to extend to infinity.
+    tail_index: u64,
     capacity: usize,
 }
 
@@ -420,6 +424,7 @@ impl Default for TermCache {
     fn default() -> Self {
         TermCache {
             cache: Default::default(),
+            tail_index: 0,
             capacity: 8, /* 8 is enough for the recent updated terms.
                           * Small capacity will make the extra memory
                           * cost negligible. */
@@ -455,17 +460,22 @@ impl TermCache {
                         if cached_start_idx > index {
                             self.cache[pos].1 = index;
                         }
+                        if pos + 1 == self.cache.len() {
+                            self.tail_index = self.tail_index.max(index);
+                        }
                         return;
                     } else if self.cache.back().unwrap().0 + 1 < term {
                         // Detected a term jump indicating potential network partition.
                         // Clear the cache to prevent serving stale term information.
                         self.cache.clear();
+                        self.tail_index = 0;
                     }
                 }
             }
         }
         // New term.
         self.cache.push_back((term, index));
+        self.tail_index = index;
         if self.cache.len() > self.capacity {
             self.cache.pop_front();
         }
@@ -492,6 +502,9 @@ impl TermCache {
         // Meanwhile, the capacity of `TermCache` is limited to 8, so the
         // traversal cost is low.
         self.cache.retain(|(_, start_idx)| *start_idx >= index);
+        if self.cache.is_empty() {
+            self.tail_index = 0;
+        }
     }
 
     /// Return the term of the given index.
@@ -502,7 +515,7 @@ impl TermCache {
             return None;
         }
         let (_, start_idx) = self.cache.front().unwrap();
-        if idx < *start_idx {
+        if idx < *start_idx || idx > self.tail_index {
             return None;
         }
         let (end_term, end_idx) = self.cache.back().unwrap();
@@ -1591,7 +1604,7 @@ pub mod tests {
             }
             assert_eq!(cache.entry(0), None);
             assert_eq!(cache.entry(20), Some(8));
-            assert_eq!(cache.entry(21), Some(8));
+            assert_eq!(cache.entry(21), None);
             // index [1..2] => term 1
             assert_eq!(cache.entry(1), Some(1));
             assert_eq!(cache.entry(2), Some(1));
@@ -1622,7 +1635,7 @@ pub mod tests {
                 new_entry(6, 6),
             ];
             cache.prepend(&ents);
-            assert_eq!(cache.entry(46), Some(11));
+            assert_eq!(cache.entry(46), None);
             assert_eq!(cache.entry(3), None);
             assert_eq!(cache.entry(4), Some(4));
             assert_eq!(cache.entry(5), Some(5));
@@ -1649,7 +1662,7 @@ pub mod tests {
             assert_eq!(cache.entry(48), None);
             assert_eq!(cache.entry(49), Some(12));
             assert_eq!(cache.entry(56), Some(19));
-            assert_eq!(cache.entry(57), Some(19));
+            assert_eq!(cache.entry(57), None);
         }
         // Abnormal cases: index hopping
         {
@@ -1662,7 +1675,7 @@ pub mod tests {
             assert_eq!(cache.entry(8), Some(6));
             cache.append(6, 8);
             assert_eq!(cache.cache.len(), 1);
-            assert_eq!(cache.entry(8), Some(8));
+            assert_eq!(cache.entry(8), None);
             drop(cache);
 
             let mut cache = TermCache::default();
@@ -1697,6 +1710,36 @@ pub mod tests {
             assert_eq!(cache.entry(18), None);
             assert_eq!(cache.entry(19), Some(9));
         }
+    }
+
+    #[test]
+    fn test_term_cache_does_not_cover_uncached_tail() {
+        let ents = vec![
+            new_entry(3, 3),
+            new_entry(4, 4),
+            new_entry(5, 4),
+            new_entry(6, 5),
+            new_entry(7, 5),
+        ];
+        let td = Builder::new().prefix("tikv-store-test").tempdir().unwrap();
+        let worker = LazyWorker::new("snap-manager");
+        let sched = worker.scheduler();
+        let (dummy_scheduler, _) = dummy_scheduler();
+        let mut store = new_storage_from_ents(sched, dummy_scheduler, &td, &ents);
+
+        // Simulate a partial committed-entry batch: only term 4 has reached
+        // TermCache, while the RaftEngine already contains term 5 at index 6.
+        store.term_cache = TermCache::default();
+        store.update_term_cache(4, 4);
+
+        // EntryCache correctly serves the newer term before eviction.
+        assert_eq!(store.term(6).unwrap(), 5);
+
+        // Once all persisted entries are evicted from EntryCache, TermCache
+        // must miss index 6 and fall back to RaftEngine.
+        store.evict_entry_cache(false);
+        assert!(store.is_entry_cache_empty());
+        assert_eq!(store.term(6).unwrap(), 5);
     }
 
     #[test]

--- a/doc/maintenance-guides/components/raftstore.md
+++ b/doc/maintenance-guides/components/raftstore.md
@@ -111,7 +111,8 @@ High-risk contracts:
 ### Persistent region/raft state
 
 - `store/peer_storage.rs` owns apply/raft state persistence and snapshot state.
-- `store/entry_storage.rs` owns raft log entry storage and fetch behavior.
+- `store/entry_storage.rs` owns raft log entry storage, cache-assisted fetches,
+  and term lookup fallback to the Raft log engine.
 - `store/region_meta.rs` models persisted region and raft metadata.
 
 ### Reads, snapshots, and async IO
@@ -141,6 +142,11 @@ High-risk contracts:
   safety depends on this.
 - A `Peer` must preserve role, applied index, raft log, and lease/read-progress
   consistency across ticks and messages.
+- `EntryStorage` caches are performance hints, not an authority for unknown
+  Raft-log state. `TermCache` may answer a lookup only within its explicitly
+  known index interval; in particular, its final cached term must not be
+  inferred to cover later indices. A miss must fall back to the Raft log
+  engine.
 - Snapshot lifecycle must not leak:
   generation, transport, application, and cleanup are all coupled.
 - Local reads must only bypass raft when lease and read-progress guarantees are


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: close #19060

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

- Track the last log index explicitly covered by `TermCache`.
- Fall back to RaftEngine when a term lookup is outside the known cache range.
- Add a regression test for an evicted EntryCache with persisted logs beyond the TermCache tail.
- Document the TermCache coverage invariant in the raftstore maintenance guide.

```commit-message
raftstore: bound TermCache to known log indexes

TermCache previously treated its final cached term as covering all later
log indexes. Track its known tail index and fall back to RaftEngine for
lookups beyond that boundary, preventing incorrect commit terms from
reaching the apply path.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!--
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Fix a potential TiKV panic caused by an incorrect cached Raft log term.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved raft log term lookups to avoid returning results for uncached log entries.
  * Cache misses now correctly fall back to the underlying raft log storage.

* **Documentation**
  * Clarified cache behavior, known lookup ranges, and fallback handling in the maintenance guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->