### PR TITLE
sst_importer, engine_rocks: optionally bypass the page cache on DDL ingest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4502,7 +4502,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git#1c17b59dcb506302ed4684b3628c4a7165e0b86d"
+source = "git+https://github.com/sanketkedia/rust-rocksdb?branch=sst-direct-io-setters#f5efbde3998b4fe39f4bf70aa4072736a8278271"
 dependencies = [
  "bindgen 0.65.1",
  "bzip2-sys",
@@ -4521,7 +4521,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/tikv/rust-rocksdb.git#1c17b59dcb506302ed4684b3628c4a7165e0b86d"
+source = "git+https://github.com/sanketkedia/rust-rocksdb?branch=sst-direct-io-setters#f5efbde3998b4fe39f4bf70aa4072736a8278271"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -6719,7 +6719,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git#1c17b59dcb506302ed4684b3628c4a7165e0b86d"
+source = "git+https://github.com/sanketkedia/rust-rocksdb?branch=sst-direct-io-setters#f5efbde3998b4fe39f4bf70aa4072736a8278271"
 dependencies = [
  "libc 0.2.176",
  "librocksdb_sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -229,8 +229,10 @@ sysinfo = { git = "https://github.com/tikv/sysinfo", branch = "0.26-fix-cpu" }
 # kvproto = { git = "https://github.com/your_github_id/kvproto", branch = "your_branch" }
 #
 # After the PR to rust-rocksdb is merged, remember to comment this out and run `cargo update -p rocksdb`.
-# [patch.'https://github.com/tikv/rust-rocksdb']
-# rocksdb = { git = "https://github.com/your_github_id/rust-rocksdb", branch = "your_branch" }
+# TODO: remove once tikv/rust-rocksdb#856 (direct-IO setters for the SST writer and
+# reader) is merged; this PR cannot build without it.
+[patch.'https://github.com/tikv/rust-rocksdb']
+rocksdb = { git = "https://github.com/sanketkedia/rust-rocksdb", branch = "sst-direct-io-setters" }
 
 [workspace]
 # See https://github.com/rust-lang/rfcs/blob/master/text/2957-cargo-features2.md

--- a/components/engine_rocks/src/sst.rs
+++ b/components/engine_rocks/src/sst.rs
@@ -29,9 +29,23 @@ pub struct RocksSstReader {
 
 impl RocksSstReader {
     pub fn open_with_env(path: &str, env: Option<Arc<Env>>) -> Result<Self> {
+        Self::open_with_env_and_direct_reads(path, env, false)
+    }
+
+    fn open_with_env_and_direct_reads(
+        path: &str,
+        env: Option<Arc<Env>>,
+        use_direct_reads: bool,
+    ) -> Result<Self> {
         let mut cf_options = ColumnFamilyOptions::new();
         if let Some(env) = env {
             cf_options.set_env(env);
+        }
+        // Read with O_DIRECT so a one-shot full read of the SST does not populate
+        // the OS page cache. Pairs with the direct-I/O SST write on the ingest
+        // path: without this, the verification read-back undoes it.
+        if use_direct_reads {
+            cf_options.set_use_direct_reads(true);
         }
         let mut reader = SstFileReader::new(cf_options);
         reader.open(path).map_err(r2e)?;
@@ -57,6 +71,15 @@ impl SstReader for RocksSstReader {
     fn open(path: &str, mgr: Option<Arc<DataKeyManager>>) -> Result<Self> {
         let env = get_env(mgr, get_io_rate_limiter())?;
         Self::open_with_env(path, Some(env))
+    }
+
+    fn open_for_one_shot_read(
+        path: &str,
+        mgr: Option<Arc<DataKeyManager>>,
+        use_direct_io: bool,
+    ) -> Result<Self> {
+        let env = get_env(mgr, get_io_rate_limiter())?;
+        Self::open_with_env_and_direct_reads(path, Some(env), use_direct_io)
     }
 
     fn verify_checksum(&self) -> Result<()> {
@@ -209,6 +232,7 @@ pub struct RocksSstWriterBuilder {
     in_memory: bool,
     compression_type: Option<DBCompressionType>,
     compression_level: i32,
+    use_direct_writes: bool,
 }
 
 impl SstWriterBuilder<RocksEngine> for RocksSstWriterBuilder {
@@ -219,6 +243,7 @@ impl SstWriterBuilder<RocksEngine> for RocksSstWriterBuilder {
             db: None,
             compression_type: None,
             compression_level: 0,
+            use_direct_writes: false,
         }
     }
 
@@ -244,6 +269,11 @@ impl SstWriterBuilder<RocksEngine> for RocksSstWriterBuilder {
 
     fn set_compression_level(mut self, level: i32) -> Self {
         self.compression_level = level;
+        self
+    }
+
+    fn set_use_direct_writes(mut self, use_direct_writes: bool) -> Self {
+        self.use_direct_writes = use_direct_writes;
         self
     }
 
@@ -299,7 +329,11 @@ impl SstWriterBuilder<RocksEngine> for RocksSstWriterBuilder {
         // being used, we must set them empty or disabled.
         io_options.compression_per_level(&[]);
         io_options.bottommost_compression(DBCompressionType::Disable);
-        let mut writer = SstFileWriter::new(EnvOptions::new(), io_options);
+        let mut env_options = EnvOptions::new();
+        // Write with O_DIRECT so the SST write stream does not evict the hot read
+        // working set from the OS page cache. Write path only.
+        env_options.set_use_direct_writes(self.use_direct_writes);
+        let mut writer = SstFileWriter::new(env_options, io_options);
         fail_point!("on_open_sst_writer");
         writer.open(path).map_err(r2e)?;
         Ok(RocksSstWriter { writer, env })
@@ -505,6 +539,42 @@ mod tests {
         let in_memory_reader = RocksSstReader::open_in_memory("downloaded.sst", &buf).unwrap();
         in_memory_reader.verify_checksum().unwrap();
         let mut iter = in_memory_reader.iter(IterOptions::default()).unwrap();
+        assert!(iter.seek_to_first().unwrap());
+        assert_eq!(iter.key(), k);
+        assert_eq!(iter.value(), v);
+        assert!(!iter.next().unwrap());
+    }
+
+    #[test]
+    fn test_direct_io_sst_round_trip() {
+        let path = Builder::new()
+            .prefix("test_direct_io_sst_round_trip")
+            .tempdir()
+            .unwrap();
+        let engine = new_default_engine(path.path().to_str().unwrap()).unwrap();
+        let (k, v) = (b"foo", b"bar");
+
+        let p = path.path().join("direct.sst");
+        let mut writer = RocksSstWriterBuilder::new()
+            .set_cf(CF_DEFAULT)
+            .set_db(&engine)
+            .set_use_direct_writes(true)
+            .build(p.to_str().unwrap())
+            .unwrap();
+        writer.put(k, v).unwrap();
+        let sst_file = writer.finish().unwrap();
+        assert_eq!(sst_file.num_entries(), 1);
+
+        // Verifying with direct I/O must succeed, ...
+        let reader =
+            RocksSstReader::open_for_one_shot_read(p.to_str().unwrap(), None, true).unwrap();
+        reader.verify_checksum().unwrap();
+
+        // ... and the file must still be an ordinary, buffered-readable SST: the
+        // alignment padding direct I/O requires must not leak into the format.
+        let reader = RocksSstReader::open(p.to_str().unwrap(), None).unwrap();
+        reader.verify_checksum().unwrap();
+        let mut iter = reader.iter(IterOptions::default()).unwrap();
         assert!(iter.seek_to_first().unwrap());
         assert_eq!(iter.key(), k);
         assert_eq!(iter.value(), v);

--- a/components/engine_traits/src/sst.rs
+++ b/components/engine_traits/src/sst.rs
@@ -23,6 +23,18 @@ pub trait SstExt: Sized {
 /// SstReader is used to read an SST file.
 pub trait SstReader: RefIterable + Sized + Send {
     fn open(path: &str, mgr: Option<Arc<DataKeyManager>>) -> Result<Self>;
+    /// Open the SST for a one-shot read, such as ingest checksum verification.
+    ///
+    /// With `use_direct_io` set, the read bypasses the OS page cache, so
+    /// reading a large SST once does not evict the working set of concurrent
+    /// readers. Engines without direct-I/O support fall back to `open`.
+    fn open_for_one_shot_read(
+        path: &str,
+        mgr: Option<Arc<DataKeyManager>>,
+        _use_direct_io: bool,
+    ) -> Result<Self> {
+        Self::open(path, mgr)
+    }
     fn verify_checksum(&self) -> Result<()>;
     fn kv_count_and_size(&self) -> (u64, u64);
 }
@@ -101,6 +113,18 @@ where
 
     #[must_use]
     fn set_compression_level(self, level: i32) -> Self;
+
+    /// If set, the SST is written with direct I/O so the write stream does not
+    /// populate the OS page cache. Only affects the write path; reads of the
+    /// resulting SST are buffered as usual unless the reader opts out too.
+    /// Engines without direct-I/O support ignore this.
+    #[must_use]
+    fn set_use_direct_writes(self, _use_direct_writes: bool) -> Self
+    where
+        Self: Sized,
+    {
+        self
+    }
 
     /// Builder a SstWriter.
     fn build(self, path: &str) -> Result<E::SstWriter>;

--- a/components/sst_importer/src/config.rs
+++ b/components/sst_importer/src/config.rs
@@ -22,6 +22,21 @@ pub struct Config {
     pub import_mode_timeout: ReadableDuration,
     /// the ratio of system memory used for import.
     pub memory_use_ratio: f64,
+    /// Write ingested SSTs with direct I/O, and verify their checksums with
+    /// direct I/O too, so the ingest does not populate the OS page cache and
+    /// evict the working set that concurrent foreground reads depend on.
+    ///
+    /// Only applies to DDL-sourced ingest (an `ImportSST.Write` whose
+    /// `request_source` task name is `ddl`); all other ingest, and the
+    /// download/restore path, stay buffered.
+    ///
+    /// Requires a data directory on a filesystem that supports direct I/O
+    /// (`O_DIRECT` on Linux). Enabling it elsewhere will fail SST writes, so it
+    /// is off by default.
+    ///
+    /// Read at `SstImporter` construction, so changing it needs a restart.
+    #[online_config(skip)]
+    pub use_direct_io_for_ingest: bool,
 }
 
 impl Default for Config {
@@ -31,6 +46,7 @@ impl Default for Config {
             stream_channel_window: 128,
             import_mode_timeout: ReadableDuration::minutes(10),
             memory_use_ratio: 0.3,
+            use_direct_io_for_ingest: false,
         }
     }
 }

--- a/components/sst_importer/src/import_file.rs
+++ b/components/sst_importer/src/import_file.rs
@@ -430,11 +430,16 @@ impl<E: KvEngine> ImportDir<E> {
         &self,
         metas: &[SstMeta],
         key_manager: Option<Arc<DataKeyManager>>,
+        use_direct_io: bool,
     ) -> Result<()> {
         for meta in metas {
             let path = self.join_for_read(meta)?;
             let path_str = path.save.to_str().unwrap();
-            let sst_reader = E::SstReader::open(path_str, key_manager.clone())?;
+            // This reads the just-written SST in full. When the write used direct
+            // I/O, the read must too, or it repopulates the OS page cache with the
+            // data the write deliberately kept out of it.
+            let sst_reader =
+                E::SstReader::open_for_one_shot_read(path_str, key_manager.clone(), use_direct_io)?;
             sst_reader.verify_checksum()?;
         }
         Ok(())

--- a/components/sst_importer/src/sst_importer.rs
+++ b/components/sst_importer/src/sst_importer.rs
@@ -465,8 +465,9 @@ impl<E: KvEngine> SstImporter<E> {
         }
     }
 
-    pub fn verify_checksum(&self, metas: &[SstMeta]) -> Result<()> {
-        self.dir.verify_checksum(metas, self.key_manager.clone())
+    pub fn verify_checksum(&self, metas: &[SstMeta], use_direct_io: bool) -> Result<()> {
+        self.dir
+            .verify_checksum(metas, self.key_manager.clone(), use_direct_io)
     }
 
     pub fn exist(&self, meta: &SstMeta) -> bool {
@@ -2256,6 +2257,7 @@ impl<E: KvEngine> SstImporter<E> {
         db: &E,
         meta: SstMeta,
         txn_source: u64,
+        use_direct_io: bool,
     ) -> Result<TxnSstWriter<E>> {
         let mut default_meta = meta.clone();
         default_meta.set_cf_name(CF_DEFAULT.to_owned());
@@ -2264,6 +2266,7 @@ impl<E: KvEngine> SstImporter<E> {
             .set_db(db)
             .set_cf(CF_DEFAULT)
             .set_compression_type(self.compression_types.get(CF_DEFAULT).copied())
+            .set_use_direct_writes(use_direct_io)
             .build(default_path.temp.to_str().unwrap())
             .unwrap();
 
@@ -2274,6 +2277,7 @@ impl<E: KvEngine> SstImporter<E> {
             .set_db(db)
             .set_cf(CF_WRITE)
             .set_compression_type(self.compression_types.get(CF_WRITE).copied())
+            .set_use_direct_writes(use_direct_io)
             .build(write_path.temp.to_str().unwrap())
             .unwrap();
 
@@ -2290,7 +2294,13 @@ impl<E: KvEngine> SstImporter<E> {
         ))
     }
 
-    pub fn new_raw_writer(&self, db: &E, mut meta: SstMeta, _: u64) -> Result<RawSstWriter<E>> {
+    pub fn new_raw_writer(
+        &self,
+        db: &E,
+        mut meta: SstMeta,
+        _: u64,
+        _: bool,
+    ) -> Result<RawSstWriter<E>> {
         meta.set_cf_name(CF_DEFAULT.to_owned());
         let default_path = self.dir.join_for_write(&meta)?;
         let default = E::SstWriterBuilder::new()
@@ -5423,7 +5433,7 @@ mod tests {
         let db_path = importer_dir.path().join("db");
         let db = new_test_engine(db_path.to_str().unwrap(), DATA_CFS);
 
-        let mut w = importer.new_txn_writer(&db, meta, 0).unwrap();
+        let mut w = importer.new_txn_writer(&db, meta, 0, false).unwrap();
         let mut batch = WriteBatch::default();
         let mut pairs = vec![];
 

--- a/components/sst_importer/src/sst_writer.rs
+++ b/components/sst_importer/src/sst_writer.rs
@@ -312,7 +312,10 @@ mod tests {
     use crate::{Config, SstImporter};
 
     // Return the temp dir path to avoid it drop out of the scope.
-    fn new_writer<W, F: Fn(&SstImporter<RocksEngine>, &RocksEngine, SstMeta, u64) -> Result<W>>(
+    fn new_writer<
+        W,
+        F: Fn(&SstImporter<RocksEngine>, &RocksEngine, SstMeta, u64, bool) -> Result<W>,
+    >(
         f: F,
         api_version: ApiVersion,
     ) -> (W, TempDir) {
@@ -325,7 +328,7 @@ mod tests {
             SstImporter::<RocksEngine>::new(&cfg, &importer_dir, None, api_version, false).unwrap();
         let db_path = importer_dir.path().join("db");
         let db = new_test_engine(db_path.to_str().unwrap(), DATA_CFS);
-        (f(&importer, &db, meta, 0).unwrap(), importer_dir)
+        (f(&importer, &db, meta, 0, false).unwrap(), importer_dir)
     }
 
     #[test]
@@ -341,7 +344,7 @@ mod tests {
         let mut meta = SstMeta::default();
         meta.set_uuid(Uuid::new_v4().as_bytes().to_vec());
 
-        let writer = SstImporter::new_txn_writer(&importer, &db, meta, 1 << 16);
+        let writer = SstImporter::new_txn_writer(&importer, &db, meta, 1 << 16, false);
         assert_eq!(writer.unwrap().txn_source, 1 << 16);
     }
 

--- a/src/import/sst_service.rs
+++ b/src/import/sst_service.rs
@@ -626,13 +626,14 @@ macro_rules! impl_write {
             let timer = Instant::now_coarse();
             let label = stringify!($fn);
             let resource_manager = self.resource_manager.clone();
+            let direct_io_enabled = self.cfg.rl().use_direct_io_for_ingest;
             let handle_task = async move {
                 let (res, rx) = async move {
                     let first_req = match rx.try_next().await {
                         Ok(r) => r,
                         Err(e) => return (Err(e), Some(rx)),
                     };
-                    let (meta, resource_limiter, txn_source) = match first_req {
+                    let (meta, resource_limiter, txn_source, use_direct_io) = match first_req {
                         Some(r) => {
                             let limiter = resource_manager.as_ref().and_then(|m| {
                                 m.get_background_resource_limiter(
@@ -643,8 +644,20 @@ macro_rules! impl_write {
                                 )
                             });
                             let txn_source = r.get_context().get_txn_source();
+                            // Only DDL-sourced ingest bypasses the page cache. The task
+                            // name is the trailing `_`-separated component of
+                            // request_source, which is
+                            // `{external|internal}_{tidb_req_source}_{source_task_name}`
+                            // -- the same convention resource control uses to recognise
+                            // background jobs.
+                            let use_direct_io = direct_io_enabled
+                                && r.get_context()
+                                    .get_request_source()
+                                    .rsplit('_')
+                                    .next()
+                                    .is_some_and(|task_name| task_name == "ddl");
                             match r.chunk {
-                                Some($chunk_ty::Meta(m)) => (m, limiter, txn_source),
+                                Some($chunk_ty::Meta(m)) => (m, limiter, txn_source, use_direct_io),
                                 _ => return (Err(Error::InvalidChunk), Some(rx)),
                             }
                         }
@@ -695,7 +708,8 @@ macro_rules! impl_write {
                         return (Err(e), Some(rx));
                     }
 
-                    let writer = match import.$writer_fn(&*tablet, meta, txn_source) {
+                    let writer = match import.$writer_fn(&*tablet, meta, txn_source, use_direct_io)
+                    {
                         Ok(w) => w,
                         Err(e) => {
                             error!("build writer failed {:?}", e);
@@ -727,7 +741,7 @@ macro_rules! impl_write {
 
                     let finish_fn = async {
                         let metas = writer.finish()?;
-                        import.verify_checksum(&metas)?;
+                        import.verify_checksum(&metas, use_direct_io)?;
                         Ok(metas)
                     };
 

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -855,6 +855,7 @@ fn test_serde_custom_tikv_config() {
         stream_channel_window: 123,
         import_mode_timeout: ReadableDuration::secs(1453),
         memory_use_ratio: 0.3,
+        use_direct_io_for_ingest: true,
     };
     value.panic_when_unexpected_key_or_data = true;
     value.gc = GcConfig {

--- a/tests/integrations/config/test-custom.toml
+++ b/tests/integrations/config/test-custom.toml
@@ -639,6 +639,7 @@ linux-user = "hadoop"
 num-threads = 123
 stream-channel-window = 123
 import-mode-timeout = "1453s"
+use-direct-io-for-ingest = true
 
 [gc]
 ratio-threshold = 1.2


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: ref #19917

> [!IMPORTANT]
> **Draft: blocked on tikv/rust-rocksdb#856.** This needs two direct-IO setters that
> `rust-rocksdb` does not expose yet, so `Cargo.toml` currently carries a `[patch]` pointing at
> the branch behind that PR. Once #856 merges I will drop the `[patch]` and replace it with a
> plain `cargo update -p rocksdb`, then mark this ready for review. 

What's Changed:

sst_importer, engine_rocks: optionally bypass the page cache on DDL ingest

An ImportSST.Write writes each SST buffered and then reads it back in full,
also buffered, to verify checksums. For a large ADD INDEX with DXF + global
sort, that streams the whole index through the OS page cache twice and evicts
the working set that concurrent foreground reads depend on: reads that were
page-cache hits (~50us) become device reads (~400us), and foreground p99
degrades ~2x while throughput falls to 0.72x of baseline.

Add import.use-direct-io-for-ingest. When set, DDL-sourced ingest writes its
SSTs with direct I/O and verifies them with direct I/O too, so ingested data
never enters the page cache. Off by default.

Scoped to DDL-sourced writes because that is the only workload measured. 

### Related changes

- Depends on tikv/rust-rocksdb#856 (must merge first).
- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`: needed for the new config item before
      this merges.
- [ ] Need to cherry-pick to the release branch: no — new opt-in config, master only.

### Check List

Tests

- [x] Unit test
  - `engine_rocks`: `test_direct_io_sst_round_trip` — writes an SST with direct writes, reads
    it back with direct reads, then reads it again *buffered* to confirm the alignment padding
    direct I/O requires does not leak into the SST format.
  - `sst_importer`: existing writer tests updated for the new parameter.
- [x] Integration test — `import.use-direct-io-for-ingest` added to the config round-trip test.
- [x] Manual test — measured on a 3-store cluster (16 vCPU / 128 GiB, gp3 8000 IOPS /
      800 MiB/s, 44 GiB block cache) building a ~390 GiB index on a 2B-row table under a
      concurrent sysbench `oltp_read_only` workload. Foreground p99 went flat and matched
      baseline; throughput recovered from 0.72x to 0.92x of baseline. Full analysis in #19917.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

No behaviour change unless the new config is enabled.

### Release note

Add `import.use-direct-io-for-ingest` (default off). When enabled, SSTs ingested by DDL
backfill are written and checksum-verified with direct I/O, so a large `ADD INDEX` no longer
evicts the working set of concurrent foreground reads from the OS page cache. Requires a data
directory on a filesystem that supports direct I/O.
