### PR TITLE
engine_rocks: temporarily disable `allow_write` during SST ingestion

### DIFF
--- a/components/engine_rocks/src/import.rs
+++ b/components/engine_rocks/src/import.rs
@@ -13,6 +13,9 @@ use crate::{
     r2e, util,
 };
 
+// Temporarily disabled due to https://github.com/tikv/tikv/issues/19891.
+const ENABLE_INGEST_ALLOW_WRITE: bool = false;
+
 impl ImportExt for RocksEngine {
     type IngestExternalFileOptions = RocksIngestExternalFileOptions;
 
@@ -23,18 +26,19 @@ impl ImportExt for RocksEngine {
         range: Option<Range<'_>>,
         force_allow_write: bool,
     ) -> Result<()> {
+        let allow_write = ENABLE_INGEST_ALLOW_WRITE && (range.is_some() || force_allow_write);
         // Acquire latch to prevent concurrency with compaction-filter operations
         // when using RocksDB IngestExternalFileOptions.allow_write = true.
-        let _region_inject_latch_guard = range.as_ref().map(|r| {
-            self.ingest_latch
-                .acquire(r.start_key.to_vec(), r.end_key.to_vec())
-        });
+        let _region_inject_latch_guard =
+            range.as_ref().filter(|_| allow_write).map(|r| {
+                self.ingest_latch
+                    .acquire(r.start_key.to_vec(), r.end_key.to_vec())
+            });
         fail_point!("after_apply_snapshot_ingest_latch_acquired");
 
         let cf = util::get_cf_handle(self.as_inner(), cf_name)?;
         let mut opts = RocksIngestExternalFileOptions::new();
         opts.move_files(true);
-        let allow_write = range.is_some() || force_allow_write;
         opts.allow_write(allow_write);
         if allow_write {
             INGEST_EXTERNAL_FILE_ALLOW_WRITE_COUNTER

--- a/components/engine_rocks/src/import.rs
+++ b/components/engine_rocks/src/import.rs
@@ -29,11 +29,10 @@ impl ImportExt for RocksEngine {
         let allow_write = ENABLE_INGEST_ALLOW_WRITE && (range.is_some() || force_allow_write);
         // Acquire latch to prevent concurrency with compaction-filter operations
         // when using RocksDB IngestExternalFileOptions.allow_write = true.
-        let _region_inject_latch_guard =
-            range.as_ref().filter(|_| allow_write).map(|r| {
-                self.ingest_latch
-                    .acquire(r.start_key.to_vec(), r.end_key.to_vec())
-            });
+        let _region_inject_latch_guard = range.as_ref().filter(|_| allow_write).map(|r| {
+            self.ingest_latch
+                .acquire(r.start_key.to_vec(), r.end_key.to_vec())
+        });
         fail_point!("after_apply_snapshot_ingest_latch_acquired");
 
         let cf = util::get_cf_handle(self.as_inner(), cf_name)?;

--- a/components/engine_rocks/src/import.rs
+++ b/components/engine_rocks/src/import.rs
@@ -29,10 +29,14 @@ impl ImportExt for RocksEngine {
         let allow_write = ENABLE_INGEST_ALLOW_WRITE && (range.is_some() || force_allow_write);
         // Acquire latch to prevent concurrency with compaction-filter operations
         // when using RocksDB IngestExternalFileOptions.allow_write = true.
-        let _region_inject_latch_guard = range.as_ref().filter(|_| allow_write).map(|r| {
-            self.ingest_latch
-                .acquire(r.start_key.to_vec(), r.end_key.to_vec())
-        });
+        let _region_inject_latch_guard = if allow_write {
+            range.as_ref().map(|r| {
+                self.ingest_latch
+                    .acquire(r.start_key.to_vec(), r.end_key.to_vec())
+            })
+        } else {
+            None
+        };
         fail_point!("after_apply_snapshot_ingest_latch_acquired");
 
         let cf = util::get_cf_handle(self.as_inner(), cf_name)?;

--- a/components/engine_rocks/src/import.rs
+++ b/components/engine_rocks/src/import.rs
@@ -26,22 +26,18 @@ impl ImportExt for RocksEngine {
         range: Option<Range<'_>>,
         force_allow_write: bool,
     ) -> Result<()> {
-        let allow_write = ENABLE_INGEST_ALLOW_WRITE && (range.is_some() || force_allow_write);
         // Acquire latch to prevent concurrency with compaction-filter operations
         // when using RocksDB IngestExternalFileOptions.allow_write = true.
-        let _region_inject_latch_guard = if allow_write {
-            range.as_ref().map(|r| {
-                self.ingest_latch
-                    .acquire(r.start_key.to_vec(), r.end_key.to_vec())
-            })
-        } else {
-            None
-        };
+        let _region_inject_latch_guard = range.as_ref().map(|r| {
+            self.ingest_latch
+                .acquire(r.start_key.to_vec(), r.end_key.to_vec())
+        });
         fail_point!("after_apply_snapshot_ingest_latch_acquired");
 
         let cf = util::get_cf_handle(self.as_inner(), cf_name)?;
         let mut opts = RocksIngestExternalFileOptions::new();
         opts.move_files(true);
+        let allow_write = ENABLE_INGEST_ALLOW_WRITE && (range.is_some() || force_allow_write);
         opts.allow_write(allow_write);
         if allow_write {
             INGEST_EXTERNAL_FILE_ALLOW_WRITE_COUNTER


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close https://github.com/tikv/tikv/issues/19891

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Temporarily disable RocksDB `allow_write` for external SST ingestion to prevent the global sequence number from moving backwards when ingestion races with foreground writes.

See https://github.com/tikv/tikv/issues/19891#issuecomment-5129839846 for more information.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [x] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Temporarily disable `allow_write during SST ingestion
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Permanently disabled write permission for external file ingestion to prevent unintended database modifications.
  * Updated ingestion gating so write-related behavior only activates when the ingestion range is present and write permission is allowed.
  * Improved latch handling so the system consistently acquires the required guard whenever an ingestion range is provided, regardless of the gated write setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->