### PR TITLE
*: upgrade vulnerable Rust dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3310,7 +3310,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
- "serde_with 3.18.0",
+ "serde_with",
  "tracing",
 ]
 
@@ -3333,7 +3333,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
- "serde_with 3.18.0",
+ "serde_with",
  "tracing",
 ]
 
@@ -3352,7 +3352,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
- "serde_with 3.18.0",
+ "serde_with",
  "tracing",
 ]
 
@@ -3372,7 +3372,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
- "serde_with 3.18.0",
+ "serde_with",
  "tracing",
 ]
 
@@ -3400,7 +3400,7 @@ dependencies = [
  "google-cloud-wkt",
  "serde",
  "serde_json",
- "serde_with 3.18.0",
+ "serde_with",
 ]
 
 [[package]]
@@ -3435,7 +3435,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
- "serde_with 3.18.0",
+ "serde_with",
  "sha2",
  "thiserror 2.0.12",
  "tokio",
@@ -3454,7 +3454,7 @@ dependencies = [
  "google-cloud-wkt",
  "serde",
  "serde_json",
- "serde_with 3.18.0",
+ "serde_with",
 ]
 
 [[package]]
@@ -3467,7 +3467,7 @@ dependencies = [
  "bytes",
  "serde",
  "serde_json",
- "serde_with 3.18.0",
+ "serde_with",
  "thiserror 2.0.12",
  "time 0.3.47",
  "url",
@@ -5203,15 +5203,14 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "openssl"
-version = "0.10.73"
+version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
  "bitflags 2.11.0",
  "cfg-if 1.0.0",
  "foreign-types",
  "libc 0.2.176",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -5250,9 +5249,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.109"
+version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
  "libc 0.2.176",
@@ -5960,9 +5959,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",
@@ -6152,7 +6151,7 @@ dependencies = [
  "resource_metering",
  "serde",
  "serde_derive",
- "serde_with 1.4.0",
+ "serde_with",
  "service",
  "slog",
  "slog-global",
@@ -7138,21 +7137,12 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "1.4.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d3d595d64120bbbc70b7f6d5ae63298b62a3d9f373ec2f56acf5365ca8a444"
-dependencies = [
- "serde",
- "serde_with_macros 1.1.0",
-]
-
-[[package]]
-name = "serde_with"
-version = "3.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
  "base64 0.22.1",
+ "bs58",
  "chrono",
  "hex 0.4.3",
  "indexmap 1.9.3",
@@ -7161,26 +7151,15 @@ dependencies = [
  "schemars 1.0.3",
  "serde_core",
  "serde_json",
- "serde_with_macros 3.18.0",
+ "serde_with_macros",
  "time 0.3.47",
 ]
 
 [[package]]
 name = "serde_with_macros"
-version = "1.1.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4070d2c9b9d258465ad1d82aabb985b84cd9a3afa94da25ece5a9938ba5f1606"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.103",
-]
-
-[[package]]
-name = "serde_with_macros"
-version = "3.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -398,7 +398,7 @@ tracing = { version = "0.1.39", default-features = false, features = [
   "attributes",
   "std",
 ] }
-openssl = "0.10"
+openssl = "0.10.80"
 openssl-sys = "0.9"
 compact-log-backup = { path = "components/compact-log-backup" }
 heck = "0.3"

--- a/components/raftstore/Cargo.toml
+++ b/components/raftstore/Cargo.toml
@@ -66,7 +66,7 @@ resource_control = { workspace = true }
 resource_metering = { workspace = true }
 serde = "1.0"
 serde_derive = "1.0"
-serde_with = "1.4"
+serde_with = "3.21"
 service = { workspace = true }
 slog = { workspace = true }
 slog-global = { workspace = true }

--- a/deny.toml
+++ b/deny.toml
@@ -49,17 +49,6 @@ version = 2
 yanked = "deny"
 unmaintained = 'workspace'
 ignore = [
-    # Ignore RUSTSEC-2023-0072 as we ban the unsound `X509StoreRef::objects`.
-    #
-    # NB: Upgrading rust-openssl the latest version do fix the issue but it
-    # also upgrade the OpenSSL to v3.x which causes performance degradation.
-    # See https://github.com/openssl/openssl/issues/17064
-    "RUSTSEC-2023-0072",
-    # Ignore RUSTSEC-2024-0357 as there is no `MemBio::get_buf` in TiKV, also
-    # we ban all openssl (Rust) APIs that call `MemBio::get_buf`.
-    #
-    # See https://github.com/sfackler/rust-openssl/pull/2266
-    "RUSTSEC-2024-0357",
     # Ignore RUSTSEC-2021-0145 (unsound issue of "atty" crate) as it only
     # affects Windows plaform which is not supported offically by TiKV, and 2)
     # we have disabled the clap feature "color" so that the "atty" crate is not
@@ -67,20 +56,6 @@ ignore = [
     #
     # TODO: Upgrade clap to v4.x.
     "RUSTSEC-2021-0145",
-    # Ignore RUSTSEC-2025-0004, as it will trigger a recursive upgrade of OpenSSL
-    # to version 3.x.
-    #
-    # NB: Upgrading openssl the version >= 0.10.70 do fix the issue but it
-    # also upgrade the OpenSSL to v3.x which causes performance degradation.
-    # See https://github.com/openssl/openssl/issues/17064
-    "RUSTSEC-2025-0004",
-    # Ignore RUSTSEC-2025-0022, as it will trigger a recursive upgrade of OpenSSL
-    # to version 3.x.
-    #
-    # NB: Upgrading openssl the version >= 0.10.72 do fix the issue but it
-    # also upgrade the OpenSSL to v3.x which causes performance degradation.
-    # See https://github.com/openssl/openssl/issues/17064
-    "RUSTSEC-2025-0022",
     # Ignore RUSTSEC-2024-0436, as there is no widely used replacement of 
     # package 'paste', and the package itself is very stable.
     "RUSTSEC-2024-0436",
@@ -88,12 +63,6 @@ ignore = [
     # replace FxHash. Currently, this package is stable and there are no known
     # exploitable vulnerabilities affecting our use case.
     "RUSTSEC-2025-0057",
-    # Ignore RUSTSEC-2026-0009 temporarily. This advisory comes from the
-    # transitive cloud SDK dependency chain pulling in time 0.3.47. The fixed
-    # time release requires serde 1.0.220 through serde_core, but the current
-    # raft-engine revision in this workspace still hard-pins serde = 1.0.228,
-    # so this cannot be resolved with a lockfile-only update.
-    "RUSTSEC-2026-0009",
     # Ignore RUSTSEC-2026-0097 (unsound issue in rand with a custom logger using
     # rand::rng()). The vulnerability requires a custom logger that calls
     # rand::rng() / thread_rng() during logging, which TiKV does not do.


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: close #19931

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Upgrade openssl to 0.10.80, openssl-sys to 0.9.117, quinn-proto to
0.11.15, and serde_with to 3.21.0 to address known vulnerabilities.

Remove obsolete OpenSSL and time advisory exceptions now that the locked
versions contain the fixes. The vendored C OpenSSL version remains 3.5.2.
```

Vulnerabilities addressed:

- `openssl` 0.10.73 -> 0.10.80: `CVE-2026-41676`, `CVE-2026-41677`,
  `CVE-2026-41678`, `CVE-2026-41681`, `CVE-2026-41898`, `CVE-2026-42327`,
  `CVE-2026-44662`, and `CVE-2026-45784`.
- `quinn-proto` 0.11.14 -> 0.11.15: `CVE-2026-25800`.
- `serde_with` 1.4.0/3.18.0 -> 3.21.0: `GHSA-7gcf-g7xr-8hxj`.

This PR also removes stale `cargo-deny` suppressions for
`RUSTSEC-2023-0072`, `RUSTSEC-2024-0357`, `RUSTSEC-2025-0004`,
`RUSTSEC-2025-0022`, and `RUSTSEC-2026-0009`; the locked dependency versions
already satisfy these advisories.

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [x] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Manual test:

```text
cargo check -p raftstore --locked --offline
cargo fmt --all -- --check
make clippy
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Upgrade vulnerable Rust dependencies used by TiKV.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Maintenance**
  * Updated underlying security and serialization components to newer supported versions.
  * Refreshed security audit settings to reflect current advisory status.
  * Improved compatibility with the latest supported development environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->