### PR TITLE
storage: remove stale in-memory locks on fallback

### DIFF
--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -4421,7 +4421,7 @@ mod tests {
         metapb::RegionEpoch,
     };
     use parking_lot::Mutex;
-    use tikv_util::config::ReadableSize;
+    use tikv_util::{Either, config::ReadableSize};
     use tracker::INVALID_TRACKER_TOKEN;
     use txn_types::{LastChange, Mutation, PessimisticLock, SHORT_VALUE_MAX_LEN, WriteType};
 
@@ -11869,6 +11869,86 @@ mod tests {
             let pessimistic_locks = txn_ext.pessimistic_locks.read();
             assert!(pessimistic_locks.get(&k1).is_none());
         }
+    }
+
+    #[test]
+    fn test_raft_fallback_removes_stale_in_memory_pessimistic_lock() {
+        let txn_ext = Arc::new(TxnExt::default());
+        let builder = TestStorageBuilderApiV1::new(MockLockManager::new())
+            .pipelined_pessimistic_lock(true)
+            .in_memory_pessimistic_lock(true);
+        let in_memory_peer_size_limit = builder.in_memory_peer_size_limit.clone();
+        let storage = builder.build_for_txn(txn_ext.clone()).unwrap();
+        let key = Key::from_raw(b"k1");
+
+        let (tx, rx) = channel();
+        storage
+            .sched_txn_command(
+                new_acquire_pessimistic_lock_command(
+                    vec![(key.clone(), false)],
+                    10,
+                    10,
+                    false,
+                    false,
+                ),
+                expect_ok_callback(tx, 0),
+            )
+            .unwrap();
+        rx.recv().unwrap();
+
+        // Make overwriting the existing in-memory lock exceed the peer quota so the
+        // next request falls back to Raft.
+        in_memory_peer_size_limit.store(0, Ordering::Relaxed);
+        let (tx, rx) = channel();
+        storage
+            .sched_txn_command(
+                new_acquire_pessimistic_lock_command(
+                    vec![(key.clone(), false)],
+                    10,
+                    20,
+                    false,
+                    false,
+                ),
+                expect_ok_callback(tx, 0),
+            )
+            .unwrap();
+        rx.recv().unwrap();
+
+        // Pipelined pessimistic locking may respond before apply. Wait until the
+        // fallback lock is visible in CF_LOCK before comparing the two copies.
+        let mut engine = storage.get_engine().engine;
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            let snapshot = engine.snapshot(Default::default()).unwrap();
+            let mut reader = mvcc::MvccReader::new(snapshot, None, true);
+            match reader.load_lock(&key).unwrap() {
+                Some(Either::Left(lock)) if lock.for_update_ts == 20.into() => break,
+                _ if std::time::Instant::now() < deadline => thread::yield_now(),
+                lock => panic!("fallback lock was not applied to CF_LOCK: {:?}", lock),
+            }
+        }
+
+        // Applying the fallback lock must remove the old in-memory lock so the
+        // newer lock in CF_LOCK is visible.
+        assert!(txn_ext.pessimistic_locks.read().get(&key).is_none());
+
+        let (tx, rx) = channel();
+        storage
+            .sched_txn_command(
+                commands::PrewritePessimistic::with_for_update_ts_constraints(
+                    vec![(
+                        Mutation::make_put(key.clone(), b"v".to_vec()),
+                        DoPessimisticCheck,
+                    )],
+                    key.to_raw().unwrap(),
+                    10.into(),
+                    20.into(),
+                    [(0, 20.into())],
+                ),
+                expect_ok_callback(tx, 0),
+            )
+            .unwrap();
+        rx.recv().unwrap();
     }
 
     #[test]

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -1799,6 +1799,16 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
                                     key.to_owned()
                                 })
                             }
+                            // A Raft fallback may overwrite CF_LOCK with a larger
+                            // for_update_ts while an older in-memory lock still exists.
+                            // Remove the stale copy after apply so a delayed rollback
+                            // checks the newer lock and cannot delete it.
+                            Modify::PessimisticLock(key, _) => {
+                                locks.get_mut(key).map(|(_, deleted)| {
+                                    *deleted = true;
+                                    key.to_owned()
+                                })
+                            }
                             _ => None,
                         })
                         .collect::<Vec<_>>()


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #19864

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

Remove a stale in-memory pessimistic lock after its Raft fallback is applied, so lock reads observe the newer lock in `CF_LOCK`. Add a regression test for the fallback path.

```commit-message
Remove stale in-memory pessimistic locks after a Raft fallback is applied.
This prevents an older in-memory lock from shadowing the newer lock persisted
in `CF_LOCK`.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!--
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Fix a potential pessimistic transaction failure caused by a stale in-memory
pessimistic lock after falling back to Raft.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed stale in-memory pessimistic locks remaining after raft fallback.
  * Ensured subsequent transaction checks respect the latest lock state.
  * Improved cleanup of in-memory locks after pessimistic lock operations are applied.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->