### PR TITLE
raftstore: reset stale transfer leader state

### DIFF
--- a/components/raftstore-v2/src/operation/command/admin/transfer_leader.rs
+++ b/components/raftstore-v2/src/operation/command/admin/transfer_leader.rs
@@ -263,9 +263,10 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
             return false;
         }
         let current_leader = self.leader_id();
+        let current_term = self.term();
         if self
             .transfer_leader_state_mut()
-            .reset_if_stale(current_leader)
+            .reset_if_stale(current_leader, current_term)
         {
             return false;
         }

--- a/components/raftstore-v2/src/operation/command/admin/transfer_leader.rs
+++ b/components/raftstore-v2/src/operation/command/admin/transfer_leader.rs
@@ -259,6 +259,13 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
             self.transfer_leader_state_mut().transfer_leader_msg = None;
             return false;
         }
+        let current_leader = self.leader_id();
+        if self
+            .transfer_leader_state_mut()
+            .reset_if_stale(current_leader)
+        {
+            return false;
+        }
         let Some((msg, deadline)) = &self.transfer_leader_state().transfer_leader_msg else {
             // There is no pending transfer leader message, do not ack.
             return false;

--- a/components/raftstore-v2/src/operation/command/admin/transfer_leader.rs
+++ b/components/raftstore-v2/src/operation/command/admin/transfer_leader.rs
@@ -159,6 +159,9 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         if !self.is_leader() {
             if !self.maybe_reject_transfer_leader_msg(ctx, msg.get_from(), peer_disk_usage) {
                 self.set_pending_transfer_leader_msg(&ctx.cfg, msg);
+                // A retry keeps the original deadline, which may have already
+                // elapsed. Check it immediately instead of waiting for another
+                // poll cycle.
                 if self.maybe_ack_transfer_leader_msg(ctx) {
                     self.set_has_ready();
                 }

--- a/components/raftstore-v2/src/operation/ready/mod.rs
+++ b/components/raftstore-v2/src/operation/ready/mod.rs
@@ -1053,6 +1053,11 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
     pub fn on_role_changed<T>(&mut self, ctx: &mut StoreContext<EK, ER, T>, ready: &Ready) {
         // Update leader lease when the Raft state changes.
         if let Some(ss) = ready.ss() {
+            // A pending pre-transfer request belongs to the previous SoftState.
+            // In particular, a follower can learn about a new leader without
+            // changing its role. Do not let it ACK the old request to the new
+            // leader.
+            self.transfer_leader_state_mut().reset_transferee_state();
             let term = self.term();
             match ss.raft_state {
                 StateRole::Leader => {
@@ -1090,9 +1095,6 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
                         self.region(),
                         &self.logger,
                     );
-
-                    // Exit entry cache warmup state when the peer becomes leader.
-                    self.transfer_leader_state_mut().cache_warmup_state = None;
 
                     if !ctx.store_disk_usages.is_empty() {
                         self.refill_disk_full_peers(ctx);

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -4031,6 +4031,9 @@ where
             self.fsm
                 .peer
                 .set_pending_transfer_leader_msg(&self.ctx.cfg, msg);
+            // A retry keeps the original deadline, which may have already
+            // elapsed. Check it immediately instead of waiting for another
+            // poll cycle.
             if self.fsm.peer.maybe_ack_transfer_leader_msg(self.ctx) {
                 self.fsm.has_ready = true;
             }

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -6564,6 +6564,9 @@ impl TransferLeaderState {
     ///
     /// The peer FSM checks pending messages before processing Ready, so the
     /// SoftState cleanup may not have run when this check is made.
+    /// This check must also happen before deadline evaluation: an expired
+    /// request from the previous leader must be discarded, not ACKed to the
+    /// current leader.
     pub fn reset_if_stale(&mut self, current_leader: u64) -> bool {
         let is_stale = match &self.transfer_leader_msg {
             Some((msg, _)) => msg.get_from() != current_leader,
@@ -6587,6 +6590,10 @@ impl TransferLeaderState {
     /// Records a pre-transfer-leader message without extending the deadline
     /// when the leader retries the same transfer attempt. A different sender
     /// or leader term starts a new attempt.
+    ///
+    /// The preserved deadline may already have elapsed. Callers immediately
+    /// check the pending message: a request from the current leader receives
+    /// its timeout ACK, while a stale request is discarded first.
     pub fn set_pending_message(&mut self, msg: &eraftpb::Message, deadline: Instant) {
         let is_retry = self
             .transfer_leader_msg

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -2449,6 +2449,11 @@ where
     fn on_role_changed<T>(&mut self, ctx: &mut PollContext<EK, ER, T>, ready: &Ready) {
         // Update leader lease when the Raft state changes.
         if let Some(ss) = ready.ss() {
+            // A pending pre-transfer request belongs to the previous SoftState.
+            // In particular, a follower can learn about a new leader without
+            // changing its role. Do not let it ACK the old request to the new
+            // leader.
+            self.transfer_leader_state.reset_transferee_state();
             match ss.raft_state {
                 StateRole::Leader => {
                     // The local read can only be performed after a new leader has applied
@@ -2484,8 +2489,6 @@ where
                     self.require_updating_max_ts(&ctx.pd_scheduler);
                     // Init the in-memory pessimistic lock table when the peer becomes leader.
                     self.activate_in_memory_pessimistic_locks();
-                    // Exit entry cache warmup state when the peer becomes leader.
-                    self.transfer_leader_state.cache_warmup_state = None;
 
                     if !ctx.store_disk_usages.is_empty() {
                         self.refill_disk_full_peers(ctx);
@@ -4942,6 +4945,10 @@ where
             return false;
         }
 
+        let current_leader = self.leader_id();
+        if self.transfer_leader_state.reset_if_stale(current_leader) {
+            return false;
+        }
         let Some((msg, deadline)) = &self.transfer_leader_state.transfer_leader_msg else {
             // There is no pending transfer leader message, do not ack.
             return false;
@@ -6553,6 +6560,30 @@ pub struct TransferLeaderState {
 }
 
 impl TransferLeaderState {
+    /// Discards transferee state created for a previous leader.
+    ///
+    /// The peer FSM checks pending messages before processing Ready, so the
+    /// SoftState cleanup may not have run when this check is made.
+    pub fn reset_if_stale(&mut self, current_leader: u64) -> bool {
+        let is_stale = match &self.transfer_leader_msg {
+            Some((msg, _)) => msg.get_from() != current_leader,
+            None => false,
+        };
+        if is_stale {
+            self.reset_transferee_state();
+        }
+        is_stale
+    }
+
+    /// Clears state created while this peer was a leader transferee.
+    ///
+    /// The state is valid only while the Raft SoftState that accepted the
+    /// pre-transfer request remains current.
+    pub fn reset_transferee_state(&mut self) {
+        self.transfer_leader_msg = None;
+        self.cache_warmup_state = None;
+    }
+
     /// Records a pre-transfer-leader message without extending the deadline
     /// when the leader retries the same transfer attempt. A different sender
     /// or leader term starts a new attempt.
@@ -6646,6 +6677,34 @@ mod tests {
         assert_eq!(pending.get_index(), 20);
         assert_eq!(pending.get_log_term(), 2);
         assert_eq!(*deadline, next_deadline);
+    }
+
+    #[test]
+    fn test_reset_transfer_leader_transferee_state() {
+        let mut msg = eraftpb::Message::default();
+        msg.set_from(1);
+        let mut state = TransferLeaderState {
+            leader_transferee: 10,
+            transfer_leader_msg: Some((msg.clone(), Instant::now() - Duration::from_secs(1))),
+            cache_warmup_state: Some(CacheWarmupState::new(
+                1,
+                2,
+                Duration::from_secs(1),
+                Duration::from_secs(1),
+            )),
+        };
+
+        // Even an expired request must not be ACKed to a different leader.
+        assert!(state.reset_if_stale(2));
+
+        // The leader-side state is handled separately when Ready is processed.
+        assert_eq!(state.leader_transferee, 10);
+        assert!(state.transfer_leader_msg.is_none());
+        assert!(state.cache_warmup_state.is_none());
+
+        state.transfer_leader_msg = Some((msg, Instant::now() - Duration::from_secs(1)));
+        assert!(!state.reset_if_stale(1));
+        assert!(state.transfer_leader_msg.is_some());
     }
 
     #[test]

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -4946,7 +4946,11 @@ where
         }
 
         let current_leader = self.leader_id();
-        if self.transfer_leader_state.reset_if_stale(current_leader) {
+        let current_term = self.term();
+        if self
+            .transfer_leader_state
+            .reset_if_stale(current_leader, current_term)
+        {
             return false;
         }
         let Some((msg, deadline)) = &self.transfer_leader_state.transfer_leader_msg else {
@@ -6560,16 +6564,20 @@ pub struct TransferLeaderState {
 }
 
 impl TransferLeaderState {
-    /// Discards transferee state created for a previous leader.
+    /// Discards transferee state created for a previous leader or term.
     ///
     /// The peer FSM checks pending messages before processing Ready, so the
     /// SoftState cleanup may not have run when this check is made.
+    /// A term change with the same leader ID may not produce a new SoftState,
+    /// so the leader ID alone cannot establish that the request is current.
     /// This check must also happen before deadline evaluation: an expired
-    /// request from the previous leader must be discarded, not ACKed to the
-    /// current leader.
-    pub fn reset_if_stale(&mut self, current_leader: u64) -> bool {
+    /// request from a previous leader or term must be discarded, not ACKed to
+    /// the current leader.
+    pub fn reset_if_stale(&mut self, current_leader: u64, current_term: u64) -> bool {
         let is_stale = match &self.transfer_leader_msg {
-            Some((msg, _)) => msg.get_from() != current_leader,
+            Some((msg, _)) => {
+                msg.get_from() != current_leader || msg.get_log_term() != current_term
+            }
             None => false,
         };
         if is_stale {
@@ -6580,8 +6588,8 @@ impl TransferLeaderState {
 
     /// Clears state created while this peer was a leader transferee.
     ///
-    /// The state is valid only while the Raft SoftState that accepted the
-    /// pre-transfer request remains current.
+    /// The state is valid only while the leader ID and term that accepted the
+    /// pre-transfer request remain current.
     pub fn reset_transferee_state(&mut self) {
         self.transfer_leader_msg = None;
         self.cache_warmup_state = None;
@@ -6690,6 +6698,7 @@ mod tests {
     fn test_reset_transfer_leader_transferee_state() {
         let mut msg = eraftpb::Message::default();
         msg.set_from(1);
+        msg.set_log_term(5);
         let mut state = TransferLeaderState {
             leader_transferee: 10,
             transfer_leader_msg: Some((msg.clone(), Instant::now() - Duration::from_secs(1))),
@@ -6702,15 +6711,19 @@ mod tests {
         };
 
         // Even an expired request must not be ACKed to a different leader.
-        assert!(state.reset_if_stale(2));
+        assert!(state.reset_if_stale(2, 5));
 
         // The leader-side state is handled separately when Ready is processed.
         assert_eq!(state.leader_transferee, 10);
         assert!(state.transfer_leader_msg.is_none());
         assert!(state.cache_warmup_state.is_none());
 
+        state.transfer_leader_msg = Some((msg.clone(), Instant::now() - Duration::from_secs(1)));
+        assert!(state.reset_if_stale(1, 6));
+        assert!(state.transfer_leader_msg.is_none());
+
         state.transfer_leader_msg = Some((msg, Instant::now() - Duration::from_secs(1)));
-        assert!(!state.reset_if_stale(1));
+        assert!(!state.reset_if_stale(1, 5));
         assert!(state.transfer_leader_msg.is_some());
     }
 

--- a/doc/maintenance-guides/components/raftstore-v2.md
+++ b/doc/maintenance-guides/components/raftstore-v2.md
@@ -118,7 +118,8 @@ High-risk contracts:
 - Tablet-backed state transitions must remain aligned with region/raft
   metadata.
 - Pending pre-transfer-leader messages and cache warm-up state belong to the
-  current Raft `SoftState` and must be discarded when it changes.
+  leader ID and term that accepted them. They must be discarded when either
+  changes, including term changes that do not yield a new Raft `SoftState`.
 - Split/merge/bootstrap/destroy flows must keep router, FSM, and tablet state
   mutually consistent.
 

--- a/doc/maintenance-guides/components/raftstore-v2.md
+++ b/doc/maintenance-guides/components/raftstore-v2.md
@@ -117,6 +117,8 @@ High-risk contracts:
   apply guarantees.
 - Tablet-backed state transitions must remain aligned with region/raft
   metadata.
+- Pending pre-transfer-leader messages and cache warm-up state belong to the
+  current Raft `SoftState` and must be discarded when it changes.
 - Split/merge/bootstrap/destroy flows must keep router, FSM, and tablet state
   mutually consistent.
 

--- a/doc/maintenance-guides/components/raftstore.md
+++ b/doc/maintenance-guides/components/raftstore.md
@@ -154,7 +154,8 @@ High-risk contracts:
 - FSM messages must preserve ordering assumptions between peer/store/apply
   workers.
 - Pending pre-transfer-leader messages and cache warm-up state belong to the
-  current Raft `SoftState` and must be discarded when it changes.
+  leader ID and term that accepted them. They must be discarded when either
+  changes, including term changes that do not yield a new Raft `SoftState`.
 - Any write-path change must preserve callback completion and region-error
   semantics.
 

--- a/doc/maintenance-guides/components/raftstore.md
+++ b/doc/maintenance-guides/components/raftstore.md
@@ -153,6 +153,8 @@ High-risk contracts:
   valid.
 - FSM messages must preserve ordering assumptions between peer/store/apply
   workers.
+- Pending pre-transfer-leader messages and cache warm-up state belong to the
+  current Raft `SoftState` and must be discarded when it changes.
 - Any write-path change must preserve callback completion and region-error
   semantics.
 

--- a/tests/failpoints/cases/test_in_memory_engine.rs
+++ b/tests/failpoints/cases/test_in_memory_engine.rs
@@ -955,11 +955,14 @@ fn test_new_leader_clears_pending_transfer_leader_warmup() {
     let (blocked_tx, blocked_rx) = unbounded();
     let (unblock_tx, unblock_rx) = unbounded();
     let (finished_tx, finished_rx) = unbounded();
+    let (next_finished_tx, next_finished_rx) = unbounded();
     fail::cfg_callback("ime_on_snapshot_load_finished", move || {
         if first_load.swap(false, Ordering::SeqCst) {
             blocked_tx.send(()).unwrap();
             unblock_rx.recv().unwrap();
             finished_tx.send(()).unwrap();
+        } else {
+            next_finished_tx.send(()).unwrap();
         }
     })
     .unwrap();
@@ -968,6 +971,12 @@ fn test_new_leader_clears_pending_transfer_leader_warmup() {
     let first_load_blocked = blocked_rx.recv_timeout(Duration::from_secs(5)).is_ok();
 
     cluster.transfer_leader(region.id, new_peer(3, 3));
+    // Wait for peer 3's load to finish before checking leadership. The load is
+    // asynchronous and can legitimately take almost the entire old polling
+    // window, making the leadership check race with the transfer itself.
+    let peer3_load_finished = next_finished_rx
+        .recv_timeout(Duration::from_secs(10))
+        .is_ok();
     let mut peer3_became_leader = false;
     for _ in 0..50 {
         cluster.reset_leader_of_region(region.id);
@@ -1000,6 +1009,7 @@ fn test_new_leader_clears_pending_transfer_leader_warmup() {
     fail::remove("ime_on_snapshot_load_finished");
 
     assert!(first_load_blocked, "peer 2 did not start loading IME");
+    assert!(peer3_load_finished, "peer 3 did not finish loading IME");
     assert!(peer3_became_leader, "peer 3 did not become leader");
     assert!(first_load_finished, "peer 2 did not finish loading IME");
     assert!(

--- a/tests/failpoints/cases/test_in_memory_engine.rs
+++ b/tests/failpoints/cases/test_in_memory_engine.rs
@@ -30,7 +30,10 @@ use pd_client::PdClient;
 use protobuf::Message;
 use raft::eraftpb::MessageType;
 use raftstore::{
-    coprocessor::ObserveHandle,
+    coprocessor::{
+        Coprocessor, ObserveHandle, ObserverContext, TransferLeaderObserver,
+        dispatcher::BoxTransferLeaderObserver,
+    },
     store::{
         fsm::{ApplyTask, apply::ChangeObserver},
         msg::Callback,
@@ -42,8 +45,8 @@ use test_coprocessor::{
 };
 use test_raftstore::{
     CloneFilterFactory, Cluster, Direction, RegionPacketFilter, ServerCluster, Simulator,
-    configure_for_merge, get_tso, must_get_equal, new_learner_peer, new_peer, new_put_cf_cmd,
-    new_server_cluster_with_hybrid_engine, sleep_ms,
+    configure_for_merge, get_tso, must_get_equal, new_learner_peer, new_node_cluster, new_peer,
+    new_put_cf_cmd, new_server_cluster_with_hybrid_engine, sleep_ms,
 };
 use test_util::eventually;
 use tidb_query_datatype::{
@@ -1018,6 +1021,132 @@ fn test_new_leader_clears_pending_transfer_leader_warmup() {
     );
     cluster.reset_leader_of_region(region.id);
     assert_eq!(cluster.leader_of_region(region.id), Some(new_peer(3, 3)));
+}
+
+#[test]
+fn test_new_term_clears_pending_transfer_leader_warmup() {
+    #[derive(Clone)]
+    struct WarmupObserver {
+        started: Arc<AtomicBool>,
+        ready: Arc<AtomicBool>,
+    }
+
+    impl Coprocessor for WarmupObserver {}
+
+    impl TransferLeaderObserver for WarmupObserver {
+        fn pre_ack_transfer_leader(
+            &self,
+            _: &mut ObserverContext<'_>,
+            _: &raft::eraftpb::Message,
+        ) -> bool {
+            self.started.store(true, Ordering::SeqCst);
+            self.ready.load(Ordering::SeqCst)
+        }
+    }
+
+    // A node cluster keeps Raft traffic in-process. The observer blocks the
+    // same pre-ACK stage used by IME warmup without depending on server ports.
+    let mut cluster = new_node_cluster(0, 3);
+    cluster.cfg.raft_store.max_entry_cache_warmup_duration.0 = Duration::from_secs(1000);
+    cluster.pd_client.disable_default_operator();
+    let warmup_started = Arc::new(AtomicBool::new(false));
+    let warmup_ready = Arc::new(AtomicBool::new(false));
+    let started = Arc::clone(&warmup_started);
+    let ready = Arc::clone(&warmup_ready);
+    cluster
+        .sim
+        .wl()
+        .post_create_coprocessor_host(Box::new(move |store_id, host| {
+            if store_id == 2 {
+                host.registry.register_transfer_leader_observer(
+                    0,
+                    BoxTransferLeaderObserver::new(WarmupObserver {
+                        started: Arc::clone(&started),
+                        ready: Arc::clone(&ready),
+                    }),
+                );
+            }
+        }));
+    cluster.run();
+
+    let region = cluster.get_region(b"");
+    cluster.must_transfer_leader(region.id, new_peer(1, 1));
+    cluster.must_put(b"k", b"v");
+
+    cluster.transfer_leader(region.id, new_peer(2, 2));
+    eventually(Duration::from_millis(10), Duration::from_secs(5), || {
+        warmup_started.load(Ordering::SeqCst)
+    });
+    let original_term = cluster
+        .raft_local_state(region.id, 2)
+        .get_hard_state()
+        .get_term();
+
+    // Observe and drop a stale ACK from peer 2, if one is emitted after its
+    // blocked pre-ACK preparation finishes.
+    let (stale_ack_tx, stale_ack_rx) = unbounded();
+    let recv_filter = Box::new(
+        RegionPacketFilter::new(region.id, 1)
+            .direction(Direction::Recv)
+            .msg_type(MessageType::MsgTransferLeader)
+            .set_msg_callback(Arc::new(move |msg| {
+                if msg.get_from_peer().get_store_id() == 2 {
+                    stale_ack_tx.send(()).unwrap();
+                }
+            })),
+    );
+    cluster.sim.wl().add_recv_filter(1, recv_filter);
+
+    // Simulate peer 2 missing a peer 1 -> peer 3 -> peer 1 transition. Drop
+    // peer 2's responses so the synthetic newer term does not affect peer 1.
+    let send_filter = Box::new(
+        RegionPacketFilter::new(region.id, 2)
+            .direction(Direction::Send)
+            .skip(MessageType::MsgTransferLeader),
+    );
+    cluster.sim.wl().add_send_filter(2, send_filter);
+    let new_term = original_term + 1;
+    let mut message = raft::eraftpb::Message::default();
+    message.set_msg_type(MessageType::MsgHeartbeat);
+    message.set_from(1);
+    message.set_to(2);
+    message.set_term(new_term);
+    let mut raft_message = RaftMessage::default();
+    raft_message.set_region_id(region.id);
+    raft_message.set_from_peer(new_peer(1, 1));
+    raft_message.set_to_peer(new_peer(2, 2));
+    raft_message.set_region_epoch(region.get_region_epoch().clone());
+    raft_message.set_message(message);
+    cluster.send_raft_msg(raft_message.clone()).unwrap();
+
+    let mut peer2_observed_new_term = false;
+    for _ in 0..50 {
+        let peer2_term = cluster
+            .raft_local_state(region.id, 2)
+            .get_hard_state()
+            .get_term();
+        if peer2_term == new_term {
+            peer2_observed_new_term = true;
+            break;
+        }
+        sleep(Duration::from_millis(100));
+    }
+
+    assert!(
+        peer2_observed_new_term,
+        "peer 2 did not observe the new term"
+    );
+
+    // Let the pre-ACK preparation complete, then wake peer 2. Without the term
+    // check, it would ACK the pending request using the newer term.
+    warmup_ready.store(true, Ordering::SeqCst);
+    cluster.send_raft_msg(raft_message).unwrap();
+    assert!(
+        stale_ack_rx.recv_timeout(Duration::from_secs(1)).is_err(),
+        "peer 2 ACKed a transfer request from the previous term"
+    );
+    cluster.reset_leader_of_region(region.id);
+    assert_eq!(cluster.leader_of_region(region.id), Some(new_peer(1, 1)));
 }
 
 #[test]

--- a/tests/failpoints/cases/test_in_memory_engine.rs
+++ b/tests/failpoints/cases/test_in_memory_engine.rs
@@ -3,7 +3,11 @@
 use std::{
     fs::File,
     io::Read,
-    sync::{Arc, Mutex, mpsc::sync_channel},
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, Ordering},
+        mpsc::sync_channel,
+    },
     thread::sleep,
     time::Duration,
 };
@@ -37,8 +41,8 @@ use test_coprocessor::{
     DagChunkSpliter, DagSelect, ProductTable, handle_request, init_data_with_details_pd_client,
 };
 use test_raftstore::{
-    CloneFilterFactory, Cluster, Direction, RegionPacketFilter, ServerCluster, configure_for_merge,
-    get_tso, must_get_equal, new_learner_peer, new_peer, new_put_cf_cmd,
+    CloneFilterFactory, Cluster, Direction, RegionPacketFilter, ServerCluster, Simulator,
+    configure_for_merge, get_tso, must_get_equal, new_learner_peer, new_peer, new_put_cf_cmd,
     new_server_cluster_with_hybrid_engine, sleep_ms,
 };
 use test_util::eventually;
@@ -921,6 +925,89 @@ fn test_warmup_timeout_does_not_block_transfer_leader() {
             .snapshot(cache_region.clone(), 100, 100)
             .is_ok()
     });
+}
+
+#[test]
+fn test_new_leader_clears_pending_transfer_leader_warmup() {
+    let mut cluster = new_server_cluster_with_hybrid_engine(0, 3);
+    cluster.cfg.raft_store.max_entry_cache_warmup_duration.0 = Duration::from_secs(1000);
+    cluster.pd_client.disable_default_operator();
+    cluster.run();
+
+    let region = cluster.get_region(b"");
+    cluster.must_transfer_leader(region.id, new_peer(1, 1));
+    let cache_region = CacheRegion::from_region(&region);
+    let leader_cache_engine = cluster.sim.rl().get_region_cache_engine(1);
+    leader_cache_engine
+        .load_region(cache_region.clone())
+        .unwrap();
+    cluster.must_put(b"k", b"v");
+    eventually(Duration::from_millis(100), Duration::from_secs(5), || {
+        leader_cache_engine
+            .snapshot(cache_region.clone(), 100, 100)
+            .is_ok()
+    });
+
+    // Block only the first follower's IME load. The second transferee can
+    // finish loading and become leader while the first one still has a pending
+    // pre-transfer request from the old leader.
+    let first_load = Arc::new(AtomicBool::new(true));
+    let (blocked_tx, blocked_rx) = unbounded();
+    let (unblock_tx, unblock_rx) = unbounded();
+    let (finished_tx, finished_rx) = unbounded();
+    fail::cfg_callback("ime_on_snapshot_load_finished", move || {
+        if first_load.swap(false, Ordering::SeqCst) {
+            blocked_tx.send(()).unwrap();
+            unblock_rx.recv().unwrap();
+            finished_tx.send(()).unwrap();
+        }
+    })
+    .unwrap();
+
+    cluster.transfer_leader(region.id, new_peer(2, 2));
+    let first_load_blocked = blocked_rx.recv_timeout(Duration::from_secs(5)).is_ok();
+
+    cluster.transfer_leader(region.id, new_peer(3, 3));
+    let mut peer3_became_leader = false;
+    for _ in 0..50 {
+        cluster.reset_leader_of_region(region.id);
+        if cluster.leader_of_region(region.id) == Some(new_peer(3, 3)) {
+            peer3_became_leader = true;
+            break;
+        }
+        sleep(Duration::from_millis(100));
+    }
+
+    // Observe and drop a stale ACK from peer 2, if one is emitted after its
+    // blocked load finishes.
+    let (stale_ack_tx, stale_ack_rx) = unbounded();
+    let recv_filter = Box::new(
+        RegionPacketFilter::new(region.id, 3)
+            .direction(Direction::Recv)
+            .msg_type(MessageType::MsgTransferLeader)
+            .set_msg_callback(Arc::new(move |msg| {
+                if msg.get_from_peer().get_store_id() == 2 {
+                    stale_ack_tx.send(()).unwrap();
+                }
+            })),
+    );
+    cluster.sim.wl().add_recv_filter(3, recv_filter);
+
+    // Always release the failpoint before assertions so a failed setup cannot
+    // leave an IME worker blocked for other tests.
+    unblock_tx.send(()).unwrap();
+    let first_load_finished = finished_rx.recv_timeout(Duration::from_secs(5)).is_ok();
+    fail::remove("ime_on_snapshot_load_finished");
+
+    assert!(first_load_blocked, "peer 2 did not start loading IME");
+    assert!(peer3_became_leader, "peer 3 did not become leader");
+    assert!(first_load_finished, "peer 2 did not finish loading IME");
+    assert!(
+        stale_ack_rx.recv_timeout(Duration::from_secs(3)).is_err(),
+        "peer 2 ACKed a transfer request from the previous leader"
+    );
+    cluster.reset_leader_of_region(region.id);
+    assert_eq!(cluster.leader_of_region(region.id), Some(new_peer(3, 3)));
 }
 
 #[test]

--- a/tests/failpoints/cases/test_merge.rs
+++ b/tests/failpoints/cases/test_merge.rs
@@ -123,9 +123,15 @@ fn test_node_merge_rollback() {
 fn test_node_merge_restart() {
     let mut cluster = new_node_cluster(0, 3);
     configure_for_merge(&mut cluster.cfg);
+    let pd_client = Arc::clone(&cluster.pd_client);
+    // This test explicitly controls all merge and peer-removal operators. If the
+    // default operator is enabled, it may restore the removed peer on store 3
+    // during restart before stale data is cleaned up, making the final checks
+    // race with the newly added replica.
+    pd_client.disable_default_operator();
+
     cluster.run();
 
-    let pd_client = Arc::clone(&cluster.pd_client);
     let region = pd_client.get_region(b"k1").unwrap();
     cluster.must_split(&region, b"k2");
     let left = pd_client.get_region(b"k1").unwrap();


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: close #18453

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Reset pending transfer-leader warm-up state whenever Raft SoftState
changes, including when a follower observes a different leader without
changing its own role.

Before acknowledging a pending transfer-leader request, verify that its
sender is still the current leader. This prevents an expired request
from the previous leader from being acknowledged to the new leader and
triggering an election before IME warm-up finishes.

Apply the invariant to classic raftstore and raftstore-v2, document it
in the maintenance guides, and add unit and failpoint regression tests.
```

Validation:

- `./scripts/test test_reset_transfer_leader_transferee_state -- --nocapture`
- `cargo check -p raftstore-v2`
- `./scripts/test test_new_leader_clears_pending_transfer_leader_warmup -- --nocapture`
- Repeated the new failpoint test 10 times
- `make format`
- `git diff --check`

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Fix an issue where stale transfer-leader warm-up state could trigger an election before the in-memory engine finishes warming up
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved leader-transfer retries and acknowledgements when messages are delayed or deadlines expire.
  * Prevented stale transfer requests and acknowledgements from previous leaders or terms from affecting current transfers.
  * Ensured transfer state and cache warm-up data are cleared correctly when leadership changes.

* **Tests**
  * Added coverage for concurrent transfers, delayed loading, stale acknowledgements, term changes, and restart scenarios.

* **Documentation**
  * Documented transfer-state requirements across leadership and term changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->