### PR TITLE
copr: support short-circuit evaluation for logical AND and OR expressions

### DIFF
--- a/components/tidb_query_datatype/src/codec/data_type/chunked_vec_sized.rs
+++ b/components/tidb_query_datatype/src/codec/data_type/chunked_vec_sized.rs
@@ -33,6 +33,29 @@ impl<T: Sized + Clone> ChunkedVecSized<T> {
     }
 }
 
+impl<T: Sized + Default> ChunkedVecSized<T> {
+    /// Replaces the value at `idx` while keeping the data and validity bitmap
+    /// layouts in sync.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `idx` is out of bounds.
+    #[inline]
+    pub fn set(&mut self, idx: usize, value: Option<T>) {
+        assert!(idx < self.data.len());
+        match value {
+            Some(value) => {
+                self.data[idx] = value;
+                self.bitmap.replace(idx, true);
+            }
+            None => {
+                self.data[idx] = T::default();
+                self.bitmap.replace(idx, false);
+            }
+        }
+    }
+}
+
 impl<T: Clone> ChunkedVec<T> for ChunkedVecSized<T> {
     impl_chunked_vec_common! { T }
 
@@ -204,6 +227,21 @@ mod tests {
         assert_eq!(x.get(3), None);
         assert_eq!(x.len(), 4);
         assert!(!x.is_empty());
+    }
+
+    #[test]
+    fn test_set() {
+        let mut x = ChunkedVecSized::<Int>::from_slice(&[Some(1), None, Some(3)]);
+
+        x.set(0, None);
+        x.set(1, Some(2));
+        x.set(2, Some(4));
+
+        assert_eq!(x.to_vec(), vec![None, Some(2), Some(4)]);
+        assert_eq!(
+            x,
+            ChunkedVecSized::<Int>::from_slice(&[None, Some(2), Some(4)])
+        );
     }
 
     #[test]

--- a/components/tidb_query_datatype/src/expr/ctx.rs
+++ b/components/tidb_query_datatype/src/expr/ctx.rs
@@ -50,7 +50,8 @@ bitflags! {
         /// `IN_LOAD_DATA_STMT` indicates if this is a LOAD DATA statement.
         const IN_LOAD_DATA_STMT = 1 << 10;
 
-        /// `ENABLE_SHORT_CIRCUIT_EXPRESSION` indicates whether the expression requires short-circuit calculation. 
+        /// `ENABLE_SHORT_CIRCUIT_EXPRESSION` enables short-circuit evaluation for logical
+        /// expressions that benefit from lazy argument evaluation.
         const ENABLE_SHORT_CIRCUIT_EXPRESSION = 1 << 12;
     }
 }
@@ -347,6 +348,17 @@ mod tests {
     use std::sync::Arc;
 
     use super::{super::Error, *};
+
+    #[test]
+    fn test_short_circuit_flag_from_dag_request() {
+        assert_eq!(Flag::ENABLE_SHORT_CIRCUIT_EXPRESSION.bits(), 1 << 12);
+
+        let mut req = DagRequest::default();
+        req.set_flags(Flag::ENABLE_SHORT_CIRCUIT_EXPRESSION.bits());
+
+        let cfg = EvalConfig::from_request(&req).unwrap();
+        assert!(cfg.flag.contains(Flag::ENABLE_SHORT_CIRCUIT_EXPRESSION));
+    }
 
     #[test]
     fn test_handle_truncate() {

--- a/components/tidb_query_datatype/src/expr/ctx.rs
+++ b/components/tidb_query_datatype/src/expr/ctx.rs
@@ -49,6 +49,9 @@ bitflags! {
         const DIVIDED_BY_ZERO_AS_WARNING = 1 << 8;
         /// `IN_LOAD_DATA_STMT` indicates if this is a LOAD DATA statement.
         const IN_LOAD_DATA_STMT = 1 << 10;
+
+        /// `ENABLE_SHORT_CIRCUIT_EXPRESSION` indicates whether the expression requires short-circuit calculation. 
+        const ENABLE_SHORT_CIRCUIT_EXPRESSION = 1 << 12;
     }
 }
 

--- a/components/tidb_query_executors/src/selection_executor.rs
+++ b/components/tidb_query_executors/src/selection_executor.rs
@@ -9,7 +9,7 @@ use tidb_query_datatype::{
     expr::{EvalConfig, EvalContext},
     match_template_evaltype,
 };
-use tidb_query_expr::{RpnExpression, RpnExpressionBuilder, RpnExpressionNode, RpnStackNode};
+use tidb_query_expr::{RpnExpression, RpnExpressionBuilder, RpnStackNode};
 use tipb::{Expr, FieldType, Selection};
 
 use crate::interface::*;
@@ -92,7 +92,7 @@ impl<Src: BatchExecutor> BatchSelectionExecutor<Src> {
             // Approximate work as rows * (number_of_rpn_nodes + number_of_column_refs),
             // once per evaluated condition.
             let rows_u64 = src_logical_rows_copy.len() as u64;
-            let rpn_nodes_u64 = self.conditions[condition_index].len() as u64;
+            let rpn_nodes_u64 = self.conditions[condition_index].node_count() as u64;
             let col_refs_u64 = self.condition_column_ref_counts[condition_index] as u64;
             let weighted_nodes_u64 = rpn_nodes_u64.saturating_add(col_refs_u64);
             tidb_query_common::metrics::record_executor_work(
@@ -139,11 +139,7 @@ impl<Src: BatchExecutor> BatchSelectionExecutor<Src> {
 }
 
 fn count_column_refs(expr: &RpnExpression) -> u32 {
-    expr.iter()
-        .filter(|node| matches!(node, RpnExpressionNode::ColumnRef { .. }))
-        .count()
-        .try_into()
-        .unwrap_or(u32::MAX)
+    expr.column_ref_count().try_into().unwrap_or(u32::MAX)
 }
 
 fn update_logical_rows_by_scalar_value(

--- a/components/tidb_query_expr/src/impl_op.rs
+++ b/components/tidb_query_expr/src/impl_op.rs
@@ -2,7 +2,13 @@
 
 use tidb_query_codegen::rpn_fn;
 use tidb_query_common::Result;
-use tidb_query_datatype::codec::{Error, data_type::*};
+use tidb_query_datatype::{
+    codec::{Error, batch::LazyBatchColumnVec, data_type::*},
+    expr::EvalContext,
+};
+use tipb::FieldType;
+
+use crate::{RpnExpression, RpnStackNode, RpnStackNodeVectorValue};
 
 #[rpn_fn(nullable)]
 #[inline]
@@ -24,6 +30,246 @@ pub fn logical_or(arg0: Option<&i64>, arg1: Option<&i64>) -> Result<Option<i64>>
         (None, None) | (None, Some(0)) | (Some(0), None) => None,
         _ => Some(1),
     })
+}
+
+/// Evaluates logical AND from left to right and only evaluates each argument
+/// for rows whose result has not been determined by previous arguments.
+pub fn sc_logical_and(
+    ctx: &mut EvalContext,
+    schema: &[FieldType],
+    input_physical_columns: &LazyBatchColumnVec,
+    input_logical_rows: &[usize],
+    output_rows: usize,
+    args: &[RpnExpression],
+) -> Result<VectorValue> {
+    eval_logical_short_circuit::<ScLogicalAnd>(
+        ctx,
+        schema,
+        input_physical_columns,
+        input_logical_rows,
+        output_rows,
+        args,
+    )
+}
+
+/// Evaluates logical OR from left to right and only evaluates each argument for
+/// rows whose result has not been determined by previous arguments.
+pub fn sc_logical_or(
+    ctx: &mut EvalContext,
+    schema: &[FieldType],
+    input_physical_columns: &LazyBatchColumnVec,
+    input_logical_rows: &[usize],
+    output_rows: usize,
+    args: &[RpnExpression],
+) -> Result<VectorValue> {
+    eval_logical_short_circuit::<ScLogicalOr>(
+        ctx,
+        schema,
+        input_physical_columns,
+        input_logical_rows,
+        output_rows,
+        args,
+    )
+}
+
+trait ScLogicalOp {
+    const IDENTITY: Int;
+
+    fn normalize_value(value: Option<Int>) -> Option<Int> {
+        value.map(|v| if v != 0 { 1 } else { 0 })
+    }
+
+    fn handle_res_value(
+        result: &mut ChunkedVecSized<Int>,
+        idx: usize,
+        value: Option<Int>,
+        resolved_count: &mut usize,
+    ) {
+        match Self::normalize_value(value) {
+            Some(value) if value != Self::IDENTITY => {
+                // An absorbing value determines the final result even if a
+                // previous argument was NULL.
+                result.set(idx, Some(value));
+                (*resolved_count) += 1;
+            }
+            // An identity value does not change the accumulated result. In
+            // particular, it must not overwrite a previous NULL.
+            Some(_) => {}
+            None => result.set(idx, None),
+        }
+    }
+}
+
+struct ScLogicalAnd;
+
+impl ScLogicalOp for ScLogicalAnd {
+    const IDENTITY: Int = 1;
+}
+
+struct ScLogicalOr;
+
+impl ScLogicalOp for ScLogicalOr {
+    const IDENTITY: Int = 0;
+}
+
+fn eval_logical_short_circuit<Op: ScLogicalOp>(
+    ctx: &mut EvalContext,
+    schema: &[FieldType],
+    input_physical_columns: &LazyBatchColumnVec,
+    input_logical_rows: &[usize],
+    output_rows: usize,
+    args: &[RpnExpression],
+) -> Result<VectorValue> {
+    assert!(args.len() >= 2);
+    assert!(input_logical_rows.is_empty() || input_logical_rows.len() == output_rows);
+
+    let mut result = ChunkedVecSized::<Int>::with_capacity(output_rows);
+    for _ in 0..output_rows {
+        result.push(Some(Op::IDENTITY));
+    }
+
+    if output_rows == 0 {
+        return Ok(VectorValue::Int(result));
+    }
+
+    // `None` means all output rows are still pending. Keep this state implicit
+    // until an argument resolves only part of the rows, so the common no-short-
+    // circuit path does not allocate or copy row mappings.
+    let mut pending_rows: Option<(Vec<usize>, Vec<usize>)> = None;
+
+    for (arg_index, arg) in args.iter().enumerate() {
+        let (pending_positions, pending_logical_rows, pending_len) = match pending_rows.as_ref() {
+            Some((positions, logical_rows)) => (
+                Some(positions.as_slice()),
+                logical_rows.as_slice(),
+                positions.len(),
+            ),
+            None => (None, input_logical_rows, output_rows),
+        };
+
+        let arg_result = arg.eval_decoded(
+            ctx,
+            schema,
+            input_physical_columns,
+            pending_logical_rows,
+            pending_len,
+        )?;
+
+        let mut resolved_count = 0;
+        match arg_result {
+            RpnStackNode::Scalar { value, .. } => {
+                let value = value.as_int().copied();
+                for i in 0..pending_len {
+                    let output_index = pending_positions.map_or(i, |positions| positions[i]);
+                    Op::handle_res_value(&mut result, output_index, value, &mut resolved_count);
+                }
+            }
+            RpnStackNode::Vector {
+                value: RpnStackNodeVectorValue::Generated { physical_value },
+                ..
+            } => {
+                let ints = Int::borrow_vector_value(&physical_value);
+                for i in 0..pending_len {
+                    let output_index = pending_positions.map_or(i, |positions| positions[i]);
+                    Op::handle_res_value(
+                        &mut result,
+                        output_index,
+                        ints.get_option_ref(i).copied(),
+                        &mut resolved_count,
+                    );
+                }
+            }
+            RpnStackNode::Vector {
+                value:
+                    RpnStackNodeVectorValue::Ref {
+                        physical_value,
+                        logical_rows,
+                    },
+                ..
+            } => {
+                let ints = Int::borrow_vector_value(physical_value);
+                for i in 0..pending_len {
+                    let output_index = pending_positions.map_or(i, |positions| positions[i]);
+                    Op::handle_res_value(
+                        &mut result,
+                        output_index,
+                        ints.get_option_ref(logical_rows[i]).copied(),
+                        &mut resolved_count,
+                    );
+                }
+            }
+        }
+
+        if resolved_count == 0 {
+            continue;
+        }
+        if resolved_count == pending_len || arg_index + 1 == args.len() {
+            return Ok(VectorValue::Int(result));
+        }
+
+        match &mut pending_rows {
+            Some((positions, logical_rows)) => {
+                let old_pending_len = positions.len();
+                let has_logical_rows = !logical_rows.is_empty();
+                let (mut read_index, mut write_index) = (0, 0);
+                positions.retain(|&output_index| {
+                    let keep = !matches!(
+                        (&result).get_option_ref(output_index),
+                        Some(value) if *value != Op::IDENTITY
+                    );
+                    if keep && has_logical_rows {
+                        logical_rows[write_index] = logical_rows[read_index];
+                        write_index += 1;
+                    }
+
+                    read_index += 1;
+                    keep
+                });
+
+                debug_assert_eq!(read_index, old_pending_len);
+                if has_logical_rows {
+                    logical_rows.truncate(write_index);
+                }
+            }
+            None => {
+                let new_pending_len = pending_len - resolved_count;
+                let mut positions = Vec::with_capacity(new_pending_len);
+                let mut logical_rows = if input_logical_rows.is_empty() {
+                    Vec::new()
+                } else {
+                    Vec::with_capacity(new_pending_len)
+                };
+
+                for output_index in 0..output_rows {
+                    let keep = !matches!(
+                        (&result).get_option_ref(output_index),
+                        Some(value) if *value != Op::IDENTITY
+                    );
+                    if keep {
+                        positions.push(output_index);
+                        if !input_logical_rows.is_empty() {
+                            logical_rows.push(input_logical_rows[output_index]);
+                        }
+                    }
+                }
+
+                debug_assert_eq!(positions.len(), new_pending_len);
+                pending_rows = Some((positions, logical_rows));
+            }
+        }
+
+        let (pending_positions, pending_logical_rows) = pending_rows.as_ref().unwrap();
+        debug_assert_eq!(
+            pending_logical_rows.len(),
+            if input_logical_rows.is_empty() {
+                0
+            } else {
+                pending_positions.len()
+            }
+        );
+    }
+
+    Ok(VectorValue::Int(result))
 }
 
 #[rpn_fn(nullable)]

--- a/components/tidb_query_expr/src/impl_op.rs
+++ b/components/tidb_query_expr/src/impl_op.rs
@@ -75,10 +75,20 @@ pub fn sc_logical_or(
 trait ScLogicalOp {
     const IDENTITY: Int;
 
+    #[inline]
     fn normalize_value(value: Option<Int>) -> Option<Int> {
         value.map(|v| if v != 0 { 1 } else { 0 })
     }
 
+    #[inline]
+    fn is_short_circuit(value: Option<Int>) -> bool {
+        matches!(
+            value,
+            Some(value) if value != Self::IDENTITY
+        )
+    }
+
+    #[inline]
     fn handle_res_value(
         result: &mut ChunkedVecSized<Int>,
         idx: usize,
@@ -122,15 +132,10 @@ fn eval_logical_short_circuit<Op: ScLogicalOp>(
 ) -> Result<VectorValue> {
     assert!(args.len() >= 2);
     assert!(input_logical_rows.is_empty() || input_logical_rows.len() == output_rows);
-
-    let mut result = ChunkedVecSized::<Int>::with_capacity(output_rows);
-    for _ in 0..output_rows {
-        result.push(Some(Op::IDENTITY));
-    }
-
     if output_rows == 0 {
-        return Ok(VectorValue::Int(result));
+        return Ok(VectorValue::from_scalar(&ScalarValue::Int(Some(0)), 0));
     }
+    let mut result = ChunkedVecSized::<Int>::with_capacity(0);
 
     // `None` means all output rows are still pending. Keep this state implicit
     // until an argument resolves only part of the rows, so the common no-short-
@@ -156,27 +161,60 @@ fn eval_logical_short_circuit<Op: ScLogicalOp>(
         )?;
 
         let mut resolved_count = 0;
+        let is_first = result.is_empty();
         match arg_result {
             RpnStackNode::Scalar { value, .. } => {
-                let value = value.as_int().copied();
-                for i in 0..pending_len {
-                    let output_index = pending_positions.map_or(i, |positions| positions[i]);
-                    Op::handle_res_value(&mut result, output_index, value, &mut resolved_count);
+                let value = Op::normalize_value(value.as_int().copied());
+                resolved_count = if Op::is_short_circuit(value) {
+                    pending_len
+                } else {
+                    0
+                };
+                if is_first {
+                    result = ChunkedVecSized::with_capacity(output_rows);
+                    for _ in 0..pending_len {
+                        result.push(value);
+                    }
+                } else if resolved_count == pending_len || value.is_none() {
+                    for i in 0..pending_len {
+                        let output_index = pending_positions.map_or(i, |positions| positions[i]);
+                        result.set(output_index, value);
+                    }
                 }
             }
             RpnStackNode::Vector {
-                value: RpnStackNodeVectorValue::Generated { physical_value },
+                value:
+                    RpnStackNodeVectorValue::Generated {
+                        physical_value: VectorValue::Int(vec_result),
+                    },
                 ..
             } => {
-                let ints = Int::borrow_vector_value(&physical_value);
-                for i in 0..pending_len {
-                    let output_index = pending_positions.map_or(i, |positions| positions[i]);
-                    Op::handle_res_value(
-                        &mut result,
-                        output_index,
-                        ints.get_option_ref(i).copied(),
-                        &mut resolved_count,
-                    );
+                if is_first {
+                    result = vec_result;
+
+                    for i in 0..pending_len {
+                        let value = result.get_option_ref(i).copied();
+                        let normalized = Op::normalize_value(value);
+
+                        if normalized != value {
+                            result.set(i, normalized);
+                        }
+
+                        if Op::is_short_circuit(normalized) {
+                            resolved_count += 1;
+                        }
+                    }
+                } else {
+                    for i in 0..pending_len {
+                        let output_index = pending_positions.map_or(i, |positions| positions[i]);
+
+                        Op::handle_res_value(
+                            &mut result,
+                            output_index,
+                            vec_result.get_option_ref(i).copied(),
+                            &mut resolved_count,
+                        );
+                    }
                 }
             }
             RpnStackNode::Vector {
@@ -187,17 +225,31 @@ fn eval_logical_short_circuit<Op: ScLogicalOp>(
                     },
                 ..
             } => {
-                let ints = Int::borrow_vector_value(physical_value);
-                for i in 0..pending_len {
-                    let output_index = pending_positions.map_or(i, |positions| positions[i]);
-                    Op::handle_res_value(
-                        &mut result,
-                        output_index,
-                        ints.get_option_ref(logical_rows[i]).copied(),
-                        &mut resolved_count,
-                    );
+                let vec_result = Int::borrow_vector_value(physical_value);
+                if is_first {
+                    result = ChunkedVecSized::<Int>::with_capacity(output_rows);
+                    for i in 0..pending_len {
+                        let value = Op::normalize_value(
+                            vec_result.get_option_ref(logical_rows[i]).copied(),
+                        );
+                        if Op::is_short_circuit(value) {
+                            resolved_count += 1;
+                        }
+                        result.push(value);
+                    }
+                } else {
+                    for i in 0..pending_len {
+                        let output_index = pending_positions.map_or(i, |positions| positions[i]);
+                        Op::handle_res_value(
+                            &mut result,
+                            output_index,
+                            vec_result.get_option_ref(logical_rows[i]).copied(),
+                            &mut resolved_count,
+                        );
+                    }
                 }
             }
+            _ => unreachable!("logical expression must produce Int"),
         }
 
         if resolved_count == 0 {

--- a/components/tidb_query_expr/src/impl_op.rs
+++ b/components/tidb_query_expr/src/impl_op.rs
@@ -122,6 +122,131 @@ impl ScLogicalOp for ScLogicalOr {
     const IDENTITY: Int = 0;
 }
 
+fn merge_short_circuit_arg_result<Op: ScLogicalOp>(
+    arg_result: RpnStackNode,
+    pending_positions: Option<&[usize]>,
+    pending_len: usize,
+    output_rows: usize,
+    result: &mut ChunkedVecSized<Int>,
+) -> Result<usize> {
+    let mut resolved_count = 0;
+    let is_first = result.is_empty();
+    match arg_result {
+        RpnStackNode::Scalar { value, .. } => {
+            let value = match value {
+                ScalarValue::Int(_) | ScalarValue::Enum(_) => value.as_int().copied(),
+                _ => {
+                    return Err(other_err!(
+                        "logical expression must produce Int, got {}",
+                        value.eval_type()
+                    ));
+                }
+            };
+            let value = Op::normalize_value(value);
+            resolved_count = if Op::is_short_circuit(value) {
+                pending_len
+            } else {
+                0
+            };
+            if is_first {
+                *result = ChunkedVecSized::with_capacity(output_rows);
+                for _ in 0..pending_len {
+                    result.push(value);
+                }
+            } else if resolved_count == pending_len || value.is_none() {
+                for i in 0..pending_len {
+                    let output_index = pending_positions.map_or(i, |positions| positions[i]);
+                    result.set(output_index, value);
+                }
+            }
+        }
+        RpnStackNode::Vector {
+            value: RpnStackNodeVectorValue::Generated { physical_value },
+            ..
+        } => {
+            let vec_result = match physical_value {
+                VectorValue::Int(vec_result) => vec_result,
+                VectorValue::Enum(vec_result) => vec_result.as_vec_int().clone(),
+                _ => {
+                    return Err(other_err!(
+                        "logical expression must produce Int, got {}",
+                        physical_value.eval_type()
+                    ));
+                }
+            };
+            if is_first {
+                *result = vec_result;
+
+                for i in 0..pending_len {
+                    let value = result.get_option_ref(i).copied();
+                    let normalized = Op::normalize_value(value);
+
+                    if normalized != value {
+                        result.set(i, normalized);
+                    }
+
+                    if Op::is_short_circuit(normalized) {
+                        resolved_count += 1;
+                    }
+                }
+            } else {
+                for i in 0..pending_len {
+                    let output_index = pending_positions.map_or(i, |positions| positions[i]);
+
+                    Op::handle_res_value(
+                        result,
+                        output_index,
+                        vec_result.get_option_ref(i).copied(),
+                        &mut resolved_count,
+                    );
+                }
+            }
+        }
+        RpnStackNode::Vector {
+            value:
+                RpnStackNodeVectorValue::Ref {
+                    physical_value,
+                    logical_rows,
+                },
+            ..
+        } => {
+            let vec_result = match physical_value {
+                VectorValue::Int(vec_result) => vec_result,
+                VectorValue::Enum(vec_result) => vec_result.as_vec_int(),
+                _ => {
+                    return Err(other_err!(
+                        "logical expression must produce Int, got {}",
+                        physical_value.eval_type()
+                    ));
+                }
+            };
+            if is_first {
+                *result = ChunkedVecSized::<Int>::with_capacity(output_rows);
+                for i in 0..pending_len {
+                    let value =
+                        Op::normalize_value(vec_result.get_option_ref(logical_rows[i]).copied());
+                    if Op::is_short_circuit(value) {
+                        resolved_count += 1;
+                    }
+                    result.push(value);
+                }
+            } else {
+                for i in 0..pending_len {
+                    let output_index = pending_positions.map_or(i, |positions| positions[i]);
+                    Op::handle_res_value(
+                        result,
+                        output_index,
+                        vec_result.get_option_ref(logical_rows[i]).copied(),
+                        &mut resolved_count,
+                    );
+                }
+            }
+        }
+    }
+
+    Ok(resolved_count)
+}
+
 fn eval_logical_short_circuit<Op: ScLogicalOp>(
     ctx: &mut EvalContext,
     schema: &[FieldType],
@@ -160,121 +285,13 @@ fn eval_logical_short_circuit<Op: ScLogicalOp>(
             pending_len,
         )?;
 
-        let mut resolved_count = 0;
-        let is_first = result.is_empty();
-        match arg_result {
-            RpnStackNode::Scalar { value, .. } => {
-                let value = match value {
-                    ScalarValue::Int(_) | ScalarValue::Enum(_) => value.as_int().copied(),
-                    _ => {
-                        return Err(other_err!(
-                            "logical expression must produce Int, got {}",
-                            value.eval_type()
-                        ));
-                    }
-                };
-                let value = Op::normalize_value(value);
-                resolved_count = if Op::is_short_circuit(value) {
-                    pending_len
-                } else {
-                    0
-                };
-                if is_first {
-                    result = ChunkedVecSized::with_capacity(output_rows);
-                    for _ in 0..pending_len {
-                        result.push(value);
-                    }
-                } else if resolved_count == pending_len || value.is_none() {
-                    for i in 0..pending_len {
-                        let output_index = pending_positions.map_or(i, |positions| positions[i]);
-                        result.set(output_index, value);
-                    }
-                }
-            }
-            RpnStackNode::Vector {
-                value: RpnStackNodeVectorValue::Generated { physical_value },
-                ..
-            } => {
-                let vec_result = match physical_value {
-                    VectorValue::Int(vec_result) => vec_result,
-                    VectorValue::Enum(vec_result) => vec_result.as_vec_int().clone(),
-                    _ => {
-                        return Err(other_err!(
-                            "logical expression must produce Int, got {}",
-                            physical_value.eval_type()
-                        ));
-                    }
-                };
-                if is_first {
-                    result = vec_result;
-
-                    for i in 0..pending_len {
-                        let value = result.get_option_ref(i).copied();
-                        let normalized = Op::normalize_value(value);
-
-                        if normalized != value {
-                            result.set(i, normalized);
-                        }
-
-                        if Op::is_short_circuit(normalized) {
-                            resolved_count += 1;
-                        }
-                    }
-                } else {
-                    for i in 0..pending_len {
-                        let output_index = pending_positions.map_or(i, |positions| positions[i]);
-
-                        Op::handle_res_value(
-                            &mut result,
-                            output_index,
-                            vec_result.get_option_ref(i).copied(),
-                            &mut resolved_count,
-                        );
-                    }
-                }
-            }
-            RpnStackNode::Vector {
-                value:
-                    RpnStackNodeVectorValue::Ref {
-                        physical_value,
-                        logical_rows,
-                    },
-                ..
-            } => {
-                let vec_result = match physical_value {
-                    VectorValue::Int(vec_result) => vec_result,
-                    VectorValue::Enum(vec_result) => vec_result.as_vec_int(),
-                    _ => {
-                        return Err(other_err!(
-                            "logical expression must produce Int, got {}",
-                            physical_value.eval_type()
-                        ));
-                    }
-                };
-                if is_first {
-                    result = ChunkedVecSized::<Int>::with_capacity(output_rows);
-                    for i in 0..pending_len {
-                        let value = Op::normalize_value(
-                            vec_result.get_option_ref(logical_rows[i]).copied(),
-                        );
-                        if Op::is_short_circuit(value) {
-                            resolved_count += 1;
-                        }
-                        result.push(value);
-                    }
-                } else {
-                    for i in 0..pending_len {
-                        let output_index = pending_positions.map_or(i, |positions| positions[i]);
-                        Op::handle_res_value(
-                            &mut result,
-                            output_index,
-                            vec_result.get_option_ref(logical_rows[i]).copied(),
-                            &mut resolved_count,
-                        );
-                    }
-                }
-            }
-        }
+        let resolved_count = merge_short_circuit_arg_result::<Op>(
+            arg_result,
+            pending_positions,
+            pending_len,
+            output_rows,
+            &mut result,
+        )?;
 
         if resolved_count == 0 {
             continue;

--- a/components/tidb_query_expr/src/impl_op.rs
+++ b/components/tidb_query_expr/src/impl_op.rs
@@ -164,7 +164,16 @@ fn eval_logical_short_circuit<Op: ScLogicalOp>(
         let is_first = result.is_empty();
         match arg_result {
             RpnStackNode::Scalar { value, .. } => {
-                let value = Op::normalize_value(value.as_int().copied());
+                let value = match value {
+                    ScalarValue::Int(_) | ScalarValue::Enum(_) => value.as_int().copied(),
+                    _ => {
+                        return Err(other_err!(
+                            "logical expression must produce Int, got {}",
+                            value.eval_type()
+                        ));
+                    }
+                };
+                let value = Op::normalize_value(value);
                 resolved_count = if Op::is_short_circuit(value) {
                     pending_len
                 } else {
@@ -183,12 +192,19 @@ fn eval_logical_short_circuit<Op: ScLogicalOp>(
                 }
             }
             RpnStackNode::Vector {
-                value:
-                    RpnStackNodeVectorValue::Generated {
-                        physical_value: VectorValue::Int(vec_result),
-                    },
+                value: RpnStackNodeVectorValue::Generated { physical_value },
                 ..
             } => {
+                let vec_result = match physical_value {
+                    VectorValue::Int(vec_result) => vec_result,
+                    VectorValue::Enum(vec_result) => vec_result.as_vec_int().clone(),
+                    _ => {
+                        return Err(other_err!(
+                            "logical expression must produce Int, got {}",
+                            physical_value.eval_type()
+                        ));
+                    }
+                };
                 if is_first {
                     result = vec_result;
 
@@ -257,12 +273,6 @@ fn eval_logical_short_circuit<Op: ScLogicalOp>(
                         );
                     }
                 }
-            }
-            RpnStackNode::Vector { value, .. } => {
-                return Err(other_err!(
-                    "logical expression must produce Int, got {}",
-                    value.as_ref().eval_type()
-                ));
             }
         }
 
@@ -592,6 +602,7 @@ fn right_shift(lhs: Option<&Int>, rhs: Option<&Int>) -> Result<Option<Int>> {
 
 #[cfg(test)]
 mod tests {
+    use tidb_query_codegen::rpn_fn;
     use tidb_query_datatype::{
         FieldTypeFlag, FieldTypeTp, builder::FieldTypeBuilder, codec::mysql::TimeType,
         expr::EvalContext,
@@ -600,6 +611,11 @@ mod tests {
 
     use super::*;
     use crate::test_util::RpnFnScalarEvaluator;
+
+    #[rpn_fn(nullable)]
+    fn enum_identity(arg: Option<EnumRef>) -> Result<Option<Enum>> {
+        Ok(arg.map(EnumRef::to_owned))
+    }
 
     #[test]
     fn test_logical_and() {
@@ -676,6 +692,55 @@ mod tests {
             crate::RpnExpressionBuilder::new_for_test()
                 .push_constant_for_test(1.0)
                 .push_fn_call_for_test(unary_minus_real_fn_meta(), 1, FieldTypeTp::Double)
+                .build_for_test(),
+            crate::RpnExpressionBuilder::new_for_test()
+                .push_constant_for_test(0_i64)
+                .build_for_test(),
+        ];
+
+        let err = sc_logical_or(
+            &mut EvalContext::default(),
+            &[],
+            &LazyBatchColumnVec::empty(),
+            &[],
+            1,
+            &args,
+        )
+        .unwrap_err();
+
+        assert!(err.to_string().contains("must produce Int, got Real"));
+    }
+
+    #[test]
+    fn test_logical_short_circuit_accepts_generated_enum_vector() {
+        let args = vec![
+            crate::RpnExpressionBuilder::new_for_test()
+                .push_constant_for_test(ScalarValue::Enum(Some(Enum::new(b"one".to_vec(), 1))))
+                .push_fn_call_for_test(enum_identity_fn_meta(), 1, FieldTypeTp::Enum)
+                .build_for_test(),
+            crate::RpnExpressionBuilder::new_for_test()
+                .push_constant_for_test(0_i64)
+                .build_for_test(),
+        ];
+
+        let result = sc_logical_or(
+            &mut EvalContext::default(),
+            &[],
+            &LazyBatchColumnVec::empty(),
+            &[],
+            2,
+            &args,
+        )
+        .unwrap();
+
+        assert_eq!(result.to_int_vec(), vec![Some(1), Some(1)]);
+    }
+
+    #[test]
+    fn test_logical_short_circuit_rejects_non_int_scalar() {
+        let args = vec![
+            crate::RpnExpressionBuilder::new_for_test()
+                .push_constant_for_test(1.0)
                 .build_for_test(),
             crate::RpnExpressionBuilder::new_for_test()
                 .push_constant_for_test(0_i64)

--- a/components/tidb_query_expr/src/impl_op.rs
+++ b/components/tidb_query_expr/src/impl_op.rs
@@ -225,7 +225,16 @@ fn eval_logical_short_circuit<Op: ScLogicalOp>(
                     },
                 ..
             } => {
-                let vec_result = Int::borrow_vector_value(physical_value);
+                let vec_result = match physical_value {
+                    VectorValue::Int(vec_result) => vec_result,
+                    VectorValue::Enum(vec_result) => vec_result.as_vec_int(),
+                    _ => {
+                        return Err(other_err!(
+                            "logical expression must produce Int, got {}",
+                            physical_value.eval_type()
+                        ));
+                    }
+                };
                 if is_first {
                     result = ChunkedVecSized::<Int>::with_capacity(output_rows);
                     for i in 0..pending_len {
@@ -249,7 +258,12 @@ fn eval_logical_short_circuit<Op: ScLogicalOp>(
                     }
                 }
             }
-            _ => unreachable!("logical expression must produce Int"),
+            RpnStackNode::Vector { value, .. } => {
+                return Err(other_err!(
+                    "logical expression must produce Int, got {}",
+                    value.as_ref().eval_type()
+                ));
+            }
         }
 
         if resolved_count == 0 {
@@ -625,6 +639,60 @@ mod tests {
                 .unwrap();
             assert_eq!(output, expect_output);
         }
+    }
+
+    #[test]
+    fn test_logical_short_circuit_rejects_non_int_column() {
+        let args = vec![
+            crate::RpnExpressionBuilder::new_for_test()
+                .push_column_ref_for_test(0)
+                .build_for_test(),
+            crate::RpnExpressionBuilder::new_for_test()
+                .push_column_ref_for_test(1)
+                .build_for_test(),
+        ];
+        let columns = LazyBatchColumnVec::from(vec![
+            VectorValue::Real(vec![Real::new(1.0).ok()].into()),
+            VectorValue::Int(vec![Some(0)].into()),
+        ]);
+        let schema = &[FieldTypeTp::Double.into(), FieldTypeTp::LongLong.into()];
+
+        let err = sc_logical_or(
+            &mut EvalContext::default(),
+            schema,
+            &columns,
+            &[0],
+            1,
+            &args,
+        )
+        .unwrap_err();
+
+        assert!(err.to_string().contains("must produce Int, got Real"));
+    }
+
+    #[test]
+    fn test_logical_short_circuit_rejects_non_int_generated_vector() {
+        let args = vec![
+            crate::RpnExpressionBuilder::new_for_test()
+                .push_constant_for_test(1.0)
+                .push_fn_call_for_test(unary_minus_real_fn_meta(), 1, FieldTypeTp::Double)
+                .build_for_test(),
+            crate::RpnExpressionBuilder::new_for_test()
+                .push_constant_for_test(0_i64)
+                .build_for_test(),
+        ];
+
+        let err = sc_logical_or(
+            &mut EvalContext::default(),
+            &[],
+            &LazyBatchColumnVec::empty(),
+            &[],
+            1,
+            &args,
+        )
+        .unwrap_err();
+
+        assert!(err.to_string().contains("must produce Int, got Real"));
     }
 
     #[test]

--- a/components/tidb_query_expr/src/lib.rs
+++ b/components/tidb_query_expr/src/lib.rs
@@ -972,3 +972,17 @@ fn map_expr_node_to_rpn_func(expr: &Expr) -> Result<RpnFnMeta> {
         )),
     })
 }
+
+fn map_expr_node_to_sc_func(expr: &Expr) -> Option<ShortCircuitFnMeta> {
+    match expr.get_sig() {
+        ScalarFuncSig::LogicalOr => Some(ShortCircuitFnMeta {
+            sig: ScalarFuncSig::LogicalOr,
+            fn_ptr: sc_logical_or,
+        }),
+        ScalarFuncSig::LogicalAnd => Some(ShortCircuitFnMeta {
+            sig: ScalarFuncSig::LogicalAnd,
+            fn_ptr: sc_logical_and,
+        }),
+        _ => None,
+    }
+}

--- a/components/tidb_query_expr/src/lib.rs
+++ b/components/tidb_query_expr/src/lib.rs
@@ -983,6 +983,7 @@ fn map_expr_node_to_sc_func(expr: &Expr) -> Option<ShortCircuitFnMeta> {
             sig: ScalarFuncSig::LogicalAnd,
             fn_ptr: sc_logical_and,
         }),
+        // TODO: Supports IF, IFPULL, CASE WHEN, COALESCE, etc
         _ => None,
     }
 }

--- a/components/tidb_query_expr/src/types/expr.rs
+++ b/components/tidb_query_expr/src/types/expr.rs
@@ -1,15 +1,24 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::any::Any;
+use std::{any::Any, sync::OnceLock};
 
 use tidb_query_datatype::codec::data_type::ScalarValue;
 use tipb::FieldType;
 
 use super::super::function::RpnFnMeta;
+use crate::ShortCircuitFnMeta;
 
 /// A type for each node in the RPN expression list.
 #[derive(Debug)]
 pub enum RpnExpressionNode {
+    /// Represents a function call that decides which arguments and rows need to
+    /// be evaluated. Each argument remains an independent RPN expression.
+    ShortCircuitFnCall {
+        func_meta: ShortCircuitFnMeta,
+        args: Box<[RpnExpression]>,
+        field_type: FieldType,
+    },
+
     /// Represents a function call.
     FnCall {
         func_meta: RpnFnMeta,
@@ -34,6 +43,7 @@ impl RpnExpressionNode {
     #[cfg(test)]
     pub fn field_type(&self) -> &FieldType {
         match self {
+            RpnExpressionNode::ShortCircuitFnCall { field_type, .. } => field_type,
             RpnExpressionNode::FnCall { field_type, .. } => field_type,
             RpnExpressionNode::Constant { field_type, .. } => field_type,
             RpnExpressionNode::ColumnRef { .. } => panic!(),
@@ -46,6 +56,7 @@ impl RpnExpressionNode {
         use tipb::ExprType;
 
         match self {
+            RpnExpressionNode::ShortCircuitFnCall { .. } => ExprType::ScalarFunc,
             RpnExpressionNode::FnCall { .. } => ExprType::ScalarFunc,
             RpnExpressionNode::Constant { value, .. } => match value.eval_type() {
                 EvalType::Bytes => ExprType::Bytes,
@@ -80,6 +91,29 @@ impl RpnExpressionNode {
             _ => panic!(),
         }
     }
+
+    fn collect_metadata(&self, metadata: &mut RpnExpressionMetadata) {
+        metadata.node_count += 1;
+        match self {
+            RpnExpressionNode::ShortCircuitFnCall { args, .. } => {
+                for arg in args {
+                    arg.collect_metadata(metadata);
+                }
+            }
+            RpnExpressionNode::ColumnRef { offset } => {
+                metadata.column_ref_count += 1;
+                metadata.referenced_column_offsets.push(*offset);
+            }
+            _ => {}
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct RpnExpressionMetadata {
+    node_count: usize,
+    column_ref_count: usize,
+    referenced_column_offsets: Vec<usize>,
 }
 
 /// An expression in Reverse Polish notation, which is simply a list of RPN
@@ -87,62 +121,136 @@ impl RpnExpressionNode {
 ///
 /// You may want to build it using `RpnExpressionBuilder`.
 #[derive(Debug)]
-pub struct RpnExpression(Vec<RpnExpressionNode>);
+pub struct RpnExpression {
+    nodes: Vec<RpnExpressionNode>,
+    metadata: OnceLock<Box<RpnExpressionMetadata>>,
+}
 
 impl std::ops::Deref for RpnExpression {
     type Target = Vec<RpnExpressionNode>;
 
     fn deref(&self) -> &Vec<RpnExpressionNode> {
-        &self.0
+        &self.nodes
     }
 }
 
 impl std::ops::DerefMut for RpnExpression {
     fn deref_mut(&mut self) -> &mut Vec<RpnExpressionNode> {
-        &mut self.0
+        // Any mutable access may change the expression tree, so cached metadata
+        // must be rebuilt the next time it is requested.
+        self.metadata = OnceLock::new();
+        &mut self.nodes
     }
 }
 
 impl From<Vec<RpnExpressionNode>> for RpnExpression {
     fn from(v: Vec<RpnExpressionNode>) -> Self {
-        Self(v)
+        Self {
+            nodes: v,
+            metadata: OnceLock::new(),
+        }
     }
 }
 
 impl AsRef<[RpnExpressionNode]> for RpnExpression {
     fn as_ref(&self) -> &[RpnExpressionNode] {
-        self.0.as_ref()
+        self.nodes.as_ref()
     }
 }
 
 impl AsMut<[RpnExpressionNode]> for RpnExpression {
     fn as_mut(&mut self) -> &mut [RpnExpressionNode] {
-        self.0.as_mut()
+        self.metadata = OnceLock::new();
+        self.nodes.as_mut()
     }
 }
 
 impl RpnExpression {
+    fn metadata(&self) -> &RpnExpressionMetadata {
+        self.metadata
+            .get_or_init(|| {
+                let mut metadata = RpnExpressionMetadata::default();
+                self.collect_metadata(&mut metadata);
+                metadata.referenced_column_offsets.sort_unstable();
+                metadata.referenced_column_offsets.dedup();
+                Box::new(metadata)
+            })
+            .as_ref()
+    }
+
+    fn collect_metadata(&self, metadata: &mut RpnExpressionMetadata) {
+        for node in &self.nodes {
+            node.collect_metadata(metadata);
+        }
+    }
+
     /// Gets the field type of the return value.
     pub fn ret_field_type<'a>(&'a self, schema: &'a [FieldType]) -> &'a FieldType {
-        assert!(!self.0.is_empty());
-        let last_node = self.0.last().unwrap();
+        assert!(!self.nodes.is_empty());
+        let last_node = self.nodes.last().unwrap();
         match last_node {
             RpnExpressionNode::FnCall { field_type, .. } => field_type,
             RpnExpressionNode::Constant { field_type, .. } => field_type,
             RpnExpressionNode::ColumnRef { offset } => &schema[*offset],
+            RpnExpressionNode::ShortCircuitFnCall { field_type, .. } => field_type,
         }
     }
 
     /// Unwraps into the underlying expression node vector.
     pub fn into_inner(self) -> Vec<RpnExpressionNode> {
-        self.0
+        self.nodes
     }
 
     /// Returns true if the last element of expression is a `Constant` variant.
     pub fn is_last_constant(&self) -> bool {
-        assert!(!self.0.is_empty());
-        matches!(self.0.last().unwrap(), RpnExpressionNode::Constant { .. })
+        assert!(!self.nodes.is_empty());
+        matches!(
+            self.nodes.last().unwrap(),
+            RpnExpressionNode::Constant { .. }
+        )
+    }
+
+    /// Returns the number of nodes, including nodes nested in short-circuit
+    /// arguments.
+    pub fn node_count(&self) -> usize {
+        self.metadata().node_count
+    }
+
+    /// Returns the number of column references, including references nested in
+    /// short-circuit arguments.
+    pub fn column_ref_count(&self) -> usize {
+        self.metadata().column_ref_count
+    }
+
+    /// Returns sorted, deduplicated offsets of all referenced columns,
+    /// including references nested in short-circuit arguments.
+    pub(crate) fn referenced_column_offsets(&self) -> &[usize] {
+        &self.metadata().referenced_column_offsets
     }
 }
 
 // For `RpnExpression::eval`, see `expr_eval` file.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cached_metadata_is_deduplicated_and_invalidated_by_mutation() {
+        let mut expr = RpnExpression::from(vec![
+            RpnExpressionNode::ColumnRef { offset: 2 },
+            RpnExpressionNode::ColumnRef { offset: 0 },
+            RpnExpressionNode::ColumnRef { offset: 2 },
+        ]);
+
+        assert_eq!(expr.node_count(), 3);
+        assert_eq!(expr.column_ref_count(), 3);
+        assert_eq!(expr.referenced_column_offsets(), &[0, 2]);
+
+        expr.push(RpnExpressionNode::ColumnRef { offset: 1 });
+
+        assert_eq!(expr.node_count(), 4);
+        assert_eq!(expr.column_ref_count(), 4);
+        assert_eq!(expr.referenced_column_offsets(), &[0, 1, 2]);
+    }
+}

--- a/components/tidb_query_expr/src/types/expr_builder.rs
+++ b/components/tidb_query_expr/src/types/expr_builder.rs
@@ -10,7 +10,7 @@ use tidb_query_datatype::{
         data_type::*,
         mysql::{EnumDecoder, JsonDecoder, MAX_FSP, VectorFloat32Decoder},
     },
-    expr::EvalContext,
+    expr::{EvalContext, Flag},
     match_template_evaltype,
 };
 use tipb::{Expr, ExprType, FieldType, ScalarFuncSig};
@@ -333,57 +333,60 @@ where
     let args: Vec<_> = tree_node.take_children().into();
     let args_len = args.len();
 
-    if let Some(short_circuit_func_meta) = short_circuit_func_meta {
-        let mut parsed_args = Vec::with_capacity(args_len);
-        for arg in args {
-            let mut arg_nodes = Vec::new();
-            append_rpn_nodes_recursively(
-                arg,
-                &mut arg_nodes,
-                ctx,
-                fn_mapper,
-                sc_fn_mapper,
-                max_columns,
-            )?;
-            parsed_args.push(arg_nodes);
-        }
-
-        if is_short_circuit_worthwhile(short_circuit_func_meta, &parsed_args) {
-            let mut short_circuit_args = Vec::with_capacity(args_len);
-            for arg_nodes in parsed_args {
-                append_short_circuit_arg(
-                    short_circuit_func_meta,
-                    arg_nodes,
-                    &mut short_circuit_args,
-                );
+    match short_circuit_func_meta {
+        Some(short_circuit_func_meta) if ctx.cfg.flag.contains(Flag::ENABLE_SHORT_CIRCUIT_EXPRESSION) => {
+            let mut parsed_args = Vec::with_capacity(args_len);
+            for arg in args {
+                let mut arg_nodes = Vec::new();
+                append_rpn_nodes_recursively(
+                    arg,
+                    &mut arg_nodes,
+                    ctx,
+                    fn_mapper,
+                    sc_fn_mapper,
+                    max_columns,
+                )?;
+                parsed_args.push(arg_nodes);
             }
 
-            rpn_nodes.push(RpnExpressionNode::ShortCircuitFnCall {
-                func_meta: short_circuit_func_meta,
-                args: short_circuit_args.into_boxed_slice(),
-                field_type: tree_node.take_field_type(),
-            });
-            return Ok(());
-        }
+            if is_short_circuit_worthwhile(short_circuit_func_meta, &parsed_args) {
+                let mut short_circuit_args = Vec::with_capacity(args_len);
+                for arg_nodes in parsed_args {
+                    append_short_circuit_arg(
+                        short_circuit_func_meta,
+                        arg_nodes,
+                        &mut short_circuit_args,
+                    );
+                }
 
-        // The children have already been converted to RPN while deciding whether
-        // short-circuit evaluation is worthwhile. Reuse them for the regular call
-        // instead of traversing the expression tree again.
-        for mut arg_nodes in parsed_args {
-            rpn_nodes.append(&mut arg_nodes);
+                rpn_nodes.push(RpnExpressionNode::ShortCircuitFnCall {
+                    func_meta: short_circuit_func_meta,
+                    args: short_circuit_args.into_boxed_slice(),
+                    field_type: tree_node.take_field_type(),
+                });
+                return Ok(());
+            }
+
+            // The children have already been converted to RPN while deciding whether
+            // short-circuit evaluation is worthwhile. Reuse them for the regular call
+            // instead of traversing the expression tree again.
+            for mut arg_nodes in parsed_args {
+                rpn_nodes.append(&mut arg_nodes);
+            }
         }
-    } else {
-        // Visit children first, then push current node, so that it is a post-order
-        // traversal.
-        for arg in args {
-            append_rpn_nodes_recursively(
-                arg,
-                rpn_nodes,
-                ctx,
-                fn_mapper,
-                sc_fn_mapper,
-                max_columns,
-            )?;
+        _ => {
+            // Visit children first, then push current node, so that it is a post-order
+            // traversal.
+            for arg in args {
+                append_rpn_nodes_recursively(
+                    arg,
+                    rpn_nodes,
+                    ctx,
+                    fn_mapper,
+                    sc_fn_mapper,
+                    max_columns,
+                )?;
+            }
         }
     }
 

--- a/components/tidb_query_expr/src/types/expr_builder.rs
+++ b/components/tidb_query_expr/src/types/expr_builder.rs
@@ -108,11 +108,31 @@ impl RpnExpressionBuilder {
     where
         F: Fn(&Expr) -> Result<RpnFnMeta> + Copy,
     {
+        Self::build_from_expr_tree_with_fn_mapper_and_ctx(
+            tree_node,
+            &mut EvalContext::default(),
+            fn_mapper,
+            max_columns,
+        )
+    }
+
+    /// Only used in tests, with a customized function mapper and evaluation
+    /// context. The context controls request flags used while building.
+    #[cfg(test)]
+    pub fn build_from_expr_tree_with_fn_mapper_and_ctx<F>(
+        tree_node: Expr,
+        ctx: &mut EvalContext,
+        fn_mapper: F,
+        max_columns: usize,
+    ) -> Result<RpnExpression>
+    where
+        F: Fn(&Expr) -> Result<RpnFnMeta> + Copy,
+    {
         let mut expr_nodes = Vec::new();
         append_rpn_nodes_recursively(
             tree_node,
             &mut expr_nodes,
-            &mut EvalContext::default(),
+            ctx,
             fn_mapper,
             super::super::map_expr_node_to_sc_func,
             max_columns,
@@ -334,7 +354,9 @@ where
     let args_len = args.len();
 
     match short_circuit_func_meta {
-        Some(short_circuit_func_meta) if ctx.cfg.flag.contains(Flag::ENABLE_SHORT_CIRCUIT_EXPRESSION) => {
+        Some(short_circuit_func_meta)
+            if ctx.cfg.flag.contains(Flag::ENABLE_SHORT_CIRCUIT_EXPRESSION) =>
+        {
             let mut parsed_args = Vec::with_capacity(args_len);
             for arg in args {
                 let mut arg_nodes = Vec::new();
@@ -405,19 +427,15 @@ fn should_flatten(father_func: ShortCircuitFnMeta, arg: &[RpnExpressionNode]) ->
         return false;
     }
 
-    match arg.last().unwrap() {
+    matches!(
+        arg.last().unwrap(),
         RpnExpressionNode::ShortCircuitFnCall {
             func_meta: son_func,
-            args,
             ..
         } if son_func.sig == father_func.sig
             && (son_func.sig == ScalarFuncSig::LogicalOr
-                || son_func.sig == ScalarFuncSig::LogicalAnd) =>
-        {
-            true
-        }
-        _ => false,
-    }
+                || son_func.sig == ScalarFuncSig::LogicalAnd)
+    )
 }
 
 /// Returns whether a binary AND/OR call benefits from short-circuit evaluation.
@@ -636,13 +654,24 @@ fn extract_scalar_value_vector_float32(val: Vec<u8>) -> Result<ScalarValue> {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use tidb_query_codegen::rpn_fn;
     use tidb_query_common::Result;
-    use tidb_query_datatype::FieldTypeTp;
+    use tidb_query_datatype::{
+        FieldTypeTp,
+        expr::{EvalConfig, Flag},
+    };
     use tipb::ScalarFuncSig;
     use tipb_helper::ExprDefBuilder;
 
     use super::*;
+
+    fn short_circuit_context() -> EvalContext {
+        EvalContext::new(Arc::new(EvalConfig::from_flag(
+            Flag::ENABLE_SHORT_CIRCUIT_EXPRESSION,
+        )))
+    }
 
     /// An RPN function for test. It accepts 1 int argument, returns float.
     #[rpn_fn(nullable)]
@@ -969,8 +998,10 @@ mod tests {
             .push_child(ExprDefBuilder::column_ref(0, FieldTypeTp::LongLong))
             .build();
 
-        let exp = RpnExpressionBuilder::build_from_expr_tree_with_fn_mapper(
+        let mut ctx = short_circuit_context();
+        let exp = RpnExpressionBuilder::build_from_expr_tree_with_fn_mapper_and_ctx(
             node,
+            &mut ctx,
             crate::map_expr_node_to_rpn_func,
             1,
         )
@@ -997,8 +1028,22 @@ mod tests {
             .push_child(ExprDefBuilder::constant_int(3))
             .build();
 
-        let exp = RpnExpressionBuilder::build_from_expr_tree_with_fn_mapper(
+        let eager_exp = RpnExpressionBuilder::build_from_expr_tree_with_fn_mapper(
+            node.clone(),
+            crate::map_expr_node_to_rpn_func,
+            0,
+        )
+        .unwrap();
+        assert!(
+            eager_exp
+                .iter()
+                .all(|node| !matches!(node, RpnExpressionNode::ShortCircuitFnCall { .. }))
+        );
+
+        let mut ctx = short_circuit_context();
+        let exp = RpnExpressionBuilder::build_from_expr_tree_with_fn_mapper_and_ctx(
             node,
+            &mut ctx,
             crate::map_expr_node_to_rpn_func,
             0,
         )
@@ -1036,8 +1081,10 @@ mod tests {
             .push_child(ExprDefBuilder::column_ref(3, FieldTypeTp::LongLong))
             .build();
 
-        let exp = RpnExpressionBuilder::build_from_expr_tree_with_fn_mapper(
+        let mut ctx = short_circuit_context();
+        let exp = RpnExpressionBuilder::build_from_expr_tree_with_fn_mapper_and_ctx(
             node,
+            &mut ctx,
             crate::map_expr_node_to_rpn_func,
             4,
         )

--- a/components/tidb_query_expr/src/types/expr_builder.rs
+++ b/components/tidb_query_expr/src/types/expr_builder.rs
@@ -21,6 +21,10 @@ use super::{
 };
 use crate::ShortCircuitFnMeta;
 
+// Each active short-circuit call retains batch results and may retain row maps.
+// Bound nesting to keep both the evaluator stack and retained batch state small.
+const MAX_SHORT_CIRCUIT_NESTING_DEPTH: usize = 32;
+
 /// Helper to build an `RpnExpression`.
 #[derive(Debug)]
 pub struct RpnExpressionBuilder(Vec<RpnExpressionNode>);
@@ -281,7 +285,7 @@ fn append_rpn_nodes_recursively<F, SCF>(
     // TODO: Passing `max_columns` is only a workaround solution that works when we only check
     // column offset. To totally check whether or not the expression is valid, we need to pass in
     // the full schema instead.
-) -> Result<()>
+) -> Result<usize>
 where
     F: Fn(&Expr) -> Result<RpnFnMeta> + Copy,
     SCF: Fn(&Expr) -> Option<ShortCircuitFnMeta> + Copy,
@@ -295,8 +299,14 @@ where
             sc_fn_mapper,
             max_columns,
         ),
-        ExprType::ColumnRef => handle_node_column_ref(tree_node, rpn_nodes, max_columns),
-        _ => handle_node_constant(tree_node, rpn_nodes, ctx),
+        ExprType::ColumnRef => {
+            handle_node_column_ref(tree_node, rpn_nodes, max_columns)?;
+            Ok(0)
+        }
+        _ => {
+            handle_node_constant(tree_node, rpn_nodes, ctx)?;
+            Ok(0)
+        }
     }
 }
 
@@ -330,7 +340,7 @@ fn handle_node_fn_call<F, SCF>(
     fn_mapper: F,
     sc_fn_mapper: SCF,
     max_columns: usize,
-) -> Result<()>
+) -> Result<usize>
 where
     F: Fn(&Expr) -> Result<RpnFnMeta> + Copy,
     SCF: Fn(&Expr) -> Option<ShortCircuitFnMeta> + Copy,
@@ -353,14 +363,18 @@ where
     let args: Vec<_> = tree_node.take_children().into();
     let args_len = args.len();
 
+    let mut max_argument_depth = 0;
+
     match short_circuit_func_meta {
         Some(short_circuit_func_meta)
             if ctx.cfg.flag.contains(Flag::ENABLE_SHORT_CIRCUIT_EXPRESSION) =>
         {
             let mut parsed_args = Vec::with_capacity(args_len);
+            let mut is_short_circuit_worthwhile = false;
+            let mut max_sc_depth = 0;
             for arg in args {
                 let mut arg_nodes = Vec::new();
-                append_rpn_nodes_recursively(
+                let short_circuit_depth = append_rpn_nodes_recursively(
                     arg,
                     &mut arg_nodes,
                     ctx,
@@ -368,10 +382,22 @@ where
                     sc_fn_mapper,
                     max_columns,
                 )?;
+
+                let should_flatten = should_flatten(short_circuit_func_meta, &arg_nodes);
+                max_argument_depth = max_argument_depth.max(short_circuit_depth);
+                max_sc_depth = max_sc_depth.max(if should_flatten {
+                    short_circuit_depth.saturating_sub(1)
+                } else {
+                    short_circuit_depth
+                });
+                is_short_circuit_worthwhile |= should_flatten || !is_simple_expr(&arg_nodes);
+                is_short_circuit_worthwhile &=
+                    max_sc_depth.saturating_add(1) <= MAX_SHORT_CIRCUIT_NESTING_DEPTH;
+
                 parsed_args.push(arg_nodes);
             }
 
-            if is_short_circuit_worthwhile(short_circuit_func_meta, &parsed_args) {
+            if is_short_circuit_worthwhile {
                 let mut short_circuit_args = Vec::with_capacity(args_len);
                 for arg_nodes in parsed_args {
                     append_short_circuit_arg(
@@ -386,7 +412,7 @@ where
                     args: short_circuit_args.into_boxed_slice(),
                     field_type: tree_node.take_field_type(),
                 });
-                return Ok(());
+                return Ok(max_sc_depth + 1);
             }
 
             // The children have already been converted to RPN while deciding whether
@@ -400,17 +426,17 @@ where
             // Visit children first, then push current node, so that it is a post-order
             // traversal.
             for arg in args {
-                append_rpn_nodes_recursively(
+                max_argument_depth = max_argument_depth.max(append_rpn_nodes_recursively(
                     arg,
                     rpn_nodes,
                     ctx,
                     fn_mapper,
                     sc_fn_mapper,
                     max_columns,
-                )?;
+                )?)
             }
         }
-    }
+    };
 
     rpn_nodes.push(RpnExpressionNode::FnCall {
         func_meta,
@@ -418,9 +444,10 @@ where
         field_type: tree_node.take_field_type(),
         metadata,
     });
-    Ok(())
+    Ok(max_argument_depth)
 }
 
+#[inline]
 fn should_flatten(father_func: ShortCircuitFnMeta, arg: &[RpnExpressionNode]) -> bool {
     assert!(!arg.is_empty());
     if arg.len() > 1 {
@@ -438,24 +465,12 @@ fn should_flatten(father_func: ShortCircuitFnMeta, arg: &[RpnExpressionNode]) ->
     )
 }
 
-/// Returns whether a binary AND/OR call benefits from short-circuit evaluation.
-///
-/// A long logical chain is represented by nested binary calls. Short-circuit
-/// evaluation is worthwhile when a nested call can be flattened, or when an
-/// argument requires more than reading a constant or column. A simple binary
-/// call with only cheap arguments stays on the regular RPN path to avoid
-/// short-circuit bookkeeping overhead.
-fn is_short_circuit_worthwhile(
-    func: ShortCircuitFnMeta,
-    parsed_args: &[Vec<RpnExpressionNode>],
-) -> bool {
-    parsed_args.iter().any(|arg| {
-        should_flatten(func, arg)
-            || !matches!(
-                arg.as_slice(),
-                [RpnExpressionNode::Constant { .. } | RpnExpressionNode::ColumnRef { .. }]
-            )
-    })
+#[inline]
+fn is_simple_expr(arg: &[RpnExpressionNode]) -> bool {
+    matches!(
+        arg,
+        [RpnExpressionNode::Constant { .. } | RpnExpressionNode::ColumnRef { .. }]
+    )
 }
 
 fn append_short_circuit_arg(
@@ -671,6 +686,22 @@ mod tests {
         EvalContext::new(Arc::new(EvalConfig::from_flag(
             Flag::ENABLE_SHORT_CIRCUIT_EXPRESSION,
         )))
+    }
+
+    fn short_circuit_depth(expr: &RpnExpression) -> usize {
+        expr.iter()
+            .map(|node| match node {
+                RpnExpressionNode::ShortCircuitFnCall { args, .. } => {
+                    1 + args.iter().map(short_circuit_depth).max().unwrap_or(0)
+                }
+                _ => 0,
+            })
+            .max()
+            .unwrap_or(0)
+    }
+
+    fn max_short_circuit_depth() -> usize {
+        MAX_SHORT_CIRCUIT_NESTING_DEPTH
     }
 
     /// An RPN function for test. It accepts 1 int argument, returns float.
@@ -1108,6 +1139,38 @@ mod tests {
         assert_eq!(exp.node_count(), 6);
         assert_eq!(exp.column_ref_count(), 4);
         assert_eq!(exp.referenced_column_offsets(), &[0, 1, 2, 3]);
+    }
+
+    #[test]
+    fn test_deep_mixed_short_circuit_calls_fall_back_to_rpn() {
+        let mut node = ExprDefBuilder::column_ref(0, FieldTypeTp::LongLong).build();
+        for i in 0..=max_short_circuit_depth() + 1 {
+            let sig = if i % 2 == 0 {
+                ScalarFuncSig::LogicalOr
+            } else {
+                ScalarFuncSig::LogicalAnd
+            };
+            node = ExprDefBuilder::scalar_func(sig, FieldTypeTp::LongLong)
+                .push_child(ExprDefBuilder::column_ref(0, FieldTypeTp::LongLong))
+                .push_child(node)
+                .build();
+        }
+
+        let mut ctx = short_circuit_context();
+        let exp = RpnExpressionBuilder::build_from_expr_tree_with_fn_mapper_and_ctx(
+            node,
+            &mut ctx,
+            crate::map_expr_node_to_rpn_func,
+            1,
+        )
+        .unwrap();
+
+        assert_eq!(short_circuit_depth(&exp), max_short_circuit_depth());
+        assert!(matches!(
+            exp.last(),
+            Some(RpnExpressionNode::FnCall { func_meta, .. })
+                if func_meta.name == "logical_or" || func_meta.name == "logical_and"
+        ));
     }
 
     #[test]

--- a/components/tidb_query_expr/src/types/expr_builder.rs
+++ b/components/tidb_query_expr/src/types/expr_builder.rs
@@ -13,12 +13,13 @@ use tidb_query_datatype::{
     expr::EvalContext,
     match_template_evaltype,
 };
-use tipb::{Expr, ExprType, FieldType};
+use tipb::{Expr, ExprType, FieldType, ScalarFuncSig};
 
 use super::{
     super::function::RpnFnMeta,
     expr::{RpnExpression, RpnExpressionNode},
 };
+use crate::ShortCircuitFnMeta;
 
 /// Helper to build an `RpnExpression`.
 #[derive(Debug)]
@@ -91,6 +92,7 @@ impl RpnExpressionBuilder {
             &mut expr_nodes,
             ctx,
             super::super::map_expr_node_to_rpn_func,
+            super::super::map_expr_node_to_sc_func,
             max_columns,
         )?;
         Ok(RpnExpression::from(expr_nodes))
@@ -112,6 +114,7 @@ impl RpnExpressionBuilder {
             &mut expr_nodes,
             &mut EvalContext::default(),
             fn_mapper,
+            super::super::map_expr_node_to_sc_func,
             max_columns,
         )?;
         Ok(RpnExpression::from(expr_nodes))
@@ -248,11 +251,12 @@ impl AsRef<[RpnExpressionNode]> for RpnExpressionBuilder {
 ///
 /// The transform process is very much like a post-order traversal. This
 /// function does it recursively.
-fn append_rpn_nodes_recursively<F>(
+fn append_rpn_nodes_recursively<F, SCF>(
     tree_node: Expr,
     rpn_nodes: &mut Vec<RpnExpressionNode>,
     ctx: &mut EvalContext,
     fn_mapper: F,
+    sc_fn_mapper: SCF,
     max_columns: usize,
     // TODO: Passing `max_columns` is only a workaround solution that works when we only check
     // column offset. To totally check whether or not the expression is valid, we need to pass in
@@ -260,11 +264,17 @@ fn append_rpn_nodes_recursively<F>(
 ) -> Result<()>
 where
     F: Fn(&Expr) -> Result<RpnFnMeta> + Copy,
+    SCF: Fn(&Expr) -> Option<ShortCircuitFnMeta> + Copy,
 {
     match tree_node.get_tp() {
-        ExprType::ScalarFunc => {
-            handle_node_fn_call(tree_node, rpn_nodes, ctx, fn_mapper, max_columns)
-        }
+        ExprType::ScalarFunc => handle_node_fn_call(
+            tree_node,
+            rpn_nodes,
+            ctx,
+            fn_mapper,
+            sc_fn_mapper,
+            max_columns,
+        ),
         ExprType::ColumnRef => handle_node_column_ref(tree_node, rpn_nodes, max_columns),
         _ => handle_node_constant(tree_node, rpn_nodes, ctx),
     }
@@ -293,20 +303,23 @@ fn handle_node_column_ref(
 }
 
 #[inline]
-fn handle_node_fn_call<F>(
+fn handle_node_fn_call<F, SCF>(
     mut tree_node: Expr,
     rpn_nodes: &mut Vec<RpnExpressionNode>,
     ctx: &mut EvalContext,
     fn_mapper: F,
+    sc_fn_mapper: SCF,
     max_columns: usize,
 ) -> Result<()>
 where
     F: Fn(&Expr) -> Result<RpnFnMeta> + Copy,
+    SCF: Fn(&Expr) -> Option<ShortCircuitFnMeta> + Copy,
 {
-    // Map pb func to `RpnFnMeta`.
-    let func_meta = fn_mapper(&tree_node)?;
+    let short_circuit_func_meta = sc_fn_mapper(&tree_node);
 
-    // Validate the input expression.
+    // Map, validate, and initialize metadata before taking the children because
+    // each of these operations may inspect the original expression tree.
+    let func_meta = fn_mapper(&tree_node)?;
     (func_meta.validator_ptr)(&tree_node).map_err(|e| {
         other_err!(
             "Invalid {} (sig = {:?}) signature: {}",
@@ -320,11 +333,60 @@ where
     let args: Vec<_> = tree_node.take_children().into();
     let args_len = args.len();
 
-    // Visit children first, then push current node, so that it is a post-order
-    // traversal.
-    for arg in args {
-        append_rpn_nodes_recursively(arg, rpn_nodes, ctx, fn_mapper, max_columns)?;
+    if let Some(short_circuit_func_meta) = short_circuit_func_meta {
+        let mut parsed_args = Vec::with_capacity(args_len);
+        for arg in args {
+            let mut arg_nodes = Vec::new();
+            append_rpn_nodes_recursively(
+                arg,
+                &mut arg_nodes,
+                ctx,
+                fn_mapper,
+                sc_fn_mapper,
+                max_columns,
+            )?;
+            parsed_args.push(arg_nodes);
+        }
+
+        if is_short_circuit_worthwhile(short_circuit_func_meta, &parsed_args) {
+            let mut short_circuit_args = Vec::with_capacity(args_len);
+            for arg_nodes in parsed_args {
+                append_short_circuit_arg(
+                    short_circuit_func_meta,
+                    arg_nodes,
+                    &mut short_circuit_args,
+                );
+            }
+
+            rpn_nodes.push(RpnExpressionNode::ShortCircuitFnCall {
+                func_meta: short_circuit_func_meta,
+                args: short_circuit_args.into_boxed_slice(),
+                field_type: tree_node.take_field_type(),
+            });
+            return Ok(());
+        }
+
+        // The children have already been converted to RPN while deciding whether
+        // short-circuit evaluation is worthwhile. Reuse them for the regular call
+        // instead of traversing the expression tree again.
+        for mut arg_nodes in parsed_args {
+            rpn_nodes.append(&mut arg_nodes);
+        }
+    } else {
+        // Visit children first, then push current node, so that it is a post-order
+        // traversal.
+        for arg in args {
+            append_rpn_nodes_recursively(
+                arg,
+                rpn_nodes,
+                ctx,
+                fn_mapper,
+                sc_fn_mapper,
+                max_columns,
+            )?;
+        }
     }
+
     rpn_nodes.push(RpnExpressionNode::FnCall {
         func_meta,
         args_len,
@@ -332,6 +394,65 @@ where
         metadata,
     });
     Ok(())
+}
+
+fn should_flatten(father_func: ShortCircuitFnMeta, arg: &[RpnExpressionNode]) -> bool {
+    assert!(!arg.is_empty());
+    if arg.len() > 1 {
+        return false;
+    }
+
+    match arg.last().unwrap() {
+        RpnExpressionNode::ShortCircuitFnCall {
+            func_meta: son_func,
+            args,
+            ..
+        } if son_func.sig == father_func.sig
+            && (son_func.sig == ScalarFuncSig::LogicalOr
+                || son_func.sig == ScalarFuncSig::LogicalAnd) =>
+        {
+            true
+        }
+        _ => false,
+    }
+}
+
+/// Returns whether a binary AND/OR call benefits from short-circuit evaluation.
+///
+/// A long logical chain is represented by nested binary calls. Short-circuit
+/// evaluation is worthwhile when a nested call can be flattened, or when an
+/// argument requires more than reading a constant or column. A simple binary
+/// call with only cheap arguments stays on the regular RPN path to avoid
+/// short-circuit bookkeeping overhead.
+fn is_short_circuit_worthwhile(
+    func: ShortCircuitFnMeta,
+    parsed_args: &[Vec<RpnExpressionNode>],
+) -> bool {
+    parsed_args.iter().any(|arg| {
+        should_flatten(func, arg)
+            || !matches!(
+                arg.as_slice(),
+                [RpnExpressionNode::Constant { .. } | RpnExpressionNode::ColumnRef { .. }]
+            )
+    })
+}
+
+fn append_short_circuit_arg(
+    func: ShortCircuitFnMeta,
+    mut arg: Vec<RpnExpressionNode>,
+    output: &mut Vec<RpnExpression>,
+) {
+    // Flattens adjacent calls of the same associative logical operator. This
+    // avoids recursive evaluation and intermediate result vectors for long
+    // AND/OR chains while preserving left-to-right argument order.
+    if should_flatten(func, &arg) {
+        match arg.pop().unwrap() {
+            RpnExpressionNode::ShortCircuitFnCall { args, .. } => output.extend(args.into_vec()),
+            _ => unreachable!(),
+        }
+    } else {
+        output.push(RpnExpression::from(arg));
+    }
 }
 
 #[inline]
@@ -836,6 +957,107 @@ mod tests {
 
         // Finish
         assert!(it.next().is_none())
+    }
+
+    #[test]
+    fn test_simple_logical_call_uses_regular_rpn() {
+        let node = ExprDefBuilder::scalar_func(ScalarFuncSig::LogicalOr, FieldTypeTp::LongLong)
+            .push_child(ExprDefBuilder::constant_int(1))
+            .push_child(ExprDefBuilder::column_ref(0, FieldTypeTp::LongLong))
+            .build();
+
+        let exp = RpnExpressionBuilder::build_from_expr_tree_with_fn_mapper(
+            node,
+            crate::map_expr_node_to_rpn_func,
+            1,
+        )
+        .unwrap();
+
+        assert_eq!(exp.len(), 3);
+        assert!(matches!(exp[0], RpnExpressionNode::Constant { .. }));
+        assert!(matches!(exp[1], RpnExpressionNode::ColumnRef { .. }));
+        assert_eq!(exp[2].fn_call_func().name, "logical_or");
+    }
+
+    #[test]
+    fn test_short_circuit_call_is_embedded_in_parent_rpn() {
+        let node = ExprDefBuilder::scalar_func(ScalarFuncSig::PlusInt, FieldTypeTp::LongLong)
+            .push_child(
+                ExprDefBuilder::scalar_func(ScalarFuncSig::LogicalOr, FieldTypeTp::LongLong)
+                    .push_child(ExprDefBuilder::constant_int(1))
+                    .push_child(
+                        ExprDefBuilder::scalar_func(ScalarFuncSig::PlusInt, FieldTypeTp::LongLong)
+                            .push_child(ExprDefBuilder::constant_int(0))
+                            .push_child(ExprDefBuilder::constant_int(0)),
+                    ),
+            )
+            .push_child(ExprDefBuilder::constant_int(3))
+            .build();
+
+        let exp = RpnExpressionBuilder::build_from_expr_tree_with_fn_mapper(
+            node,
+            crate::map_expr_node_to_rpn_func,
+            0,
+        )
+        .unwrap();
+
+        assert_eq!(exp.len(), 3);
+        match &exp[0] {
+            RpnExpressionNode::ShortCircuitFnCall {
+                func_meta, args, ..
+            } => {
+                assert_eq!(func_meta.sig, ScalarFuncSig::LogicalOr);
+                assert_eq!(args.len(), 2);
+            }
+            node => panic!("expected short-circuit call, got {:?}", node),
+        }
+        assert!(matches!(exp[1], RpnExpressionNode::Constant { .. }));
+        assert!(matches!(exp[2], RpnExpressionNode::FnCall { .. }));
+    }
+
+    #[test]
+    fn test_adjacent_short_circuit_calls_are_flattened() {
+        let node = ExprDefBuilder::scalar_func(ScalarFuncSig::LogicalOr, FieldTypeTp::LongLong)
+            .push_child(
+                ExprDefBuilder::scalar_func(ScalarFuncSig::LogicalOr, FieldTypeTp::LongLong)
+                    .push_child(
+                        ExprDefBuilder::scalar_func(
+                            ScalarFuncSig::LogicalOr,
+                            FieldTypeTp::LongLong,
+                        )
+                        .push_child(ExprDefBuilder::column_ref(0, FieldTypeTp::LongLong))
+                        .push_child(ExprDefBuilder::column_ref(1, FieldTypeTp::LongLong)),
+                    )
+                    .push_child(ExprDefBuilder::column_ref(2, FieldTypeTp::LongLong)),
+            )
+            .push_child(ExprDefBuilder::column_ref(3, FieldTypeTp::LongLong))
+            .build();
+
+        let exp = RpnExpressionBuilder::build_from_expr_tree_with_fn_mapper(
+            node,
+            crate::map_expr_node_to_rpn_func,
+            4,
+        )
+        .unwrap();
+
+        assert_eq!(exp.len(), 1);
+        match &exp[0] {
+            RpnExpressionNode::ShortCircuitFnCall {
+                func_meta, args, ..
+            } => {
+                assert_eq!(func_meta.sig, ScalarFuncSig::LogicalOr);
+                assert_eq!(args.len(), 3);
+                assert_eq!(args[0].len(), 3);
+                assert!(matches!(
+                    args[0].last(),
+                    Some(RpnExpressionNode::FnCall { .. })
+                ));
+            }
+            node => panic!("expected short-circuit call, got {:?}", node),
+        }
+        assert_eq!(exp.node_count(), 6);
+        assert_eq!(exp.column_ref_count(), 4);
+        assert_eq!(exp.referenced_column_offsets(), &[0, 1, 2, 3]);
     }
 
     #[test]

--- a/components/tidb_query_expr/src/types/expr_builder.rs
+++ b/components/tidb_query_expr/src/types/expr_builder.rs
@@ -22,7 +22,8 @@ use super::{
 use crate::ShortCircuitFnMeta;
 
 // Each active short-circuit call retains batch results and may retain row maps.
-// Bound nesting to keep both the evaluator stack and retained batch state small.
+// Bound nesting to keep both the evaluator stack and retained batch state
+// small.
 const MAX_SHORT_CIRCUIT_NESTING_DEPTH: usize = 32;
 
 /// Helper to build an `RpnExpression`.

--- a/components/tidb_query_expr/src/types/expr_builder.rs
+++ b/components/tidb_query_expr/src/types/expr_builder.rs
@@ -670,14 +670,16 @@ fn extract_scalar_value_vector_float32(val: Vec<u8>) -> Result<ScalarValue> {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::{sync::Arc, thread};
 
     use tidb_query_codegen::rpn_fn;
     use tidb_query_common::Result;
     use tidb_query_datatype::{
         FieldTypeTp,
+        codec::batch::LazyBatchColumnVec,
         expr::{EvalConfig, Flag},
     };
+    use tikv_util::sys::thread::StdThreadBuildWrapper;
     use tipb::ScalarFuncSig;
     use tipb_helper::ExprDefBuilder;
 
@@ -701,8 +703,68 @@ mod tests {
             .unwrap_or(0)
     }
 
-    fn max_short_circuit_depth() -> usize {
-        MAX_SHORT_CIRCUIT_NESTING_DEPTH
+    fn nested_logical_sig(root_sig: ScalarFuncSig, level: usize) -> ScalarFuncSig {
+        if level.is_multiple_of(2) {
+            root_sig
+        } else if root_sig == ScalarFuncSig::LogicalOr {
+            ScalarFuncSig::LogicalAnd
+        } else {
+            ScalarFuncSig::LogicalOr
+        }
+    }
+
+    fn nested_logical_expr(depth: usize, root_sig: ScalarFuncSig, wrap_in_cast: bool) -> Expr {
+        // Make even the innermost logical call worthwhile, so `depth` is the
+        // candidate short-circuit depth, without an off-by-one for a simple call.
+        let mut node =
+            ExprDefBuilder::scalar_func(ScalarFuncSig::CastIntAsInt, FieldTypeTp::LongLong)
+                .push_child(ExprDefBuilder::column_ref(depth, FieldTypeTp::LongLong))
+                .build();
+        for level in (0..depth).rev() {
+            if wrap_in_cast {
+                node =
+                    ExprDefBuilder::scalar_func(ScalarFuncSig::CastIntAsInt, FieldTypeTp::LongLong)
+                        .push_child(node)
+                        .build();
+            }
+            node = ExprDefBuilder::scalar_func(
+                nested_logical_sig(root_sig, level),
+                FieldTypeTp::LongLong,
+            )
+            .push_child(ExprDefBuilder::column_ref(level, FieldTypeTp::LongLong))
+            .push_child(node)
+            .build();
+        }
+        node
+    }
+
+    fn nested_logical_columns(
+        depth: usize,
+        root_sig: ScalarFuncSig,
+        partial: bool,
+    ) -> LazyBatchColumnVec {
+        let mut columns = Vec::with_capacity(depth + 1);
+        for level in 0..=depth {
+            let is_or = nested_logical_sig(root_sig, level) == ScalarFuncSig::LogicalOr;
+            let values: Vec<_> = (0..2 * crate::BATCH_MAX_SIZE)
+                .map(|physical_row| {
+                    let row = physical_row / 2;
+                    if level < depth && partial && row == level {
+                        // Resolve just one new row at each level, retaining nearly
+                        // full batches and row maps throughout the recursion.
+                        Some(if is_or { 9 } else { 0 })
+                    } else if row % 3 == 2 {
+                        None
+                    } else if level == depth {
+                        Some(if row % 3 == 0 { 0 } else { -7 })
+                    } else {
+                        Some(if is_or { 0 } else { -11 })
+                    }
+                })
+                .collect();
+            columns.push(VectorValue::Int(values.into()));
+        }
+        LazyBatchColumnVec::from(columns)
     }
 
     /// An RPN function for test. It accepts 1 int argument, returns float.
@@ -1143,35 +1205,99 @@ mod tests {
     }
 
     #[test]
-    fn test_deep_mixed_short_circuit_calls_fall_back_to_rpn() {
-        let mut node = ExprDefBuilder::column_ref(0, FieldTypeTp::LongLong).build();
-        for i in 0..=max_short_circuit_depth() + 1 {
-            let sig = if i % 2 == 0 {
-                ScalarFuncSig::LogicalOr
-            } else {
-                ScalarFuncSig::LogicalAnd
-            };
-            node = ExprDefBuilder::scalar_func(sig, FieldTypeTp::LongLong)
-                .push_child(ExprDefBuilder::column_ref(0, FieldTypeTp::LongLong))
-                .push_child(node)
-                .build();
+    fn test_short_circuit_depth_limit_stress_on_small_stack() {
+        let limit = MAX_SHORT_CIRCUIT_NESTING_DEPTH;
+        for depth in [limit - 1, limit, limit + 1, 8 * limit] {
+            for root_sig in [ScalarFuncSig::LogicalOr, ScalarFuncSig::LogicalAnd] {
+                for wrap_in_cast in [false, true] {
+                    // Build on a separate stack so the 2 MiB evaluation stack
+                    // below tests runtime recursion, not AST construction.
+                    let (lazy, eager) = thread::Builder::new()
+                        .stack_size(16 * 1024 * 1024)
+                        .spawn_wrapper(move || {
+                            let build = |ctx: &mut EvalContext| {
+                                RpnExpressionBuilder::build_from_expr_tree(
+                                    nested_logical_expr(depth, root_sig, wrap_in_cast),
+                                    ctx,
+                                    depth + 1,
+                                )
+                                .unwrap()
+                            };
+                            (
+                                build(&mut short_circuit_context()),
+                                build(&mut EvalContext::default()),
+                            )
+                        })
+                        .unwrap()
+                        .join()
+                        .unwrap();
+
+                    thread::Builder::new()
+                        .stack_size(2 * 1024 * 1024)
+                        .spawn_wrapper(move || {
+                            let case =
+                                format!("depth={depth}, root={root_sig:?}, cast={wrap_in_cast}");
+                            assert_eq!(short_circuit_depth(&lazy), depth.min(limit));
+                            assert_eq!(short_circuit_depth(&eager), 0);
+                            // Collect metadata on the constrained stack too.
+                            assert_eq!(lazy.node_count(), eager.node_count());
+                            assert_eq!(lazy.column_ref_count(), depth + 1);
+                            assert_eq!(
+                                lazy.referenced_column_offsets(),
+                                &(0..=depth).collect::<Vec<_>>()
+                            );
+
+                            let batch_size = crate::BATCH_MAX_SIZE;
+                            let schema = vec![FieldTypeTp::LongLong.into(); depth + 1];
+                            // Sparse, reversed rows force nested calls to maintain
+                            // both output positions and physical row mappings.
+                            let mut logical_rows: Vec<_> =
+                                (0..batch_size).rev().map(|row| 2 * row + 1).collect();
+                            for partial in [false, true] {
+                                let mut columns = nested_logical_columns(depth, root_sig, partial);
+                                let mut lazy_ctx = short_circuit_context();
+                                let mut eager_ctx = EvalContext::default();
+                                for batch in 0..8 {
+                                    let expected = eager
+                                        .eval(
+                                            &mut eager_ctx,
+                                            &schema,
+                                            &mut columns,
+                                            &logical_rows,
+                                            batch_size,
+                                        )
+                                        .unwrap()
+                                        .vector_value()
+                                        .unwrap()
+                                        .as_ref()
+                                        .to_int_vec();
+                                    assert!(expected.contains(&Some(0)));
+                                    assert!(expected.contains(&Some(1)));
+                                    assert!(expected.contains(&None));
+                                    let result = lazy
+                                        .eval(
+                                            &mut lazy_ctx,
+                                            &schema,
+                                            &mut columns,
+                                            &logical_rows,
+                                            batch_size,
+                                        )
+                                        .unwrap();
+                                    assert_eq!(
+                                        result.vector_value().unwrap().as_ref().to_int_vec(),
+                                        expected,
+                                        "{case}, partial={partial}, batch={batch}"
+                                    );
+                                    logical_rows.rotate_left(1);
+                                }
+                            }
+                        })
+                        .unwrap()
+                        .join()
+                        .unwrap();
+                }
+            }
         }
-
-        let mut ctx = short_circuit_context();
-        let exp = RpnExpressionBuilder::build_from_expr_tree_with_fn_mapper_and_ctx(
-            node,
-            &mut ctx,
-            crate::map_expr_node_to_rpn_func,
-            1,
-        )
-        .unwrap();
-
-        assert_eq!(short_circuit_depth(&exp), max_short_circuit_depth());
-        assert!(matches!(
-            exp.last(),
-            Some(RpnExpressionNode::FnCall { func_meta, .. })
-                if func_meta.name == "logical_or" || func_meta.name == "logical_and"
-        ));
     }
 
     #[test]

--- a/components/tidb_query_expr/src/types/expr_eval.rs
+++ b/components/tidb_query_expr/src/types/expr_eval.rs
@@ -270,6 +270,7 @@ impl RpnExpression {
         // A single-node expression does not need the temporary RPN stack below.
         // This is especially common for short-circuit arguments such as constants
         // and column references, so evaluate it directly to avoid a heap allocation.
+        // TODO: Maybe import SmallVec is better?
         if self.len() == 1 {
             let (_, result) = Self::eval_one_node(
                 ctx,
@@ -283,7 +284,7 @@ impl RpnExpression {
             return Ok(result);
         }
 
-        // Is this stack can be reused?
+        // TODO: Is this stack can be reused?
         let mut stack = Vec::with_capacity(self.len());
 
         for node in self.as_ref() {
@@ -393,7 +394,10 @@ impl RpnExpression {
 mod tests {
     #![allow(clippy::float_cmp)]
 
-    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
 
     use test::{Bencher, black_box};
     use tidb_query_codegen::rpn_fn;
@@ -405,15 +409,21 @@ mod tests {
             data_type::*,
             datum::{Datum, DatumEncoder},
         },
-        expr::EvalContext,
+        expr::{EvalConfig, EvalContext, Flag},
     };
-    use tipb::FieldType;
+    use tipb::{FieldType, ScalarFuncSig};
     use tipb_helper::ExprDefBuilder;
 
     use super::*;
     use crate::{RpnExpressionBuilder, RpnFnMeta, impl_arithmetic::*, impl_compare::*};
 
     static SHORT_CIRCUIT_RHS_EVAL_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+    fn short_circuit_context() -> EvalContext {
+        EvalContext::new(Arc::new(EvalConfig::from_flag(
+            Flag::ENABLE_SHORT_CIRCUIT_EXPRESSION,
+        )))
+    }
 
     #[rpn_fn(nullable)]
     fn short_circuit_counted_identity(v: Option<&Int>) -> Result<Option<Int>> {
@@ -479,11 +489,13 @@ mod tests {
                         .push_child(ExprDefBuilder::column_ref(1, FieldTypeTp::LongLong)),
                 )
                 .build();
-            let exp = RpnExpressionBuilder::build_from_expr_tree_with_fn_mapper(node, fn_mapper, 2)
-                .unwrap();
+            let mut ctx = short_circuit_context();
+            let exp = RpnExpressionBuilder::build_from_expr_tree_with_fn_mapper_and_ctx(
+                node, &mut ctx, fn_mapper, 2,
+            )
+            .unwrap();
             let mut columns = LazyBatchColumnVec::from(vec![int_column(lhs), int_column(rhs)]);
             let schema = &[FieldTypeTp::LongLong.into(), FieldTypeTp::LongLong.into()];
-            let mut ctx = EvalContext::default();
 
             SHORT_CIRCUIT_RHS_EVAL_COUNT.store(0, Ordering::SeqCst);
             let result = exp
@@ -610,9 +622,11 @@ mod tests {
                     .push_child(ExprDefBuilder::constant_int(0)),
             )
             .build();
-        let exp =
-            RpnExpressionBuilder::build_from_expr_tree_with_fn_mapper(node, fn_mapper, 0).unwrap();
-        let mut ctx = EvalContext::default();
+        let mut ctx = short_circuit_context();
+        let exp = RpnExpressionBuilder::build_from_expr_tree_with_fn_mapper_and_ctx(
+            node, &mut ctx, fn_mapper, 0,
+        )
+        .unwrap();
         let mut columns = LazyBatchColumnVec::empty();
 
         let result = exp.eval(&mut ctx, &[], &mut columns, &[], 10).unwrap();
@@ -639,10 +653,8 @@ mod tests {
                 .push_child(constant(lhs))
                 .push_child(constant(rhs))
                 .build();
-            let exp =
-                RpnExpressionBuilder::build_from_expr_tree(node, &mut EvalContext::default(), 0)
-                    .unwrap();
-            let mut ctx = EvalContext::default();
+            let mut ctx = short_circuit_context();
+            let exp = RpnExpressionBuilder::build_from_expr_tree(node, &mut ctx, 0).unwrap();
             let mut columns = LazyBatchColumnVec::empty();
 
             let result = exp.eval(&mut ctx, &[], &mut columns, &[], 3).unwrap();
@@ -662,6 +674,38 @@ mod tests {
     }
 
     #[test]
+    fn test_short_circuit_suppresses_cast_warning() {
+        fn run_case(flag: Flag) -> usize {
+            let node = ExprDefBuilder::scalar_func(ScalarFuncSig::LogicalOr, FieldTypeTp::LongLong)
+                .push_child(ExprDefBuilder::constant_int(1))
+                .push_child(
+                    ExprDefBuilder::scalar_func(
+                        ScalarFuncSig::CastStringAsInt,
+                        FieldTypeTp::LongLong,
+                    )
+                    .push_child(ExprDefBuilder::constant_bytes(b"invalid-int".to_vec())),
+                )
+                .build();
+            let mut ctx = EvalContext::new(Arc::new(EvalConfig::from_flag(flag)));
+            let exp = RpnExpressionBuilder::build_from_expr_tree(node, &mut ctx, 0).unwrap();
+            let mut columns = LazyBatchColumnVec::empty();
+
+            let result = exp.eval(&mut ctx, &[], &mut columns, &[], 3).unwrap();
+            assert_eq!(
+                result.vector_value().unwrap().as_ref().to_int_vec(),
+                vec![Some(1); 3]
+            );
+            ctx.warnings.warning_cnt
+        }
+
+        assert_eq!(
+            run_case(Flag::ENABLE_SHORT_CIRCUIT_EXPRESSION | Flag::TRUNCATE_AS_WARNING),
+            0
+        );
+        assert!(run_case(Flag::TRUNCATE_AS_WARNING) > 0);
+    }
+
+    #[test]
     fn test_normal_parent_consumes_short_circuit_result() {
         use tipb::ScalarFuncSig;
 
@@ -669,19 +713,23 @@ mod tests {
             .push_child(
                 ExprDefBuilder::scalar_func(ScalarFuncSig::LogicalOr, FieldTypeTp::LongLong)
                     .push_child(ExprDefBuilder::column_ref(0, FieldTypeTp::LongLong))
-                    .push_child(ExprDefBuilder::column_ref(1, FieldTypeTp::LongLong)),
+                    .push_child(
+                        ExprDefBuilder::scalar_func(
+                            ScalarFuncSig::CastIntAsInt,
+                            FieldTypeTp::LongLong,
+                        )
+                        .push_child(ExprDefBuilder::column_ref(1, FieldTypeTp::LongLong)),
+                    ),
             )
             .push_child(ExprDefBuilder::constant_int(10))
             .build();
-        let exp = RpnExpressionBuilder::build_from_expr_tree(node, &mut EvalContext::default(), 2)
-            .unwrap();
+        let mut ctx = short_circuit_context();
+        let exp = RpnExpressionBuilder::build_from_expr_tree(node, &mut ctx, 2).unwrap();
         let mut columns = LazyBatchColumnVec::from(vec![
             VectorValue::Int(vec![Some(0), Some(1), None].into()),
             VectorValue::Int(vec![Some(0), None, Some(0)].into()),
         ]);
         let schema = &[FieldTypeTp::LongLong.into(), FieldTypeTp::LongLong.into()];
-        let mut ctx = EvalContext::default();
-
         let result = exp
             .eval(&mut ctx, schema, &mut columns, &[2, 0, 1], 3)
             .unwrap();
@@ -700,12 +748,18 @@ mod tests {
             .push_child(
                 ExprDefBuilder::scalar_func(ScalarFuncSig::LogicalOr, FieldTypeTp::LongLong)
                     .push_child(ExprDefBuilder::column_ref(0, FieldTypeTp::LongLong))
-                    .push_child(ExprDefBuilder::column_ref(1, FieldTypeTp::LongLong)),
+                    .push_child(
+                        ExprDefBuilder::scalar_func(
+                            ScalarFuncSig::CastIntAsInt,
+                            FieldTypeTp::LongLong,
+                        )
+                        .push_child(ExprDefBuilder::column_ref(1, FieldTypeTp::LongLong)),
+                    ),
             )
             .push_child(ExprDefBuilder::column_ref(2, FieldTypeTp::LongLong))
             .build();
-        let exp = RpnExpressionBuilder::build_from_expr_tree(node, &mut EvalContext::default(), 3)
-            .unwrap();
+        let mut ctx = short_circuit_context();
+        let exp = RpnExpressionBuilder::build_from_expr_tree(node, &mut ctx, 3).unwrap();
         let mut columns = LazyBatchColumnVec::from(vec![
             VectorValue::Int(vec![Some(1), Some(0), None, Some(0)].into()),
             VectorValue::Int(vec![Some(0), Some(0), Some(0), None].into()),
@@ -716,8 +770,6 @@ mod tests {
             FieldTypeTp::LongLong.into(),
             FieldTypeTp::LongLong.into(),
         ];
-        let mut ctx = EvalContext::default();
-
         let result = exp
             .eval(&mut ctx, schema, &mut columns, &[3, 1, 2, 0], 4)
             .unwrap();
@@ -740,8 +792,8 @@ mod tests {
             )
             .push_child(ExprDefBuilder::column_ref(2, FieldTypeTp::LongLong))
             .build();
-        let exp = RpnExpressionBuilder::build_from_expr_tree(node, &mut EvalContext::default(), 3)
-            .unwrap();
+        let mut ctx = short_circuit_context();
+        let exp = RpnExpressionBuilder::build_from_expr_tree(node, &mut ctx, 3).unwrap();
         let mut columns = LazyBatchColumnVec::from(vec![
             VectorValue::Int(vec![Some(1), Some(0), None, Some(0)].into()),
             VectorValue::Int(vec![Some(0), Some(0), Some(0), None].into()),
@@ -752,8 +804,6 @@ mod tests {
             FieldTypeTp::LongLong.into(),
             FieldTypeTp::LongLong.into(),
         ];
-        let mut ctx = EvalContext::default();
-
         let result = exp
             .eval(&mut ctx, schema, &mut columns, &[3, 1, 2, 0], 4)
             .unwrap();
@@ -783,8 +833,8 @@ mod tests {
             )
             .push_child(ExprDefBuilder::column_ref(3, FieldTypeTp::LongLong))
             .build();
-        let exp = RpnExpressionBuilder::build_from_expr_tree(node, &mut EvalContext::default(), 4)
-            .unwrap();
+        let mut ctx = short_circuit_context();
+        let exp = RpnExpressionBuilder::build_from_expr_tree(node, &mut ctx, 4).unwrap();
         let mut columns = LazyBatchColumnVec::from(vec![
             VectorValue::Int(vec![Some(1), Some(0), None, Some(0), Some(0), Some(1)].into()),
             VectorValue::Int(vec![Some(0); 6].into()),
@@ -797,8 +847,6 @@ mod tests {
             FieldTypeTp::LongLong.into(),
             FieldTypeTp::LongLong.into(),
         ];
-        let mut ctx = EvalContext::default();
-
         let result = exp
             .eval(&mut ctx, schema, &mut columns, &[5, 2, 0, 4, 1, 3], 6)
             .unwrap();

--- a/components/tidb_query_expr/src/types/expr_eval.rs
+++ b/components/tidb_query_expr/src/types/expr_eval.rs
@@ -233,14 +233,9 @@ impl RpnExpression {
         input_physical_columns: &'a mut LazyBatchColumnVec,
         input_logical_rows: &[usize],
     ) -> Result<()> {
-        for node in self.as_ref() {
-            if let RpnExpressionNode::ColumnRef { offset, .. } = node {
-                input_physical_columns[*offset].ensure_decoded(
-                    ctx,
-                    &schema[*offset],
-                    LogicalRows::from_slice(input_logical_rows),
-                )?;
-            }
+        let logical_rows = LogicalRows::from_slice(input_logical_rows);
+        for &offset in self.referenced_column_offsets() {
+            input_physical_columns[offset].ensure_decoded(ctx, &schema[offset], logical_rows)?;
         }
         Ok(())
     }
@@ -271,66 +266,134 @@ impl RpnExpression {
     ) -> Result<RpnStackNode<'a>> {
         assert!(output_rows > 0);
         assert!(output_rows <= BATCH_MAX_SIZE);
+
+        // A single-node expression does not need the temporary RPN stack below.
+        // This is especially common for short-circuit arguments such as constants
+        // and column references, so evaluate it directly to avoid a heap allocation.
+        if self.len() == 1 {
+            let (_, result) = Self::eval_one_node(
+                ctx,
+                schema,
+                input_physical_columns,
+                input_logical_rows,
+                output_rows,
+                &self.as_ref()[0],
+                &[],
+            )?;
+            return Ok(result);
+        }
+
+        // Is this stack can be reused?
         let mut stack = Vec::with_capacity(self.len());
 
         for node in self.as_ref() {
-            match node {
-                RpnExpressionNode::Constant { value, field_type } => {
-                    stack.push(RpnStackNode::Scalar { value, field_type });
-                }
-                RpnExpressionNode::ColumnRef { offset } => {
-                    let field_type = &schema[*offset];
-                    let decoded_physical_column = input_physical_columns[*offset].decoded();
-                    assert_eq!(input_logical_rows.len(), output_rows);
-                    stack.push(RpnStackNode::Vector {
+            let (consumed_args, result) = Self::eval_one_node(
+                ctx,
+                schema,
+                input_physical_columns,
+                input_logical_rows,
+                output_rows,
+                node,
+                &stack,
+            )?;
+            stack.truncate(stack.len() - consumed_args);
+            stack.push(result);
+        }
+
+        assert_eq!(stack.len(), 1);
+        Ok(stack.into_iter().next().unwrap())
+    }
+
+    #[inline]
+    fn eval_one_node<'a>(
+        ctx: &mut EvalContext,
+        schema: &'a [FieldType],
+        input_physical_columns: &'a LazyBatchColumnVec,
+        input_logical_rows: &'a [usize],
+        output_rows: usize,
+        node: &'a RpnExpressionNode,
+        stack: &[RpnStackNode<'a>],
+    ) -> Result<(usize, RpnStackNode<'a>)> {
+        match node {
+            RpnExpressionNode::Constant { value, field_type } => {
+                Ok((0, RpnStackNode::Scalar { value, field_type }))
+            }
+            RpnExpressionNode::ColumnRef { offset } => {
+                let field_type = &schema[*offset];
+                let decoded_physical_column = input_physical_columns[*offset].decoded();
+                assert_eq!(input_logical_rows.len(), output_rows);
+                Ok((
+                    0,
+                    RpnStackNode::Vector {
                         value: RpnStackNodeVectorValue::Ref {
                             physical_value: decoded_physical_column,
                             logical_rows: input_logical_rows,
                         },
                         field_type,
-                    });
-                }
-                RpnExpressionNode::FnCall {
-                    func_meta,
-                    args_len,
-                    field_type: ret_field_type,
-                    metadata,
-                } => {
-                    // Suppose that we have function call `Foo(A, B, C)`, the RPN nodes looks like
-                    // `[A, B, C, Foo]`.
-                    // Now we receives a function call `Foo`, so there are `[A, B, C]` in the stack
-                    // as the last several elements. We will directly use the last N (N = number of
-                    // arguments) elements in the stack as function arguments.
-                    assert!(stack.len() >= *args_len);
-                    let stack_slice_begin = stack.len() - *args_len;
-                    let stack_slice = &stack[stack_slice_begin..];
-                    let mut call_extra = RpnFnCallExtra { ret_field_type };
-                    let ret = (func_meta.fn_ptr)(
-                        ctx,
-                        output_rows,
-                        stack_slice,
-                        &mut call_extra,
-                        &**metadata,
-                    )?;
-                    stack.truncate(stack_slice_begin);
-                    stack.push(RpnStackNode::Vector {
+                    },
+                ))
+            }
+            RpnExpressionNode::ShortCircuitFnCall {
+                func_meta,
+                args,
+                field_type,
+            } => {
+                let ret = (func_meta.fn_ptr)(
+                    ctx,
+                    schema,
+                    input_physical_columns,
+                    input_logical_rows,
+                    output_rows,
+                    args,
+                )?;
+                Ok((
+                    0,
+                    RpnStackNode::Vector {
+                        value: RpnStackNodeVectorValue::Generated {
+                            physical_value: ret,
+                        },
+                        field_type,
+                    },
+                ))
+            }
+            RpnExpressionNode::FnCall {
+                func_meta,
+                args_len,
+                field_type: ret_field_type,
+                metadata,
+            } => {
+                // Suppose that we have a function call `Foo(A, B, C)`, the RPN nodes look like
+                // `[A, B, C, Foo]`. The last N stack elements are its arguments.
+                assert!(stack.len() >= *args_len);
+                let stack_slice_begin = stack.len() - *args_len;
+                let stack_slice = &stack[stack_slice_begin..];
+                let mut call_extra = RpnFnCallExtra { ret_field_type };
+                let ret = (func_meta.fn_ptr)(
+                    ctx,
+                    output_rows,
+                    stack_slice,
+                    &mut call_extra,
+                    &**metadata,
+                )?;
+                Ok((
+                    *args_len,
+                    RpnStackNode::Vector {
                         value: RpnStackNodeVectorValue::Generated {
                             physical_value: ret,
                         },
                         field_type: ret_field_type,
-                    });
-                }
+                    },
+                ))
             }
         }
-
-        assert_eq!(stack.len(), 1);
-        Ok(stack.into_iter().next().unwrap())
     }
 }
 
 #[cfg(test)]
 mod tests {
     #![allow(clippy::float_cmp)]
+
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     use test::{Bencher, black_box};
     use tidb_query_codegen::rpn_fn;
@@ -350,6 +413,19 @@ mod tests {
     use super::*;
     use crate::{RpnExpressionBuilder, RpnFnMeta, impl_arithmetic::*, impl_compare::*};
 
+    static SHORT_CIRCUIT_RHS_EVAL_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+    #[rpn_fn(nullable)]
+    fn short_circuit_counted_identity(v: Option<&Int>) -> Result<Option<Int>> {
+        SHORT_CIRCUIT_RHS_EVAL_COUNT.fetch_add(1, Ordering::SeqCst);
+        Ok(v.copied())
+    }
+
+    #[rpn_fn(nullable)]
+    fn short_circuit_unreachable(_v: Option<&Int>) -> Result<Option<Int>> {
+        unreachable!("short-circuited argument must not be evaluated")
+    }
+
     /// Single constant node
     #[test]
     fn test_eval_single_constant_node() {
@@ -366,6 +442,371 @@ mod tests {
             Real::new(1.5).ok().as_ref()
         );
         assert_eq!(val.field_type().as_accessor().tp(), FieldTypeTp::Double);
+    }
+
+    #[test]
+    fn test_logical_short_circuit_skips_rhs_rows() {
+        use tipb::{Expr, ScalarFuncSig};
+
+        fn fn_mapper(expr: &Expr) -> Result<RpnFnMeta> {
+            if expr.get_sig() == ScalarFuncSig::CastIntAsInt {
+                return Ok(short_circuit_counted_identity_fn_meta());
+            }
+            crate::map_expr_node_to_rpn_func(expr)
+        }
+
+        fn int_column(values: &[Option<Int>]) -> LazyBatchColumn {
+            let mut col =
+                LazyBatchColumn::decoded_with_capacity_and_tp(values.len(), EvalType::Int);
+            for value in values {
+                col.mut_decoded().push_int(*value);
+            }
+            col
+        }
+
+        fn run_case(
+            sig: ScalarFuncSig,
+            lhs: &[Option<Int>],
+            rhs: &[Option<Int>],
+            logical_rows: &[usize],
+            expected: &[Option<Int>],
+            expected_rhs_eval_count: usize,
+        ) {
+            let node = ExprDefBuilder::scalar_func(sig, FieldTypeTp::LongLong)
+                .push_child(ExprDefBuilder::column_ref(0, FieldTypeTp::LongLong))
+                .push_child(
+                    ExprDefBuilder::scalar_func(ScalarFuncSig::CastIntAsInt, FieldTypeTp::LongLong)
+                        .push_child(ExprDefBuilder::column_ref(1, FieldTypeTp::LongLong)),
+                )
+                .build();
+            let exp = RpnExpressionBuilder::build_from_expr_tree_with_fn_mapper(node, fn_mapper, 2)
+                .unwrap();
+            let mut columns = LazyBatchColumnVec::from(vec![int_column(lhs), int_column(rhs)]);
+            let schema = &[FieldTypeTp::LongLong.into(), FieldTypeTp::LongLong.into()];
+            let mut ctx = EvalContext::default();
+
+            SHORT_CIRCUIT_RHS_EVAL_COUNT.store(0, Ordering::SeqCst);
+            let result = exp
+                .eval(
+                    &mut ctx,
+                    schema,
+                    &mut columns,
+                    logical_rows,
+                    logical_rows.len(),
+                )
+                .unwrap();
+
+            assert_eq!(
+                result.vector_value().unwrap().as_ref().to_int_vec(),
+                expected
+            );
+            assert_eq!(
+                SHORT_CIRCUIT_RHS_EVAL_COUNT.load(Ordering::SeqCst),
+                expected_rhs_eval_count
+            );
+        }
+
+        run_case(
+            ScalarFuncSig::LogicalAnd,
+            &[
+                Some(0),
+                Some(0),
+                Some(0),
+                Some(2),
+                Some(2),
+                Some(2),
+                None,
+                None,
+                None,
+            ],
+            &[
+                Some(0),
+                Some(3),
+                None,
+                Some(0),
+                Some(3),
+                None,
+                Some(0),
+                Some(3),
+                None,
+            ],
+            &[0, 1, 2, 3, 4, 5, 6, 7, 8],
+            &[
+                Some(0),
+                Some(0),
+                Some(0),
+                Some(0),
+                Some(1),
+                None,
+                Some(0),
+                None,
+                None,
+            ],
+            6,
+        );
+        run_case(
+            ScalarFuncSig::LogicalOr,
+            &[
+                Some(0),
+                Some(0),
+                Some(0),
+                Some(2),
+                Some(2),
+                Some(2),
+                None,
+                None,
+                None,
+            ],
+            &[
+                Some(0),
+                Some(3),
+                None,
+                Some(0),
+                Some(3),
+                None,
+                Some(0),
+                Some(3),
+                None,
+            ],
+            &[0, 1, 2, 3, 4, 5, 6, 7, 8],
+            &[
+                Some(0),
+                Some(1),
+                None,
+                Some(1),
+                Some(1),
+                Some(1),
+                None,
+                Some(1),
+                None,
+            ],
+            6,
+        );
+        run_case(
+            ScalarFuncSig::LogicalOr,
+            &[Some(1), Some(0), None, Some(2), Some(0)],
+            &[Some(0), Some(0), Some(1), None, None],
+            &[4, 0, 2, 3, 1],
+            &[None, Some(1), Some(1), Some(1), Some(0)],
+            3,
+        );
+    }
+
+    #[test]
+    fn test_constant_short_circuit_skips_all_rhs_rows() {
+        use tipb::{Expr, ScalarFuncSig};
+
+        fn fn_mapper(expr: &Expr) -> Result<RpnFnMeta> {
+            if expr.get_sig() == ScalarFuncSig::CastIntAsInt {
+                return Ok(short_circuit_unreachable_fn_meta());
+            }
+            crate::map_expr_node_to_rpn_func(expr)
+        }
+
+        let node = ExprDefBuilder::scalar_func(ScalarFuncSig::LogicalOr, FieldTypeTp::LongLong)
+            .push_child(ExprDefBuilder::constant_int(1))
+            .push_child(
+                ExprDefBuilder::scalar_func(ScalarFuncSig::CastIntAsInt, FieldTypeTp::LongLong)
+                    .push_child(ExprDefBuilder::constant_int(0)),
+            )
+            .build();
+        let exp =
+            RpnExpressionBuilder::build_from_expr_tree_with_fn_mapper(node, fn_mapper, 0).unwrap();
+        let mut ctx = EvalContext::default();
+        let mut columns = LazyBatchColumnVec::empty();
+
+        let result = exp.eval(&mut ctx, &[], &mut columns, &[], 10).unwrap();
+
+        assert_eq!(
+            result.vector_value().unwrap().as_ref().to_int_vec(),
+            vec![Some(1); 10]
+        );
+    }
+
+    #[test]
+    fn test_constant_short_circuit_without_logical_rows() {
+        use tipb::ScalarFuncSig;
+
+        fn constant(value: Option<Int>) -> ExprDefBuilder {
+            match value {
+                Some(value) => ExprDefBuilder::constant_int(value),
+                None => ExprDefBuilder::constant_null(FieldTypeTp::LongLong),
+            }
+        }
+
+        fn run_case(sig: ScalarFuncSig, lhs: Option<Int>, rhs: Option<Int>, expected: Option<Int>) {
+            let node = ExprDefBuilder::scalar_func(sig, FieldTypeTp::LongLong)
+                .push_child(constant(lhs))
+                .push_child(constant(rhs))
+                .build();
+            let exp =
+                RpnExpressionBuilder::build_from_expr_tree(node, &mut EvalContext::default(), 0)
+                    .unwrap();
+            let mut ctx = EvalContext::default();
+            let mut columns = LazyBatchColumnVec::empty();
+
+            let result = exp.eval(&mut ctx, &[], &mut columns, &[], 3).unwrap();
+
+            assert_eq!(
+                result.vector_value().unwrap().as_ref().to_int_vec(),
+                vec![expected; 3]
+            );
+        }
+
+        run_case(ScalarFuncSig::LogicalOr, Some(0), Some(1), Some(1));
+        run_case(ScalarFuncSig::LogicalAnd, Some(1), Some(0), Some(0));
+        run_case(ScalarFuncSig::LogicalOr, None, Some(1), Some(1));
+        run_case(ScalarFuncSig::LogicalAnd, None, Some(0), Some(0));
+        run_case(ScalarFuncSig::LogicalOr, None, Some(0), None);
+        run_case(ScalarFuncSig::LogicalAnd, None, Some(1), None);
+    }
+
+    #[test]
+    fn test_normal_parent_consumes_short_circuit_result() {
+        use tipb::ScalarFuncSig;
+
+        let node = ExprDefBuilder::scalar_func(ScalarFuncSig::PlusInt, FieldTypeTp::LongLong)
+            .push_child(
+                ExprDefBuilder::scalar_func(ScalarFuncSig::LogicalOr, FieldTypeTp::LongLong)
+                    .push_child(ExprDefBuilder::column_ref(0, FieldTypeTp::LongLong))
+                    .push_child(ExprDefBuilder::column_ref(1, FieldTypeTp::LongLong)),
+            )
+            .push_child(ExprDefBuilder::constant_int(10))
+            .build();
+        let exp = RpnExpressionBuilder::build_from_expr_tree(node, &mut EvalContext::default(), 2)
+            .unwrap();
+        let mut columns = LazyBatchColumnVec::from(vec![
+            VectorValue::Int(vec![Some(0), Some(1), None].into()),
+            VectorValue::Int(vec![Some(0), None, Some(0)].into()),
+        ]);
+        let schema = &[FieldTypeTp::LongLong.into(), FieldTypeTp::LongLong.into()];
+        let mut ctx = EvalContext::default();
+
+        let result = exp
+            .eval(&mut ctx, schema, &mut columns, &[2, 0, 1], 3)
+            .unwrap();
+
+        assert_eq!(
+            result.vector_value().unwrap().as_ref().to_int_vec(),
+            &[None, Some(10), Some(11)]
+        );
+    }
+
+    #[test]
+    fn test_nested_mixed_short_circuit_calls() {
+        use tipb::ScalarFuncSig;
+
+        let node = ExprDefBuilder::scalar_func(ScalarFuncSig::LogicalAnd, FieldTypeTp::LongLong)
+            .push_child(
+                ExprDefBuilder::scalar_func(ScalarFuncSig::LogicalOr, FieldTypeTp::LongLong)
+                    .push_child(ExprDefBuilder::column_ref(0, FieldTypeTp::LongLong))
+                    .push_child(ExprDefBuilder::column_ref(1, FieldTypeTp::LongLong)),
+            )
+            .push_child(ExprDefBuilder::column_ref(2, FieldTypeTp::LongLong))
+            .build();
+        let exp = RpnExpressionBuilder::build_from_expr_tree(node, &mut EvalContext::default(), 3)
+            .unwrap();
+        let mut columns = LazyBatchColumnVec::from(vec![
+            VectorValue::Int(vec![Some(1), Some(0), None, Some(0)].into()),
+            VectorValue::Int(vec![Some(0), Some(0), Some(0), None].into()),
+            VectorValue::Int(vec![Some(1), Some(1), Some(0), Some(1)].into()),
+        ]);
+        let schema = &[
+            FieldTypeTp::LongLong.into(),
+            FieldTypeTp::LongLong.into(),
+            FieldTypeTp::LongLong.into(),
+        ];
+        let mut ctx = EvalContext::default();
+
+        let result = exp
+            .eval(&mut ctx, schema, &mut columns, &[3, 1, 2, 0], 4)
+            .unwrap();
+
+        assert_eq!(
+            result.vector_value().unwrap().as_ref().to_int_vec(),
+            &[None, Some(0), Some(0), Some(1)]
+        );
+    }
+
+    #[test]
+    fn test_flattened_short_circuit_call() {
+        use tipb::ScalarFuncSig;
+
+        let node = ExprDefBuilder::scalar_func(ScalarFuncSig::LogicalOr, FieldTypeTp::LongLong)
+            .push_child(
+                ExprDefBuilder::scalar_func(ScalarFuncSig::LogicalOr, FieldTypeTp::LongLong)
+                    .push_child(ExprDefBuilder::column_ref(0, FieldTypeTp::LongLong))
+                    .push_child(ExprDefBuilder::column_ref(1, FieldTypeTp::LongLong)),
+            )
+            .push_child(ExprDefBuilder::column_ref(2, FieldTypeTp::LongLong))
+            .build();
+        let exp = RpnExpressionBuilder::build_from_expr_tree(node, &mut EvalContext::default(), 3)
+            .unwrap();
+        let mut columns = LazyBatchColumnVec::from(vec![
+            VectorValue::Int(vec![Some(1), Some(0), None, Some(0)].into()),
+            VectorValue::Int(vec![Some(0), Some(0), Some(0), None].into()),
+            VectorValue::Int(vec![Some(0), Some(1), Some(1), Some(0)].into()),
+        ]);
+        let schema = &[
+            FieldTypeTp::LongLong.into(),
+            FieldTypeTp::LongLong.into(),
+            FieldTypeTp::LongLong.into(),
+        ];
+        let mut ctx = EvalContext::default();
+
+        let result = exp
+            .eval(&mut ctx, schema, &mut columns, &[3, 1, 2, 0], 4)
+            .unwrap();
+
+        assert_eq!(
+            result.vector_value().unwrap().as_ref().to_int_vec(),
+            &[None, Some(1), Some(1), Some(1)]
+        );
+    }
+
+    #[test]
+    fn test_flattened_short_circuit_multiple_partial_compactions() {
+        use tipb::ScalarFuncSig;
+
+        let node = ExprDefBuilder::scalar_func(ScalarFuncSig::LogicalOr, FieldTypeTp::LongLong)
+            .push_child(
+                ExprDefBuilder::scalar_func(ScalarFuncSig::LogicalOr, FieldTypeTp::LongLong)
+                    .push_child(
+                        ExprDefBuilder::scalar_func(
+                            ScalarFuncSig::LogicalOr,
+                            FieldTypeTp::LongLong,
+                        )
+                        .push_child(ExprDefBuilder::column_ref(0, FieldTypeTp::LongLong))
+                        .push_child(ExprDefBuilder::column_ref(1, FieldTypeTp::LongLong)),
+                    )
+                    .push_child(ExprDefBuilder::column_ref(2, FieldTypeTp::LongLong)),
+            )
+            .push_child(ExprDefBuilder::column_ref(3, FieldTypeTp::LongLong))
+            .build();
+        let exp = RpnExpressionBuilder::build_from_expr_tree(node, &mut EvalContext::default(), 4)
+            .unwrap();
+        let mut columns = LazyBatchColumnVec::from(vec![
+            VectorValue::Int(vec![Some(1), Some(0), None, Some(0), Some(0), Some(1)].into()),
+            VectorValue::Int(vec![Some(0); 6].into()),
+            VectorValue::Int(vec![Some(0), Some(1), Some(0), Some(0), Some(1), Some(0)].into()),
+            VectorValue::Int(vec![Some(0); 6].into()),
+        ]);
+        let schema = &[
+            FieldTypeTp::LongLong.into(),
+            FieldTypeTp::LongLong.into(),
+            FieldTypeTp::LongLong.into(),
+            FieldTypeTp::LongLong.into(),
+        ];
+        let mut ctx = EvalContext::default();
+
+        let result = exp
+            .eval(&mut ctx, schema, &mut columns, &[5, 2, 0, 4, 1, 3], 6)
+            .unwrap();
+
+        assert_eq!(
+            result.vector_value().unwrap().as_ref().to_int_vec(),
+            &[Some(1), None, Some(1), Some(1), Some(1), Some(0)]
+        );
     }
 
     /// Creates fixture to be used in `test_eval_single_column_node_xxx`.

--- a/components/tidb_query_expr/src/types/function.rs
+++ b/components/tidb_query_expr/src/types/function.rs
@@ -26,10 +26,30 @@ use std::{any::Any, convert::TryFrom, marker::PhantomData};
 
 use static_assertions::assert_eq_size;
 use tidb_query_common::Result;
-use tidb_query_datatype::{EvalType, FieldTypeAccessor, codec::data_type::*, expr::EvalContext};
-use tipb::{Expr, FieldType};
+use tidb_query_datatype::{
+    EvalType, FieldTypeAccessor,
+    codec::{batch::LazyBatchColumnVec, data_type::*},
+    expr::EvalContext,
+};
+use tipb::{Expr, FieldType, ScalarFuncSig};
 
 use super::{RpnStackNode, expr_eval::LogicalRows};
+use crate::RpnExpression;
+
+#[derive(Debug, Clone, Copy)]
+pub struct ShortCircuitFnMeta {
+    pub sig: ScalarFuncSig,
+
+    /// A function that evaluates its arguments on demand for selected rows.
+    pub fn_ptr: fn(
+        ctx: &mut EvalContext,
+        schema: &[FieldType],
+        input_physical_columns: &LazyBatchColumnVec,
+        input_logical_rows: &[usize],
+        output_rows: usize,
+        args: &[RpnExpression],
+    ) -> Result<VectorValue>,
+}
 
 /// Metadata of an RPN function.
 #[derive(Clone, Copy)]

--- a/components/tidb_query_expr/src/types/mod.rs
+++ b/components/tidb_query_expr/src/types/mod.rs
@@ -10,6 +10,6 @@ pub mod test_util;
 pub use self::{
     expr::{RpnExpression, RpnExpressionNode},
     expr_builder::RpnExpressionBuilder,
-    expr_eval::{BATCH_MAX_SIZE, RpnStackNode},
-    function::{RpnFnCallExtra, RpnFnMeta},
+    expr_eval::{BATCH_MAX_SIZE, RpnStackNode, RpnStackNodeVectorValue},
+    function::{RpnFnCallExtra, RpnFnMeta, ShortCircuitFnMeta},
 };

--- a/doc/maintenance-guides/src/coprocessor.md
+++ b/doc/maintenance-guides/src/coprocessor.md
@@ -77,6 +77,8 @@ It is a read-heavy hot path and directly impacts query latency.
 6. `src/coprocessor/interceptors/concurrency_limiter.rs`
 7. `src/coprocessor/dag/mod.rs`
 8. `src/coprocessor/statistics/analyze_context.rs`
+9. `components/tidb_query_expr/src/types/expr_eval.rs`
+10. `components/tidb_query_expr/src/impl_op.rs`
 
 ## Main Responsibilities
 
@@ -97,6 +99,10 @@ It is a read-heavy hot path and directly impacts query latency.
 - Memory quota and concurrency limiters must remain cheap and correct.
 - Streaming and unary response handling must preserve stats and partial-progress
   semantics.
+- Short-circuit AND/OR evaluation must preserve Kleene three-valued logic while
+  keeping pending output positions aligned with non-empty logical-row mappings.
+  An empty logical-row mapping is valid for constant expressions with non-zero
+  output rows and must not be indexed during pending-row compaction.
 
 ## Observability And Operational Signals
 
@@ -141,7 +147,7 @@ It is a read-heavy hot path and directly impacts query latency.
 - Timeout or concurrency admission changes:
   inspect interceptors, `tracker.rs`, metrics, and read-pool behavior
 - DAG execution changes:
-  inspect `dag/*`, snapshot/store setup, and query-side statistics paths
+  inspect `dag/*`, snapshot/store setup, query-side statistics paths
 - Analyze or checksum changes:
   inspect `statistics/*` or `checksum.rs` plus exec-detail accounting
 

--- a/doc/maintenance-guides/src/coprocessor.md
+++ b/doc/maintenance-guides/src/coprocessor.md
@@ -77,8 +77,6 @@ It is a read-heavy hot path and directly impacts query latency.
 6. `src/coprocessor/interceptors/concurrency_limiter.rs`
 7. `src/coprocessor/dag/mod.rs`
 8. `src/coprocessor/statistics/analyze_context.rs`
-9. `components/tidb_query_expr/src/types/expr_eval.rs`
-10. `components/tidb_query_expr/src/impl_op.rs`
 
 ## Main Responsibilities
 
@@ -99,10 +97,6 @@ It is a read-heavy hot path and directly impacts query latency.
 - Memory quota and concurrency limiters must remain cheap and correct.
 - Streaming and unary response handling must preserve stats and partial-progress
   semantics.
-- Short-circuit AND/OR evaluation must preserve Kleene three-valued logic while
-  keeping pending output positions aligned with non-empty logical-row mappings.
-  An empty logical-row mapping is valid for constant expressions with non-zero
-  output rows and must not be indexed during pending-row compaction.
 
 ## Observability And Operational Signals
 
@@ -147,7 +141,7 @@ It is a read-heavy hot path and directly impacts query latency.
 - Timeout or concurrency admission changes:
   inspect interceptors, `tracker.rs`, metrics, and read-pool behavior
 - DAG execution changes:
-  inspect `dag/*`, snapshot/store setup, query-side statistics paths
+  inspect `dag/*`, snapshot/store setup, and query-side statistics paths
 - Analyze or checksum changes:
   inspect `statistics/*` or `checksum.rs` plus exec-detail accounting
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: ref #19801

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

- Add request-controlled short-circuit evaluation for pushed-down logical `AND` and `OR` expressions.
- Evaluate logical arguments from left to right and evaluate subsequent arguments only for unresolved rows.
- Flatten adjacent calls using the same logical operator and keep simple expressions on the regular RPN path to reduce short-circuit bookkeeping overhead.
- Limit the maximum recursion depth for short circuits to 32, and expressions exceeding the limit are rolled back to RPN.
- Add tests for request flag propagation, expression construction, nested and flattened expressions, `NULL` handling, partial-row evaluation, and skipped warnings.

>The current implementation is only for performance optimization and does not guarantee skipping expressions that may cause warnings. 

I conducted a performance comparison benchmark. Benchmark environment:

```
Apple M5, 10 cores (4 performance and 6 efficiency), 24 GB memory
macOS 26.4, arm64
rustc 1.95.0-nightly (842bd5be2 2026-01-29)
Each iteration evaluates 1,048,576 rows in batches of 1,024 rows
One benchmark invocation; each libtest case performs its own sampling
```
Benchmark cases:
- **Constant OR:** Uses an always-true left-hand side and a complex right-hand side to measure the case where all rows are resolved immediately.
- **Simple AND/OR:** Uses two column references to verify that inexpensive expressions remain on the regular RPN path even when short-circuit evaluation is enabled.
- **Complex AND/OR:** Uses arithmetic and comparison expressions on both sides and tests 0%, 95%, and 100% short-circuit rates.
- **32-term AND/OR:** Uses long logical chains to measure the benefits of flattening adjacent operators, evaluating only unresolved rows, and reusing results.

Benchmark results for 100w rows (lower is better):

| Expression | Short-circuit rate | Eager | Lazy | Speedup | Time reduction |
|---|---:|---:|---:|---:|---:|
| Constant OR | 100% | 13.854 ms | 1.891 ms | **7.33x** | 86.3% |
| Complex OR | 0% | 30.860 ms | 31.001 ms | 1.00x | -0.5% |
| Complex OR | 95% | 30.860 ms | 16.408 ms | **1.88x** | 46.8% |
| Complex AND | 0% | 30.865 ms | 29.971 ms | 1.03x | 2.9% |
| Complex AND | 95% | 30.865 ms | 16.307 ms | **1.89x** | 47.2% |
| 32-term OR | 0% | 67.535 ms | 25.279 ms | **2.67x** | 62.6% |
| 32-term OR | 95% | 67.535 ms | 5.533 ms | **12.20x** | 91.8% |
| 32-term AND | 0% | 68.932 ms | 24.882 ms | **2.77x** | 63.9% |
| 32-term AND | 95% | 68.932 ms | 5.594 ms | **12.32x** | 91.9% |

Simple expressions remain on the regular RPN path:

Expression | Flag off | Flag on 
-- | -- | -- 
Simple OR | 2.617 ms | 2.585 ms
Simple AND | 2.764 ms | 2.766 ms


### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Support short-circuit evaluation for pushed-down logical AND and OR expressions to avoid evaluating unnecessary branches.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added short-circuit evaluation for logical `AND` and `OR` expressions.
- Preserves SQL `NULL` semantics while evaluating only required rows.
- Supports nested and combined logical expressions with safe depth handling.
- Added configuration support for enabling short-circuit expression evaluation.
- Added the ability to update vector values and assign or clear `NULL` values.

## Performance
- Reduces unnecessary expression processing and column decoding.
- Improves evaluation of scalar, generated, and referenced values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->