### PR TITLE
txn: improve primary-key flight recording

### DIFF
--- a/src/storage/txn/actions/cleanup.rs
+++ b/src/storage/txn/actions/cleanup.rs
@@ -35,15 +35,15 @@ pub fn cleanup<S: Snapshot>(
 }
 
 /// Returns the flight-recorder hash when `key` is the primary key recorded in
-/// its lock, or zero otherwise.
+/// its lock.
 pub(crate) fn cleanup_with_primary<S: Snapshot>(
     txn: &mut MvccTxn,
     reader: &mut SnapshotReader<S>,
     key: Key,
     current_ts: TimeStamp,
     protect_rollback: bool,
-) -> MvccResult<(Option<ReleasedLock>, u64)> {
-    let mut primary_key_hash = 0;
+) -> MvccResult<(Option<ReleasedLock>, Option<u64>)> {
+    let mut primary_key_hash = None;
     let released = cleanup_inner(
         txn,
         reader,
@@ -52,7 +52,7 @@ pub(crate) fn cleanup_with_primary<S: Snapshot>(
         protect_rollback,
         |key, primary| {
             if key.is_encoded_from(primary) {
-                primary_key_hash = hash_key(key);
+                primary_key_hash = Some(hash_key(key));
             }
         },
     )?;
@@ -352,7 +352,7 @@ pub mod tests {
             true,
         )
         .unwrap();
-        assert_eq!(primary_key_hash, hash_key(&Key::from_raw(primary)));
+        assert_eq!(primary_key_hash, Some(hash_key(&Key::from_raw(primary))));
 
         let (_, primary_key_hash) = cleanup_with_primary(
             &mut txn,
@@ -362,7 +362,7 @@ pub mod tests {
             true,
         )
         .unwrap();
-        assert_eq!(primary_key_hash, 0);
+        assert_eq!(primary_key_hash, None);
 
         let (_, primary_key_hash) = cleanup_with_primary(
             &mut txn,
@@ -372,7 +372,7 @@ pub mod tests {
             true,
         )
         .unwrap();
-        assert_eq!(primary_key_hash, 0);
+        assert_eq!(primary_key_hash, None);
     }
 
     #[test]

--- a/src/storage/txn/actions/cleanup.rs
+++ b/src/storage/txn/actions/cleanup.rs
@@ -8,8 +8,11 @@ use crate::storage::{
         metrics::{MVCC_CONFLICT_COUNTER, MVCC_DUPLICATE_CMD_COUNTER_VEC},
         ErrorInner, Key, MvccTxn, ReleasedLock, Result as MvccResult, SnapshotReader, TimeStamp,
     },
-    txn::actions::check_txn_status::{
-        check_txn_status_missing_lock, rollback_lock, rollback_shared_lock, MissingLockAction,
+    txn::{
+        actions::check_txn_status::{
+            check_txn_status_missing_lock, rollback_lock, rollback_shared_lock, MissingLockAction,
+        },
+        flight_recorder::hash_key,
     },
     Snapshot, TxnStatus,
 };
@@ -27,6 +30,42 @@ pub fn cleanup<S: Snapshot>(
     key: Key,
     current_ts: TimeStamp,
     protect_rollback: bool,
+) -> MvccResult<Option<ReleasedLock>> {
+    cleanup_inner(txn, reader, key, current_ts, protect_rollback, |_, _| {})
+}
+
+/// Returns the flight-recorder hash when `key` is the primary key recorded in
+/// its lock, or zero otherwise.
+pub(crate) fn cleanup_with_primary<S: Snapshot>(
+    txn: &mut MvccTxn,
+    reader: &mut SnapshotReader<S>,
+    key: Key,
+    current_ts: TimeStamp,
+    protect_rollback: bool,
+) -> MvccResult<(Option<ReleasedLock>, u64)> {
+    let mut primary_key_hash = 0;
+    let released = cleanup_inner(
+        txn,
+        reader,
+        key,
+        current_ts,
+        protect_rollback,
+        |key, primary| {
+            if key.is_encoded_from(primary) {
+                primary_key_hash = hash_key(key);
+            }
+        },
+    )?;
+    Ok((released, primary_key_hash))
+}
+
+fn cleanup_inner<S: Snapshot>(
+    txn: &mut MvccTxn,
+    reader: &mut SnapshotReader<S>,
+    key: Key,
+    current_ts: TimeStamp,
+    protect_rollback: bool,
+    record_primary: impl FnOnce(&Key, &[u8]),
 ) -> MvccResult<Option<ReleasedLock>> {
     fail_point!("cleanup", |err| Err(
         crate::storage::mvcc::txn::make_txn_error(err, &key, reader.start_ts).into()
@@ -64,6 +103,7 @@ pub fn cleanup<S: Snapshot>(
                     .into());
                 }
             }
+            record_primary(&key, &lock.primary);
             rollback_lock(
                 txn,
                 reader,
@@ -288,6 +328,51 @@ pub mod tests {
         let w = must_written(&mut engine, b"k", 10, 20, WriteType::Put);
         assert!(w.has_overlapped_rollback);
         assert_eq!(w.gc_fence.unwrap(), 30.into());
+    }
+
+    #[test]
+    fn test_cleanup_identifies_primary_key() {
+        let mut engine = TestEngineBuilder::new().build().unwrap();
+        let primary = b"primary";
+        let secondary = b"secondary";
+        let start_ts = TimeStamp::new(10);
+        must_prewrite_put(&mut engine, primary, b"v1", primary, start_ts);
+        must_prewrite_put(&mut engine, secondary, b"v2", primary, start_ts);
+
+        let snapshot = engine.snapshot(Default::default()).unwrap();
+        let cm = ConcurrencyManager::new(start_ts);
+        let mut txn = MvccTxn::new(start_ts, cm);
+        let mut reader = SnapshotReader::new(start_ts, snapshot, true);
+
+        let (_, primary_key_hash) = cleanup_with_primary(
+            &mut txn,
+            &mut reader,
+            Key::from_raw(primary),
+            TimeStamp::zero(),
+            true,
+        )
+        .unwrap();
+        assert_eq!(primary_key_hash, hash_key(&Key::from_raw(primary)));
+
+        let (_, primary_key_hash) = cleanup_with_primary(
+            &mut txn,
+            &mut reader,
+            Key::from_raw(secondary),
+            TimeStamp::zero(),
+            true,
+        )
+        .unwrap();
+        assert_eq!(primary_key_hash, 0);
+
+        let (_, primary_key_hash) = cleanup_with_primary(
+            &mut txn,
+            &mut reader,
+            Key::from_raw(b"missing"),
+            TimeStamp::zero(),
+            true,
+        )
+        .unwrap();
+        assert_eq!(primary_key_hash, 0);
     }
 
     #[test]

--- a/src/storage/txn/actions/commit.rs
+++ b/src/storage/txn/actions/commit.rs
@@ -56,17 +56,17 @@ pub fn commit<S: Snapshot>(
 }
 
 /// Returns the flight-recorder hash when `key` is the primary key recorded in
-/// its lock, or zero otherwise.
+/// its lock.
 pub(crate) fn commit_with_primary<S: Snapshot>(
     txn: &mut MvccTxn,
     reader: &mut SnapshotReader<S>,
     key: Key,
     commit_ts: TimeStamp,
-) -> MvccResult<(Option<ReleasedLock>, u64)> {
-    let mut primary_key_hash = 0;
+) -> MvccResult<(Option<ReleasedLock>, Option<u64>)> {
+    let mut primary_key_hash = None;
     let released = commit_inner(txn, reader, key, commit_ts, |key, primary| {
         if key.is_encoded_from(primary) {
-            primary_key_hash = hash_key(key);
+            primary_key_hash = Some(hash_key(key));
         }
     })?;
     Ok((released, primary_key_hash))
@@ -373,12 +373,12 @@ pub mod tests {
 
         let (_, primary_key_hash) =
             commit_with_primary(&mut txn, &mut reader, Key::from_raw(primary), 20.into()).unwrap();
-        assert_eq!(primary_key_hash, hash_key(&Key::from_raw(primary)));
+        assert_eq!(primary_key_hash, Some(hash_key(&Key::from_raw(primary))));
 
         let (_, primary_key_hash) =
             commit_with_primary(&mut txn, &mut reader, Key::from_raw(secondary), 20.into())
                 .unwrap();
-        assert_eq!(primary_key_hash, 0);
+        assert_eq!(primary_key_hash, None);
     }
 
     #[cfg(test)]

--- a/src/storage/txn/commands/cleanup.rs
+++ b/src/storage/txn/commands/cleanup.rs
@@ -8,11 +8,13 @@ use crate::storage::{
     lock_manager::LockManager,
     mvcc::{MvccTxn, SnapshotReader},
     txn::{
+        actions::cleanup::cleanup_with_primary,
         cleanup,
         commands::{
             Command, CommandExt, ReaderWithStats, ReleasedLocks, ResponsePolicy, TypedCommand,
             WriteCommand, WriteContext, WriteResult,
         },
+        flight_recorder::TXN_FLIGHT_RECORDER,
         Result,
     },
     ProcessResult, Snapshot,
@@ -64,13 +66,15 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for Cleanup {
         let mut released_locks = ReleasedLocks::new();
         // The rollback must be protected, see more on
         // [issue #7364](https://github.com/tikv/tikv/issues/7364)
-        released_locks.push(cleanup(
-            &mut txn,
-            &mut reader,
-            self.key,
-            self.current_ts,
-            true,
-        )?);
+        let released = if TXN_FLIGHT_RECORDER.is_enabled() {
+            let (released, primary_key_hash) =
+                cleanup_with_primary(&mut txn, &mut reader, self.key, self.current_ts, true)?;
+            released_locks.set_flight_primary_key_hash(primary_key_hash);
+            released
+        } else {
+            cleanup(&mut txn, &mut reader, self.key, self.current_ts, true)?
+        };
+        released_locks.push(released);
 
         let new_acquired_locks = txn.take_new_locks();
         let mut write_data = WriteData::from_modifies(txn.into_modifies());

--- a/src/storage/txn/commands/mod.rs
+++ b/src/storage/txn/commands/mod.rs
@@ -543,7 +543,7 @@ impl WriteResultLockInfo {
 // while processing a write command and consumed before the locks reach the lock
 // manager.
 #[derive(Default, Debug)]
-pub struct ReleasedLocks(Vec<ReleasedLock>, u64);
+pub struct ReleasedLocks(Vec<ReleasedLock>, Option<u64>);
 
 impl ReleasedLocks {
     pub fn new() -> Self {
@@ -562,21 +562,21 @@ impl ReleasedLocks {
 
     pub fn clear(&mut self) {
         self.0.clear();
-        self.1 = 0;
+        self.1 = None;
     }
 
     pub fn into_iter(self) -> impl Iterator<Item = ReleasedLock> {
         self.0.into_iter()
     }
 
-    pub(crate) fn set_flight_primary_key_hash(&mut self, key_hash: u64) {
-        if key_hash != 0 {
-            debug_assert!(self.1 == 0 || self.1 == key_hash);
-            self.1 = key_hash;
+    pub(crate) fn set_flight_primary_key_hash(&mut self, key_hash: Option<u64>) {
+        if let Some(key_hash) = key_hash {
+            debug_assert!(self.1.is_none() || self.1 == Some(key_hash));
+            self.1 = Some(key_hash);
         }
     }
 
-    pub(crate) fn flight_primary_key_hash(&self) -> u64 {
+    pub(crate) fn flight_primary_key_hash(&self) -> Option<u64> {
         self.1
     }
 }

--- a/src/storage/txn/commands/mod.rs
+++ b/src/storage/txn/commands/mod.rs
@@ -540,7 +540,8 @@ impl WriteResultLockInfo {
 }
 
 // The second field is an optional flight-recorder primary-key hash, identified
-// while preparing commit and consumed before the locks reach the lock manager.
+// while processing a write command and consumed before the locks reach the lock
+// manager.
 #[derive(Default, Debug)]
 pub struct ReleasedLocks(Vec<ReleasedLock>, u64);
 

--- a/src/storage/txn/commands/pessimistic_rollback.rs
+++ b/src/storage/txn/commands/pessimistic_rollback.rs
@@ -15,6 +15,7 @@ use crate::storage::{
             Command, CommandExt, PessimisticRollbackReadPhase, ReaderWithStats, ReleasedLocks,
             ResponsePolicy, TypedCommand, WriteCommand, WriteContext, WriteResult,
         },
+        flight_recorder::{hash_key, TXN_FLIGHT_RECORDER},
         Result,
     },
     ProcessResult, Result as StorageResult, Snapshot,
@@ -69,6 +70,7 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for PessimisticRollback {
 
         let rows = keys.len();
         let mut released_locks = ReleasedLocks::new();
+        let record_primary = TXN_FLIGHT_RECORDER.is_enabled();
         for key in keys {
             fail_point!("pessimistic_rollback", |err| Err(
                 crate::storage::mvcc::Error::from(crate::storage::mvcc::txn::make_txn_error(
@@ -85,6 +87,9 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for PessimisticRollback {
                             && lock.ts == self.start_ts
                             && lock.for_update_ts <= self.for_update_ts
                         {
+                            if record_primary && key.is_encoded_from(&lock.primary) {
+                                released_locks.set_flight_primary_key_hash(hash_key(&key));
+                            }
                             Ok(txn.unlock_key(key, true, TimeStamp::zero()))
                         } else {
                             Ok(None)

--- a/src/storage/txn/commands/pessimistic_rollback.rs
+++ b/src/storage/txn/commands/pessimistic_rollback.rs
@@ -88,7 +88,7 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for PessimisticRollback {
                             && lock.for_update_ts <= self.for_update_ts
                         {
                             if record_primary && key.is_encoded_from(&lock.primary) {
-                                released_locks.set_flight_primary_key_hash(hash_key(&key));
+                                released_locks.set_flight_primary_key_hash(Some(hash_key(&key)));
                             }
                             Ok(txn.unlock_key(key, true, TimeStamp::zero()))
                         } else {

--- a/src/storage/txn/commands/resolve_lock_lite.rs
+++ b/src/storage/txn/commands/resolve_lock_lite.rs
@@ -8,7 +8,7 @@ use crate::storage::{
     lock_manager::LockManager,
     mvcc::{MvccTxn, SnapshotReader},
     txn::{
-        actions::commit::commit_with_primary,
+        actions::{cleanup::cleanup_with_primary, commit::commit_with_primary},
         cleanup,
         commands::{
             Command, CommandExt, ReaderWithStats, ReleasedLocks, ResponsePolicy, TypedCommand,
@@ -64,10 +64,13 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for ResolveLockLite {
         // ti-client guarantees the size of resolve_keys will not too large, so no
         // necessary to control the write_size as ResolveLock.
         let mut released_locks = ReleasedLocks::new();
-        if !self.commit_ts.is_zero() && TXN_FLIGHT_RECORDER.is_enabled() {
+        if TXN_FLIGHT_RECORDER.is_enabled() {
             for key in self.resolve_keys {
-                let (released, primary_key_hash) =
-                    commit_with_primary(&mut txn, &mut reader, key, self.commit_ts)?;
+                let (released, primary_key_hash) = if self.commit_ts.is_zero() {
+                    cleanup_with_primary(&mut txn, &mut reader, key, TimeStamp::zero(), false)?
+                } else {
+                    commit_with_primary(&mut txn, &mut reader, key, self.commit_ts)?
+                };
                 released_locks.set_flight_primary_key_hash(primary_key_hash);
                 released_locks.push(released);
             }

--- a/src/storage/txn/commands/rollback.rs
+++ b/src/storage/txn/commands/rollback.rs
@@ -8,11 +8,13 @@ use crate::storage::{
     lock_manager::LockManager,
     mvcc::{MvccTxn, SnapshotReader},
     txn::{
+        actions::cleanup::cleanup_with_primary,
         cleanup,
         commands::{
             Command, CommandExt, ReaderWithStats, ReleasedLocks, ResponsePolicy, TypedCommand,
             WriteCommand, WriteContext, WriteResult,
         },
+        flight_recorder::TXN_FLIGHT_RECORDER,
         Result,
     },
     ProcessResult, Snapshot,
@@ -57,11 +59,20 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for Rollback {
 
         let rows = self.keys.len();
         let mut released_locks = ReleasedLocks::new();
-        for k in self.keys {
-            // Rollback is called only if the transaction is known to fail. Under the
-            // circumstances, the rollback record needn't be protected.
-            let released_lock = cleanup(&mut txn, &mut reader, k, TimeStamp::zero(), false)?;
-            released_locks.push(released_lock);
+        // Rollback is called only if the transaction is known to fail. Under the
+        // circumstances, the rollback record needn't be protected.
+        if TXN_FLIGHT_RECORDER.is_enabled() {
+            for k in self.keys {
+                let (released, primary_key_hash) =
+                    cleanup_with_primary(&mut txn, &mut reader, k, TimeStamp::zero(), false)?;
+                released_locks.set_flight_primary_key_hash(primary_key_hash);
+                released_locks.push(released);
+            }
+        } else {
+            for k in self.keys {
+                let released = cleanup(&mut txn, &mut reader, k, TimeStamp::zero(), false)?;
+                released_locks.push(released);
+            }
         }
 
         let new_acquired_locks = txn.take_new_locks();

--- a/src/storage/txn/flight_recorder.rs
+++ b/src/storage/txn/flight_recorder.rs
@@ -210,8 +210,11 @@ impl TxnCommandEventMetadata {
         (!metadata.keys.is_empty() || identifies_primary_while_processing).then_some(metadata)
     }
 
-    pub(crate) fn set_primary_key_hash(&mut self, key_hash: u64) {
-        if key_hash == 0 || !self.keys.is_empty() {
+    pub(crate) fn set_primary_key_hash(&mut self, key_hash: Option<u64>) {
+        let Some(key_hash) = key_hash else {
+            return;
+        };
+        if !self.keys.is_empty() {
             return;
         }
         self.keys.push(CommandKey {
@@ -707,8 +710,9 @@ mod tests {
         for command in commands {
             let mut metadata = TxnCommandEventMetadata::from_command(&command, 1, None).unwrap();
             assert!(metadata.keys.is_empty());
-            metadata.set_primary_key_hash(1);
+            metadata.set_primary_key_hash(Some(0));
             assert_eq!(metadata.keys.len(), 1);
+            assert_eq!(metadata.keys[0].key_hash, 0);
             assert!(!metadata.keys.spilled());
         }
     }
@@ -784,7 +788,7 @@ mod tests {
         assert_eq!(events[1].write_type, Some(WriteType::Put));
 
         metadata.keys.clear();
-        metadata.set_primary_key_hash(key_hash);
+        metadata.set_primary_key_hash(Some(key_hash));
         let events = metadata.events_for_modifies(&modifies);
         assert_eq!(events.len(), 2);
         assert!(events.iter().all(|event| event.key_hash == key_hash));

--- a/src/storage/txn/flight_recorder.rs
+++ b/src/storage/txn/flight_recorder.rs
@@ -18,6 +18,7 @@ use engine_traits::{CF_LOCK, CF_WRITE};
 use kvproto::kvrpcpb::PrewriteRequestPessimisticAction;
 use lazy_static::lazy_static;
 use parking_lot::Mutex;
+use smallvec::SmallVec;
 use tikv_kv::Modify;
 use tikv_util::{config::ReadableSize, Either};
 use txn_types::{parse_lock, Key, LockType, TimeStamp, WriteRef, WriteType};
@@ -61,7 +62,7 @@ struct CommandKey {
 /// Metadata captured before a command is moved into its MVCC command handler.
 pub(crate) struct TxnCommandEventMetadata {
     event: TxnCommandEvent,
-    keys: Vec<CommandKey>,
+    keys: SmallVec<[CommandKey; 1]>,
 }
 
 impl TxnCommandEventMetadata {
@@ -69,7 +70,7 @@ impl TxnCommandEventMetadata {
         let ctx = cmd.ctx();
         let mut metadata = Self {
             event: TxnCommandEvent::new(cmd.tag(), cid, ctx, snapshot_data_version),
-            keys: Vec::new(),
+            keys: SmallVec::new(),
         };
         metadata.event.txn_start_ts = cmd.ts().into_inner();
 
@@ -153,6 +154,12 @@ impl TxnCommandEventMetadata {
                 metadata.event.verify_is_primary = c.verify_is_primary;
                 metadata.keys.push(command_key(&c.primary_key));
             }
+            Command::Cleanup(c) => {
+                metadata.event.current_ts = c.current_ts.into_inner();
+            }
+            Command::PessimisticRollback(c) => {
+                metadata.event.for_update_ts = c.for_update_ts.into_inner();
+            }
             Command::ResolveLock(c) => {
                 metadata.keys.extend(
                     c.key_locks
@@ -167,9 +174,9 @@ impl TxnCommandEventMetadata {
             }
             Command::ResolveLockLite(c) => {
                 metadata.event.commit_ts = c.commit_ts.into_inner();
-                // ResolveLockLite also learns the primary key only after
-                // reading the lock, so only its successfully applied
-                // primary-key modifies are recorded.
+                // ResolveLockLite learns the primary key only after reading
+                // the lock, so only its successfully applied primary-key
+                // modifies are recorded.
             }
             Command::Flush(c) => {
                 metadata.event.lock_ttl = c.lock_ttl;
@@ -190,8 +197,16 @@ impl TxnCommandEventMetadata {
         }
 
         metadata.keys.sort_unstable_by_key(|key| key.key_hash);
-        let identifies_primary_while_processing = matches!(cmd, Command::Commit(_))
-            || matches!(cmd, Command::ResolveLockLite(c) if !c.commit_ts.is_zero());
+        // These commands can identify the primary only after reading a
+        // matching lock.
+        let identifies_primary_while_processing = matches!(
+            cmd,
+            Command::Commit(_)
+                | Command::Cleanup(_)
+                | Command::Rollback(_)
+                | Command::PessimisticRollback(_)
+                | Command::ResolveLockLite(_)
+        );
         (!metadata.keys.is_empty() || identifies_primary_while_processing).then_some(metadata)
     }
 
@@ -641,6 +656,9 @@ mod tests {
     use txn_types::{Lock, Write};
 
     use super::*;
+    use crate::storage::txn::commands::{
+        Cleanup, Commit, PessimisticRollback, ResolveLockLite, Rollback,
+    };
 
     fn event_for_key(key: &Key, cid: u64) -> TxnCommandEvent {
         let mut event = TxnCommandEvent::new(CommandKind::prewrite, cid, &Context::default(), None);
@@ -669,6 +687,33 @@ mod tests {
     }
 
     #[test]
+    fn test_processing_identified_primary_uses_inline_key() {
+        let key = Key::from_raw(b"key");
+        let commands: [Command; 5] = [
+            Commit::new(vec![key.clone()], 10.into(), 20.into(), Context::default()).into(),
+            Cleanup::new(key.clone(), 10.into(), 20.into(), Context::default()).into(),
+            Rollback::new(vec![key.clone()], 10.into(), Context::default()).into(),
+            PessimisticRollback::new(
+                vec![key.clone()],
+                10.into(),
+                15.into(),
+                None,
+                Context::default(),
+            )
+            .into(),
+            ResolveLockLite::new(10.into(), 0.into(), vec![key], Context::default()).into(),
+        ];
+
+        for command in commands {
+            let mut metadata = TxnCommandEventMetadata::from_command(&command, 1, None).unwrap();
+            assert!(metadata.keys.is_empty());
+            metadata.set_primary_key_hash(1);
+            assert_eq!(metadata.keys.len(), 1);
+            assert!(!metadata.keys.spilled());
+        }
+    }
+
+    #[test]
     fn test_modify_events_are_normalized_to_user_key() {
         let key = Key::from_raw(b"key");
         let secondary_key = Key::from_raw(b"secondary-key");
@@ -681,11 +726,11 @@ mod tests {
         event.lock_ttl = 20_000;
         let mut metadata = TxnCommandEventMetadata {
             event,
-            keys: vec![CommandKey {
+            keys: SmallVec::from_buf([CommandKey {
                 key_hash,
                 pessimistic_action: Some(PrewriteRequestPessimisticAction::DoPessimisticCheck),
                 txn_start_ts: 10,
-            }],
+            }]),
         };
         let lock = Lock::new(
             LockType::Put,


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: ref #19891

Picks up the latest commit from #19869 (master) into `release-8.5-20260727-v8.5.6`:

- Use `SmallVec` for command keys to avoid allocation in the common single-key case.
- Record rollback-related commands (cleanup / rollback / pessimistic-rollback / resolve-lock-lite with `commit_ts == 0`) only when the lock confirms the key is the primary key, so a secondary-key panic dump is not polluted by irrelevant rollback history.

Cherry-picked from master (#19869):
- cc249959d txn: improve primary-key flight recording
- 72715f600 txn: avoid zero sentinel for primary key hash

Conflict resolution note: all conflicts were import blocks (master's new rustfmt ordering vs this branch's old ordering, plus this branch's existing `Result` / `TXN_FLIGHT_RECORDER` imports). Resolutions keep the branch's existing imports and add the new `cleanup_with_primary` / `hash_key` imports only. `make format` and `cargo check -p tikv --lib` pass locally.

```release-note
None
```