### PR TITLE
raftstore: keep transfer leader deadline

### DIFF
--- a/components/raftstore-v2/src/operation/command/admin/transfer_leader.rs
+++ b/components/raftstore-v2/src/operation/command/admin/transfer_leader.rs
@@ -313,7 +313,8 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         let max_wait_duration =
             std::cmp::max(half_election_timeout, cfg.max_entry_cache_warmup_duration.0);
         let deadline = Instant::now() + max_wait_duration;
-        self.transfer_leader_state_mut().transfer_leader_msg = Some((msg.clone(), deadline));
+        self.transfer_leader_state_mut()
+            .set_pending_message(msg, deadline);
     }
 
     /// Before ack the transfer leader message sent by the leader.

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -4928,7 +4928,8 @@ where
         let max_wait_duration =
             std::cmp::max(half_election_timeout, cfg.max_entry_cache_warmup_duration.0);
         let deadline = Instant::now() + max_wait_duration;
-        self.transfer_leader_state.transfer_leader_msg = Some((msg.clone(), deadline));
+        self.transfer_leader_state
+            .set_pending_message(msg, deadline);
     }
 
     /// Ack transfer leader message if there is a pending transfer leader
@@ -6551,6 +6552,23 @@ pub struct TransferLeaderState {
     pub cache_warmup_state: Option<CacheWarmupState>,
 }
 
+impl TransferLeaderState {
+    /// Records a pre-transfer-leader message without extending the deadline
+    /// when the leader retries the same transfer attempt. A different sender
+    /// or leader term starts a new attempt.
+    pub fn set_pending_message(&mut self, msg: &eraftpb::Message, deadline: Instant) {
+        let is_retry = self
+            .transfer_leader_msg
+            .as_ref()
+            .is_some_and(|(pending, _)| {
+                pending.get_from() == msg.get_from() && pending.get_log_term() == msg.get_log_term()
+            });
+        if !is_retry {
+            self.transfer_leader_msg = Some((msg.clone(), deadline));
+        }
+    }
+}
+
 mod memtrace {
     use std::mem;
 
@@ -6597,6 +6615,38 @@ mod tests {
 
     use super::*;
     use crate::store::{msg::ExtCallback, util::u64_to_timespec};
+
+    #[test]
+    fn test_pending_transfer_leader_message_deadline() {
+        let mut state = TransferLeaderState::default();
+        let first_deadline = Instant::now() + Duration::from_secs(1);
+        let mut first = eraftpb::Message::default();
+        first.set_from(1);
+        first.set_log_term(1);
+        first.set_index(10);
+        state.set_pending_message(&first, first_deadline);
+
+        // A retry of the same transfer attempt must preserve the first message
+        // and deadline even if fields such as the cache warmup index change.
+        let retry_deadline = first_deadline + Duration::from_secs(1);
+        let mut retry = first.clone();
+        retry.set_index(20);
+        state.set_pending_message(&retry, retry_deadline);
+        let (pending, deadline) = state.transfer_leader_msg.as_ref().unwrap();
+        assert_eq!(pending.get_index(), 10);
+        assert_eq!(*deadline, first_deadline);
+
+        // A request from a new leader term is a new attempt and gets its own
+        // message and deadline.
+        let next_deadline = retry_deadline + Duration::from_secs(1);
+        let mut next = retry;
+        next.set_log_term(2);
+        state.set_pending_message(&next, next_deadline);
+        let (pending, deadline) = state.transfer_leader_msg.as_ref().unwrap();
+        assert_eq!(pending.get_index(), 20);
+        assert_eq!(pending.get_log_term(), 2);
+        assert_eq!(*deadline, next_deadline);
+    }
 
     #[test]
     fn test_sync_log() {

--- a/tests/failpoints/cases/test_in_memory_engine.rs
+++ b/tests/failpoints/cases/test_in_memory_engine.rs
@@ -860,8 +860,7 @@ fn test_warmup_when_transfer_leader() {
 #[test]
 fn test_warmup_timeout_does_not_block_transfer_leader() {
     let mut cluster = new_server_cluster_with_hybrid_engine(0, 3);
-    // Using a large warmup timeout to stable the test.
-    cluster.cfg.raft_store.max_entry_cache_warmup_duration.0 = Duration::from_secs(1);
+    cluster.cfg.raft_store.max_entry_cache_warmup_duration.0 = Duration::from_millis(500);
     cluster.run();
 
     let r = cluster.get_region(b"");
@@ -885,22 +884,36 @@ fn test_warmup_timeout_does_not_block_transfer_leader() {
     })
     .unwrap();
 
-    cluster.transfer_leader(r.id, new_peer(2, 2));
-    // Transfer leader will not block forever when warmup times out.
-    sleep(cluster.cfg.raft_store.max_entry_cache_warmup_duration.0);
-    eventually(Duration::from_millis(100), Duration::from_secs(50), || {
+    // Retry faster than the overall ACK deadline. The retries must not extend
+    // the deadline even though IME remains unready.
+    let mut transferred = false;
+    for _ in 0..20 {
         cluster.reset_leader_of_region(r.id);
-        let leader = cluster.leader_of_region(r.id).unwrap();
-        leader == new_peer(2, 2)
-    });
+        match cluster.leader_of_region(r.id) {
+            Some(leader) if leader == new_peer(2, 2) => {
+                transferred = true;
+                break;
+            }
+            Some(_) => cluster.transfer_leader(r.id, new_peer(2, 2)),
+            None => {}
+        }
+        sleep(Duration::from_millis(100));
+    }
     let region_cache_engine = cluster.sim.rl().get_region_cache_engine(2);
-    region_cache_engine
+    let cache_is_still_loading = region_cache_engine
         .snapshot(cache_region.clone(), 100, 100)
-        .unwrap_err();
+        .is_err();
 
-    // Unpause the snapshot load.
+    // Unpause the snapshot load before checking assertions so a failure does
+    // not leave the failpoint blocked for other tests.
     drop(tx);
     fail::remove("ime_on_snapshot_load_finished");
+    assert!(
+        transferred,
+        "repeated transfer requests extended the ACK deadline"
+    );
+    assert!(cache_is_still_loading);
+
     // put some key to trigger load
     cluster.must_put(b"k2", b"val");
     eventually(Duration::from_millis(100), Duration::from_secs(5), || {


### PR DESCRIPTION
### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: close #19776 ref #19776

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

- Preserve the original pre-transfer-leader ACK deadline when the same leader retries a transfer request.
- Start a new deadline when the request comes from a different sender or leader term.
- Apply the behavior consistently to Raftstore v1 and v2.
- Add coverage for repeated transfer requests while in-memory engine cache loading remains blocked.

```commit-message
Prevent repeated transfer-leader requests from indefinitely extending the
pre-transfer ACK deadline.

Retries from the same sender and leader term now preserve the original
pending message and deadline. Requests from a different sender or leader
term are treated as a new transfer attempt and receive a fresh deadline.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!--
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Fix an issue where transferring a Region leader could be blocked indefinitely when in-memory engine cache warmup is stuck and transfer requests are retried before the ACK deadline.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
- Improved leader-transfer retry handling so repeated attempts preserve the correct transfer state.
- New leader-transfer attempts correctly replace outdated transfer information.

- **Tests**
- Enhanced coverage for leader-transfer retries and new attempts.
- Improved validation that transfers can complete while snapshot loading is still in progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->