### PR TITLE
txn: add a transaction command flight recorder for MVCC debugging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,9 +120,9 @@ checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
 
 [[package]]
 name = "anyhow"
-version = "1.0.75"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "api_version"
@@ -1844,9 +1844,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -6535,9 +6535,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
 dependencies = [
  "lock_api",
 ]

--- a/components/test_coprocessor/src/store.rs
+++ b/components/test_coprocessor/src/store.rs
@@ -224,13 +224,20 @@ impl<E: Engine> Store<E> {
     }
 
     pub fn put(&mut self, ctx: Context, mut kv: Vec<(Vec<u8>, Vec<u8>)>) {
+        // Reuse one primary for every prewrite batch in the transaction.
+        let primary = self
+            .handles
+            .first()
+            .cloned()
+            .unwrap_or_else(|| kv[0].0.clone());
         self.handles.extend(kv.iter().map(|(k, _)| k.clone()));
-        let pk = kv[0].0.clone();
         let kv = kv
             .drain(..)
             .map(|(k, v)| Mutation::make_put(Key::from_raw(&k), v))
             .collect();
-        self.store.prewrite(ctx, kv, pk, self.current_ts).unwrap();
+        self.store
+            .prewrite(ctx, kv, primary, self.current_ts)
+            .unwrap();
     }
 
     pub fn insert_into<'a>(&'a mut self, table: &'a Table) -> Insert<'a, E> {
@@ -239,14 +246,19 @@ impl<E: Engine> Store<E> {
 
     pub fn delete(&mut self, ctx: Context, mut keys: Vec<Vec<u8>>) {
         keys.dedup();
+        // Reuse one primary for every prewrite batch in the transaction.
+        let primary = self
+            .handles
+            .first()
+            .cloned()
+            .unwrap_or_else(|| keys[0].clone());
         self.handles.extend(keys.clone());
-        let pk = keys[0].clone();
         let mutations = keys
             .drain(..)
             .map(|k| Mutation::make_delete(Key::from_raw(&k)))
             .collect();
         self.store
-            .prewrite(ctx, mutations, pk, self.current_ts)
+            .prewrite(ctx, mutations, primary, self.current_ts)
             .unwrap();
     }
 

--- a/deny.toml
+++ b/deny.toml
@@ -71,6 +71,11 @@ ignore = [
     #
     # TODO: Upgrade clap to v4.x.
     "RUSTSEC-2021-0145",
+    # Ignore RUSTSEC-2022-0104 because structopt is only used by tikv-ctl and
+    # does not affect the server runtime. This is safe to ignore.
+    #
+    # TODO: Replace structopt with clap-v3 derives as in #19744.
+    "RUSTSEC-2022-0104",
     # Ignore RUSTSEC-2024-0006 as it only included by "rusoto_credential" crate.
     #
     # TODO: Upgrade shlex@0.1.1 to v1.3.x.
@@ -105,6 +110,34 @@ ignore = [
     # in master branch. Because the modification is too large,
     # we decided on the release branch to ignore it.
     "RUSTSEC-2026-0009",
+    # Ignore RUSTSEC-2026-0186 temporarily. memmap2 is pulled in transitively by
+    # raft-engine and symbolic-common, so release-8.5 cannot resolve it with a
+    # local code change in this PR.
+    #
+    # TODO: Upgrade memmap2 to >= 0.9.11 when dependency constraints allow it.
+    "RUSTSEC-2026-0186",
+    # azure_core transitively depends on http-types/rand, which triggers
+    # RUSTSEC-2026-0097 (unsound with custom logger). Upstream dependency
+    # constraints prevent upgrading at the moment.
+    "RUSTSEC-2026-0097",
+    # Ignore RUSTSEC-2026-0174, as it does not introduce safety issues, only
+    # violating ASCII invariants. Meanwhile, it only affects the `azure` crate,
+    # which can be upgraded after it fixes the issue.
+    #
+    # See: https://github.com/http-rs/http-types/issues/534
+    "RUSTSEC-2026-0174",
+    # Ignore RUSTSEC-2026-0194 and RUSTSEC-2026-0195 temporarily. Both come
+    # from quick-xml through two transitive chains:
+    #   1. pprof -> inferno -> quick-xml, which TiKV uses only to generate
+    #      local flamegraph SVG output rather than parse untrusted XML input.
+    #   2. azure_core 0.18 -> quick-xml, which requires an Azure SDK upgrade
+    #      instead of a lockfile-only update to reach quick-xml >= 0.41.
+    # The remaining practical exposure is limited to XML returned by the
+    # configured Azure endpoint over TLS, so we accept the temporary DoS risk
+    # until we schedule the SDK upgrade and pprof/inferno dependency refresh.
+    # TODO: Remove after both dependency chains can move to quick-xml >= 0.41.
+    "RUSTSEC-2026-0194",
+    "RUSTSEC-2026-0195",
 ]
 
 # TiKV is licensed under Apache 2.0, according to ASF 3RD PARTY LICENSE POLICY,

--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -289,6 +289,10 @@
 ## latency jittering when apply duration is not stable.
 # enable-async-apply-prewrite = false
 
+## Records a bounded in-memory history of transaction commands and their lock/write
+## modifications. Enable it only while diagnosing transaction consistency issues.
+# enable-txn-command-flight-recorder = false
+
 ## Reserve some space to ensure recovering the store from `no space left` must succeed.
 ## `max(reserve-space, capacity * 5%)` will be reserved exactly.
 ##

--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -291,7 +291,8 @@
 
 ## Records a bounded in-memory history of transaction commands and their lock/write
 ## modifications. Enable it only while diagnosing transaction consistency issues.
-# enable-txn-command-flight-recorder = false
+## NOTE: this debug build enables it by default.
+# enable-txn-command-flight-recorder = true
 
 ## Reserve some space to ensure recovering the store from `no space left` must succeed.
 ## `max(reserve-space, capacity * 5%)` will be reserved exactly.

--- a/src/storage/config.rs
+++ b/src/storage/config.rs
@@ -133,7 +133,7 @@ impl Default for Config {
             reserve_space: ReadableSize::gb(DEFAULT_RESERVED_SPACE_GB),
             reserve_raft_space: ReadableSize::gb(DEFAULT_RESERVED_RAFT_SPACE_GB),
             enable_async_apply_prewrite: false,
-            enable_txn_command_flight_recorder: false,
+            enable_txn_command_flight_recorder: true,
             api_version: 1,
             enable_ttl: false,
             ttl_check_poll_interval: ReadableDuration::hours(12),

--- a/src/storage/config.rs
+++ b/src/storage/config.rs
@@ -94,9 +94,7 @@ pub struct Config {
     pub reserve_raft_space: ReadableSize,
     #[online_config(skip)]
     pub enable_async_apply_prewrite: bool,
-    /// Records bounded transaction command history for diagnosing MVCC
-    /// invariants. Disabled by default because it retains additional in-memory
-    /// metadata and adds work to the transaction scheduler.
+    /// Enables bounded in-memory transaction history for MVCC diagnostics.
     pub enable_txn_command_flight_recorder: bool,
     #[online_config(skip)]
     pub api_version: u8,

--- a/src/storage/config.rs
+++ b/src/storage/config.rs
@@ -94,6 +94,10 @@ pub struct Config {
     pub reserve_raft_space: ReadableSize,
     #[online_config(skip)]
     pub enable_async_apply_prewrite: bool,
+    /// Records bounded transaction command history for diagnosing MVCC
+    /// invariants. Disabled by default because it retains additional in-memory
+    /// metadata and adds work to the transaction scheduler.
+    pub enable_txn_command_flight_recorder: bool,
     #[online_config(skip)]
     pub api_version: u8,
     #[online_config(skip)]
@@ -131,6 +135,7 @@ impl Default for Config {
             reserve_space: ReadableSize::gb(DEFAULT_RESERVED_SPACE_GB),
             reserve_raft_space: ReadableSize::gb(DEFAULT_RESERVED_RAFT_SPACE_GB),
             enable_async_apply_prewrite: false,
+            enable_txn_command_flight_recorder: false,
             api_version: 1,
             enable_ttl: false,
             ttl_check_poll_interval: ReadableDuration::hours(12),

--- a/src/storage/config_manager.rs
+++ b/src/storage/config_manager.rs
@@ -92,6 +92,10 @@ impl<EK: Engine, K: ConfigurableDb, L: LockManager> ConfigManager
             let cap: ReadableSize = v.into();
             self.scheduler.set_memory_quota_capacity(cap.0 as usize);
         }
+        if let Some(v) = change.remove("enable_txn_command_flight_recorder") {
+            let enabled: bool = v.into();
+            crate::storage::txn::flight_recorder::TXN_COMMAND_FLIGHT_RECORDER.set_enabled(enabled);
+        }
         if let Some(ConfigValue::Module(mut io_rate_limit)) = change.remove("io_rate_limit") {
             let limiter = match get_io_rate_limiter() {
                 None => return Err("IO rate limiter is not present".into()),

--- a/src/storage/config_manager.rs
+++ b/src/storage/config_manager.rs
@@ -25,7 +25,7 @@ use crate::{
     storage::{
         TxnScheduler,
         lock_manager::LockManager,
-        txn::{flight_recorder::TXN_COMMAND_FLIGHT_RECORDER, flow_controller::FlowController},
+        txn::{flight_recorder::TXN_FLIGHT_RECORDER, flow_controller::FlowController},
     },
 >>>>>>> 78d1887b9 (u)
 };
@@ -101,10 +101,6 @@ impl<EK: Engine, K: ConfigurableDb, L: LockManager> ConfigManager
             let cap: ReadableSize = v.into();
             self.scheduler.set_memory_quota_capacity(cap.0 as usize);
         }
-        if let Some(v) = change.remove("enable_txn_command_flight_recorder") {
-            let enabled: bool = v.into();
-            TXN_COMMAND_FLIGHT_RECORDER.set_enabled(enabled);
-        }
         if let Some(ConfigValue::Module(mut io_rate_limit)) = change.remove("io_rate_limit") {
             let limiter = match get_io_rate_limiter() {
                 None => return Err("IO rate limiter is not present".into()),
@@ -123,6 +119,7 @@ impl<EK: Engine, K: ConfigurableDb, L: LockManager> ConfigManager
                 }
             }
         }
+<<<<<<< HEAD
         if let Some(v) = change.remove("action_on_invalid_max_ts") {
             let str_v: String = v.into();
             let action: concurrency_manager::ActionOnInvalidMaxTs = str_v.try_into()?;
@@ -132,6 +129,11 @@ impl<EK: Engine, K: ConfigurableDb, L: LockManager> ConfigManager
         if let Some(v) = change.remove("max_ts_drift_allowance") {
             let dur_v: ReadableDuration = v.into();
             self.concurrency_manager.set_max_ts_drift_allowance(dur_v.0);
+=======
+        dispatch_max_ts_config_change(&self.concurrency_manager, &mut change)?;
+        if let Some(v) = change.remove("enable_txn_command_flight_recorder") {
+            TXN_FLIGHT_RECORDER.set_enabled(v.into());
+>>>>>>> 958078793 (record primary key command)
         }
         Ok(())
     }

--- a/src/storage/config_manager.rs
+++ b/src/storage/config_manager.rs
@@ -17,8 +17,17 @@ use tikv_util::{
 
 use crate::{
     config::ConfigurableDb,
+<<<<<<< HEAD
     server::{ttl::TtlCheckerTask, CONFIG_ROCKSDB_GAUGE},
     storage::{lock_manager::LockManager, txn::flow_controller::FlowController, TxnScheduler},
+=======
+    server::{CONFIG_ROCKSDB_GAUGE, ttl::TtlCheckerTask},
+    storage::{
+        TxnScheduler,
+        lock_manager::LockManager,
+        txn::{flight_recorder::TXN_COMMAND_FLIGHT_RECORDER, flow_controller::FlowController},
+    },
+>>>>>>> 78d1887b9 (u)
 };
 
 pub struct StorageConfigManger<E: Engine, K, L: LockManager> {
@@ -94,7 +103,7 @@ impl<EK: Engine, K: ConfigurableDb, L: LockManager> ConfigManager
         }
         if let Some(v) = change.remove("enable_txn_command_flight_recorder") {
             let enabled: bool = v.into();
-            crate::storage::txn::flight_recorder::TXN_COMMAND_FLIGHT_RECORDER.set_enabled(enabled);
+            TXN_COMMAND_FLIGHT_RECORDER.set_enabled(enabled);
         }
         if let Some(ConfigValue::Module(mut io_rate_limit)) = change.remove("io_rate_limit") {
             let limiter = match get_io_rate_limiter() {

--- a/src/storage/config_manager.rs
+++ b/src/storage/config_manager.rs
@@ -17,17 +17,12 @@ use tikv_util::{
 
 use crate::{
     config::ConfigurableDb,
-<<<<<<< HEAD
     server::{ttl::TtlCheckerTask, CONFIG_ROCKSDB_GAUGE},
-    storage::{lock_manager::LockManager, txn::flow_controller::FlowController, TxnScheduler},
-=======
-    server::{CONFIG_ROCKSDB_GAUGE, ttl::TtlCheckerTask},
     storage::{
-        TxnScheduler,
         lock_manager::LockManager,
         txn::{flight_recorder::TXN_FLIGHT_RECORDER, flow_controller::FlowController},
+        TxnScheduler,
     },
->>>>>>> 78d1887b9 (u)
 };
 
 pub struct StorageConfigManger<E: Engine, K, L: LockManager> {
@@ -119,7 +114,6 @@ impl<EK: Engine, K: ConfigurableDb, L: LockManager> ConfigManager
                 }
             }
         }
-<<<<<<< HEAD
         if let Some(v) = change.remove("action_on_invalid_max_ts") {
             let str_v: String = v.into();
             let action: concurrency_manager::ActionOnInvalidMaxTs = str_v.try_into()?;
@@ -129,11 +123,9 @@ impl<EK: Engine, K: ConfigurableDb, L: LockManager> ConfigManager
         if let Some(v) = change.remove("max_ts_drift_allowance") {
             let dur_v: ReadableDuration = v.into();
             self.concurrency_manager.set_max_ts_drift_allowance(dur_v.0);
-=======
-        dispatch_max_ts_config_change(&self.concurrency_manager, &mut change)?;
+        }
         if let Some(v) = change.remove("enable_txn_command_flight_recorder") {
             TXN_FLIGHT_RECORDER.set_enabled(v.into());
->>>>>>> 958078793 (record primary key command)
         }
         Ok(())
     }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -138,6 +138,7 @@ use crate::{
         test_util::latest_feature_gate,
         txn::{
             commands::{RawAtomicStore, RawCompareAndSwap, TypedCommand},
+            flight_recorder::TXN_COMMAND_FLIGHT_RECORDER,
             flow_controller::{EngineFlowController, FlowController},
             scheduler::TxnScheduler,
             txn_status_cache::{TxnState, TxnStatusCache},
@@ -288,6 +289,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
         txn_status_cache: Arc<TxnStatusCache>,
     ) -> Result<Self> {
         assert_eq!(config.api_version(), F::TAG, "Api version not match");
+        TXN_COMMAND_FLIGHT_RECORDER.set_enabled(config.enable_txn_command_flight_recorder);
 
         let sched = TxnScheduler::new(
             engine.clone(),

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -138,7 +138,7 @@ use crate::{
         test_util::latest_feature_gate,
         txn::{
             commands::{RawAtomicStore, RawCompareAndSwap, TypedCommand},
-            flight_recorder::TXN_COMMAND_FLIGHT_RECORDER,
+            flight_recorder::TXN_FLIGHT_RECORDER,
             flow_controller::{EngineFlowController, FlowController},
             scheduler::TxnScheduler,
             txn_status_cache::{TxnState, TxnStatusCache},
@@ -289,7 +289,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
         txn_status_cache: Arc<TxnStatusCache>,
     ) -> Result<Self> {
         assert_eq!(config.api_version(), F::TAG, "Api version not match");
-        TXN_COMMAND_FLIGHT_RECORDER.set_enabled(config.enable_txn_command_flight_recorder);
+        TXN_FLIGHT_RECORDER.set_enabled(config.enable_txn_command_flight_recorder);
 
         let sched = TxnScheduler::new(
             engine.clone(),

--- a/src/storage/txn/actions/check_txn_status.rs
+++ b/src/storage/txn/actions/check_txn_status.rs
@@ -10,15 +10,8 @@ use crate::storage::{
         metrics::MVCC_CHECK_TXN_STATUS_COUNTER_VEC, reader::OverlappedWrite, ErrorInner, LockType,
         MvccTxn, ReleasedLock, Result, SnapshotReader, TxnCommitRecord,
     },
-<<<<<<< HEAD
-<<<<<<< HEAD
-    Snapshot, TxnStatus,
-=======
-    txn::flight_recorder::TXN_COMMAND_FLIGHT_RECORDER,
->>>>>>> 78d1887b9 (u)
-=======
     txn::flight_recorder::TXN_FLIGHT_RECORDER,
->>>>>>> 958078793 (record primary key command)
+    Snapshot, TxnStatus,
 };
 
 // The returned `TxnStatus` is Some(..) if the transaction status is already

--- a/src/storage/txn/actions/check_txn_status.rs
+++ b/src/storage/txn/actions/check_txn_status.rs
@@ -3,7 +3,7 @@
 use engine_traits::CF_LOCK;
 use tikv_kv::SnapshotExt;
 // #[PerformanceCriticalPath]
-use txn_types::{Key, Lock, SharedLocks, TimeStamp, Write, WriteType, parse_lock};
+use txn_types::{parse_lock, Key, Lock, SharedLocks, TimeStamp, Write, WriteType};
 
 use crate::storage::{
     mvcc::{

--- a/src/storage/txn/actions/check_txn_status.rs
+++ b/src/storage/txn/actions/check_txn_status.rs
@@ -1,8 +1,9 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
+use engine_traits::CF_LOCK;
 use tikv_kv::SnapshotExt;
 // #[PerformanceCriticalPath]
-use txn_types::{Key, Lock, SharedLocks, TimeStamp, Write, WriteType};
+use txn_types::{Key, Lock, SharedLocks, TimeStamp, Write, WriteType, parse_lock};
 
 use crate::storage::{
     mvcc::{
@@ -525,6 +526,68 @@ fn log_write_history(reader: &mut SnapshotReader<impl Snapshot>, key: &Key) {
 }
 
 #[cold]
+fn log_lock_sources(reader: &SnapshotReader<impl Snapshot>, key: &Key) {
+    let txn_ext = reader.reader.snapshot_ext().get_txn_ext().cloned();
+    match txn_ext {
+        Some(txn_ext) => match txn_ext.pessimistic_locks.try_read() {
+            Some(locks) => {
+                let entry = locks.get(key);
+                error!(
+                    "txn record found but not expected: panic-time in-memory pessimistic lock";
+                    "lock" => ?entry.map(|(lock, _)| lock),
+                    "deleted" => ?entry.map(|(_, deleted)| *deleted),
+                    "table_status" => ?locks.status,
+                    "table_term" => locks.term,
+                    "table_version" => locks.version,
+                );
+            }
+            None => {
+                error!(
+                    "txn record found but not expected: failed to inspect panic-time in-memory pessimistic lock";
+                    "reason" => "lock table is locked",
+                );
+            }
+        },
+        None => {
+            error!(
+                "txn record found but not expected: failed to inspect panic-time in-memory pessimistic lock";
+                "reason" => "transaction extension is unavailable",
+            );
+        }
+    }
+
+    match reader.reader.snapshot().get_cf(CF_LOCK, key) {
+        Ok(Some(value)) => match parse_lock(&value) {
+            Ok(lock) => {
+                error!(
+                    "txn record found but not expected: snapshot CF_LOCK";
+                    "lock" => ?lock,
+                );
+            }
+            Err(err) => {
+                error!(
+                    "txn record found but not expected: failed to parse snapshot CF_LOCK";
+                    "error" => ?err,
+                    "value_len" => value.len(),
+                );
+            }
+        },
+        Ok(None) => {
+            error!(
+                "txn record found but not expected: snapshot CF_LOCK";
+                "lock" => "None",
+            );
+        }
+        Err(err) => {
+            error!(
+                "txn record found but not expected: failed to read snapshot CF_LOCK";
+                "error" => ?err,
+            );
+        }
+    }
+}
+
+#[cold]
 #[inline(never)]
 fn panic_txn_record_found(
     txn: &MvccTxn,
@@ -554,6 +617,7 @@ fn panic_txn_record_found(
         "snapshot_data_version" => snapshot_data_version,
         "flight_event_count" => flight_events.len(),
     );
+    log_lock_sources(reader, key);
     for event in &flight_events {
         error!(
             "txn record found but not expected: flight recorder event";

--- a/src/storage/txn/actions/check_txn_status.rs
+++ b/src/storage/txn/actions/check_txn_status.rs
@@ -10,10 +10,14 @@ use crate::storage::{
         MvccTxn, ReleasedLock, Result, SnapshotReader, TxnCommitRecord,
     },
 <<<<<<< HEAD
+<<<<<<< HEAD
     Snapshot, TxnStatus,
 =======
     txn::flight_recorder::TXN_COMMAND_FLIGHT_RECORDER,
 >>>>>>> 78d1887b9 (u)
+=======
+    txn::flight_recorder::TXN_FLIGHT_RECORDER,
+>>>>>>> 958078793 (record primary key command)
 };
 
 // The returned `TxnStatus` is Some(..) if the transaction status is already
@@ -487,11 +491,11 @@ impl MissingLockAction {
     }
 }
 
-const MAX_INVARIANT_PANIC_WRITE_HISTORY: usize = 32;
+const MAX_PANIC_WRITE_HISTORY: usize = 32;
 
-fn log_bounded_write_history(reader: &mut SnapshotReader<impl Snapshot>, key: &Key) {
+fn log_write_history(reader: &mut SnapshotReader<impl Snapshot>, key: &Key) {
     let mut next_ts = TimeStamp::max();
-    for _ in 0..MAX_INVARIANT_PANIC_WRITE_HISTORY {
+    for _ in 0..MAX_PANIC_WRITE_HISTORY {
         match reader.seek_write(key, next_ts) {
             Ok(Some((commit_ts, write))) => {
                 error!(
@@ -516,7 +520,7 @@ fn log_bounded_write_history(reader: &mut SnapshotReader<impl Snapshot>, key: &K
     }
     error!(
         "txn record found but not expected: mvcc write history reached record limit";
-        "limit" => MAX_INVARIANT_PANIC_WRITE_HISTORY,
+        "limit" => MAX_PANIC_WRITE_HISTORY,
     );
 }
 
@@ -538,8 +542,7 @@ fn panic_txn_record_found(
             ext.get_data_version().unwrap_or(0),
         )
     };
-    let flight_events = TXN_COMMAND_FLIGHT_RECORDER.events_for_key(key);
-    let overwritten_events = TXN_COMMAND_FLIGHT_RECORDER.overwritten_events();
+    let flight_events = TXN_FLIGHT_RECORDER.events_for_key(key);
 
     error!(
         "txn record found but not expected: diagnostic summary";
@@ -550,7 +553,6 @@ fn panic_txn_record_found(
         "term" => term,
         "snapshot_data_version" => snapshot_data_version,
         "flight_event_count" => flight_events.len(),
-        "flight_recorder_overwritten_events" => overwritten_events,
     );
     for event in &flight_events {
         error!(
@@ -558,7 +560,7 @@ fn panic_txn_record_found(
             "event" => ?event,
         );
     }
-    log_bounded_write_history(reader, key);
+    log_write_history(reader, key);
 
     panic!(
         "txn record found but not expected: {:?} {} {:?} {:?} [region_id={}]",

--- a/src/storage/txn/actions/check_txn_status.rs
+++ b/src/storage/txn/actions/check_txn_status.rs
@@ -313,14 +313,7 @@ pub fn rollback_lock(
         TxnCommitRecord::SingleRecord { write, commit_ts }
             if write.write_type != WriteType::Rollback =>
         {
-            panic!(
-                "txn record found but not expected: {:?} {} {:?} {:?} [region_id={}]",
-                write,
-                commit_ts,
-                txn,
-                lock,
-                reader.reader.snapshot_ext().get_region_id().unwrap_or(0)
-            )
+            panic_txn_record_found(txn, reader, &key, lock, &write, commit_ts)
         }
         _ => return Ok(txn.unlock_key(key, is_pessimistic_txn, TimeStamp::zero())),
     };
@@ -384,14 +377,7 @@ pub fn rollback_shared_lock(
         TxnCommitRecord::SingleRecord { write, commit_ts }
             if write.write_type != WriteType::Rollback =>
         {
-            panic!(
-                "txn record found but not expected: {:?} {} {:?} {:?} [region_id={}]",
-                write,
-                commit_ts,
-                txn,
-                lock,
-                reader.reader.snapshot_ext().get_region_id().unwrap_or(0)
-            )
+            panic_txn_record_found(txn, reader, &key, &lock, &write, commit_ts)
         }
         _ => {
             return if shared_locks.is_empty() {
@@ -495,4 +481,85 @@ impl MissingLockAction {
     ) -> Option<Write> {
         make_rollback(ts, !self.collapse_rollback(), overlapped_write)
     }
+}
+
+const MAX_INVARIANT_PANIC_WRITE_HISTORY: usize = 32;
+
+fn log_bounded_write_history(reader: &mut SnapshotReader<impl Snapshot>, key: &Key) {
+    let mut next_ts = TimeStamp::max();
+    for _ in 0..MAX_INVARIANT_PANIC_WRITE_HISTORY {
+        match reader.seek_write(key, next_ts) {
+            Ok(Some((commit_ts, write))) => {
+                error!(
+                    "txn record found but not expected: mvcc write history";
+                    "commit_ts" => commit_ts,
+                    "write" => ?write,
+                );
+                if commit_ts.is_zero() {
+                    return;
+                }
+                next_ts = commit_ts.prev();
+            }
+            Ok(None) => return,
+            Err(err) => {
+                error!(
+                    "txn record found but not expected: failed to read mvcc write history";
+                    "error" => ?err,
+                );
+                return;
+            }
+        }
+    }
+    error!(
+        "txn record found but not expected: mvcc write history reached record limit";
+        "limit" => MAX_INVARIANT_PANIC_WRITE_HISTORY,
+    );
+}
+
+#[cold]
+#[inline(never)]
+fn panic_txn_record_found(
+    txn: &MvccTxn,
+    reader: &mut SnapshotReader<impl Snapshot>,
+    key: &Key,
+    lock: &Lock,
+    write: &Write,
+    commit_ts: TimeStamp,
+) -> ! {
+    let (region_id, term, snapshot_data_version) = {
+        let ext = reader.reader.snapshot_ext();
+        (
+            ext.get_region_id().unwrap_or(0),
+            ext.get_term().map(|term| term.get()).unwrap_or(0),
+            ext.get_data_version().unwrap_or(0),
+        )
+    };
+    let flight_events =
+        crate::storage::txn::flight_recorder::TXN_COMMAND_FLIGHT_RECORDER.events_for_key(key);
+    let overwritten_events =
+        crate::storage::txn::flight_recorder::TXN_COMMAND_FLIGHT_RECORDER.overwritten_events();
+
+    error!(
+        "txn record found but not expected: diagnostic summary";
+        "key" => ?key,
+        "start_ts" => reader.start_ts,
+        "commit_ts" => commit_ts,
+        "region_id" => region_id,
+        "term" => term,
+        "snapshot_data_version" => snapshot_data_version,
+        "flight_event_count" => flight_events.len(),
+        "flight_recorder_overwritten_events" => overwritten_events,
+    );
+    for event in &flight_events {
+        error!(
+            "txn record found but not expected: flight recorder event";
+            "event" => ?event,
+        );
+    }
+    log_bounded_write_history(reader, key);
+
+    panic!(
+        "txn record found but not expected: {:?} {} {:?} {:?} [region_id={}]",
+        write, commit_ts, txn, lock, region_id
+    )
 }

--- a/src/storage/txn/actions/check_txn_status.rs
+++ b/src/storage/txn/actions/check_txn_status.rs
@@ -9,7 +9,11 @@ use crate::storage::{
         metrics::MVCC_CHECK_TXN_STATUS_COUNTER_VEC, reader::OverlappedWrite, ErrorInner, LockType,
         MvccTxn, ReleasedLock, Result, SnapshotReader, TxnCommitRecord,
     },
+<<<<<<< HEAD
     Snapshot, TxnStatus,
+=======
+    txn::flight_recorder::TXN_COMMAND_FLIGHT_RECORDER,
+>>>>>>> 78d1887b9 (u)
 };
 
 // The returned `TxnStatus` is Some(..) if the transaction status is already
@@ -534,10 +538,8 @@ fn panic_txn_record_found(
             ext.get_data_version().unwrap_or(0),
         )
     };
-    let flight_events =
-        crate::storage::txn::flight_recorder::TXN_COMMAND_FLIGHT_RECORDER.events_for_key(key);
-    let overwritten_events =
-        crate::storage::txn::flight_recorder::TXN_COMMAND_FLIGHT_RECORDER.overwritten_events();
+    let flight_events = TXN_COMMAND_FLIGHT_RECORDER.events_for_key(key);
+    let overwritten_events = TXN_COMMAND_FLIGHT_RECORDER.overwritten_events();
 
     error!(
         "txn record found but not expected: diagnostic summary";

--- a/src/storage/txn/actions/commit.rs
+++ b/src/storage/txn/actions/commit.rs
@@ -9,11 +9,8 @@ use crate::storage::{
         metrics::{MVCC_CONFLICT_COUNTER, MVCC_DUPLICATE_CMD_COUNTER_VEC},
         ErrorInner, MvccTxn, ReleasedLock, Result as MvccResult, SnapshotReader,
     },
-<<<<<<< HEAD
-    Snapshot,
-=======
     txn::flight_recorder::hash_key,
->>>>>>> 958078793 (record primary key command)
+    Snapshot,
 };
 
 /// Helper function to handle the case when the lock is not found for our

--- a/src/storage/txn/actions/commit.rs
+++ b/src/storage/txn/actions/commit.rs
@@ -9,7 +9,11 @@ use crate::storage::{
         metrics::{MVCC_CONFLICT_COUNTER, MVCC_DUPLICATE_CMD_COUNTER_VEC},
         ErrorInner, MvccTxn, ReleasedLock, Result as MvccResult, SnapshotReader,
     },
+<<<<<<< HEAD
     Snapshot,
+=======
+    txn::flight_recorder::hash_key,
+>>>>>>> 958078793 (record primary key command)
 };
 
 /// Helper function to handle the case when the lock is not found for our
@@ -51,6 +55,33 @@ pub fn commit<S: Snapshot>(
     key: Key,
     commit_ts: TimeStamp,
 ) -> MvccResult<Option<ReleasedLock>> {
+    commit_inner(txn, reader, key, commit_ts, |_, _| {})
+}
+
+/// Returns the flight-recorder hash when `key` is the primary key recorded in
+/// its lock, or zero otherwise.
+pub(crate) fn commit_with_primary<S: Snapshot>(
+    txn: &mut MvccTxn,
+    reader: &mut SnapshotReader<S>,
+    key: Key,
+    commit_ts: TimeStamp,
+) -> MvccResult<(Option<ReleasedLock>, u64)> {
+    let mut primary_key_hash = 0;
+    let released = commit_inner(txn, reader, key, commit_ts, |key, primary| {
+        if key.is_encoded_from(primary) {
+            primary_key_hash = hash_key(key);
+        }
+    })?;
+    Ok((released, primary_key_hash))
+}
+
+fn commit_inner<S: Snapshot>(
+    txn: &mut MvccTxn,
+    reader: &mut SnapshotReader<S>,
+    key: Key,
+    commit_ts: TimeStamp,
+    record_primary: impl FnOnce(&Key, &[u8]),
+) -> MvccResult<Option<ReleasedLock>> {
     fail_point!("commit", |err| Err(
         crate::storage::mvcc::txn::make_txn_error(err, &key, reader.start_ts,).into()
     ));
@@ -91,6 +122,7 @@ pub fn commit<S: Snapshot>(
                     }
                 }
             };
+            record_primary(&key, &lock.primary);
             // A lock with larger min_commit_ts than current commit_ts can't be committed
             if commit_ts < lock.min_commit_ts {
                 info!(
@@ -327,6 +359,29 @@ pub mod tests {
 
         let long_value = "v".repeat(SHORT_VALUE_MAX_LEN + 1).into_bytes();
         test_commit_ok_imp(b"x", &long_value, b"y", b"z");
+    }
+
+    #[test]
+    fn test_commit_identifies_primary_key() {
+        let mut engine = TestEngineBuilder::new().build().unwrap();
+        let primary = b"primary";
+        let secondary = b"secondary";
+        must_prewrite_put(&mut engine, primary, b"v1", primary, 10);
+        must_prewrite_put(&mut engine, secondary, b"v2", primary, 10);
+
+        let snapshot = engine.snapshot(Default::default()).unwrap();
+        let cm = ConcurrencyManager::new(10.into());
+        let mut txn = MvccTxn::new(10.into(), cm);
+        let mut reader = SnapshotReader::new(10.into(), snapshot, true);
+
+        let (_, primary_key_hash) =
+            commit_with_primary(&mut txn, &mut reader, Key::from_raw(primary), 20.into()).unwrap();
+        assert_eq!(primary_key_hash, hash_key(&Key::from_raw(primary)));
+
+        let (_, primary_key_hash) =
+            commit_with_primary(&mut txn, &mut reader, Key::from_raw(secondary), 20.into())
+                .unwrap();
+        assert_eq!(primary_key_hash, 0);
     }
 
     #[cfg(test)]

--- a/src/storage/txn/commands/commit.rs
+++ b/src/storage/txn/commands/commit.rs
@@ -8,21 +8,14 @@ use crate::storage::{
     lock_manager::LockManager,
     mvcc::{MvccTxn, SnapshotReader},
     txn::{
-<<<<<<< HEAD
-=======
         Error, ErrorInner, Result,
         actions::commit::commit_with_primary,
->>>>>>> 958078793 (record primary key command)
         commands::{
             Command, CommandExt, ReaderWithStats, ReleasedLocks, ResponsePolicy, TypedCommand,
             WriteCommand, WriteContext, WriteResult,
         },
-<<<<<<< HEAD
-        commit, Error, ErrorInner, Result,
-=======
         commit,
         flight_recorder::TXN_FLIGHT_RECORDER,
->>>>>>> 958078793 (record primary key command)
     },
     ProcessResult, Snapshot, TxnStatus,
 };

--- a/src/storage/txn/commands/commit.rs
+++ b/src/storage/txn/commands/commit.rs
@@ -8,7 +8,6 @@ use crate::storage::{
     lock_manager::LockManager,
     mvcc::{MvccTxn, SnapshotReader},
     txn::{
-        Error, ErrorInner, Result,
         actions::commit::commit_with_primary,
         commands::{
             Command, CommandExt, ReaderWithStats, ReleasedLocks, ResponsePolicy, TypedCommand,
@@ -16,6 +15,7 @@ use crate::storage::{
         },
         commit,
         flight_recorder::TXN_FLIGHT_RECORDER,
+        Error, ErrorInner, Result,
     },
     ProcessResult, Snapshot, TxnStatus,
 };

--- a/src/storage/txn/commands/commit.rs
+++ b/src/storage/txn/commands/commit.rs
@@ -8,11 +8,21 @@ use crate::storage::{
     lock_manager::LockManager,
     mvcc::{MvccTxn, SnapshotReader},
     txn::{
+<<<<<<< HEAD
+=======
+        Error, ErrorInner, Result,
+        actions::commit::commit_with_primary,
+>>>>>>> 958078793 (record primary key command)
         commands::{
             Command, CommandExt, ReaderWithStats, ReleasedLocks, ResponsePolicy, TypedCommand,
             WriteCommand, WriteContext, WriteResult,
         },
+<<<<<<< HEAD
         commit, Error, ErrorInner, Result,
+=======
+        commit,
+        flight_recorder::TXN_FLIGHT_RECORDER,
+>>>>>>> 958078793 (record primary key command)
     },
     ProcessResult, Snapshot, TxnStatus,
 };
@@ -63,8 +73,17 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for Commit {
         let rows = self.keys.len();
         // Pessimistic txn needs key_hashes to wake up waiters
         let mut released_locks = ReleasedLocks::new();
-        for k in self.keys {
-            released_locks.push(commit(&mut txn, &mut reader, k, self.commit_ts)?);
+        if TXN_FLIGHT_RECORDER.is_enabled() {
+            for k in self.keys {
+                let (released, primary_key_hash) =
+                    commit_with_primary(&mut txn, &mut reader, k, self.commit_ts)?;
+                released_locks.set_flight_primary_key_hash(primary_key_hash);
+                released_locks.push(released);
+            }
+        } else {
+            for k in self.keys {
+                released_locks.push(commit(&mut txn, &mut reader, k, self.commit_ts)?);
+            }
         }
 
         let pr = ProcessResult::TxnStatus {

--- a/src/storage/txn/commands/mod.rs
+++ b/src/storage/txn/commands/mod.rs
@@ -539,8 +539,10 @@ impl WriteResultLockInfo {
     }
 }
 
+// The second field is an optional flight-recorder primary-key hash, identified
+// while preparing commit and consumed before the locks reach the lock manager.
 #[derive(Default, Debug)]
-pub struct ReleasedLocks(Vec<ReleasedLock>);
+pub struct ReleasedLocks(Vec<ReleasedLock>, u64);
 
 impl ReleasedLocks {
     pub fn new() -> Self {
@@ -558,11 +560,23 @@ impl ReleasedLocks {
     }
 
     pub fn clear(&mut self) {
-        self.0.clear()
+        self.0.clear();
+        self.1 = 0;
     }
 
     pub fn into_iter(self) -> impl Iterator<Item = ReleasedLock> {
         self.0.into_iter()
+    }
+
+    pub(crate) fn set_flight_primary_key_hash(&mut self, key_hash: u64) {
+        if key_hash != 0 {
+            debug_assert!(self.1 == 0 || self.1 == key_hash);
+            self.1 = key_hash;
+        }
+    }
+
+    pub(crate) fn flight_primary_key_hash(&self) -> u64 {
+        self.1
     }
 }
 

--- a/src/storage/txn/commands/prewrite.rs
+++ b/src/storage/txn/commands/prewrite.rs
@@ -506,10 +506,19 @@ impl<K: PrewriteKind> Prewriter<K> {
         // Handle special cases about retried prewrite requests for pessimistic
         // transactions.
         if let TransactionKind::Pessimistic(_) = self.kind.txn_kind() {
-            if let Some(commit_ts) = context
+            let committed_ts = context
                 .txn_status_cache
-                .get_committed_no_promote(self.start_ts)
-            {
+                .get_committed_no_promote(self.start_ts);
+            crate::storage::txn::flight_recorder::TXN_COMMAND_FLIGHT_RECORDER
+                .record_txn_status_cache_lookup(
+                    self.mutations.iter().map(MutationLock::key),
+                    &self.primary,
+                    self.start_ts,
+                    committed_ts,
+                    &self.ctx,
+                    snapshot.ext().get_data_version(),
+                );
+            if let Some(commit_ts) = committed_ts {
                 fail_point!("before_prewrite_txn_status_cache_hit");
                 if self.ctx.is_retry_request {
                     MVCC_PREWRITE_REQUEST_AFTER_COMMIT_COUNTER_VEC
@@ -886,12 +895,17 @@ impl PrewriteKind for Pessimistic {
 /// For pessimistic txns, this is `PessimisticMutation` which contains a
 /// `Mutation` and some other extra information necessary for pessimistic txns.
 trait MutationLock {
+    fn key(&self) -> &Key;
     fn pessimistic_action(&self) -> PrewriteRequestPessimisticAction;
     fn pessimistic_expected_for_update_ts(&self) -> Option<TimeStamp>;
     fn into_mutation(self) -> Mutation;
 }
 
 impl MutationLock for Mutation {
+    fn key(&self) -> &Key {
+        Mutation::key(self)
+    }
+
     fn pessimistic_action(&self) -> PrewriteRequestPessimisticAction {
         SkipPessimisticCheck
     }
@@ -919,6 +933,10 @@ pub struct PessimisticMutation {
 }
 
 impl MutationLock for PessimisticMutation {
+    fn key(&self) -> &Key {
+        self.mutation.key()
+    }
+
     fn pessimistic_action(&self) -> PrewriteRequestPessimisticAction {
         self.pessimistic_action
     }

--- a/src/storage/txn/commands/prewrite.rs
+++ b/src/storage/txn/commands/prewrite.rs
@@ -517,14 +517,16 @@ impl<K: PrewriteKind> Prewriter<K> {
             let committed_ts = context
                 .txn_status_cache
                 .get_committed_no_promote(self.start_ts);
-            TXN_FLIGHT_RECORDER.record_txn_status_cache_lookup(
-                self.mutations.iter().map(MutationLock::key),
-                &self.primary,
-                self.start_ts,
-                committed_ts,
-                &self.ctx,
-                snapshot.ext().get_data_version(),
-            );
+            if TXN_FLIGHT_RECORDER.is_enabled() {
+                TXN_FLIGHT_RECORDER.record_txn_status_cache_lookup(
+                    self.mutations.iter().map(MutationLock::key),
+                    &self.primary,
+                    self.start_ts,
+                    committed_ts,
+                    &self.ctx,
+                    snapshot.ext().get_data_version(),
+                );
+            }
             if let Some(commit_ts) = committed_ts {
                 fail_point!("before_prewrite_txn_status_cache_hit");
                 if self.ctx.is_retry_request {

--- a/src/storage/txn/commands/prewrite.rs
+++ b/src/storage/txn/commands/prewrite.rs
@@ -36,10 +36,14 @@ use crate::storage::{
             WriteContext, WriteResult,
         },
 <<<<<<< HEAD
+<<<<<<< HEAD
         Error, ErrorInner, Result,
 =======
         flight_recorder::TXN_COMMAND_FLIGHT_RECORDER,
 >>>>>>> 78d1887b9 (u)
+=======
+        flight_recorder::TXN_FLIGHT_RECORDER,
+>>>>>>> 958078793 (record primary key command)
     },
     types::PrewriteResult,
     Context, Error as StorageError, ProcessResult, Snapshot,
@@ -513,7 +517,7 @@ impl<K: PrewriteKind> Prewriter<K> {
             let committed_ts = context
                 .txn_status_cache
                 .get_committed_no_promote(self.start_ts);
-            TXN_COMMAND_FLIGHT_RECORDER.record_txn_status_cache_lookup(
+            TXN_FLIGHT_RECORDER.record_txn_status_cache_lookup(
                 self.mutations.iter().map(MutationLock::key),
                 &self.primary,
                 self.start_ts,

--- a/src/storage/txn/commands/prewrite.rs
+++ b/src/storage/txn/commands/prewrite.rs
@@ -35,15 +35,8 @@ use crate::storage::{
             Command, CommandExt, ReleasedLocks, ResponsePolicy, TypedCommand, WriteCommand,
             WriteContext, WriteResult,
         },
-<<<<<<< HEAD
-<<<<<<< HEAD
-        Error, ErrorInner, Result,
-=======
-        flight_recorder::TXN_COMMAND_FLIGHT_RECORDER,
->>>>>>> 78d1887b9 (u)
-=======
         flight_recorder::TXN_FLIGHT_RECORDER,
->>>>>>> 958078793 (record primary key command)
+        Error, ErrorInner, Result,
     },
     types::PrewriteResult,
     Context, Error as StorageError, ProcessResult, Snapshot,

--- a/src/storage/txn/commands/prewrite.rs
+++ b/src/storage/txn/commands/prewrite.rs
@@ -35,7 +35,11 @@ use crate::storage::{
             Command, CommandExt, ReleasedLocks, ResponsePolicy, TypedCommand, WriteCommand,
             WriteContext, WriteResult,
         },
+<<<<<<< HEAD
         Error, ErrorInner, Result,
+=======
+        flight_recorder::TXN_COMMAND_FLIGHT_RECORDER,
+>>>>>>> 78d1887b9 (u)
     },
     types::PrewriteResult,
     Context, Error as StorageError, ProcessResult, Snapshot,
@@ -509,15 +513,14 @@ impl<K: PrewriteKind> Prewriter<K> {
             let committed_ts = context
                 .txn_status_cache
                 .get_committed_no_promote(self.start_ts);
-            crate::storage::txn::flight_recorder::TXN_COMMAND_FLIGHT_RECORDER
-                .record_txn_status_cache_lookup(
-                    self.mutations.iter().map(MutationLock::key),
-                    &self.primary,
-                    self.start_ts,
-                    committed_ts,
-                    &self.ctx,
-                    snapshot.ext().get_data_version(),
-                );
+            TXN_COMMAND_FLIGHT_RECORDER.record_txn_status_cache_lookup(
+                self.mutations.iter().map(MutationLock::key),
+                &self.primary,
+                self.start_ts,
+                committed_ts,
+                &self.ctx,
+                snapshot.ext().get_data_version(),
+            );
             if let Some(commit_ts) = committed_ts {
                 fail_point!("before_prewrite_txn_status_cache_hit");
                 if self.ctx.is_retry_request {

--- a/src/storage/txn/commands/resolve_lock_lite.rs
+++ b/src/storage/txn/commands/resolve_lock_lite.rs
@@ -8,7 +8,6 @@ use crate::storage::{
     lock_manager::LockManager,
     mvcc::{MvccTxn, SnapshotReader},
     txn::{
-        Result,
         actions::commit::commit_with_primary,
         cleanup,
         commands::{
@@ -17,6 +16,7 @@ use crate::storage::{
         },
         commit,
         flight_recorder::TXN_FLIGHT_RECORDER,
+        Result,
     },
     ProcessResult, Snapshot,
 };

--- a/src/storage/txn/commands/resolve_lock_lite.rs
+++ b/src/storage/txn/commands/resolve_lock_lite.rs
@@ -8,12 +8,22 @@ use crate::storage::{
     lock_manager::LockManager,
     mvcc::{MvccTxn, SnapshotReader},
     txn::{
+<<<<<<< HEAD
+=======
+        Result,
+        actions::commit::commit_with_primary,
+>>>>>>> 958078793 (record primary key command)
         cleanup,
         commands::{
             Command, CommandExt, ReaderWithStats, ReleasedLocks, ResponsePolicy, TypedCommand,
             WriteCommand, WriteContext, WriteResult,
         },
+<<<<<<< HEAD
         commit, Result,
+=======
+        commit,
+        flight_recorder::TXN_FLIGHT_RECORDER,
+>>>>>>> 958078793 (record primary key command)
     },
     ProcessResult, Snapshot,
 };
@@ -61,12 +71,21 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for ResolveLockLite {
         // ti-client guarantees the size of resolve_keys will not too large, so no
         // necessary to control the write_size as ResolveLock.
         let mut released_locks = ReleasedLocks::new();
-        for key in self.resolve_keys {
-            released_locks.push(if !self.commit_ts.is_zero() {
-                commit(&mut txn, &mut reader, key, self.commit_ts)?
-            } else {
-                cleanup(&mut txn, &mut reader, key, TimeStamp::zero(), false)?
-            });
+        if !self.commit_ts.is_zero() && TXN_FLIGHT_RECORDER.is_enabled() {
+            for key in self.resolve_keys {
+                let (released, primary_key_hash) =
+                    commit_with_primary(&mut txn, &mut reader, key, self.commit_ts)?;
+                released_locks.set_flight_primary_key_hash(primary_key_hash);
+                released_locks.push(released);
+            }
+        } else {
+            for key in self.resolve_keys {
+                released_locks.push(if !self.commit_ts.is_zero() {
+                    commit(&mut txn, &mut reader, key, self.commit_ts)?
+                } else {
+                    cleanup(&mut txn, &mut reader, key, TimeStamp::zero(), false)?
+                });
+            }
         }
 
         let known_txn_status = if !self.commit_ts.is_zero() {

--- a/src/storage/txn/commands/resolve_lock_lite.rs
+++ b/src/storage/txn/commands/resolve_lock_lite.rs
@@ -8,22 +8,15 @@ use crate::storage::{
     lock_manager::LockManager,
     mvcc::{MvccTxn, SnapshotReader},
     txn::{
-<<<<<<< HEAD
-=======
         Result,
         actions::commit::commit_with_primary,
->>>>>>> 958078793 (record primary key command)
         cleanup,
         commands::{
             Command, CommandExt, ReaderWithStats, ReleasedLocks, ResponsePolicy, TypedCommand,
             WriteCommand, WriteContext, WriteResult,
         },
-<<<<<<< HEAD
-        commit, Result,
-=======
         commit,
         flight_recorder::TXN_FLIGHT_RECORDER,
->>>>>>> 958078793 (record primary key command)
     },
     ProcessResult, Snapshot,
 };

--- a/src/storage/txn/flight_recorder.rs
+++ b/src/storage/txn/flight_recorder.rs
@@ -1,0 +1,778 @@
+// Copyright 2026 TiKV Project Authors. Licensed under Apache-2.0.
+
+//! A bounded in-memory flight recorder for transaction commands.
+//!
+//! It captures transaction command arrivals, cache observations, and successful
+//! lock/write modifications. It stores neither raw keys nor user values.
+
+use std::{
+    collections::{VecDeque, hash_map::DefaultHasher},
+    hash::{Hash, Hasher},
+    sync::atomic::{AtomicBool, AtomicU64, Ordering},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use crossbeam::utils::CachePadded;
+use engine_traits::{CF_LOCK, CF_WRITE};
+use kvproto::kvrpcpb::PrewriteRequestPessimisticAction;
+use lazy_static::lazy_static;
+use parking_lot::Mutex;
+use tikv_kv::Modify;
+use tikv_util::Either;
+use txn_types::{Key, LockType, TimeStamp, WriteRef, WriteType, parse_lock};
+
+use crate::storage::{Context, metrics::CommandKind, txn::commands::Command};
+
+const TXN_COMMAND_FLIGHT_RECORDER_SHARDS: usize = 128;
+const TXN_COMMAND_FLIGHT_RECORDER_EVENTS_PER_SHARD: usize = 4096;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum TxnCommandEventKind {
+    Received,
+    PutLock,
+    PutInMemoryPessimisticLock,
+    DeleteLock,
+    PutWrite,
+    DeleteWrite,
+    TxnStatusCacheHit,
+    TxnStatusCacheMiss,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum RecordedPessimisticAction {
+    Unknown,
+    SkipPessimisticCheck,
+    DoPessimisticCheck,
+    DoConstraintCheck,
+}
+
+impl From<PrewriteRequestPessimisticAction> for RecordedPessimisticAction {
+    fn from(action: PrewriteRequestPessimisticAction) -> Self {
+        use PrewriteRequestPessimisticAction::*;
+        match action {
+            SkipPessimisticCheck => Self::SkipPessimisticCheck,
+            DoPessimisticCheck => Self::DoPessimisticCheck,
+            DoConstraintCheck => Self::DoConstraintCheck,
+        }
+    }
+}
+
+fn hash_key(key: &Key) -> u64 {
+    // Hash the encoded key so diagnostics cannot panic on a malformed
+    // memcomparable key.
+    let mut hasher = DefaultHasher::new();
+    key.as_encoded().hash(&mut hasher);
+    hasher.finish()
+}
+
+fn hash_raw_key(raw_key: &[u8]) -> u64 {
+    hash_key(&Key::from_raw(raw_key))
+}
+
+#[derive(Clone, Copy)]
+struct CommandKey {
+    key_hash: u64,
+    pessimistic_action: RecordedPessimisticAction,
+    txn_start_ts: u64,
+}
+
+/// Metadata captured before a command is moved into its MVCC command handler.
+pub(crate) struct TxnCommandEventMetadata {
+    cid: u64,
+    command: CommandKind,
+    txn_start_ts: u64,
+    commit_ts: u64,
+    caller_start_ts: u64,
+    current_ts: u64,
+    for_update_ts: u64,
+    min_commit_ts: u64,
+    lock_ttl: u64,
+    primary_key_hash: u64,
+    region_id: u64,
+    term: u64,
+    snapshot_data_version: u64,
+    is_retry_request: bool,
+    skip_constraint_check: bool,
+    try_one_pc: bool,
+    rollback_if_not_exist: bool,
+    force_sync_commit: bool,
+    resolving_pessimistic_lock: bool,
+    verify_is_primary: bool,
+    keys: Vec<CommandKey>,
+}
+
+impl TxnCommandEventMetadata {
+    fn from_command(cmd: &Command, cid: u64, snapshot_data_version: Option<u64>) -> Self {
+        let ctx = cmd.ctx();
+        let mut metadata = Self {
+            cid,
+            command: cmd.tag(),
+            txn_start_ts: cmd.ts().into_inner(),
+            commit_ts: 0,
+            caller_start_ts: 0,
+            current_ts: 0,
+            for_update_ts: 0,
+            min_commit_ts: 0,
+            lock_ttl: 0,
+            primary_key_hash: 0,
+            region_id: ctx.get_region_id(),
+            term: ctx.get_term(),
+            snapshot_data_version: snapshot_data_version.unwrap_or(0),
+            is_retry_request: ctx.get_is_retry_request(),
+            skip_constraint_check: false,
+            try_one_pc: false,
+            rollback_if_not_exist: false,
+            force_sync_commit: false,
+            resolving_pessimistic_lock: false,
+            verify_is_primary: false,
+            keys: Vec::new(),
+        };
+
+        match cmd {
+            Command::Prewrite(c) => {
+                metadata.txn_start_ts = c.start_ts.into_inner();
+                metadata.lock_ttl = c.lock_ttl;
+                metadata.min_commit_ts = c.min_commit_ts.into_inner();
+                metadata.primary_key_hash = hash_raw_key(&c.primary);
+                metadata.skip_constraint_check = c.skip_constraint_check;
+                metadata.try_one_pc = c.try_one_pc;
+                metadata
+                    .keys
+                    .extend(c.mutations.iter().map(|mutation| CommandKey {
+                        key_hash: hash_key(mutation.key()),
+                        pessimistic_action: RecordedPessimisticAction::SkipPessimisticCheck,
+                        txn_start_ts: c.start_ts.into_inner(),
+                    }));
+            }
+            Command::PrewritePessimistic(c) => {
+                metadata.txn_start_ts = c.start_ts.into_inner();
+                metadata.for_update_ts = c.for_update_ts.into_inner();
+                metadata.lock_ttl = c.lock_ttl;
+                metadata.min_commit_ts = c.min_commit_ts.into_inner();
+                metadata.primary_key_hash = hash_raw_key(&c.primary);
+                metadata.try_one_pc = c.try_one_pc;
+                metadata
+                    .keys
+                    .extend(c.mutations.iter().map(|(mutation, action)| CommandKey {
+                        key_hash: hash_key(mutation.key()),
+                        pessimistic_action: (*action).into(),
+                        txn_start_ts: c.start_ts.into_inner(),
+                    }));
+            }
+            Command::AcquirePessimisticLock(c) => {
+                metadata.txn_start_ts = c.start_ts.into_inner();
+                metadata.for_update_ts = c.for_update_ts.into_inner();
+                metadata.lock_ttl = c.lock_ttl;
+                metadata.min_commit_ts = c.min_commit_ts.into_inner();
+                metadata.primary_key_hash = hash_raw_key(&c.primary);
+                metadata
+                    .keys
+                    .extend(c.keys.iter().map(|(key, ..)| command_key(key, c.start_ts)));
+            }
+            Command::AcquirePessimisticLockResumed(c) => {
+                metadata.keys.extend(c.items.iter().map(|item| CommandKey {
+                    key_hash: hash_key(&item.key),
+                    pessimistic_action: RecordedPessimisticAction::Unknown,
+                    txn_start_ts: item.params.start_ts.into_inner(),
+                }));
+            }
+            Command::Commit(c) => {
+                metadata.txn_start_ts = c.lock_ts.into_inner();
+                metadata.commit_ts = c.commit_ts.into_inner();
+                metadata
+                    .keys
+                    .extend(c.keys.iter().map(|key| command_key(key, c.lock_ts)));
+            }
+            Command::Cleanup(c) => {
+                metadata.txn_start_ts = c.start_ts.into_inner();
+                metadata.keys.push(command_key(&c.key, c.start_ts));
+            }
+            Command::Rollback(c) => {
+                metadata.txn_start_ts = c.start_ts.into_inner();
+                metadata
+                    .keys
+                    .extend(c.keys.iter().map(|key| command_key(key, c.start_ts)));
+            }
+            Command::PessimisticRollback(c) => {
+                metadata.txn_start_ts = c.start_ts.into_inner();
+                metadata.for_update_ts = c.for_update_ts.into_inner();
+                metadata
+                    .keys
+                    .extend(c.keys.iter().map(|key| command_key(key, c.start_ts)));
+            }
+            Command::TxnHeartBeat(c) => {
+                metadata.txn_start_ts = c.start_ts.into_inner();
+                metadata.min_commit_ts = c.min_commit_ts;
+                metadata.keys.push(command_key(&c.primary_key, c.start_ts));
+                metadata.primary_key_hash = hash_key(&c.primary_key);
+            }
+            Command::CheckTxnStatus(c) => {
+                metadata.txn_start_ts = c.lock_ts.into_inner();
+                metadata.caller_start_ts = c.caller_start_ts.into_inner();
+                metadata.current_ts = c.current_ts.into_inner();
+                metadata.rollback_if_not_exist = c.rollback_if_not_exist;
+                metadata.force_sync_commit = c.force_sync_commit;
+                metadata.resolving_pessimistic_lock = c.resolving_pessimistic_lock;
+                metadata.verify_is_primary = c.verify_is_primary;
+                metadata.keys.push(command_key(&c.primary_key, c.lock_ts));
+                metadata.primary_key_hash = hash_key(&c.primary_key);
+            }
+            Command::CheckSecondaryLocks(c) => {
+                metadata.txn_start_ts = c.start_ts.into_inner();
+                metadata
+                    .keys
+                    .extend(c.keys.iter().map(|key| command_key(key, c.start_ts)));
+            }
+            Command::ResolveLock(c) => {
+                metadata
+                    .keys
+                    .extend(c.key_locks.iter().map(|(key, lock)| CommandKey {
+                        key_hash: hash_key(key),
+                        pessimistic_action: RecordedPessimisticAction::Unknown,
+                        txn_start_ts: lock.ts.into_inner(),
+                    }));
+            }
+            Command::ResolveLockLite(c) => {
+                metadata.txn_start_ts = c.start_ts.into_inner();
+                metadata.commit_ts = c.commit_ts.into_inner();
+                metadata.keys.extend(
+                    c.resolve_keys
+                        .iter()
+                        .map(|key| command_key(key, c.start_ts)),
+                );
+            }
+            Command::Flush(c) => {
+                metadata.txn_start_ts = c.start_ts.into_inner();
+                metadata.lock_ttl = c.lock_ttl;
+                metadata.primary_key_hash = hash_raw_key(&c.primary);
+                metadata
+                    .keys
+                    .extend(c.mutations.iter().map(|mutation| CommandKey {
+                        key_hash: hash_key(mutation.key()),
+                        pessimistic_action: RecordedPessimisticAction::Unknown,
+                        txn_start_ts: c.start_ts.into_inner(),
+                    }));
+            }
+            _ => {}
+        }
+
+        metadata.keys.sort_unstable_by_key(|key| key.key_hash);
+        metadata
+    }
+
+    pub(crate) fn events_for_modifies(&self, modifies: &[Modify]) -> Vec<TxnCommandEvent> {
+        modifies
+            .iter()
+            .filter_map(|modify| self.event_for_modify(modify))
+            .collect()
+    }
+
+    fn event_for_command_key(&self, key: CommandKey) -> TxnCommandEvent {
+        self.base_event(key.key_hash, TxnCommandEventKind::Received)
+    }
+
+    fn base_event(&self, key_hash: u64, kind: TxnCommandEventKind) -> TxnCommandEvent {
+        let command_key = self.command_key(key_hash);
+        TxnCommandEvent {
+            unix_time_ms: 0,
+            kind,
+            command: self.command,
+            cid: self.cid,
+            key_hash,
+            primary_key_hash: self.primary_key_hash,
+            txn_start_ts: command_key
+                .map(|key| key.txn_start_ts)
+                .filter(|ts| *ts != 0)
+                .unwrap_or(self.txn_start_ts),
+            commit_ts: self.commit_ts,
+            caller_start_ts: self.caller_start_ts,
+            current_ts: self.current_ts,
+            for_update_ts: self.for_update_ts,
+            min_commit_ts: self.min_commit_ts,
+            lock_ttl: self.lock_ttl,
+            region_id: self.region_id,
+            term: self.term,
+            snapshot_data_version: self.snapshot_data_version,
+            is_retry_request: self.is_retry_request,
+            skip_constraint_check: self.skip_constraint_check,
+            try_one_pc: self.try_one_pc,
+            rollback_if_not_exist: self.rollback_if_not_exist,
+            force_sync_commit: self.force_sync_commit,
+            resolving_pessimistic_lock: self.resolving_pessimistic_lock,
+            verify_is_primary: self.verify_is_primary,
+            pessimistic_action: command_key
+                .map(|key| key.pessimistic_action)
+                .unwrap_or(RecordedPessimisticAction::Unknown),
+            lock_type: None,
+            write_type: None,
+            generation: 0,
+        }
+    }
+
+    fn command_key(&self, key_hash: u64) -> Option<CommandKey> {
+        self.keys
+            .binary_search_by_key(&key_hash, |key| key.key_hash)
+            .ok()
+            .map(|index| self.keys[index])
+    }
+
+    fn event_for_modify(&self, modify: &Modify) -> Option<TxnCommandEvent> {
+        match modify {
+            Modify::Put(cf, key, value) if *cf == CF_LOCK => {
+                let mut event = self.base_event(hash_key(key), TxnCommandEventKind::PutLock);
+                match parse_lock(value).ok()? {
+                    Either::Left(lock) => {
+                        event.lock_type = Some(lock.lock_type);
+                        event.txn_start_ts = lock.ts.into_inner();
+                        event.for_update_ts = lock.for_update_ts.into_inner();
+                        event.min_commit_ts = lock.min_commit_ts.into_inner();
+                        event.lock_ttl = lock.ttl;
+                        event.primary_key_hash = hash_raw_key(&lock.primary);
+                        event.generation = lock.generation;
+                    }
+                    Either::Right(_) => event.lock_type = Some(LockType::Shared),
+                }
+                Some(event)
+            }
+            Modify::Delete(cf, key) if *cf == CF_LOCK => {
+                Some(self.base_event(hash_key(key), TxnCommandEventKind::DeleteLock))
+            }
+            Modify::Put(cf, key, value) if *cf == CF_WRITE => {
+                let commit_ts = key.decode_ts().ok()?;
+                let user_key = key.clone().truncate_ts().ok()?;
+                let write = WriteRef::parse(value).ok()?;
+                let mut event = self.base_event(hash_key(&user_key), TxnCommandEventKind::PutWrite);
+                event.commit_ts = commit_ts.into_inner();
+                event.write_type = Some(write.write_type);
+                event.txn_start_ts = write.start_ts.into_inner();
+                Some(event)
+            }
+            Modify::Delete(cf, key) if *cf == CF_WRITE => {
+                let commit_ts = key.decode_ts().ok()?;
+                let user_key = key.clone().truncate_ts().ok()?;
+                let mut event =
+                    self.base_event(hash_key(&user_key), TxnCommandEventKind::DeleteWrite);
+                event.commit_ts = commit_ts.into_inner();
+                Some(event)
+            }
+            Modify::PessimisticLock(key, lock) => {
+                let mut event = self.base_event(hash_key(key), TxnCommandEventKind::PutLock);
+                event.lock_type = Some(LockType::Pessimistic);
+                event.txn_start_ts = lock.start_ts.into_inner();
+                event.for_update_ts = lock.for_update_ts.into_inner();
+                event.min_commit_ts = lock.min_commit_ts.into_inner();
+                event.lock_ttl = lock.ttl;
+                event.primary_key_hash = hash_raw_key(&lock.primary);
+                Some(event)
+            }
+            _ => None,
+        }
+    }
+}
+
+fn command_key(key: &Key, start_ts: TimeStamp) -> CommandKey {
+    CommandKey {
+        key_hash: hash_key(key),
+        pessimistic_action: RecordedPessimisticAction::Unknown,
+        txn_start_ts: start_ts.into_inner(),
+    }
+}
+
+/// A single immutable record. It deliberately contains no raw key or user
+/// value.
+#[derive(Clone, Debug)]
+#[allow(dead_code)] // Fields are consumed by the derived Debug output in panic diagnostics.
+pub(crate) struct TxnCommandEvent {
+    unix_time_ms: u64,
+    kind: TxnCommandEventKind,
+    command: CommandKind,
+    cid: u64,
+    key_hash: u64,
+    primary_key_hash: u64,
+    txn_start_ts: u64,
+    commit_ts: u64,
+    caller_start_ts: u64,
+    current_ts: u64,
+    for_update_ts: u64,
+    min_commit_ts: u64,
+    lock_ttl: u64,
+    region_id: u64,
+    term: u64,
+    snapshot_data_version: u64,
+    is_retry_request: bool,
+    skip_constraint_check: bool,
+    try_one_pc: bool,
+    rollback_if_not_exist: bool,
+    force_sync_commit: bool,
+    resolving_pessimistic_lock: bool,
+    verify_is_primary: bool,
+    pessimistic_action: RecordedPessimisticAction,
+    lock_type: Option<LockType>,
+    write_type: Option<WriteType>,
+    generation: u64,
+}
+
+pub(crate) struct TxnCommandFlightRecorder {
+    enabled: AtomicBool,
+    shards: Vec<CachePadded<Mutex<VecDeque<TxnCommandEvent>>>>,
+    shard_mask: usize,
+    events_per_shard: usize,
+    overwritten_events: AtomicU64,
+}
+
+impl TxnCommandFlightRecorder {
+    fn new(shard_count: usize, events_per_shard: usize, enabled: bool) -> Self {
+        assert!(shard_count.is_power_of_two() && events_per_shard > 0);
+        let shards = (0..shard_count)
+            .map(|_| CachePadded::new(Mutex::new(VecDeque::new())))
+            .collect();
+        Self {
+            enabled: AtomicBool::new(enabled),
+            shards,
+            shard_mask: shard_count - 1,
+            events_per_shard,
+            overwritten_events: AtomicU64::new(0),
+        }
+    }
+
+    #[inline]
+    fn is_enabled(&self) -> bool {
+        self.enabled.load(Ordering::Relaxed)
+    }
+
+    /// Disabling clears retained events and releases their ring-buffer memory.
+    pub(crate) fn set_enabled(&self, enabled: bool) {
+        if !enabled {
+            if !self.enabled.swap(false, Ordering::AcqRel) {
+                return;
+            }
+            for shard in &self.shards {
+                let mut shard = shard.lock();
+                shard.clear();
+                shard.shrink_to_fit();
+            }
+            self.overwritten_events.store(0, Ordering::Relaxed);
+            return;
+        }
+        if self.enabled.load(Ordering::Acquire) {
+            return;
+        }
+        self.enabled.store(true, Ordering::Release);
+    }
+
+    #[inline]
+    pub(crate) fn command_metadata(
+        &self,
+        cmd: &Command,
+        cid: u64,
+        snapshot_data_version: Option<u64>,
+    ) -> Option<TxnCommandEventMetadata> {
+        self.is_enabled()
+            .then(|| TxnCommandEventMetadata::from_command(cmd, cid, snapshot_data_version))
+    }
+
+    #[inline]
+    pub(crate) fn record_received(&self, cmd: &Command) {
+        if let Some(metadata) = self.command_metadata(cmd, 0, None) {
+            self.record(
+                metadata
+                    .keys
+                    .iter()
+                    .map(|key| metadata.event_for_command_key(*key)),
+            );
+        }
+    }
+
+    fn record(&self, events: impl IntoIterator<Item = TxnCommandEvent>) {
+        if !self.is_enabled() {
+            return;
+        }
+        let mut events = events.into_iter().peekable();
+        if events.peek().is_none() {
+            return;
+        }
+        let unix_time_ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as u64;
+        for mut event in events {
+            let shard_index = event.key_hash as usize & self.shard_mask;
+            let mut shard = self.shards[shard_index].lock();
+            // Pair with set_enabled(false): a recorder that passed the first
+            // check before disabling must not repopulate a cleared shard.
+            if !self.is_enabled() {
+                continue;
+            }
+            event.unix_time_ms = unix_time_ms;
+            if shard.len() == self.events_per_shard {
+                shard.pop_front();
+                self.overwritten_events.fetch_add(1, Ordering::Relaxed);
+            }
+            shard.push_back(event);
+        }
+    }
+
+    pub(crate) fn record_persistent_modifies(&self, events: &[TxnCommandEvent]) {
+        if events.is_empty() {
+            return;
+        }
+        self.record(events.iter().cloned())
+    }
+
+    pub(crate) fn record_in_memory_pessimistic_locks(&self, events: &[TxnCommandEvent]) {
+        if events.is_empty() {
+            return;
+        }
+        self.record(events.iter().cloned().map(|mut event| {
+            event.kind = TxnCommandEventKind::PutInMemoryPessimisticLock;
+            event
+        }))
+    }
+
+    pub(crate) fn record_txn_status_cache_lookup<'a>(
+        &self,
+        keys: impl IntoIterator<Item = &'a Key>,
+        primary_key: &[u8],
+        start_ts: TimeStamp,
+        committed_ts: Option<TimeStamp>,
+        ctx: &Context,
+        snapshot_data_version: Option<u64>,
+    ) {
+        if !self.is_enabled() {
+            return;
+        }
+        let metadata = TxnCommandEventMetadata {
+            cid: 0,
+            command: CommandKind::prewrite,
+            txn_start_ts: start_ts.into_inner(),
+            commit_ts: committed_ts.unwrap_or_default().into_inner(),
+            caller_start_ts: 0,
+            current_ts: 0,
+            for_update_ts: 0,
+            min_commit_ts: 0,
+            lock_ttl: 0,
+            primary_key_hash: hash_raw_key(primary_key),
+            region_id: ctx.get_region_id(),
+            term: ctx.get_term(),
+            snapshot_data_version: snapshot_data_version.unwrap_or(0),
+            is_retry_request: ctx.get_is_retry_request(),
+            skip_constraint_check: false,
+            try_one_pc: false,
+            rollback_if_not_exist: false,
+            force_sync_commit: false,
+            resolving_pessimistic_lock: false,
+            verify_is_primary: false,
+            keys: Vec::new(),
+        };
+        let kind = if committed_ts.is_some() {
+            TxnCommandEventKind::TxnStatusCacheHit
+        } else {
+            TxnCommandEventKind::TxnStatusCacheMiss
+        };
+        self.record(
+            keys.into_iter()
+                .map(|key| metadata.base_event(hash_key(key), kind)),
+        );
+    }
+
+    pub(crate) fn events_for_key(&self, key: &Key) -> Vec<TxnCommandEvent> {
+        let key_hash = hash_key(key);
+        let shard_index = key_hash as usize & self.shard_mask;
+        self.shards[shard_index]
+            .lock()
+            .iter()
+            .filter(|event| event.key_hash == key_hash)
+            .cloned()
+            .collect()
+    }
+
+    pub(crate) fn overwritten_events(&self) -> u64 {
+        self.overwritten_events.load(Ordering::Relaxed)
+    }
+}
+
+lazy_static! {
+    pub(crate) static ref TXN_COMMAND_FLIGHT_RECORDER: TxnCommandFlightRecorder =
+        TxnCommandFlightRecorder::new(
+            TXN_COMMAND_FLIGHT_RECORDER_SHARDS,
+            TXN_COMMAND_FLIGHT_RECORDER_EVENTS_PER_SHARD,
+            false,
+        );
+}
+
+#[cfg(test)]
+mod tests {
+    use std::mem::size_of;
+
+    use txn_types::{Lock, Write};
+
+    use super::*;
+
+    fn event_for_key(key: &Key, cid: u64) -> TxnCommandEvent {
+        TxnCommandEvent {
+            unix_time_ms: 0,
+            kind: TxnCommandEventKind::Received,
+            command: CommandKind::prewrite,
+            cid,
+            key_hash: hash_key(key),
+            primary_key_hash: 0,
+            txn_start_ts: 0,
+            commit_ts: 0,
+            caller_start_ts: 0,
+            current_ts: 0,
+            for_update_ts: 0,
+            min_commit_ts: 0,
+            lock_ttl: 0,
+            region_id: 0,
+            term: 0,
+            snapshot_data_version: 0,
+            is_retry_request: false,
+            skip_constraint_check: false,
+            try_one_pc: false,
+            rollback_if_not_exist: false,
+            force_sync_commit: false,
+            resolving_pessimistic_lock: false,
+            verify_is_primary: false,
+            pessimistic_action: RecordedPessimisticAction::Unknown,
+            lock_type: None,
+            write_type: None,
+            generation: 0,
+        }
+    }
+
+    #[test]
+    fn test_bounded_history_for_key() {
+        let recorder = TxnCommandFlightRecorder::new(2, 4, true);
+        let key = Key::from_raw(b"key");
+        let other_key = Key::from_raw(b"other-key");
+
+        for cid in 1..=5 {
+            recorder.record([event_for_key(&key, cid)]);
+        }
+        recorder.record([event_for_key(&other_key, 100)]);
+
+        let events = recorder.events_for_key(&key);
+        assert!(events.len() <= 4);
+        assert_eq!(events.last().unwrap().cid, 5);
+        assert!(events.iter().all(|event| event.cid != 100));
+        assert!(recorder.overwritten_events() >= 1);
+    }
+
+    #[test]
+    fn test_modify_events_are_normalized_to_user_key() {
+        let key = Key::from_raw(b"key");
+        let key_hash = hash_key(&key);
+        let metadata = TxnCommandEventMetadata {
+            cid: 42,
+            command: CommandKind::prewrite,
+            txn_start_ts: 10,
+            commit_ts: 0,
+            caller_start_ts: 0,
+            current_ts: 0,
+            for_update_ts: 11,
+            min_commit_ts: 12,
+            lock_ttl: 20_000,
+            primary_key_hash: key_hash,
+            region_id: 1,
+            term: 2,
+            snapshot_data_version: 4,
+            is_retry_request: true,
+            skip_constraint_check: false,
+            try_one_pc: false,
+            rollback_if_not_exist: false,
+            force_sync_commit: false,
+            resolving_pessimistic_lock: false,
+            verify_is_primary: false,
+            keys: vec![CommandKey {
+                key_hash,
+                pessimistic_action: RecordedPessimisticAction::DoPessimisticCheck,
+                txn_start_ts: 10,
+            }],
+        };
+        let lock = Lock::new(
+            LockType::Put,
+            b"key".to_vec(),
+            10.into(),
+            20_000,
+            None,
+            11.into(),
+            1,
+            12.into(),
+            false,
+        );
+        let write = Write::new(WriteType::Put, 10.into(), None);
+        let modifies = vec![
+            Modify::Put(CF_LOCK, key.clone(), lock.to_bytes()),
+            Modify::Put(
+                CF_WRITE,
+                key.clone().append_ts(20.into()),
+                write.as_ref().to_bytes(),
+            ),
+        ];
+
+        let events = metadata.events_for_modifies(&modifies);
+        assert_eq!(events.len(), 2);
+        assert!(events.iter().all(|event| event.key_hash == key_hash));
+        assert_eq!(events[0].kind, TxnCommandEventKind::PutLock);
+        assert_eq!(events[0].txn_start_ts, 10);
+        assert_eq!(
+            events[0].pessimistic_action,
+            RecordedPessimisticAction::DoPessimisticCheck
+        );
+        assert_eq!(events[1].kind, TxnCommandEventKind::PutWrite);
+        assert_eq!(events[1].commit_ts, 20);
+        assert_eq!(events[1].write_type, Some(WriteType::Put));
+    }
+
+    #[test]
+    fn test_event_size_is_bounded() {
+        // 128 * 4096 records should remain below roughly 80 MiB, excluding the small
+        // per-shard VecDeque bookkeeping.
+        let size = size_of::<TxnCommandEvent>();
+        assert!(size <= 160, "event size is {size}");
+    }
+
+    #[test]
+    fn test_txn_status_cache_lookup_event() {
+        let recorder = TxnCommandFlightRecorder::new(2, 4, true);
+        let key = Key::from_raw(b"key");
+        let mut ctx = Context::default();
+        ctx.set_region_id(7);
+        ctx.set_is_retry_request(true);
+
+        recorder.record_txn_status_cache_lookup(
+            [&key],
+            b"key",
+            10.into(),
+            Some(20.into()),
+            &ctx,
+            Some(30),
+        );
+
+        let events = recorder.events_for_key(&key);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].kind, TxnCommandEventKind::TxnStatusCacheHit);
+        assert_eq!(events[0].txn_start_ts, 10);
+        assert_eq!(events[0].commit_ts, 20);
+        assert_eq!(events[0].snapshot_data_version, 30);
+        assert!(events[0].is_retry_request);
+    }
+
+    #[test]
+    fn test_disabled_recorder_does_not_record_and_enable_starts_fresh() {
+        let recorder = TxnCommandFlightRecorder::new(2, 4, false);
+        let key = Key::from_raw(b"key");
+
+        recorder.record([event_for_key(&key, 1)]);
+        assert!(recorder.events_for_key(&key).is_empty());
+
+        recorder.set_enabled(true);
+        recorder.record([event_for_key(&key, 2)]);
+        assert_eq!(recorder.events_for_key(&key).len(), 1);
+
+        recorder.set_enabled(false);
+        assert!(recorder.events_for_key(&key).is_empty());
+        recorder.set_enabled(true);
+        assert!(recorder.events_for_key(&key).is_empty());
+    }
+}

--- a/src/storage/txn/flight_recorder.rs
+++ b/src/storage/txn/flight_recorder.rs
@@ -494,6 +494,12 @@ impl TxnCommandFlightRecorder {
         }))
     }
 
+    /// Records a txn-status-cache lookup observed while processing a prewrite.
+    ///
+    /// The command cid is not plumbed into command processing, so the event
+    /// keeps `cid == 0` as an auxiliary record; correlate it with the owning
+    /// command through its key hash, `txn_start_ts`, `is_retry_request`, and
+    /// timestamp.
     pub(crate) fn record_txn_status_cache_lookup<'a>(
         &self,
         keys: impl IntoIterator<Item = &'a Key>,

--- a/src/storage/txn/flight_recorder.rs
+++ b/src/storage/txn/flight_recorder.rs
@@ -8,7 +8,7 @@
 use std::{
     collections::{VecDeque, hash_map::DefaultHasher},
     hash::{Hash, Hasher},
-    sync::atomic::{AtomicBool, AtomicU64, Ordering},
+    sync::atomic::{AtomicBool, Ordering},
     time::{SystemTime, UNIX_EPOCH},
 };
 
@@ -23,8 +23,8 @@ use txn_types::{Key, LockType, TimeStamp, WriteRef, WriteType, parse_lock};
 
 use crate::storage::{Context, metrics::CommandKind, txn::commands::Command};
 
-const TXN_COMMAND_FLIGHT_RECORDER_SHARDS: usize = 128;
-const TXN_COMMAND_FLIGHT_RECORDER_EVENTS_PER_SHARD: usize = 4096;
+const SHARD_COUNT: usize = 128;
+const EVENTS_PER_SHARD: usize = 4096;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum TxnCommandEventKind {
@@ -38,30 +38,15 @@ enum TxnCommandEventKind {
     TxnStatusCacheMiss,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum RecordedPessimisticAction {
-    Unknown,
-    SkipPessimisticCheck,
-    DoPessimisticCheck,
-    DoConstraintCheck,
+pub(crate) fn hash_key(key: &Key) -> u64 {
+    hash_encoded_key(key.as_encoded())
 }
 
-impl From<PrewriteRequestPessimisticAction> for RecordedPessimisticAction {
-    fn from(action: PrewriteRequestPessimisticAction) -> Self {
-        use PrewriteRequestPessimisticAction::*;
-        match action {
-            SkipPessimisticCheck => Self::SkipPessimisticCheck,
-            DoPessimisticCheck => Self::DoPessimisticCheck,
-            DoConstraintCheck => Self::DoConstraintCheck,
-        }
-    }
-}
-
-fn hash_key(key: &Key) -> u64 {
+fn hash_encoded_key(key: &[u8]) -> u64 {
     // Hash the encoded key so diagnostics cannot panic on a malformed
     // memcomparable key.
     let mut hasher = DefaultHasher::new();
-    key.as_encoded().hash(&mut hasher);
+    key.hash(&mut hasher);
     hasher.finish()
 }
 
@@ -72,241 +57,178 @@ fn hash_raw_key(raw_key: &[u8]) -> u64 {
 #[derive(Clone, Copy)]
 struct CommandKey {
     key_hash: u64,
-    pessimistic_action: RecordedPessimisticAction,
+    pessimistic_action: Option<PrewriteRequestPessimisticAction>,
     txn_start_ts: u64,
 }
 
 /// Metadata captured before a command is moved into its MVCC command handler.
 pub(crate) struct TxnCommandEventMetadata {
-    cid: u64,
-    command: CommandKind,
-    txn_start_ts: u64,
-    commit_ts: u64,
-    caller_start_ts: u64,
-    current_ts: u64,
-    for_update_ts: u64,
-    min_commit_ts: u64,
-    lock_ttl: u64,
-    primary_key_hash: u64,
-    region_id: u64,
-    term: u64,
-    snapshot_data_version: u64,
-    is_retry_request: bool,
-    skip_constraint_check: bool,
-    try_one_pc: bool,
-    rollback_if_not_exist: bool,
-    force_sync_commit: bool,
-    resolving_pessimistic_lock: bool,
-    verify_is_primary: bool,
+    event: TxnCommandEvent,
     keys: Vec<CommandKey>,
 }
 
 impl TxnCommandEventMetadata {
-    fn from_command(cmd: &Command, cid: u64, snapshot_data_version: Option<u64>) -> Self {
+    fn from_command(cmd: &Command, cid: u64, snapshot_data_version: Option<u64>) -> Option<Self> {
         let ctx = cmd.ctx();
         let mut metadata = Self {
-            cid,
-            command: cmd.tag(),
-            txn_start_ts: cmd.ts().into_inner(),
-            commit_ts: 0,
-            caller_start_ts: 0,
-            current_ts: 0,
-            for_update_ts: 0,
-            min_commit_ts: 0,
-            lock_ttl: 0,
-            primary_key_hash: 0,
-            region_id: ctx.get_region_id(),
-            term: ctx.get_term(),
-            snapshot_data_version: snapshot_data_version.unwrap_or(0),
-            is_retry_request: ctx.get_is_retry_request(),
-            skip_constraint_check: false,
-            try_one_pc: false,
-            rollback_if_not_exist: false,
-            force_sync_commit: false,
-            resolving_pessimistic_lock: false,
-            verify_is_primary: false,
+            event: TxnCommandEvent::new(cmd.tag(), cid, ctx, snapshot_data_version),
             keys: Vec::new(),
         };
+        metadata.event.txn_start_ts = cmd.ts().into_inner();
 
         match cmd {
             Command::Prewrite(c) => {
-                metadata.txn_start_ts = c.start_ts.into_inner();
-                metadata.lock_ttl = c.lock_ttl;
-                metadata.min_commit_ts = c.min_commit_ts.into_inner();
-                metadata.primary_key_hash = hash_raw_key(&c.primary);
-                metadata.skip_constraint_check = c.skip_constraint_check;
-                metadata.try_one_pc = c.try_one_pc;
-                metadata
-                    .keys
-                    .extend(c.mutations.iter().map(|mutation| CommandKey {
+                metadata.event.lock_ttl = c.lock_ttl;
+                metadata.event.min_commit_ts = c.min_commit_ts.into_inner();
+                metadata.event.skip_constraint_check = c.skip_constraint_check;
+                metadata.event.try_one_pc = c.try_one_pc;
+                let primary_key = Key::from_raw(&c.primary);
+                if let Some(mutation) = c
+                    .mutations
+                    .iter()
+                    .find(|mutation| mutation.key() == &primary_key)
+                {
+                    metadata.keys.push(CommandKey {
                         key_hash: hash_key(mutation.key()),
-                        pessimistic_action: RecordedPessimisticAction::SkipPessimisticCheck,
-                        txn_start_ts: c.start_ts.into_inner(),
-                    }));
+                        pessimistic_action: Some(
+                            PrewriteRequestPessimisticAction::SkipPessimisticCheck,
+                        ),
+                        txn_start_ts: 0,
+                    });
+                }
             }
             Command::PrewritePessimistic(c) => {
-                metadata.txn_start_ts = c.start_ts.into_inner();
-                metadata.for_update_ts = c.for_update_ts.into_inner();
-                metadata.lock_ttl = c.lock_ttl;
-                metadata.min_commit_ts = c.min_commit_ts.into_inner();
-                metadata.primary_key_hash = hash_raw_key(&c.primary);
-                metadata.try_one_pc = c.try_one_pc;
-                metadata
-                    .keys
-                    .extend(c.mutations.iter().map(|(mutation, action)| CommandKey {
+                metadata.event.for_update_ts = c.for_update_ts.into_inner();
+                metadata.event.lock_ttl = c.lock_ttl;
+                metadata.event.min_commit_ts = c.min_commit_ts.into_inner();
+                metadata.event.try_one_pc = c.try_one_pc;
+                let primary_key = Key::from_raw(&c.primary);
+                if let Some((mutation, action)) = c
+                    .mutations
+                    .iter()
+                    .find(|(mutation, _)| mutation.key() == &primary_key)
+                {
+                    metadata.keys.push(CommandKey {
                         key_hash: hash_key(mutation.key()),
-                        pessimistic_action: (*action).into(),
-                        txn_start_ts: c.start_ts.into_inner(),
-                    }));
+                        pessimistic_action: Some(*action),
+                        txn_start_ts: 0,
+                    });
+                }
             }
             Command::AcquirePessimisticLock(c) => {
-                metadata.txn_start_ts = c.start_ts.into_inner();
-                metadata.for_update_ts = c.for_update_ts.into_inner();
-                metadata.lock_ttl = c.lock_ttl;
-                metadata.min_commit_ts = c.min_commit_ts.into_inner();
-                metadata.primary_key_hash = hash_raw_key(&c.primary);
-                metadata
-                    .keys
-                    .extend(c.keys.iter().map(|(key, ..)| command_key(key, c.start_ts)));
+                metadata.event.for_update_ts = c.for_update_ts.into_inner();
+                metadata.event.lock_ttl = c.lock_ttl;
+                metadata.event.min_commit_ts = c.min_commit_ts.into_inner();
+                let primary_key = Key::from_raw(&c.primary);
+                if let Some((key, ..)) = c.keys.iter().find(|(key, ..)| key == &primary_key) {
+                    metadata.keys.push(command_key(key));
+                }
             }
             Command::AcquirePessimisticLockResumed(c) => {
-                metadata.keys.extend(c.items.iter().map(|item| CommandKey {
-                    key_hash: hash_key(&item.key),
-                    pessimistic_action: RecordedPessimisticAction::Unknown,
-                    txn_start_ts: item.params.start_ts.into_inner(),
-                }));
-            }
-            Command::Commit(c) => {
-                metadata.txn_start_ts = c.lock_ts.into_inner();
-                metadata.commit_ts = c.commit_ts.into_inner();
-                metadata
-                    .keys
-                    .extend(c.keys.iter().map(|key| command_key(key, c.lock_ts)));
-            }
-            Command::Cleanup(c) => {
-                metadata.txn_start_ts = c.start_ts.into_inner();
-                metadata.keys.push(command_key(&c.key, c.start_ts));
-            }
-            Command::Rollback(c) => {
-                metadata.txn_start_ts = c.start_ts.into_inner();
-                metadata
-                    .keys
-                    .extend(c.keys.iter().map(|key| command_key(key, c.start_ts)));
-            }
-            Command::PessimisticRollback(c) => {
-                metadata.txn_start_ts = c.start_ts.into_inner();
-                metadata.for_update_ts = c.for_update_ts.into_inner();
-                metadata
-                    .keys
-                    .extend(c.keys.iter().map(|key| command_key(key, c.start_ts)));
-            }
-            Command::TxnHeartBeat(c) => {
-                metadata.txn_start_ts = c.start_ts.into_inner();
-                metadata.min_commit_ts = c.min_commit_ts;
-                metadata.keys.push(command_key(&c.primary_key, c.start_ts));
-                metadata.primary_key_hash = hash_key(&c.primary_key);
-            }
-            Command::CheckTxnStatus(c) => {
-                metadata.txn_start_ts = c.lock_ts.into_inner();
-                metadata.caller_start_ts = c.caller_start_ts.into_inner();
-                metadata.current_ts = c.current_ts.into_inner();
-                metadata.rollback_if_not_exist = c.rollback_if_not_exist;
-                metadata.force_sync_commit = c.force_sync_commit;
-                metadata.resolving_pessimistic_lock = c.resolving_pessimistic_lock;
-                metadata.verify_is_primary = c.verify_is_primary;
-                metadata.keys.push(command_key(&c.primary_key, c.lock_ts));
-                metadata.primary_key_hash = hash_key(&c.primary_key);
-            }
-            Command::CheckSecondaryLocks(c) => {
-                metadata.txn_start_ts = c.start_ts.into_inner();
-                metadata
-                    .keys
-                    .extend(c.keys.iter().map(|key| command_key(key, c.start_ts)));
-            }
-            Command::ResolveLock(c) => {
-                metadata
-                    .keys
-                    .extend(c.key_locks.iter().map(|(key, lock)| CommandKey {
-                        key_hash: hash_key(key),
-                        pessimistic_action: RecordedPessimisticAction::Unknown,
-                        txn_start_ts: lock.ts.into_inner(),
-                    }));
-            }
-            Command::ResolveLockLite(c) => {
-                metadata.txn_start_ts = c.start_ts.into_inner();
-                metadata.commit_ts = c.commit_ts.into_inner();
                 metadata.keys.extend(
-                    c.resolve_keys
+                    c.items
                         .iter()
-                        .map(|key| command_key(key, c.start_ts)),
+                        .filter(|item| item.key.is_encoded_from(&item.params.primary))
+                        .map(|item| CommandKey {
+                            key_hash: hash_key(&item.key),
+                            pessimistic_action: None,
+                            txn_start_ts: item.params.start_ts.into_inner(),
+                        }),
                 );
             }
+            Command::Commit(c) => {
+                metadata.event.txn_start_ts = c.lock_ts.into_inner();
+                metadata.event.commit_ts = c.commit_ts.into_inner();
+                // A Commit request does not identify its primary key. It is
+                // populated after the command reads the lock, so only its
+                // successfully applied primary-key modifies are recorded.
+            }
+            Command::TxnHeartBeat(c) => {
+                metadata.event.min_commit_ts = c.min_commit_ts;
+                metadata.keys.push(command_key(&c.primary_key));
+            }
+            Command::CheckTxnStatus(c) => {
+                metadata.event.caller_start_ts = c.caller_start_ts.into_inner();
+                metadata.event.current_ts = c.current_ts.into_inner();
+                metadata.event.rollback_if_not_exist = c.rollback_if_not_exist;
+                metadata.event.force_sync_commit = c.force_sync_commit;
+                metadata.event.resolving_pessimistic_lock = c.resolving_pessimistic_lock;
+                metadata.event.verify_is_primary = c.verify_is_primary;
+                metadata.keys.push(command_key(&c.primary_key));
+            }
+            Command::ResolveLock(c) => {
+                metadata.keys.extend(
+                    c.key_locks
+                        .iter()
+                        .filter(|(key, lock)| key.is_encoded_from(&lock.primary))
+                        .map(|(key, lock)| CommandKey {
+                            key_hash: hash_key(key),
+                            pessimistic_action: None,
+                            txn_start_ts: lock.ts.into_inner(),
+                        }),
+                );
+            }
+            Command::ResolveLockLite(c) => {
+                metadata.event.commit_ts = c.commit_ts.into_inner();
+                // ResolveLockLite also learns the primary key only after
+                // reading the lock, so only its successfully applied
+                // primary-key modifies are recorded.
+            }
             Command::Flush(c) => {
-                metadata.txn_start_ts = c.start_ts.into_inner();
-                metadata.lock_ttl = c.lock_ttl;
-                metadata.primary_key_hash = hash_raw_key(&c.primary);
-                metadata
-                    .keys
-                    .extend(c.mutations.iter().map(|mutation| CommandKey {
+                metadata.event.lock_ttl = c.lock_ttl;
+                let primary_key = Key::from_raw(&c.primary);
+                if let Some(mutation) = c
+                    .mutations
+                    .iter()
+                    .find(|mutation| mutation.key() == &primary_key)
+                {
+                    metadata.keys.push(CommandKey {
                         key_hash: hash_key(mutation.key()),
-                        pessimistic_action: RecordedPessimisticAction::Unknown,
-                        txn_start_ts: c.start_ts.into_inner(),
-                    }));
+                        pessimistic_action: None,
+                        txn_start_ts: 0,
+                    });
+                }
             }
             _ => {}
         }
 
         metadata.keys.sort_unstable_by_key(|key| key.key_hash);
-        metadata
+        let identifies_primary_while_processing = matches!(cmd, Command::Commit(_))
+            || matches!(cmd, Command::ResolveLockLite(c) if !c.commit_ts.is_zero());
+        (!metadata.keys.is_empty() || identifies_primary_while_processing).then_some(metadata)
+    }
+
+    pub(crate) fn set_primary_key_hash(&mut self, key_hash: u64) {
+        if key_hash == 0 || !self.keys.is_empty() {
+            return;
+        }
+        self.keys.push(CommandKey {
+            key_hash,
+            pessimistic_action: None,
+            txn_start_ts: self.event.txn_start_ts,
+        });
     }
 
     pub(crate) fn events_for_modifies(&self, modifies: &[Modify]) -> Vec<TxnCommandEvent> {
+        if self.keys.is_empty() {
+            return Vec::new();
+        }
         modifies
             .iter()
             .filter_map(|modify| self.event_for_modify(modify))
             .collect()
     }
 
-    fn event_for_command_key(&self, key: CommandKey) -> TxnCommandEvent {
-        self.base_event(key.key_hash, TxnCommandEventKind::Received)
-    }
-
-    fn base_event(&self, key_hash: u64, kind: TxnCommandEventKind) -> TxnCommandEvent {
-        let command_key = self.command_key(key_hash);
-        TxnCommandEvent {
-            unix_time_ms: 0,
-            kind,
-            command: self.command,
-            cid: self.cid,
-            key_hash,
-            primary_key_hash: self.primary_key_hash,
-            txn_start_ts: command_key
-                .map(|key| key.txn_start_ts)
-                .filter(|ts| *ts != 0)
-                .unwrap_or(self.txn_start_ts),
-            commit_ts: self.commit_ts,
-            caller_start_ts: self.caller_start_ts,
-            current_ts: self.current_ts,
-            for_update_ts: self.for_update_ts,
-            min_commit_ts: self.min_commit_ts,
-            lock_ttl: self.lock_ttl,
-            region_id: self.region_id,
-            term: self.term,
-            snapshot_data_version: self.snapshot_data_version,
-            is_retry_request: self.is_retry_request,
-            skip_constraint_check: self.skip_constraint_check,
-            try_one_pc: self.try_one_pc,
-            rollback_if_not_exist: self.rollback_if_not_exist,
-            force_sync_commit: self.force_sync_commit,
-            resolving_pessimistic_lock: self.resolving_pessimistic_lock,
-            verify_is_primary: self.verify_is_primary,
-            pessimistic_action: command_key
-                .map(|key| key.pessimistic_action)
-                .unwrap_or(RecordedPessimisticAction::Unknown),
-            lock_type: None,
-            write_type: None,
-            generation: 0,
+    fn base_event(&self, command_key: CommandKey, kind: TxnCommandEventKind) -> TxnCommandEvent {
+        let mut event = self.event;
+        event.kind = kind;
+        event.key_hash = command_key.key_hash;
+        event.primary_key_hash = command_key.key_hash;
+        if command_key.txn_start_ts != 0 {
+            event.txn_start_ts = command_key.txn_start_ts;
         }
+        event.pessimistic_action = command_key.pessimistic_action;
+        event
     }
 
     fn command_key(&self, key_hash: u64) -> Option<CommandKey> {
@@ -319,7 +241,9 @@ impl TxnCommandEventMetadata {
     fn event_for_modify(&self, modify: &Modify) -> Option<TxnCommandEvent> {
         match modify {
             Modify::Put(cf, key, value) if *cf == CF_LOCK => {
-                let mut event = self.base_event(hash_key(key), TxnCommandEventKind::PutLock);
+                let key_hash = hash_key(key);
+                let command_key = self.command_key(key_hash)?;
+                let mut event = self.base_event(command_key, TxnCommandEventKind::PutLock);
                 match parse_lock(value).ok()? {
                     Either::Left(lock) => {
                         event.lock_type = Some(lock.lock_type);
@@ -327,7 +251,9 @@ impl TxnCommandEventMetadata {
                         event.for_update_ts = lock.for_update_ts.into_inner();
                         event.min_commit_ts = lock.min_commit_ts.into_inner();
                         event.lock_ttl = lock.ttl;
-                        event.primary_key_hash = hash_raw_key(&lock.primary);
+                        if !key.is_encoded_from(&lock.primary) {
+                            event.primary_key_hash = hash_raw_key(&lock.primary);
+                        }
                         event.generation = lock.generation;
                     }
                     Either::Right(_) => event.lock_type = Some(LockType::Shared),
@@ -335,34 +261,41 @@ impl TxnCommandEventMetadata {
                 Some(event)
             }
             Modify::Delete(cf, key) if *cf == CF_LOCK => {
-                Some(self.base_event(hash_key(key), TxnCommandEventKind::DeleteLock))
+                let key_hash = hash_key(key);
+                let command_key = self.command_key(key_hash)?;
+                Some(self.base_event(command_key, TxnCommandEventKind::DeleteLock))
             }
             Modify::Put(cf, key, value) if *cf == CF_WRITE => {
-                let commit_ts = key.decode_ts().ok()?;
-                let user_key = key.clone().truncate_ts().ok()?;
+                let (user_key, commit_ts) = Key::split_on_ts_for(key.as_encoded()).ok()?;
+                let key_hash = hash_encoded_key(user_key);
+                let command_key = self.command_key(key_hash)?;
                 let write = WriteRef::parse(value).ok()?;
-                let mut event = self.base_event(hash_key(&user_key), TxnCommandEventKind::PutWrite);
+                let mut event = self.base_event(command_key, TxnCommandEventKind::PutWrite);
                 event.commit_ts = commit_ts.into_inner();
                 event.write_type = Some(write.write_type);
                 event.txn_start_ts = write.start_ts.into_inner();
                 Some(event)
             }
             Modify::Delete(cf, key) if *cf == CF_WRITE => {
-                let commit_ts = key.decode_ts().ok()?;
-                let user_key = key.clone().truncate_ts().ok()?;
-                let mut event =
-                    self.base_event(hash_key(&user_key), TxnCommandEventKind::DeleteWrite);
+                let (user_key, commit_ts) = Key::split_on_ts_for(key.as_encoded()).ok()?;
+                let key_hash = hash_encoded_key(user_key);
+                let command_key = self.command_key(key_hash)?;
+                let mut event = self.base_event(command_key, TxnCommandEventKind::DeleteWrite);
                 event.commit_ts = commit_ts.into_inner();
                 Some(event)
             }
             Modify::PessimisticLock(key, lock) => {
-                let mut event = self.base_event(hash_key(key), TxnCommandEventKind::PutLock);
+                let key_hash = hash_key(key);
+                let command_key = self.command_key(key_hash)?;
+                let mut event = self.base_event(command_key, TxnCommandEventKind::PutLock);
                 event.lock_type = Some(LockType::Pessimistic);
                 event.txn_start_ts = lock.start_ts.into_inner();
                 event.for_update_ts = lock.for_update_ts.into_inner();
                 event.min_commit_ts = lock.min_commit_ts.into_inner();
                 event.lock_ttl = lock.ttl;
-                event.primary_key_hash = hash_raw_key(&lock.primary);
+                if !key.is_encoded_from(&lock.primary) {
+                    event.primary_key_hash = hash_raw_key(&lock.primary);
+                }
                 Some(event)
             }
             _ => None,
@@ -370,17 +303,17 @@ impl TxnCommandEventMetadata {
     }
 }
 
-fn command_key(key: &Key, start_ts: TimeStamp) -> CommandKey {
+fn command_key(key: &Key) -> CommandKey {
     CommandKey {
         key_hash: hash_key(key),
-        pessimistic_action: RecordedPessimisticAction::Unknown,
-        txn_start_ts: start_ts.into_inner(),
+        pessimistic_action: None,
+        txn_start_ts: 0,
     }
 }
 
 /// A single immutable record. It deliberately contains no raw key or user
 /// value.
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 #[allow(dead_code)] // Fields are consumed by the derived Debug output in panic diagnostics.
 pub(crate) struct TxnCommandEvent {
     unix_time_ms: u64,
@@ -406,10 +339,49 @@ pub(crate) struct TxnCommandEvent {
     force_sync_commit: bool,
     resolving_pessimistic_lock: bool,
     verify_is_primary: bool,
-    pessimistic_action: RecordedPessimisticAction,
+    pessimistic_action: Option<PrewriteRequestPessimisticAction>,
     lock_type: Option<LockType>,
     write_type: Option<WriteType>,
     generation: u64,
+}
+
+impl TxnCommandEvent {
+    fn new(
+        command: CommandKind,
+        cid: u64,
+        ctx: &Context,
+        snapshot_data_version: Option<u64>,
+    ) -> Self {
+        Self {
+            unix_time_ms: 0,
+            kind: TxnCommandEventKind::Received,
+            command,
+            cid,
+            key_hash: 0,
+            primary_key_hash: 0,
+            txn_start_ts: 0,
+            commit_ts: 0,
+            caller_start_ts: 0,
+            current_ts: 0,
+            for_update_ts: 0,
+            min_commit_ts: 0,
+            lock_ttl: 0,
+            region_id: ctx.get_region_id(),
+            term: ctx.get_term(),
+            snapshot_data_version: snapshot_data_version.unwrap_or(0),
+            is_retry_request: ctx.get_is_retry_request(),
+            skip_constraint_check: false,
+            try_one_pc: false,
+            rollback_if_not_exist: false,
+            force_sync_commit: false,
+            resolving_pessimistic_lock: false,
+            verify_is_primary: false,
+            pessimistic_action: None,
+            lock_type: None,
+            write_type: None,
+            generation: 0,
+        }
+    }
 }
 
 pub(crate) struct TxnCommandFlightRecorder {
@@ -417,7 +389,6 @@ pub(crate) struct TxnCommandFlightRecorder {
     shards: Vec<CachePadded<Mutex<VecDeque<TxnCommandEvent>>>>,
     shard_mask: usize,
     events_per_shard: usize,
-    overwritten_events: AtomicU64,
 }
 
 impl TxnCommandFlightRecorder {
@@ -431,12 +402,11 @@ impl TxnCommandFlightRecorder {
             shards,
             shard_mask: shard_count - 1,
             events_per_shard,
-            overwritten_events: AtomicU64::new(0),
         }
     }
 
     #[inline]
-    fn is_enabled(&self) -> bool {
+    pub(crate) fn is_enabled(&self) -> bool {
         self.enabled.load(Ordering::Relaxed)
     }
 
@@ -447,14 +417,8 @@ impl TxnCommandFlightRecorder {
                 return;
             }
             for shard in &self.shards {
-                let mut shard = shard.lock();
-                shard.clear();
-                shard.shrink_to_fit();
+                *shard.lock() = VecDeque::new();
             }
-            self.overwritten_events.store(0, Ordering::Relaxed);
-            return;
-        }
-        if self.enabled.load(Ordering::Acquire) {
             return;
         }
         self.enabled.store(true, Ordering::Release);
@@ -467,8 +431,10 @@ impl TxnCommandFlightRecorder {
         cid: u64,
         snapshot_data_version: Option<u64>,
     ) -> Option<TxnCommandEventMetadata> {
-        self.is_enabled()
-            .then(|| TxnCommandEventMetadata::from_command(cmd, cid, snapshot_data_version))
+        if !self.is_enabled() {
+            return None;
+        }
+        TxnCommandEventMetadata::from_command(cmd, cid, snapshot_data_version)
     }
 
     #[inline]
@@ -478,7 +444,7 @@ impl TxnCommandFlightRecorder {
                 metadata
                     .keys
                     .iter()
-                    .map(|key| metadata.event_for_command_key(*key)),
+                    .map(|key| metadata.base_event(*key, TxnCommandEventKind::Received)),
             );
         }
     }
@@ -506,24 +472,17 @@ impl TxnCommandFlightRecorder {
             event.unix_time_ms = unix_time_ms;
             if shard.len() == self.events_per_shard {
                 shard.pop_front();
-                self.overwritten_events.fetch_add(1, Ordering::Relaxed);
             }
             shard.push_back(event);
         }
     }
 
     pub(crate) fn record_persistent_modifies(&self, events: &[TxnCommandEvent]) {
-        if events.is_empty() {
-            return;
-        }
-        self.record(events.iter().cloned())
+        self.record(events.iter().copied())
     }
 
     pub(crate) fn record_in_memory_pessimistic_locks(&self, events: &[TxnCommandEvent]) {
-        if events.is_empty() {
-            return;
-        }
-        self.record(events.iter().cloned().map(|mut event| {
+        self.record(events.iter().copied().map(|mut event| {
             event.kind = TxnCommandEventKind::PutInMemoryPessimisticLock;
             event
         }))
@@ -541,38 +500,23 @@ impl TxnCommandFlightRecorder {
         if !self.is_enabled() {
             return;
         }
-        let metadata = TxnCommandEventMetadata {
-            cid: 0,
-            command: CommandKind::prewrite,
-            txn_start_ts: start_ts.into_inner(),
-            commit_ts: committed_ts.unwrap_or_default().into_inner(),
-            caller_start_ts: 0,
-            current_ts: 0,
-            for_update_ts: 0,
-            min_commit_ts: 0,
-            lock_ttl: 0,
-            primary_key_hash: hash_raw_key(primary_key),
-            region_id: ctx.get_region_id(),
-            term: ctx.get_term(),
-            snapshot_data_version: snapshot_data_version.unwrap_or(0),
-            is_retry_request: ctx.get_is_retry_request(),
-            skip_constraint_check: false,
-            try_one_pc: false,
-            rollback_if_not_exist: false,
-            force_sync_commit: false,
-            resolving_pessimistic_lock: false,
-            verify_is_primary: false,
-            keys: Vec::new(),
-        };
+        let primary_key = Key::from_raw(primary_key);
         let kind = if committed_ts.is_some() {
             TxnCommandEventKind::TxnStatusCacheHit
         } else {
             TxnCommandEventKind::TxnStatusCacheMiss
         };
-        self.record(
-            keys.into_iter()
-                .map(|key| metadata.base_event(hash_key(key), kind)),
-        );
+        if let Some(key) = keys.into_iter().find(|key| *key == &primary_key) {
+            let key_hash = hash_key(key);
+            let mut event =
+                TxnCommandEvent::new(CommandKind::prewrite, 0, ctx, snapshot_data_version);
+            event.kind = kind;
+            event.key_hash = key_hash;
+            event.primary_key_hash = key_hash;
+            event.txn_start_ts = start_ts.into_inner();
+            event.commit_ts = committed_ts.unwrap_or_default().into_inner();
+            self.record([event]);
+        }
     }
 
     pub(crate) fn events_for_key(&self, key: &Key) -> Vec<TxnCommandEvent> {
@@ -582,22 +526,14 @@ impl TxnCommandFlightRecorder {
             .lock()
             .iter()
             .filter(|event| event.key_hash == key_hash)
-            .cloned()
+            .copied()
             .collect()
-    }
-
-    pub(crate) fn overwritten_events(&self) -> u64 {
-        self.overwritten_events.load(Ordering::Relaxed)
     }
 }
 
 lazy_static! {
-    pub(crate) static ref TXN_COMMAND_FLIGHT_RECORDER: TxnCommandFlightRecorder =
-        TxnCommandFlightRecorder::new(
-            TXN_COMMAND_FLIGHT_RECORDER_SHARDS,
-            TXN_COMMAND_FLIGHT_RECORDER_EVENTS_PER_SHARD,
-            false,
-        );
+    pub(crate) static ref TXN_FLIGHT_RECORDER: TxnCommandFlightRecorder =
+        TxnCommandFlightRecorder::new(SHARD_COUNT, EVENTS_PER_SHARD, false);
 }
 
 #[cfg(test)]
@@ -609,35 +545,9 @@ mod tests {
     use super::*;
 
     fn event_for_key(key: &Key, cid: u64) -> TxnCommandEvent {
-        TxnCommandEvent {
-            unix_time_ms: 0,
-            kind: TxnCommandEventKind::Received,
-            command: CommandKind::prewrite,
-            cid,
-            key_hash: hash_key(key),
-            primary_key_hash: 0,
-            txn_start_ts: 0,
-            commit_ts: 0,
-            caller_start_ts: 0,
-            current_ts: 0,
-            for_update_ts: 0,
-            min_commit_ts: 0,
-            lock_ttl: 0,
-            region_id: 0,
-            term: 0,
-            snapshot_data_version: 0,
-            is_retry_request: false,
-            skip_constraint_check: false,
-            try_one_pc: false,
-            rollback_if_not_exist: false,
-            force_sync_commit: false,
-            resolving_pessimistic_lock: false,
-            verify_is_primary: false,
-            pessimistic_action: RecordedPessimisticAction::Unknown,
-            lock_type: None,
-            write_type: None,
-            generation: 0,
-        }
+        let mut event = TxnCommandEvent::new(CommandKind::prewrite, cid, &Context::default(), None);
+        event.key_hash = hash_key(key);
+        event
     }
 
     #[test]
@@ -655,37 +565,24 @@ mod tests {
         assert!(events.len() <= 4);
         assert_eq!(events.last().unwrap().cid, 5);
         assert!(events.iter().all(|event| event.cid != 100));
-        assert!(recorder.overwritten_events() >= 1);
     }
 
     #[test]
     fn test_modify_events_are_normalized_to_user_key() {
         let key = Key::from_raw(b"key");
+        let secondary_key = Key::from_raw(b"secondary-key");
         let key_hash = hash_key(&key);
-        let metadata = TxnCommandEventMetadata {
-            cid: 42,
-            command: CommandKind::prewrite,
-            txn_start_ts: 10,
-            commit_ts: 0,
-            caller_start_ts: 0,
-            current_ts: 0,
-            for_update_ts: 11,
-            min_commit_ts: 12,
-            lock_ttl: 20_000,
-            primary_key_hash: key_hash,
-            region_id: 1,
-            term: 2,
-            snapshot_data_version: 4,
-            is_retry_request: true,
-            skip_constraint_check: false,
-            try_one_pc: false,
-            rollback_if_not_exist: false,
-            force_sync_commit: false,
-            resolving_pessimistic_lock: false,
-            verify_is_primary: false,
+        let mut event =
+            TxnCommandEvent::new(CommandKind::prewrite, 42, &Context::default(), Some(4));
+        event.txn_start_ts = 10;
+        event.for_update_ts = 11;
+        event.min_commit_ts = 12;
+        event.lock_ttl = 20_000;
+        let mut metadata = TxnCommandEventMetadata {
+            event,
             keys: vec![CommandKey {
                 key_hash,
-                pessimistic_action: RecordedPessimisticAction::DoPessimisticCheck,
+                pessimistic_action: Some(PrewriteRequestPessimisticAction::DoPessimisticCheck),
                 txn_start_ts: 10,
             }],
         };
@@ -700,12 +597,29 @@ mod tests {
             12.into(),
             false,
         );
+        let secondary_lock = Lock::new(
+            LockType::Put,
+            b"key".to_vec(),
+            10.into(),
+            20_000,
+            None,
+            11.into(),
+            1,
+            12.into(),
+            false,
+        );
         let write = Write::new(WriteType::Put, 10.into(), None);
         let modifies = vec![
             Modify::Put(CF_LOCK, key.clone(), lock.to_bytes()),
+            Modify::Put(CF_LOCK, secondary_key.clone(), secondary_lock.to_bytes()),
             Modify::Put(
                 CF_WRITE,
                 key.clone().append_ts(20.into()),
+                write.as_ref().to_bytes(),
+            ),
+            Modify::Put(
+                CF_WRITE,
+                secondary_key.clone().append_ts(20.into()),
                 write.as_ref().to_bytes(),
             ),
         ];
@@ -717,11 +631,17 @@ mod tests {
         assert_eq!(events[0].txn_start_ts, 10);
         assert_eq!(
             events[0].pessimistic_action,
-            RecordedPessimisticAction::DoPessimisticCheck
+            Some(PrewriteRequestPessimisticAction::DoPessimisticCheck)
         );
         assert_eq!(events[1].kind, TxnCommandEventKind::PutWrite);
         assert_eq!(events[1].commit_ts, 20);
         assert_eq!(events[1].write_type, Some(WriteType::Put));
+
+        metadata.keys.clear();
+        metadata.set_primary_key_hash(key_hash);
+        let events = metadata.events_for_modifies(&modifies);
+        assert_eq!(events.len(), 2);
+        assert!(events.iter().all(|event| event.key_hash == key_hash));
     }
 
     #[test]
@@ -736,12 +656,13 @@ mod tests {
     fn test_txn_status_cache_lookup_event() {
         let recorder = TxnCommandFlightRecorder::new(2, 4, true);
         let key = Key::from_raw(b"key");
+        let secondary_key = Key::from_raw(b"secondary-key");
         let mut ctx = Context::default();
         ctx.set_region_id(7);
         ctx.set_is_retry_request(true);
 
         recorder.record_txn_status_cache_lookup(
-            [&key],
+            [&secondary_key, &key],
             b"key",
             10.into(),
             Some(20.into()),
@@ -756,6 +677,7 @@ mod tests {
         assert_eq!(events[0].commit_ts, 20);
         assert_eq!(events[0].snapshot_data_version, 30);
         assert!(events[0].is_retry_request);
+        assert!(recorder.events_for_key(&secondary_key).is_empty());
     }
 
     #[test]

--- a/src/storage/txn/flight_recorder.rs
+++ b/src/storage/txn/flight_recorder.rs
@@ -6,7 +6,7 @@
 //! lock/write modifications. It stores neither raw keys nor user values.
 
 use std::{
-    collections::{VecDeque, hash_map::DefaultHasher},
+    collections::{hash_map::DefaultHasher, VecDeque},
     hash::{Hash, Hasher},
     sync::atomic::{AtomicBool, Ordering},
     time::{SystemTime, UNIX_EPOCH},
@@ -19,9 +19,9 @@ use lazy_static::lazy_static;
 use parking_lot::Mutex;
 use tikv_kv::Modify;
 use tikv_util::Either;
-use txn_types::{Key, LockType, TimeStamp, WriteRef, WriteType, parse_lock};
+use txn_types::{parse_lock, Key, LockType, TimeStamp, WriteRef, WriteType};
 
-use crate::storage::{Context, metrics::CommandKind, txn::commands::Command};
+use crate::storage::{metrics::CommandKind, txn::commands::Command, Context};
 
 const SHARD_COUNT: usize = 128;
 const EVENTS_PER_SHARD: usize = 4096;

--- a/src/storage/txn/flight_recorder.rs
+++ b/src/storage/txn/flight_recorder.rs
@@ -274,6 +274,10 @@ impl TxnCommandEventMetadata {
                 event.commit_ts = commit_ts.into_inner();
                 event.write_type = Some(write.write_type);
                 event.txn_start_ts = write.start_ts.into_inner();
+                // An overlapped rollback reuses the older transaction's write
+                // record; without this flag the event looks like a normal
+                // commit of that older transaction at `commit_ts`.
+                event.has_overlapped_rollback = write.has_overlapped_rollback;
                 Some(event)
             }
             Modify::Delete(cf, key) if *cf == CF_WRITE => {
@@ -342,6 +346,7 @@ pub(crate) struct TxnCommandEvent {
     pessimistic_action: Option<PrewriteRequestPessimisticAction>,
     lock_type: Option<LockType>,
     write_type: Option<WriteType>,
+    has_overlapped_rollback: bool,
     generation: u64,
 }
 
@@ -379,6 +384,7 @@ impl TxnCommandEvent {
             pessimistic_action: None,
             lock_type: None,
             write_type: None,
+            has_overlapped_rollback: false,
             generation: 0,
         }
     }
@@ -438,8 +444,8 @@ impl TxnCommandFlightRecorder {
     }
 
     #[inline]
-    pub(crate) fn record_received(&self, cmd: &Command) {
-        if let Some(metadata) = self.command_metadata(cmd, 0, None) {
+    pub(crate) fn record_received(&self, cmd: &Command, cid: u64) {
+        if let Some(metadata) = self.command_metadata(cmd, cid, None) {
             self.record(
                 metadata
                     .keys
@@ -642,6 +648,23 @@ mod tests {
         let events = metadata.events_for_modifies(&modifies);
         assert_eq!(events.len(), 2);
         assert!(events.iter().all(|event| event.key_hash == key_hash));
+        assert!(events.iter().all(|event| !event.has_overlapped_rollback));
+
+        // An overlapped rollback record keeps the older transaction's write
+        // type/start_ts; the event must carry the flag so it is not mistaken
+        // for a normal commit of that older transaction.
+        let overlapped =
+            Write::new(WriteType::Put, 10.into(), None).set_overlapped_rollback(true, None);
+        let events = metadata.events_for_modifies(&[Modify::Put(
+            CF_WRITE,
+            key.clone().append_ts(30.into()),
+            overlapped.as_ref().to_bytes(),
+        )]);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].kind, TxnCommandEventKind::PutWrite);
+        assert_eq!(events[0].commit_ts, 30);
+        assert_eq!(events[0].txn_start_ts, 10);
+        assert!(events[0].has_overlapped_rollback);
     }
 
     #[test]

--- a/src/storage/txn/mod.rs
+++ b/src/storage/txn/mod.rs
@@ -3,6 +3,7 @@
 //! Storage Transactions
 
 pub mod commands;
+pub(crate) mod flight_recorder;
 pub mod flow_controller;
 pub mod sched_pool;
 pub mod scheduler;

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -549,6 +549,7 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
         cmd: Command,
         callback: StorageCallback,
         delay: Duration,
+        cid: u64,
     ) {
         let tag = cmd.tag();
         let sched = self.clone();
@@ -563,8 +564,6 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
             let mut guard = rm.delay_slot_guard();
             futures_timer::Delay::new(delay).await;
             guard.release();
-            let cid = sched.inner.gen_id();
-            TXN_FLIGHT_RECORDER.record_received(&cmd, cid);
             if let Ok(task) = Task::allocate(cid, cmd, mem_quota) {
                 sched.schedule_command(task, cb, None);
             } else {
@@ -579,6 +578,11 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
 
 >>>>>>> 1638b8384 (txn: fix flight recorder event fidelity for rollback and command correlation)
     pub(in crate::storage) fn run_cmd(&self, cmd: Command, callback: StorageCallback) {
+        // Allocate the cid and record at arrival, so the Received event keeps
+        // the command's true arrival time, shares its cid with subsequent
+        // lock/write events, and also covers commands rejected below.
+        let cid = self.inner.gen_id();
+        TXN_FLIGHT_RECORDER.record_received(&cmd, cid);
         let tag = cmd.tag();
         // write flow control
         //
@@ -589,10 +593,26 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
             Self::fail_with_busy(tag, callback.into());
             return;
         }
+<<<<<<< HEAD
         let cid = self.inner.gen_id();
         // Record after `gen_id` so the Received event shares the command's cid
         // with its subsequent lock/write events.
         TXN_FLIGHT_RECORDER.record_received(&cmd, cid);
+=======
+        // Admission control before latch acquisition so a delayed command does
+        // not block concurrent writers sharing the same keys.
+        match self.apply_admission_control(&cmd) {
+            Some(resource_control::AdmissionDecision::Reject) => {
+                Self::fail_with_busy(tag, callback.into());
+                return;
+            }
+            Some(resource_control::AdmissionDecision::Delay(delay)) => {
+                self.schedule_after_admission_delay(cmd, callback, delay, cid);
+                return;
+            }
+            _ => {}
+        }
+>>>>>>> cce3f5185 (txn: record flight-recorder command arrival with entry-allocated cid)
         if let Ok(task) = Task::allocate(cid, cmd, self.inner.memory_quota.clone()) {
             self.schedule_command(
                 task,

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -524,8 +524,61 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
         });
     }
 
+<<<<<<< HEAD
+=======
+    /// Returns true if admission control consumed the command (reject or
+    /// delay); the caller should return without further processing.
+    fn apply_admission_control(
+        &self,
+        cmd: &Command,
+    ) -> Option<resource_control::AdmissionDecision> {
+        let rm = self.inner.resource_manager.as_ref()?;
+        let rc_ctx = cmd.resource_control_ctx();
+        let rg = rc_ctx.get_resource_group_name();
+        let request_source = cmd.ctx().request_source.clone();
+        let limiter =
+            rm.get_resource_limiter(rg, &request_source, rc_ctx.get_override_priority())?;
+        Some(rm.admission_decision(false, &limiter))
+    }
+
+    /// Spawns an async task on the sched pool that sleeps for `delay` then
+    /// calls `schedule_command`. The latch is acquired only after the sleep so
+    /// the delay does not block concurrent writers with overlapping keys.
+    fn schedule_after_admission_delay(
+        &self,
+        cmd: Command,
+        callback: StorageCallback,
+        delay: Duration,
+    ) {
+        let tag = cmd.tag();
+        let sched = self.clone();
+        let cb = SchedulerTaskCallback::NormalRequestCallback(callback);
+        let metadata = TaskMetadata::from_ctx(cmd.resource_control_ctx());
+        let priority = cmd.priority();
+        let write_bytes = cmd.write_bytes() as u64;
+        let request_source = cmd.ctx().request_source.clone();
+        let mem_quota = self.inner.memory_quota.clone();
+        let rm = self.inner.resource_manager.as_ref().unwrap().clone();
+        let execution = async move {
+            let mut guard = rm.delay_slot_guard();
+            futures_timer::Delay::new(delay).await;
+            guard.release();
+            let cid = sched.inner.gen_id();
+            TXN_FLIGHT_RECORDER.record_received(&cmd, cid);
+            if let Ok(task) = Task::allocate(cid, cmd, mem_quota) {
+                sched.schedule_command(task, cb, None);
+            } else {
+                Self::fail_with_busy(tag, cb);
+            }
+        };
+        self.inner
+            .sched_worker_pool
+            .spawn(&request_source, metadata, priority, execution, write_bytes)
+            .unwrap();
+    }
+
+>>>>>>> 1638b8384 (txn: fix flight recorder event fidelity for rollback and command correlation)
     pub(in crate::storage) fn run_cmd(&self, cmd: Command, callback: StorageCallback) {
-        TXN_FLIGHT_RECORDER.record_received(&cmd);
         let tag = cmd.tag();
         // write flow control
         //
@@ -537,6 +590,9 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
             return;
         }
         let cid = self.inner.gen_id();
+        // Record after `gen_id` so the Received event shares the command's cid
+        // with its subsequent lock/write events.
+        TXN_FLIGHT_RECORDER.record_received(&cmd, cid);
         if let Ok(task) = Task::allocate(cid, cmd, self.inner.memory_quota.clone()) {
             self.schedule_command(
                 task,

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -85,7 +85,7 @@ use crate::{
                 Command, RawExt, ReleasedLocks, ResponsePolicy, WriteContext, WriteResult,
                 WriteResultLockInfo,
             },
-            flight_recorder::{TXN_FLIGHT_RECORDER, TxnCommandEvent},
+            flight_recorder::{TxnCommandEvent, TXN_FLIGHT_RECORDER},
             flow_controller::FlowController,
             latch::{Latches, Lock},
             sched_pool::{tls_collect_query, tls_collect_scan_details, SchedPool},

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -85,7 +85,7 @@ use crate::{
                 Command, RawExt, ReleasedLocks, ResponsePolicy, WriteContext, WriteResult,
                 WriteResultLockInfo,
             },
-            flight_recorder::{TXN_COMMAND_FLIGHT_RECORDER, TxnCommandEvent},
+            flight_recorder::{TXN_FLIGHT_RECORDER, TxnCommandEvent},
             flow_controller::FlowController,
             latch::{Latches, Lock},
             sched_pool::{tls_collect_query, tls_collect_scan_details, SchedPool},
@@ -525,7 +525,7 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
     }
 
     pub(in crate::storage) fn run_cmd(&self, cmd: Command, callback: StorageCallback) {
-        TXN_COMMAND_FLIGHT_RECORDER.record_received(&cmd);
+        TXN_FLIGHT_RECORDER.record_received(&cmd);
         let tag = cmd.tag();
         // write flow control
         //
@@ -1531,7 +1531,7 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
                     engine.schedule_txn_extra(to_be_write.extra);
                 })
             }
-            TXN_COMMAND_FLIGHT_RECORDER.record_in_memory_pessimistic_locks(flight_events);
+            TXN_FLIGHT_RECORDER.record_in_memory_pessimistic_locks(flight_events);
             txn_scheduler.on_write_finished(
                 cid,
                 Some(pr),
@@ -1793,7 +1793,7 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
                     fail_point!("scheduler_async_write_finish");
                     let ok = res.is_ok();
                     if ok {
-                        TXN_COMMAND_FLIGHT_RECORDER.record_persistent_modifies(flight_events);
+                        TXN_FLIGHT_RECORDER.record_persistent_modifies(flight_events);
                     }
 
                     txn_scheduler.on_write_finished(
@@ -1871,7 +1871,7 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
             false
         };
         let txn_ext = snapshot.ext().get_txn_ext().cloned();
-        let flight_metadata = TXN_COMMAND_FLIGHT_RECORDER.command_metadata(
+        let flight_metadata = TXN_FLIGHT_RECORDER.command_metadata(
             task.cmd(),
             cid,
             snapshot.ext().get_data_version(),
@@ -1899,7 +1899,11 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
             Ok(res) => res,
         };
         let flight_events = flight_metadata
-            .map(|metadata| metadata.events_for_modifies(&write_result.to_be_write.modifies))
+            .map(|mut metadata| {
+                metadata
+                    .set_primary_key_hash(write_result.released_locks.flight_primary_key_hash());
+                metadata.events_for_modifies(&write_result.to_be_write.modifies)
+            })
             .unwrap_or_default();
         SCHED_STAGE_COUNTER_VEC.get(tag).write.inc();
         debug!("process_write task handle result";

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -85,6 +85,7 @@ use crate::{
                 Command, RawExt, ReleasedLocks, ResponsePolicy, WriteContext, WriteResult,
                 WriteResultLockInfo,
             },
+            flight_recorder::{TXN_COMMAND_FLIGHT_RECORDER, TxnCommandEvent},
             flow_controller::FlowController,
             latch::{Latches, Lock},
             sched_pool::{tls_collect_query, tls_collect_scan_details, SchedPool},
@@ -524,6 +525,7 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
     }
 
     pub(in crate::storage) fn run_cmd(&self, cmd: Command, callback: StorageCallback) {
+        TXN_COMMAND_FLIGHT_RECORDER.record_received(&cmd);
         let tag = cmd.tag();
         // write flow control
         //
@@ -1410,6 +1412,7 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
         sched_details: &mut SchedulerDetails,
         txn_ext: Option<Arc<TxnExt>>,
         is_shared_lock_cmd: bool,
+        flight_events: &[TxnCommandEvent],
     ) -> Option<(WriteResult, TaskMetadata<'a>)> {
         let WriteResult {
             ctx,
@@ -1528,6 +1531,7 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
                     engine.schedule_txn_extra(to_be_write.extra);
                 })
             }
+            TXN_COMMAND_FLIGHT_RECORDER.record_in_memory_pessimistic_locks(flight_events);
             txn_scheduler.on_write_finished(
                 cid,
                 Some(pr),
@@ -1634,6 +1638,7 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
         txn_ext: Option<Arc<TxnExt>>,
         sched_details: &mut SchedulerDetails,
         task_meta_data: TaskMetadata<'_>,
+        flight_events: &[TxnCommandEvent],
         mut write_result: WriteResult,
     ) {
         let region_id = write_result.ctx.region_id;
@@ -1787,6 +1792,9 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
                 WriteEvent::Finished(res) => {
                     fail_point!("scheduler_async_write_finish");
                     let ok = res.is_ok();
+                    if ok {
+                        TXN_COMMAND_FLIGHT_RECORDER.record_persistent_modifies(flight_events);
+                    }
 
                     txn_scheduler.on_write_finished(
                         cid,
@@ -1863,6 +1871,11 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
             false
         };
         let txn_ext = snapshot.ext().get_txn_ext().cloned();
+        let flight_metadata = TXN_COMMAND_FLIGHT_RECORDER.command_metadata(
+            task.cmd(),
+            cid,
+            snapshot.ext().get_data_version(),
+        );
         let deadline = task.cmd().deadline();
         let write_result = Self::handle_task(self.clone(), snapshot, task, sched_details).await;
 
@@ -1885,6 +1898,9 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
             // `WriteFinished` message when it finishes.
             Ok(res) => res,
         };
+        let flight_events = flight_metadata
+            .map(|metadata| metadata.events_for_modifies(&write_result.to_be_write.modifies))
+            .unwrap_or_default();
         SCHED_STAGE_COUNTER_VEC.get(tag).write.inc();
         debug!("process_write task handle result";
             "req_info" => TrackerTokenArray::new(&[tracker_token]),
@@ -1905,6 +1921,7 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
                 sched_details,
                 txn_ext.clone(),
                 is_shared_lock_cmd,
+                &flight_events,
             )
         {
             write_result = write_result_res;
@@ -1927,6 +1944,7 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
             txn_ext,
             sched_details,
             task_meta_data,
+            &flight_events,
             write_result,
         )
         .await;
@@ -2784,6 +2802,7 @@ mod tests {
             &mut sched_details,
             Some(txn_ext.clone()),
             false,
+            &[],
         )
         .expect("shared lock update should be persisted");
 

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -1871,11 +1871,11 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
             false
         };
         let txn_ext = snapshot.ext().get_txn_ext().cloned();
-        let flight_metadata = TXN_FLIGHT_RECORDER.command_metadata(
-            task.cmd(),
-            cid,
-            snapshot.ext().get_data_version(),
-        );
+        let flight_metadata = if TXN_FLIGHT_RECORDER.is_enabled() {
+            TXN_FLIGHT_RECORDER.command_metadata(task.cmd(), cid, snapshot.ext().get_data_version())
+        } else {
+            None
+        };
         let deadline = task.cmd().deadline();
         let write_result = Self::handle_task(self.clone(), snapshot, task, sched_details).await;
 

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -524,59 +524,6 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
         });
     }
 
-<<<<<<< HEAD
-=======
-    /// Returns true if admission control consumed the command (reject or
-    /// delay); the caller should return without further processing.
-    fn apply_admission_control(
-        &self,
-        cmd: &Command,
-    ) -> Option<resource_control::AdmissionDecision> {
-        let rm = self.inner.resource_manager.as_ref()?;
-        let rc_ctx = cmd.resource_control_ctx();
-        let rg = rc_ctx.get_resource_group_name();
-        let request_source = cmd.ctx().request_source.clone();
-        let limiter =
-            rm.get_resource_limiter(rg, &request_source, rc_ctx.get_override_priority())?;
-        Some(rm.admission_decision(false, &limiter))
-    }
-
-    /// Spawns an async task on the sched pool that sleeps for `delay` then
-    /// calls `schedule_command`. The latch is acquired only after the sleep so
-    /// the delay does not block concurrent writers with overlapping keys.
-    fn schedule_after_admission_delay(
-        &self,
-        cmd: Command,
-        callback: StorageCallback,
-        delay: Duration,
-        cid: u64,
-    ) {
-        let tag = cmd.tag();
-        let sched = self.clone();
-        let cb = SchedulerTaskCallback::NormalRequestCallback(callback);
-        let metadata = TaskMetadata::from_ctx(cmd.resource_control_ctx());
-        let priority = cmd.priority();
-        let write_bytes = cmd.write_bytes() as u64;
-        let request_source = cmd.ctx().request_source.clone();
-        let mem_quota = self.inner.memory_quota.clone();
-        let rm = self.inner.resource_manager.as_ref().unwrap().clone();
-        let execution = async move {
-            let mut guard = rm.delay_slot_guard();
-            futures_timer::Delay::new(delay).await;
-            guard.release();
-            if let Ok(task) = Task::allocate(cid, cmd, mem_quota) {
-                sched.schedule_command(task, cb, None);
-            } else {
-                Self::fail_with_busy(tag, cb);
-            }
-        };
-        self.inner
-            .sched_worker_pool
-            .spawn(&request_source, metadata, priority, execution, write_bytes)
-            .unwrap();
-    }
-
->>>>>>> 1638b8384 (txn: fix flight recorder event fidelity for rollback and command correlation)
     pub(in crate::storage) fn run_cmd(&self, cmd: Command, callback: StorageCallback) {
         // Allocate the cid and record at arrival, so the Received event keeps
         // the command's true arrival time, shares its cid with subsequent
@@ -593,26 +540,6 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
             Self::fail_with_busy(tag, callback.into());
             return;
         }
-<<<<<<< HEAD
-        let cid = self.inner.gen_id();
-        // Record after `gen_id` so the Received event shares the command's cid
-        // with its subsequent lock/write events.
-        TXN_FLIGHT_RECORDER.record_received(&cmd, cid);
-=======
-        // Admission control before latch acquisition so a delayed command does
-        // not block concurrent writers sharing the same keys.
-        match self.apply_admission_control(&cmd) {
-            Some(resource_control::AdmissionDecision::Reject) => {
-                Self::fail_with_busy(tag, callback.into());
-                return;
-            }
-            Some(resource_control::AdmissionDecision::Delay(delay)) => {
-                self.schedule_after_admission_delay(cmd, callback, delay, cid);
-                return;
-            }
-            _ => {}
-        }
->>>>>>> cce3f5185 (txn: record flight-recorder command arrival with entry-allocated cid)
         if let Ok(task) = Task::allocate(cid, cmd, self.inner.memory_quota.clone()) {
             self.schedule_command(
                 task,

--- a/tests/failpoints/cases/test_sst_ingest.rs
+++ b/tests/failpoints/cases/test_sst_ingest.rs
@@ -46,9 +46,11 @@ fn prepare_data_used_by_compaction_filter(
         for start_ts in [101, 103] {
             let commit_ts = start_ts + 1;
 
-            for pk in &keys {
-                let muts = vec![new_mutation(Op::Put, pk.as_slice(), &large_value)];
-                must_kv_prewrite(client, ctx.clone(), muts, pk.clone(), start_ts);
+            // Prewrite the keys separately, but keep one transaction-wide primary.
+            let primary = keys[0].clone();
+            for key in &keys {
+                let muts = vec![new_mutation(Op::Put, key.as_slice(), &large_value)];
+                must_kv_prewrite(client, ctx.clone(), muts, primary.clone(), start_ts);
             }
             must_kv_commit(
                 client,

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -743,6 +743,7 @@ fn test_serde_custom_tikv_config() {
         reserve_space: ReadableSize::gb(10),
         reserve_raft_space: ReadableSize::gb(2),
         enable_async_apply_prewrite: true,
+        enable_txn_command_flight_recorder: false,
         api_version: 1,
         enable_ttl: true,
         ttl_check_poll_interval: ReadableDuration::hours(0),

--- a/tests/integrations/config/test-custom.toml
+++ b/tests/integrations/config/test-custom.toml
@@ -100,6 +100,7 @@ scheduler-concurrency = 123
 scheduler-worker-pool-size = 1
 scheduler-pending-write-threshold = "123KB"
 enable-async-apply-prewrite = true
+enable-txn-command-flight-recorder = false
 reserve-space = "10GB"
 reserve-raft-space = "2GB"
 enable-ttl = true


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: Ref #19891

What's Changed:

- Cherry-pick of tikv/tikv#19869 (through `2667beb71`) onto `release-8.5-20260727-v8.5.6` for the hotfix QA process.
- Adds an optional bounded in-memory flight recorder for transaction commands (~80 MiB cap, key hashes only, no user keys/values).
- Dumps related command events and recent MVCC write history when the `txn record found but not expected` invariant is violated.
- Enabled by default in this debug patch; can be toggled online via `storage.enable-txn-command-flight-recorder`.

Conflict resolution vs the original PR (v8.5.7-based):

- Kept the v8.5.6 max_ts config dispatch (`action_on_invalid_max_ts` / `max_ts_drift_allowance` handled inline); only added the recorder's config dispatch.
- Dropped the v8.5.7-only admission-control integration in `run_cmd`; the recorder's Received event is recorded at `run_cmd` entry with the entry-allocated cid.

Validation:

- Unit tests for the recorder and the touched commit path pass on the original branch; `cargo check` on this backport.
- Benchmark (same binary, config-only A/B, sysbench oltp_write_only, 300 threads, 3x16C TiKV): TPS within noise (+0.5%), p95 identical, total TiKV CPU +0.7%, no extra disk IO. Details in the original PR discussion.
- 12h chaos soak with the recorder enabled (20% write-RPC loss/retries, 50ms prewrite-commit delay, network jitter, rolling TiKV pod-kills): zero panics, zero crash-loops, zero OOMs.

### Related changes

- Original PR: tikv/tikv#19869
- Tracking issue: tikv/tikv#19891

### Check List

- [x] Tests pass (unit tests on the original branch; cargo check on this backport)
- [x] Performance benchmark done (see above)

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
