### PR TITLE
txn: add flight recorder capacity config and evicted-history tracking

### DIFF
--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -291,8 +291,11 @@
 
 ## Records a bounded in-memory history of transaction commands and their lock/write
 ## modifications. Enable it only while diagnosing transaction consistency issues.
-## NOTE: this debug build enables it by default.
-# enable-txn-command-flight-recorder = true
+# enable-txn-command-flight-recorder = false
+
+## Memory allocated for retained transaction command history when the flight recorder
+## is enabled.
+# txn-command-flight-recorder-capacity = "100MB"
 
 ## Reserve some space to ensure recovering the store from `no space left` must succeed.
 ## `max(reserve-space, capacity * 5%)` will be reserved exactly.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -5629,6 +5629,7 @@ mod tests {
         incoming.gc.max_write_bytes_per_sec = ReadableSize::mb(100);
         incoming.rocksdb.defaultcf.block_cache_size = Some(ReadableSize::mb(500));
         incoming.storage.io_rate_limit.import_priority = file_system::IoPriority::High;
+        incoming.storage.txn_command_flight_recorder_capacity = ReadableSize::gb(2);
         let diff = old.diff(&incoming);
         let mut change = HashMap::new();
         change.insert(
@@ -5643,6 +5644,10 @@ mod tests {
         change.insert(
             "storage.io-rate-limit.import-priority".to_owned(),
             "high".to_owned(),
+        );
+        change.insert(
+            "storage.txn-command-flight-recorder-capacity".to_owned(),
+            "2GB".to_owned(),
         );
         let res = to_config_change(change).unwrap();
         assert_eq!(diff, res);

--- a/src/storage/config.rs
+++ b/src/storage/config.rs
@@ -14,7 +14,12 @@ use tikv_util::{
     sys::SysQuota,
 };
 
-use crate::config::{DEFAULT_ROCKSDB_SUB_DIR, DEFAULT_TABLET_SUB_DIR, MIN_BLOCK_CACHE_SHARD_SIZE};
+use crate::{
+    config::{DEFAULT_ROCKSDB_SUB_DIR, DEFAULT_TABLET_SUB_DIR, MIN_BLOCK_CACHE_SHARD_SIZE},
+    storage::txn::flight_recorder::{
+        DEFAULT_TXN_COMMAND_FLIGHT_RECORDER_CAPACITY, MIN_TXN_COMMAND_FLIGHT_RECORDER_CAPACITY,
+    },
+};
 
 pub const DEFAULT_DATA_DIR: &str = "./";
 const DEFAULT_GC_RATIO_THRESHOLD: f64 = 1.1;
@@ -96,6 +101,8 @@ pub struct Config {
     pub enable_async_apply_prewrite: bool,
     /// Enables bounded in-memory transaction history for MVCC diagnostics.
     pub enable_txn_command_flight_recorder: bool,
+    /// Memory allocated for retained transaction command history when enabled.
+    pub txn_command_flight_recorder_capacity: ReadableSize,
     #[online_config(skip)]
     pub api_version: u8,
     #[online_config(skip)]
@@ -133,7 +140,8 @@ impl Default for Config {
             reserve_space: ReadableSize::gb(DEFAULT_RESERVED_SPACE_GB),
             reserve_raft_space: ReadableSize::gb(DEFAULT_RESERVED_RAFT_SPACE_GB),
             enable_async_apply_prewrite: false,
-            enable_txn_command_flight_recorder: true,
+            enable_txn_command_flight_recorder: false,
+            txn_command_flight_recorder_capacity: DEFAULT_TXN_COMMAND_FLIGHT_RECORDER_CAPACITY,
             api_version: 1,
             enable_ttl: false,
             ttl_check_poll_interval: ReadableDuration::hours(12),
@@ -220,6 +228,15 @@ impl Config {
                 self.memory_quota, self.scheduler_pending_write_threshold,
             );
             self.memory_quota = self.scheduler_pending_write_threshold;
+        }
+        if self.txn_command_flight_recorder_capacity.0
+            < MIN_TXN_COMMAND_FLIGHT_RECORDER_CAPACITY as u64
+        {
+            return Err(format!(
+                "storage.txn-command-flight-recorder-capacity must be at least {} bytes",
+                MIN_TXN_COMMAND_FLIGHT_RECORDER_CAPACITY
+            )
+            .into());
         }
 
         Ok(())
@@ -480,6 +497,11 @@ mod tests {
         cfg.validate().unwrap_err();
 
         cfg.scheduler_worker_pool_size = max_pool_size + 1;
+        cfg.validate().unwrap_err();
+
+        let mut cfg = Config::default();
+        cfg.txn_command_flight_recorder_capacity =
+            ReadableSize(MIN_TXN_COMMAND_FLIGHT_RECORDER_CAPACITY as u64 - 1);
         cfg.validate().unwrap_err();
     }
 

--- a/src/storage/config_manager.rs
+++ b/src/storage/config_manager.rs
@@ -20,7 +20,10 @@ use crate::{
     server::{ttl::TtlCheckerTask, CONFIG_ROCKSDB_GAUGE},
     storage::{
         lock_manager::LockManager,
-        txn::{flight_recorder::TXN_FLIGHT_RECORDER, flow_controller::FlowController},
+        txn::{
+            flight_recorder::{MIN_TXN_COMMAND_FLIGHT_RECORDER_CAPACITY, TXN_FLIGHT_RECORDER},
+            flow_controller::FlowController,
+        },
         TxnScheduler,
     },
 };
@@ -123,6 +126,17 @@ impl<EK: Engine, K: ConfigurableDb, L: LockManager> ConfigManager
         if let Some(v) = change.remove("max_ts_drift_allowance") {
             let dur_v: ReadableDuration = v.into();
             self.concurrency_manager.set_max_ts_drift_allowance(dur_v.0);
+        }
+        if let Some(v) = change.remove("txn_command_flight_recorder_capacity") {
+            let capacity: ReadableSize = v.into();
+            if capacity.0 < MIN_TXN_COMMAND_FLIGHT_RECORDER_CAPACITY as u64 {
+                return Err(format!(
+                    "storage.txn-command-flight-recorder-capacity must be at least {} bytes",
+                    MIN_TXN_COMMAND_FLIGHT_RECORDER_CAPACITY
+                )
+                .into());
+            }
+            TXN_FLIGHT_RECORDER.set_capacity(capacity.0 as usize);
         }
         if let Some(v) = change.remove("enable_txn_command_flight_recorder") {
             TXN_FLIGHT_RECORDER.set_enabled(v.into());

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -289,6 +289,7 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
         txn_status_cache: Arc<TxnStatusCache>,
     ) -> Result<Self> {
         assert_eq!(config.api_version(), F::TAG, "Api version not match");
+        TXN_FLIGHT_RECORDER.set_capacity(config.txn_command_flight_recorder_capacity.0 as usize);
         TXN_FLIGHT_RECORDER.set_enabled(config.enable_txn_command_flight_recorder);
 
         let sched = TxnScheduler::new(

--- a/src/storage/txn/actions/check_txn_status.rs
+++ b/src/storage/txn/actions/check_txn_status.rs
@@ -598,7 +598,9 @@ fn panic_txn_record_found(
             ext.get_data_version().unwrap_or(0),
         )
     };
-    let flight_events = TXN_FLIGHT_RECORDER.events_for_key(key);
+    let flight_history = TXN_FLIGHT_RECORDER.history_for_key(key);
+    let flight_history_complete_by_eviction =
+        flight_history.is_complete_by_eviction(reader.start_ts);
 
     error!(
         "txn record found but not expected: diagnostic summary";
@@ -608,10 +610,13 @@ fn panic_txn_record_found(
         "region_id" => region_id,
         "term" => term,
         "snapshot_data_version" => snapshot_data_version,
-        "flight_event_count" => flight_events.len(),
+        "flight_recorder_enabled" => flight_history.recorder_enabled,
+        "flight_event_count" => flight_history.events.len(),
+        "flight_shard_max_evicted_start_ts" => flight_history.max_evicted_start_ts,
+        "flight_history_complete_by_eviction" => flight_history_complete_by_eviction,
     );
     log_lock_sources(reader, key);
-    for event in &flight_events {
+    for event in &flight_history.events {
         error!(
             "txn record found but not expected: flight recorder event";
             "event" => ?event,

--- a/src/storage/txn/flight_recorder.rs
+++ b/src/storage/txn/flight_recorder.rs
@@ -8,7 +8,8 @@
 use std::{
     collections::{hash_map::DefaultHasher, VecDeque},
     hash::{Hash, Hasher},
-    sync::atomic::{AtomicBool, Ordering},
+    mem::size_of,
+    sync::atomic::{AtomicBool, AtomicUsize, Ordering},
     time::{SystemTime, UNIX_EPOCH},
 };
 
@@ -18,13 +19,13 @@ use kvproto::kvrpcpb::PrewriteRequestPessimisticAction;
 use lazy_static::lazy_static;
 use parking_lot::Mutex;
 use tikv_kv::Modify;
-use tikv_util::Either;
+use tikv_util::{config::ReadableSize, Either};
 use txn_types::{parse_lock, Key, LockType, TimeStamp, WriteRef, WriteType};
 
 use crate::storage::{metrics::CommandKind, txn::commands::Command, Context};
 
-const SHARD_COUNT: usize = 128;
-const EVENTS_PER_SHARD: usize = 4096;
+const SHARD_COUNT: usize = 256;
+pub(crate) const DEFAULT_TXN_COMMAND_FLIGHT_RECORDER_CAPACITY: ReadableSize = ReadableSize::mb(100);
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum TxnCommandEventKind {
@@ -350,6 +351,9 @@ pub(crate) struct TxnCommandEvent {
     generation: u64,
 }
 
+pub(crate) const MIN_TXN_COMMAND_FLIGHT_RECORDER_CAPACITY: usize =
+    SHARD_COUNT * size_of::<TxnCommandEvent>();
+
 impl TxnCommandEvent {
     fn new(
         command: CommandKind,
@@ -394,21 +398,36 @@ pub(crate) struct TxnCommandFlightRecorder {
     enabled: AtomicBool,
     shards: Vec<CachePadded<Mutex<VecDeque<TxnCommandEvent>>>>,
     shard_mask: usize,
-    events_per_shard: usize,
+    events_per_shard: AtomicUsize,
 }
 
 impl TxnCommandFlightRecorder {
     fn new(shard_count: usize, events_per_shard: usize, enabled: bool) -> Self {
         assert!(shard_count.is_power_of_two() && events_per_shard > 0);
         let shards = (0..shard_count)
-            .map(|_| CachePadded::new(Mutex::new(VecDeque::new())))
+            .map(|_| {
+                let events = if enabled {
+                    VecDeque::with_capacity(events_per_shard)
+                } else {
+                    VecDeque::new()
+                };
+                CachePadded::new(Mutex::new(events))
+            })
             .collect();
         Self {
             enabled: AtomicBool::new(enabled),
             shards,
             shard_mask: shard_count - 1,
-            events_per_shard,
+            events_per_shard: AtomicUsize::new(events_per_shard),
         }
+    }
+
+    fn with_capacity(shard_count: usize, capacity: usize, enabled: bool) -> Self {
+        Self::new(
+            shard_count,
+            events_per_shard(shard_count, capacity),
+            enabled,
+        )
     }
 
     #[inline]
@@ -427,7 +446,48 @@ impl TxnCommandFlightRecorder {
             }
             return;
         }
+        if self.is_enabled() {
+            return;
+        }
+        let events_per_shard = self.events_per_shard.load(Ordering::Relaxed);
+        for shard in &self.shards {
+            *shard.lock() = VecDeque::with_capacity(events_per_shard);
+        }
         self.enabled.store(true, Ordering::Release);
+    }
+
+    pub(crate) fn set_capacity(&self, capacity: usize) {
+        let events_per_shard = events_per_shard(self.shards.len(), capacity);
+        let old_events_per_shard = self.events_per_shard.load(Ordering::Relaxed);
+        if events_per_shard == old_events_per_shard {
+            return;
+        }
+        if !self.is_enabled() {
+            self.events_per_shard
+                .store(events_per_shard, Ordering::Relaxed);
+            return;
+        }
+
+        // Keep the old limit until all shards have been enlarged so recorders
+        // cannot trigger a runtime allocation. Publish a smaller limit first
+        // so recorders stop growing the retained history while shards are trimmed.
+        if events_per_shard < old_events_per_shard {
+            self.events_per_shard
+                .store(events_per_shard, Ordering::Release);
+        }
+        for shard in &self.shards {
+            let mut shard = shard.lock();
+            while shard.len() > events_per_shard {
+                shard.pop_front();
+            }
+            let mut resized = VecDeque::with_capacity(events_per_shard);
+            resized.extend(shard.drain(..));
+            *shard = resized;
+        }
+        if events_per_shard > old_events_per_shard {
+            self.events_per_shard
+                .store(events_per_shard, Ordering::Release);
+        }
     }
 
     #[inline]
@@ -476,7 +536,8 @@ impl TxnCommandFlightRecorder {
                 continue;
             }
             event.unix_time_ms = unix_time_ms;
-            if shard.len() == self.events_per_shard {
+            let events_per_shard = self.events_per_shard.load(Ordering::Relaxed);
+            if shard.len() >= events_per_shard {
                 shard.pop_front();
             }
             shard.push_back(event);
@@ -543,9 +604,17 @@ impl TxnCommandFlightRecorder {
     }
 }
 
+fn events_per_shard(shard_count: usize, capacity: usize) -> usize {
+    (capacity / shard_count / size_of::<TxnCommandEvent>()).max(1)
+}
+
 lazy_static! {
     pub(crate) static ref TXN_FLIGHT_RECORDER: TxnCommandFlightRecorder =
-        TxnCommandFlightRecorder::new(SHARD_COUNT, EVENTS_PER_SHARD, false);
+        TxnCommandFlightRecorder::with_capacity(
+            SHARD_COUNT,
+            DEFAULT_TXN_COMMAND_FLIGHT_RECORDER_CAPACITY.0 as usize,
+            false,
+        );
 }
 
 #[cfg(test)]
@@ -675,10 +744,45 @@ mod tests {
 
     #[test]
     fn test_event_size_is_bounded() {
-        // 128 * 4096 records should remain below roughly 80 MiB, excluding the small
-        // per-shard VecDeque bookkeeping.
         let size = size_of::<TxnCommandEvent>();
         assert!(size <= 160, "event size is {size}");
+
+        let events_per_shard = events_per_shard(
+            SHARD_COUNT,
+            DEFAULT_TXN_COMMAND_FLIGHT_RECORDER_CAPACITY.0 as usize,
+        );
+        let retained_event_bytes = SHARD_COUNT * events_per_shard * size;
+        assert!(retained_event_bytes <= DEFAULT_TXN_COMMAND_FLIGHT_RECORDER_CAPACITY.0 as usize);
+        assert!(
+            DEFAULT_TXN_COMMAND_FLIGHT_RECORDER_CAPACITY.0 as usize - retained_event_bytes
+                < MIN_TXN_COMMAND_FLIGHT_RECORDER_CAPACITY
+        );
+    }
+
+    #[test]
+    fn test_resize_capacity() {
+        let recorder = TxnCommandFlightRecorder::new(2, 4, true);
+        let key = Key::from_raw(b"key");
+
+        for cid in 1..=4 {
+            recorder.record([event_for_key(&key, cid)]);
+        }
+
+        recorder.set_capacity(2 * 2 * size_of::<TxnCommandEvent>());
+        assert_eq!(recorder.events_per_shard.load(Ordering::Relaxed), 2);
+        let events = recorder.events_for_key(&key);
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].cid, 3);
+        assert_eq!(events[1].cid, 4);
+
+        recorder.set_capacity(2 * 4 * size_of::<TxnCommandEvent>());
+        for cid in 5..=6 {
+            recorder.record([event_for_key(&key, cid)]);
+        }
+        let events = recorder.events_for_key(&key);
+        assert_eq!(events.len(), 4);
+        assert_eq!(events[0].cid, 3);
+        assert_eq!(events[3].cid, 6);
     }
 
     #[test]
@@ -713,16 +817,34 @@ mod tests {
     fn test_disabled_recorder_does_not_record_and_enable_starts_fresh() {
         let recorder = TxnCommandFlightRecorder::new(2, 4, false);
         let key = Key::from_raw(b"key");
+        assert!(
+            recorder
+                .shards
+                .iter()
+                .all(|shard| shard.lock().capacity() == 0)
+        );
 
         recorder.record([event_for_key(&key, 1)]);
         assert!(recorder.events_for_key(&key).is_empty());
 
         recorder.set_enabled(true);
+        assert!(
+            recorder
+                .shards
+                .iter()
+                .all(|shard| shard.lock().capacity() >= 4)
+        );
         recorder.record([event_for_key(&key, 2)]);
         assert_eq!(recorder.events_for_key(&key).len(), 1);
 
         recorder.set_enabled(false);
         assert!(recorder.events_for_key(&key).is_empty());
+        assert!(
+            recorder
+                .shards
+                .iter()
+                .all(|shard| shard.lock().capacity() == 0)
+        );
         recorder.set_enabled(true);
         assert!(recorder.events_for_key(&key).is_empty());
     }

--- a/src/storage/txn/flight_recorder.rs
+++ b/src/storage/txn/flight_recorder.rs
@@ -51,10 +51,6 @@ fn hash_encoded_key(key: &[u8]) -> u64 {
     hasher.finish()
 }
 
-fn hash_raw_key(raw_key: &[u8]) -> u64 {
-    hash_key(&Key::from_raw(raw_key))
-}
-
 #[derive(Clone, Copy)]
 struct CommandKey {
     key_hash: u64,
@@ -224,7 +220,6 @@ impl TxnCommandEventMetadata {
         let mut event = self.event;
         event.kind = kind;
         event.key_hash = command_key.key_hash;
-        event.primary_key_hash = command_key.key_hash;
         if command_key.txn_start_ts != 0 {
             event.txn_start_ts = command_key.txn_start_ts;
         }
@@ -252,9 +247,6 @@ impl TxnCommandEventMetadata {
                         event.for_update_ts = lock.for_update_ts.into_inner();
                         event.min_commit_ts = lock.min_commit_ts.into_inner();
                         event.lock_ttl = lock.ttl;
-                        if !key.is_encoded_from(&lock.primary) {
-                            event.primary_key_hash = hash_raw_key(&lock.primary);
-                        }
                         event.generation = lock.generation;
                     }
                     Either::Right(_) => event.lock_type = Some(LockType::Shared),
@@ -298,9 +290,6 @@ impl TxnCommandEventMetadata {
                 event.for_update_ts = lock.for_update_ts.into_inner();
                 event.min_commit_ts = lock.min_commit_ts.into_inner();
                 event.lock_ttl = lock.ttl;
-                if !key.is_encoded_from(&lock.primary) {
-                    event.primary_key_hash = hash_raw_key(&lock.primary);
-                }
                 Some(event)
             }
             _ => None,
@@ -326,7 +315,6 @@ pub(crate) struct TxnCommandEvent {
     command: CommandKind,
     cid: u64,
     key_hash: u64,
-    primary_key_hash: u64,
     txn_start_ts: u64,
     commit_ts: u64,
     caller_start_ts: u64,
@@ -367,7 +355,6 @@ impl TxnCommandEvent {
             command,
             cid,
             key_hash: 0,
-            primary_key_hash: 0,
             txn_start_ts: 0,
             commit_ts: 0,
             caller_start_ts: 0,
@@ -394,9 +381,50 @@ impl TxnCommandEvent {
     }
 }
 
+struct RecorderShard {
+    events: VecDeque<TxnCommandEvent>,
+    max_evicted_start_ts: u64,
+}
+
+impl RecorderShard {
+    fn new(capacity: usize) -> Self {
+        Self {
+            events: VecDeque::with_capacity(capacity),
+            max_evicted_start_ts: 0,
+        }
+    }
+
+    fn evict_oldest(&mut self) {
+        if let Some(event) = self.events.pop_front() {
+            let max_start_ts = if event.has_overlapped_rollback {
+                // The write key's commit_ts is also the start_ts of the
+                // rollback that overlapped this write record.
+                event.txn_start_ts.max(event.commit_ts)
+            } else {
+                event.txn_start_ts
+            };
+            self.max_evicted_start_ts = self.max_evicted_start_ts.max(max_start_ts);
+        }
+    }
+}
+
+pub(crate) struct TxnCommandHistory {
+    pub(crate) events: Vec<TxnCommandEvent>,
+    pub(crate) max_evicted_start_ts: u64,
+    pub(crate) recorder_enabled: bool,
+}
+
+impl TxnCommandHistory {
+    /// Returns whether this recorder session has not evicted an event whose
+    /// transaction start_ts is at least `start_ts`.
+    pub(crate) fn is_complete_by_eviction(&self, start_ts: TimeStamp) -> bool {
+        self.recorder_enabled && self.max_evicted_start_ts < start_ts.into_inner()
+    }
+}
+
 pub(crate) struct TxnCommandFlightRecorder {
     enabled: AtomicBool,
-    shards: Vec<CachePadded<Mutex<VecDeque<TxnCommandEvent>>>>,
+    shards: Vec<CachePadded<Mutex<RecorderShard>>>,
     shard_mask: usize,
     configured_events_per_shard: AtomicUsize,
 }
@@ -404,15 +432,9 @@ pub(crate) struct TxnCommandFlightRecorder {
 impl TxnCommandFlightRecorder {
     fn new(shard_count: usize, events_per_shard: usize, enabled: bool) -> Self {
         assert!(shard_count.is_power_of_two() && events_per_shard > 0);
+        let capacity = if enabled { events_per_shard } else { 0 };
         let shards = (0..shard_count)
-            .map(|_| {
-                let events = if enabled {
-                    VecDeque::with_capacity(events_per_shard)
-                } else {
-                    VecDeque::new()
-                };
-                CachePadded::new(Mutex::new(events))
-            })
+            .map(|_| CachePadded::new(Mutex::new(RecorderShard::new(capacity))))
             .collect();
         Self {
             enabled: AtomicBool::new(enabled),
@@ -435,14 +457,14 @@ impl TxnCommandFlightRecorder {
         self.enabled.load(Ordering::Relaxed)
     }
 
-    /// Disabling clears retained events and releases their ring-buffer memory.
+    /// Disabling clears the current history session and releases its memory.
     pub(crate) fn set_enabled(&self, enabled: bool) {
         if !enabled {
             if !self.enabled.swap(false, Ordering::AcqRel) {
                 return;
             }
             for shard in &self.shards {
-                *shard.lock() = VecDeque::new();
+                *shard.lock() = RecorderShard::new(0);
             }
             return;
         }
@@ -451,7 +473,7 @@ impl TxnCommandFlightRecorder {
         }
         let events_per_shard = self.configured_events_per_shard.load(Ordering::Relaxed);
         for shard in &self.shards {
-            *shard.lock() = VecDeque::with_capacity(events_per_shard);
+            *shard.lock() = RecorderShard::new(events_per_shard);
         }
         self.enabled.store(true, Ordering::Release);
     }
@@ -472,11 +494,11 @@ impl TxnCommandFlightRecorder {
         for shard in &self.shards {
             let mut shard = shard.lock();
             let mut resized = VecDeque::with_capacity(events_per_shard);
-            while shard.len() > resized.capacity() {
-                shard.pop_front();
+            while shard.events.len() > resized.capacity() {
+                shard.evict_oldest();
             }
-            resized.extend(shard.drain(..));
-            *shard = resized;
+            resized.extend(shard.events.drain(..));
+            shard.events = resized;
         }
     }
 
@@ -518,6 +540,7 @@ impl TxnCommandFlightRecorder {
             .unwrap_or_default()
             .as_millis() as u64;
         for mut event in events {
+            debug_assert_ne!(event.txn_start_ts, 0);
             let shard_index = event.key_hash as usize & self.shard_mask;
             let mut shard = self.shards[shard_index].lock();
             // Pair with set_enabled(false): a recorder that passed the first
@@ -526,10 +549,10 @@ impl TxnCommandFlightRecorder {
                 continue;
             }
             event.unix_time_ms = unix_time_ms;
-            if shard.len() == shard.capacity() {
-                shard.pop_front();
+            if shard.events.len() == shard.events.capacity() {
+                shard.evict_oldest();
             }
-            shard.push_back(event);
+            shard.events.push_back(event);
         }
     }
 
@@ -574,22 +597,27 @@ impl TxnCommandFlightRecorder {
                 TxnCommandEvent::new(CommandKind::prewrite, 0, ctx, snapshot_data_version);
             event.kind = kind;
             event.key_hash = key_hash;
-            event.primary_key_hash = key_hash;
             event.txn_start_ts = start_ts.into_inner();
             event.commit_ts = committed_ts.unwrap_or_default().into_inner();
             self.record([event]);
         }
     }
 
-    pub(crate) fn events_for_key(&self, key: &Key) -> Vec<TxnCommandEvent> {
+    pub(crate) fn history_for_key(&self, key: &Key) -> TxnCommandHistory {
         let key_hash = hash_key(key);
         let shard_index = key_hash as usize & self.shard_mask;
-        self.shards[shard_index]
-            .lock()
+        let shard = self.shards[shard_index].lock();
+        let events = shard
+            .events
             .iter()
             .filter(|event| event.key_hash == key_hash)
             .copied()
-            .collect()
+            .collect();
+        TxnCommandHistory {
+            events,
+            max_evicted_start_ts: shard.max_evicted_start_ts,
+            recorder_enabled: self.is_enabled(),
+        }
     }
 }
 
@@ -617,6 +645,7 @@ mod tests {
     fn event_for_key(key: &Key, cid: u64) -> TxnCommandEvent {
         let mut event = TxnCommandEvent::new(CommandKind::prewrite, cid, &Context::default(), None);
         event.key_hash = hash_key(key);
+        event.txn_start_ts = cid;
         event
     }
 
@@ -631,10 +660,12 @@ mod tests {
         }
         recorder.record([event_for_key(&other_key, 100)]);
 
-        let events = recorder.events_for_key(&key);
-        assert!(events.len() <= 4);
-        assert_eq!(events.last().unwrap().cid, 5);
-        assert!(events.iter().all(|event| event.cid != 100));
+        let history = recorder.history_for_key(&key);
+        assert!(history.events.len() <= 4);
+        assert_eq!(history.events.last().unwrap().cid, 5);
+        assert!(history.events.iter().all(|event| event.cid != 100));
+        assert!(!history.is_complete_by_eviction(1.into()));
+        assert!(history.is_complete_by_eviction(3.into()));
     }
 
     #[test]
@@ -715,8 +746,8 @@ mod tests {
         assert!(events.iter().all(|event| !event.has_overlapped_rollback));
 
         // An overlapped rollback record keeps the older transaction's write
-        // type/start_ts; the event must carry the flag so it is not mistaken
-        // for a normal commit of that older transaction.
+        // type/start_ts. Its commit_ts is also the overlapped rollback's
+        // start_ts, and both timestamps contribute to the eviction watermark.
         let overlapped =
             Write::new(WriteType::Put, 10.into(), None).set_overlapped_rollback(true, None);
         let events = metadata.events_for_modifies(&[Modify::Put(
@@ -729,6 +760,14 @@ mod tests {
         assert_eq!(events[0].commit_ts, 30);
         assert_eq!(events[0].txn_start_ts, 10);
         assert!(events[0].has_overlapped_rollback);
+
+        let recorder = TxnCommandFlightRecorder::new(1, 1, true);
+        recorder.record([events[0]]);
+        recorder.record([event_for_key(&key, 31)]);
+        let history = recorder.history_for_key(&key);
+        assert_eq!(history.max_evicted_start_ts, 30);
+        assert!(!history.is_complete_by_eviction(30.into()));
+        assert!(history.is_complete_by_eviction(31.into()));
     }
 
     #[test]
@@ -762,27 +801,31 @@ mod tests {
             recorder
                 .shards
                 .iter()
-                .all(|shard| shard.lock().capacity() >= 2)
+                .all(|shard| shard.lock().events.capacity() >= 2)
         );
-        let events = recorder.events_for_key(&key);
-        assert_eq!(events.len(), 2);
-        assert_eq!(events[0].cid, 3);
-        assert_eq!(events[1].cid, 4);
+        let history = recorder.history_for_key(&key);
+        assert_eq!(history.events.len(), 2);
+        assert_eq!(history.events[0].cid, 3);
+        assert_eq!(history.events[1].cid, 4);
+        assert_eq!(history.max_evicted_start_ts, 2);
+        assert!(!history.is_complete_by_eviction(2.into()));
+        assert!(history.is_complete_by_eviction(3.into()));
 
         recorder.set_capacity(2 * 4 * size_of::<TxnCommandEvent>());
         assert!(
             recorder
                 .shards
                 .iter()
-                .all(|shard| shard.lock().capacity() >= 4)
+                .all(|shard| shard.lock().events.capacity() >= 4)
         );
         for cid in 5..=6 {
             recorder.record([event_for_key(&key, cid)]);
         }
-        let events = recorder.events_for_key(&key);
-        assert_eq!(events.len(), 4);
-        assert_eq!(events[0].cid, 3);
-        assert_eq!(events[3].cid, 6);
+        let history = recorder.history_for_key(&key);
+        assert_eq!(history.events.len(), 4);
+        assert_eq!(history.events[0].cid, 3);
+        assert_eq!(history.events[3].cid, 6);
+        assert_eq!(history.max_evicted_start_ts, 2);
     }
 
     #[test]
@@ -803,14 +846,17 @@ mod tests {
             Some(30),
         );
 
-        let events = recorder.events_for_key(&key);
-        assert_eq!(events.len(), 1);
-        assert_eq!(events[0].kind, TxnCommandEventKind::TxnStatusCacheHit);
-        assert_eq!(events[0].txn_start_ts, 10);
-        assert_eq!(events[0].commit_ts, 20);
-        assert_eq!(events[0].snapshot_data_version, 30);
-        assert!(events[0].is_retry_request);
-        assert!(recorder.events_for_key(&secondary_key).is_empty());
+        let history = recorder.history_for_key(&key);
+        assert_eq!(history.events.len(), 1);
+        assert_eq!(
+            history.events[0].kind,
+            TxnCommandEventKind::TxnStatusCacheHit
+        );
+        assert_eq!(history.events[0].txn_start_ts, 10);
+        assert_eq!(history.events[0].commit_ts, 20);
+        assert_eq!(history.events[0].snapshot_data_version, 30);
+        assert!(history.events[0].is_retry_request);
+        assert!(recorder.history_for_key(&secondary_key).events.is_empty());
     }
 
     #[test]
@@ -821,38 +867,48 @@ mod tests {
             recorder
                 .shards
                 .iter()
-                .all(|shard| shard.lock().capacity() == 0)
+                .all(|shard| shard.lock().events.capacity() == 0)
         );
 
         recorder.record([event_for_key(&key, 1)]);
-        assert!(recorder.events_for_key(&key).is_empty());
+        let history = recorder.history_for_key(&key);
+        assert!(history.events.is_empty());
+        assert!(!history.is_complete_by_eviction(1.into()));
 
         recorder.set_enabled(true);
         assert!(
             recorder
                 .shards
                 .iter()
-                .all(|shard| shard.lock().capacity() >= 4)
+                .all(|shard| shard.lock().events.capacity() >= 4)
         );
-        recorder.record([event_for_key(&key, 2)]);
-        assert_eq!(recorder.events_for_key(&key).len(), 1);
+        for cid in 2..=6 {
+            recorder.record([event_for_key(&key, cid)]);
+        }
+        let history = recorder.history_for_key(&key);
+        assert_eq!(history.events.len(), 4);
+        assert_eq!(history.max_evicted_start_ts, 2);
 
         recorder.set_enabled(false);
-        assert!(recorder.events_for_key(&key).is_empty());
+        let history = recorder.history_for_key(&key);
+        assert!(history.events.is_empty());
+        assert!(!history.recorder_enabled);
         assert!(
             recorder
                 .shards
                 .iter()
-                .all(|shard| shard.lock().capacity() == 0)
+                .all(|shard| shard.lock().events.capacity() == 0)
         );
         recorder.set_capacity(2 * 2 * size_of::<TxnCommandEvent>());
         recorder.set_enabled(true);
-        assert!(recorder.events_for_key(&key).is_empty());
+        let history = recorder.history_for_key(&key);
+        assert!(history.events.is_empty());
+        assert_eq!(history.max_evicted_start_ts, 0);
         assert!(
             recorder
                 .shards
                 .iter()
-                .all(|shard| shard.lock().capacity() >= 2)
+                .all(|shard| shard.lock().events.capacity() >= 2)
         );
     }
 }

--- a/src/storage/txn/flight_recorder.rs
+++ b/src/storage/txn/flight_recorder.rs
@@ -398,7 +398,7 @@ pub(crate) struct TxnCommandFlightRecorder {
     enabled: AtomicBool,
     shards: Vec<CachePadded<Mutex<VecDeque<TxnCommandEvent>>>>,
     shard_mask: usize,
-    events_per_shard: AtomicUsize,
+    configured_events_per_shard: AtomicUsize,
 }
 
 impl TxnCommandFlightRecorder {
@@ -418,7 +418,7 @@ impl TxnCommandFlightRecorder {
             enabled: AtomicBool::new(enabled),
             shards,
             shard_mask: shard_count - 1,
-            events_per_shard: AtomicUsize::new(events_per_shard),
+            configured_events_per_shard: AtomicUsize::new(events_per_shard),
         }
     }
 
@@ -449,7 +449,7 @@ impl TxnCommandFlightRecorder {
         if self.is_enabled() {
             return;
         }
-        let events_per_shard = self.events_per_shard.load(Ordering::Relaxed);
+        let events_per_shard = self.configured_events_per_shard.load(Ordering::Relaxed);
         for shard in &self.shards {
             *shard.lock() = VecDeque::with_capacity(events_per_shard);
         }
@@ -458,35 +458,25 @@ impl TxnCommandFlightRecorder {
 
     pub(crate) fn set_capacity(&self, capacity: usize) {
         let events_per_shard = events_per_shard(self.shards.len(), capacity);
-        let old_events_per_shard = self.events_per_shard.load(Ordering::Relaxed);
-        if events_per_shard == old_events_per_shard {
+        if self
+            .configured_events_per_shard
+            .swap(events_per_shard, Ordering::Relaxed)
+            == events_per_shard
+        {
             return;
         }
         if !self.is_enabled() {
-            self.events_per_shard
-                .store(events_per_shard, Ordering::Relaxed);
             return;
         }
 
-        // Keep the old limit until all shards have been enlarged so recorders
-        // cannot trigger a runtime allocation. Publish a smaller limit first
-        // so recorders stop growing the retained history while shards are trimmed.
-        if events_per_shard < old_events_per_shard {
-            self.events_per_shard
-                .store(events_per_shard, Ordering::Release);
-        }
         for shard in &self.shards {
             let mut shard = shard.lock();
-            while shard.len() > events_per_shard {
+            let mut resized = VecDeque::with_capacity(events_per_shard);
+            while shard.len() > resized.capacity() {
                 shard.pop_front();
             }
-            let mut resized = VecDeque::with_capacity(events_per_shard);
             resized.extend(shard.drain(..));
             *shard = resized;
-        }
-        if events_per_shard > old_events_per_shard {
-            self.events_per_shard
-                .store(events_per_shard, Ordering::Release);
         }
     }
 
@@ -536,8 +526,7 @@ impl TxnCommandFlightRecorder {
                 continue;
             }
             event.unix_time_ms = unix_time_ms;
-            let events_per_shard = self.events_per_shard.load(Ordering::Relaxed);
-            if shard.len() >= events_per_shard {
+            if shard.len() == shard.capacity() {
                 shard.pop_front();
             }
             shard.push_back(event);
@@ -769,13 +758,24 @@ mod tests {
         }
 
         recorder.set_capacity(2 * 2 * size_of::<TxnCommandEvent>());
-        assert_eq!(recorder.events_per_shard.load(Ordering::Relaxed), 2);
+        assert!(
+            recorder
+                .shards
+                .iter()
+                .all(|shard| shard.lock().capacity() >= 2)
+        );
         let events = recorder.events_for_key(&key);
         assert_eq!(events.len(), 2);
         assert_eq!(events[0].cid, 3);
         assert_eq!(events[1].cid, 4);
 
         recorder.set_capacity(2 * 4 * size_of::<TxnCommandEvent>());
+        assert!(
+            recorder
+                .shards
+                .iter()
+                .all(|shard| shard.lock().capacity() >= 4)
+        );
         for cid in 5..=6 {
             recorder.record([event_for_key(&key, cid)]);
         }
@@ -845,7 +845,14 @@ mod tests {
                 .iter()
                 .all(|shard| shard.lock().capacity() == 0)
         );
+        recorder.set_capacity(2 * 2 * size_of::<TxnCommandEvent>());
         recorder.set_enabled(true);
         assert!(recorder.events_for_key(&key).is_empty());
+        assert!(
+            recorder
+                .shards
+                .iter()
+                .all(|shard| shard.lock().capacity() >= 2)
+        );
     }
 }

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -744,6 +744,7 @@ fn test_serde_custom_tikv_config() {
         reserve_raft_space: ReadableSize::gb(2),
         enable_async_apply_prewrite: true,
         enable_txn_command_flight_recorder: false,
+        txn_command_flight_recorder_capacity: ReadableSize::mb(100),
         api_version: 1,
         enable_ttl: true,
         ttl_check_poll_interval: ReadableDuration::hours(0),

--- a/tests/integrations/config/test-custom.toml
+++ b/tests/integrations/config/test-custom.toml
@@ -100,7 +100,6 @@ scheduler-concurrency = 123
 scheduler-worker-pool-size = 1
 scheduler-pending-write-threshold = "123KB"
 enable-async-apply-prewrite = true
-enable-txn-command-flight-recorder = false
 reserve-space = "10GB"
 reserve-raft-space = "2GB"
 enable-ttl = true


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: close #19901

Stacked on #19892 (same hotfix branch, `release-8.5-20260727-v8.5.6`). This PR picks up the latest changes from #19869 that are not yet in #19892 — only the last 3 commits are new:

- `txn_command_flight_recorder_capacity` config: recorder memory is now configurable (min enforced, runtime resizable via config change).
- Deque capacity update.
- Track evicted history: the recorder tracks the maximum evicted transaction start_ts per shard, so after an MVCC panic we can tell whether the recorded history may be incomplete (i.e. whether relevant events could have been evicted).

Cherry-picked from master (#19869):
- 8071fa5be add txn_command_flight_recorder_capacity config
- b203550bd update deque capacity
- 8002ae371 txn: track evicted history in the flight recorder

Conflict resolution note: `src/storage/config_manager.rs` keeps this branch's inline max-ts config handlers (master's `dispatch_max_ts_config_change` refactor is not on this branch); the capacity handler is added alongside them. `src/config/mod.rs` test only takes the capacity lines (the max-ts test lines reference a master-only config field).

```release-note
None
```