### PR TITLE
storage: return NotLeader instead of ServerIsBusy on read-pool-full rejection when the store is no longer the leader

### DIFF
--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -907,6 +907,11 @@ where
         self.snap_mgr = Some(snap_mgr.clone());
 
         // Create coprocessor endpoint.
+        let region_leaders = self.region_info_accessor.as_ref().unwrap().region_leaders();
+        let copr_leader_hint: tikv::storage::kv::LeaderHintProvider =
+            Arc::new(move |region_id: u64| {
+                Some(region_leaders.read().unwrap().contains(&region_id))
+            });
         let copr = coprocessor::Endpoint::new(
             &server_config.value(),
             cop_read_pool_handle,
@@ -914,6 +919,7 @@ where
             resource_tag_factory,
             self.quota_limiter.clone(),
             self.resource_manager.clone(),
+            Some(copr_leader_hint),
         );
         let copr_config_manager = copr.config_manager();
 

--- a/components/server/src/server2.rs
+++ b/components/server/src/server2.rs
@@ -833,6 +833,11 @@ where
         let node = self.node.as_ref().unwrap();
 
         // Create coprocessor endpoint.
+        let region_leaders = self.region_info_accessor.as_ref().unwrap().region_leaders();
+        let copr_leader_hint: tikv::storage::kv::LeaderHintProvider =
+            Arc::new(move |region_id: u64| {
+                Some(region_leaders.read().unwrap().contains(&region_id))
+            });
         let copr = coprocessor::Endpoint::new(
             &server_config.value(),
             cop_read_pool_handle,
@@ -840,6 +845,7 @@ where
             resource_tag_factory,
             self.quota_limiter.clone(),
             self.resource_manager.clone(),
+            Some(copr_leader_hint),
         );
         let copr_config_manager = copr.config_manager();
 

--- a/components/test_coprocessor/src/fixture.rs
+++ b/components/test_coprocessor/src/fixture.rs
@@ -198,6 +198,7 @@ fn init_data_with_details_impl<E: Engine>(
         ResourceTagFactory::new_for_test(),
         limiter.clone(),
         None,
+        None,
     );
     (store, copr, limiter)
 }

--- a/components/test_raftstore-v2/src/server.rs
+++ b/components/test_raftstore-v2/src/server.rs
@@ -604,6 +604,11 @@ impl<EK: KvEngine> ServerCluster<EK> {
             &tikv::config::CoprReadPoolConfig::default_for_test(),
             store.get_engine(),
         ));
+        let copr_region_leaders = region_info_accessor.region_leaders();
+        let copr_leader_hint: tikv::storage::kv::LeaderHintProvider =
+            Arc::new(move |region_id: u64| {
+                Some(copr_region_leaders.read().unwrap().contains(&region_id))
+            });
         let copr = coprocessor::Endpoint::new(
             &server_cfg.value().clone(),
             cop_read_pool.handle(),
@@ -611,6 +616,7 @@ impl<EK: KvEngine> ServerCluster<EK> {
             res_tag_factory,
             quota_limiter,
             resource_manager.clone(),
+            Some(copr_leader_hint),
         );
         let copr_v2 = coprocessor_v2::Endpoint::new(&cfg.coprocessor_v2);
         let mut server = None;

--- a/components/test_raftstore/src/server.rs
+++ b/components/test_raftstore/src/server.rs
@@ -560,6 +560,11 @@ impl ServerCluster {
             &tikv::config::CoprReadPoolConfig::default_for_test(),
             store.get_engine(),
         ));
+        let copr_region_leaders = region_info_accessor.region_leaders();
+        let copr_leader_hint: tikv::storage::kv::LeaderHintProvider =
+            Arc::new(move |region_id: u64| {
+                Some(copr_region_leaders.read().unwrap().contains(&region_id))
+            });
         let copr = coprocessor::Endpoint::new(
             &server_cfg.value().clone(),
             cop_read_pool.handle(),
@@ -567,6 +572,7 @@ impl ServerCluster {
             res_tag_factory,
             quota_limiter,
             resource_manager.clone(),
+            Some(copr_leader_hint),
         );
         let copr_v2 = coprocessor_v2::Endpoint::new(&cfg.coprocessor_v2);
         let mut server = None;

--- a/components/tikv_kv/src/lib.rs
+++ b/components/tikv_kv/src/lib.rs
@@ -358,6 +358,14 @@ pub struct SnapContext<'a> {
     pub extra_region_override: Option<ExtraRegionOverride>,
 }
 
+/// Provides a best-effort hint about whether the local store currently
+/// believes it is the leader of a region. See [`Engine::local_leader_hint`].
+///
+/// Unlike [`Engine::local_leader_hint`], this is intended for components that
+/// do not hold an [`Engine`] instance (e.g. the coprocessor endpoint, which
+/// accesses the engine only through TLS on read-pool threads).
+pub type LeaderHintProvider = Arc<dyn Fn(u64) -> Option<bool> + Send + Sync>;
+
 /// Engine defines the common behaviour for a storage engine type.
 pub trait Engine: Send + Clone + 'static {
     type Snap: Snapshot;
@@ -410,7 +418,6 @@ pub trait Engine: Send + Clone + 'static {
     fn local_leader_hint(&self, _region_id: u64) -> Option<bool> {
         None
     }
-
     type WriteRes: Stream<Item = WriteEvent> + Unpin + Send + 'static;
     /// Writes data to the engine asynchronously.
     ///

--- a/components/tikv_kv/src/lib.rs
+++ b/components/tikv_kv/src/lib.rs
@@ -400,6 +400,17 @@ pub trait Engine: Send + Clone + 'static {
         Ok(())
     }
 
+    /// Hints whether the local store currently believes it is the leader of
+    /// the given region.
+    ///
+    /// The hint is based on locally maintained information and may lag behind
+    /// the latest raft state. Returning `Some(false)` means the local store
+    /// is confident that it is *not* the leader. `None` means the information
+    /// is unavailable for this engine.
+    fn local_leader_hint(&self, _region_id: u64) -> Option<bool> {
+        None
+    }
+
     type WriteRes: Stream<Item = WriteEvent> + Unpin + Send + 'static;
     /// Writes data to the engine asynchronously.
     ///

--- a/doc/maintenance-guides/src/storage.md
+++ b/doc/maintenance-guides/src/storage.md
@@ -132,6 +132,23 @@ High-risk contracts:
   enforced.
 - Memory quota and pending-write thresholds must remain operationally effective.
 
+## Read-Pool Rejection Error Contract
+
+- Leader reads rejected because the unified read pool is full
+  (`read_pool_spawn_with_busy_check`, and the coprocessor
+  `read_pool_spawn_with_memory_quota_check`) return a `NotLeader` region error
+  instead of `ServerIsBusy` when the local `region_leaders` set says this
+  store is no longer the leader of the requested region. The rejection happens
+  before the raft layer, so without the conversion clients would keep retrying
+  a stale cached leader (tikv/client-go#2028).
+- The conversion only applies to leader reads (`!replica_read && !stale_read`);
+  replica/stale reads, engines without leader knowledge, and multi-region or
+  mixed-mode batches keep the previous `SchedTooBusy` /
+  `MaxPendingTasksExceeded` (`ServerIsBusy`) behavior.
+- The hint is best-effort and may lag raft role changes; a false `NotLeader`
+  only costs one extra PD re-resolution, and a missed conversion degrades to
+  the previous behavior.
+
 ## Observability And Operational Signals
 
 - scheduler latency, latch wait, and pending-write signals

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -32,7 +32,7 @@ use tidb_query_common::{
     storage::{FindRegionResult, RegionStorageAccessor, Result as StorageResult},
 };
 use tikv_alloc::trace::MemoryTraceGuard;
-use tikv_kv::{ExtraRegionOverride, SnapshotExt};
+use tikv_kv::{ExtraRegionOverride, LeaderHintProvider, SnapshotExt};
 use tikv_util::{
     deadline::set_deadline_exceeded_busy_error,
     future::async_timeout,
@@ -108,6 +108,12 @@ pub struct Endpoint<E: Engine> {
     quota_limiter: Arc<QuotaLimiter>,
     resource_ctl: Option<Arc<ResourceGroupManager>>,
 
+    /// Hints whether the local store is the leader of a region. Used to
+    /// report `NotLeader` instead of `ServerIsBusy` when a leader read is
+    /// rejected because the read pool is full, see
+    /// [`cop_pool_full_reject_error`].
+    leader_hint: Option<LeaderHintProvider>,
+
     _phantom: PhantomData<E>,
 }
 
@@ -182,6 +188,7 @@ impl<E: Engine> Endpoint<E> {
         resource_tag_factory: ResourceTagFactory,
         quota_limiter: Arc<QuotaLimiter>,
         resource_ctl: Option<Arc<ResourceGroupManager>>,
+        leader_hint: Option<LeaderHintProvider>,
     ) -> Self {
         let (shared_semaphore, background_limited_semaphore) =
             Self::build_request_semaphores(&read_pool, cfg.end_point_max_concurrency);
@@ -203,6 +210,7 @@ impl<E: Engine> Endpoint<E> {
             slow_log_threshold: cfg.end_point_slow_log_threshold.0,
             quota_limiter,
             resource_ctl,
+            leader_hint,
             _phantom: Default::default(),
         }
     }
@@ -691,6 +699,9 @@ impl<E: Engine> Endpoint<E> {
             )
         });
         // box the tracker so that moving it is cheap.
+        let region_id = req_ctx.context.get_region_id();
+        let is_leader_read =
+            !req_ctx.context.get_replica_read() && !req_ctx.context.get_stale_read();
         let tracker = Box::new(Tracker::new(req_ctx, req_tag, self.slow_log_threshold));
         allocated_bytes += tracker.approximate_mem_size();
 
@@ -707,6 +718,8 @@ impl<E: Engine> Endpoint<E> {
         });
         let spawn_fut_result = self.read_pool_spawn_with_memory_quota_check(
             allocated_bytes,
+            region_id,
+            is_leader_read,
             future,
             priority,
             task_id,
@@ -991,6 +1004,9 @@ impl<E: Engine> Endpoint<E> {
         let mut allocated_bytes = resource_tag.approximate_heap_size();
 
         let task_id = req_ctx.build_task_id();
+        let region_id = req_ctx.context.get_region_id();
+        let is_leader_read =
+            !req_ctx.context.get_replica_read() && !req_ctx.context.get_stale_read();
         let tracker = Box::new(Tracker::new(req_ctx, req_tag, self.slow_log_threshold));
         allocated_bytes += tracker.approximate_mem_size();
 
@@ -1008,6 +1024,8 @@ impl<E: Engine> Endpoint<E> {
 
         let spawn_fut = self.read_pool_spawn_with_memory_quota_check(
             allocated_bytes,
+            region_id,
+            is_leader_read,
             future,
             priority,
             task_id,
@@ -1018,10 +1036,9 @@ impl<E: Engine> Endpoint<E> {
         // On first poll, drives spawn_fut (sleep if delayed, then submit to
         // yatp). On error yields one error item. Then chains with rx items.
         let stream = futures::stream::once(Box::pin(async move {
-            spawn_fut
-                .await
-                .err()
-                .map(|_| Err(Error::MaxPendingTasksExceeded))
+            // Preserve the actual error (e.g. NotLeader) built by
+            // `read_pool_spawn_with_memory_quota_check`.
+            spawn_fut.await.err().map(Err)
         }))
         .filter_map(futures::future::ready)
         .chain(rx);
@@ -1060,6 +1077,8 @@ impl<E: Engine> Endpoint<E> {
     fn read_pool_spawn_with_memory_quota_check<F>(
         &self,
         mut allocated_bytes: usize,
+        region_id: u64,
+        is_leader_read: bool,
         future: F,
         priority: CommandPri,
         task_id: u64,
@@ -1076,11 +1095,39 @@ impl<E: Engine> Endpoint<E> {
             // Release quota after handle completed.
             drop(owned_quota);
         });
+        let leader_hint = self.leader_hint.clone();
         Ok(self
             .read_pool
             .spawn(fut, priority, task_id, metadata, resource_limiter)
-            .map(|r| r.map_err(|_| Error::MaxPendingTasksExceeded))
+            .map(move |r| {
+                r.map_err(move |_| {
+                    cop_pool_full_reject_error(leader_hint.as_ref(), is_leader_read, region_id)
+                })
+            })
             .boxed())
+    }
+}
+
+/// Builds the error for a coprocessor request rejected because the read pool
+/// cannot accept more tasks.
+///
+/// Same rationale as `storage::pool_full_reject_error`: the rejection happens
+/// before the request reaches the raft layer, so when this store locally
+/// knows it is no longer the leader of the region, a `NotLeader` region
+/// error is returned instead of `ServerIsBusy` (`MaxPendingTasksExceeded`)
+/// to let the client refresh its stale route. Only applies to leader reads;
+/// without a hint the behavior is unchanged.
+fn cop_pool_full_reject_error(
+    leader_hint: Option<&LeaderHintProvider>,
+    is_leader_read: bool,
+    region_id: u64,
+) -> Error {
+    if is_leader_read && leader_hint.and_then(|h| h(region_id)) == Some(false) {
+        let mut err = kvproto::errorpb::Error::default();
+        err.mut_not_leader().set_region_id(region_id);
+        Error::Region(err)
+    } else {
+        Error::MaxPendingTasksExceeded
     }
 }
 
@@ -1599,6 +1646,7 @@ mod tests {
             ResourceTagFactory::new_for_test(),
             Arc::new(QuotaLimiter::default()),
             None,
+            None,
         );
         (endpoint, read_pool)
     }
@@ -1617,6 +1665,7 @@ mod tests {
             cm,
             ResourceTagFactory::new_for_test(),
             Arc::new(QuotaLimiter::default()),
+            None,
             None,
         );
 
@@ -1667,6 +1716,7 @@ mod tests {
             ResourceTagFactory::new_for_test(),
             Arc::new(QuotaLimiter::default()),
             None,
+            None,
         );
         copr.recursion_limit = 100;
 
@@ -1706,6 +1756,7 @@ mod tests {
             ResourceTagFactory::new_for_test(),
             Arc::new(QuotaLimiter::default()),
             None,
+            None,
         );
 
         let mut req = coppb::Request::default();
@@ -1729,6 +1780,7 @@ mod tests {
             cm,
             ResourceTagFactory::new_for_test(),
             Arc::new(QuotaLimiter::default()),
+            None,
             None,
         );
 
@@ -1778,6 +1830,7 @@ mod tests {
             cm,
             ResourceTagFactory::new_for_test(),
             Arc::new(QuotaLimiter::default()),
+            None,
             None,
         );
 
@@ -1831,6 +1884,7 @@ mod tests {
             cm,
             ResourceTagFactory::new_for_test(),
             Arc::new(QuotaLimiter::default()),
+            None,
             None,
         );
 
@@ -2030,6 +2084,7 @@ mod tests {
             ResourceTagFactory::new_for_test(),
             Arc::new(QuotaLimiter::default()),
             None,
+            None,
         );
 
         let prev_tracker = ::tracker::get_tls_tracker_token();
@@ -2081,6 +2136,7 @@ mod tests {
             cm,
             ResourceTagFactory::new_for_test(),
             Arc::new(QuotaLimiter::default()),
+            None,
             None,
         );
 
@@ -2136,6 +2192,7 @@ mod tests {
             ResourceTagFactory::new_for_test(),
             Arc::new(QuotaLimiter::default()),
             None,
+            None,
         );
 
         let handler_builder = Box::new(|_, _: &_| Ok(StreamFixture::new(vec![]).into_boxed()));
@@ -2164,6 +2221,7 @@ mod tests {
             cm,
             ResourceTagFactory::new_for_test(),
             Arc::new(QuotaLimiter::default()),
+            None,
             None,
         );
 
@@ -2265,6 +2323,7 @@ mod tests {
             ResourceTagFactory::new_for_test(),
             Arc::new(QuotaLimiter::default()),
             None,
+            None,
         );
 
         let counter = Arc::new(atomic::AtomicIsize::new(0));
@@ -2334,6 +2393,7 @@ mod tests {
             cm,
             ResourceTagFactory::new_for_test(),
             Arc::new(QuotaLimiter::default()),
+            None,
             None,
         );
 
@@ -2742,6 +2802,7 @@ mod tests {
             ResourceTagFactory::new_for_test(),
             Arc::new(QuotaLimiter::default()),
             None,
+            None,
         );
 
         {
@@ -2829,6 +2890,7 @@ mod tests {
             cm,
             ResourceTagFactory::new_for_test(),
             Arc::new(QuotaLimiter::default()),
+            None,
             None,
         );
         let mut req = coppb::Request::default();
@@ -2969,6 +3031,7 @@ mod tests {
             cm,
             ResourceTagFactory::new_for_test(),
             Arc::new(QuotaLimiter::default()),
+            None,
             None,
         );
 
@@ -3499,5 +3562,38 @@ mod tests {
             assert_eq!(key, b"key".to_vec());
             true
         }));
+    }
+
+    #[test]
+    fn test_cop_pool_full_reject_error() {
+        let region_id = 42;
+        let not_leader_hint: LeaderHintProvider = Arc::new(|_| Some(false));
+        let leader_hint: LeaderHintProvider = Arc::new(|_| Some(true));
+
+        // Leader read on a store that is known not to be the leader: report
+        // NotLeader so that the client refreshes its stale route.
+        match cop_pool_full_reject_error(Some(&not_leader_hint), true, region_id) {
+            Error::Region(err) => {
+                assert!(err.has_not_leader());
+                assert_eq!(err.get_not_leader().get_region_id(), region_id);
+            }
+            other => panic!("expected NotLeader region error, got {:?}", other),
+        }
+
+        // The store is still the leader, or no hint is available: keep the
+        // previous MaxPendingTasksExceeded (ServerIsBusy) behavior.
+        for hint in [Some(&leader_hint), None] {
+            match cop_pool_full_reject_error(hint, true, region_id) {
+                Error::MaxPendingTasksExceeded => {}
+                other => panic!("expected MaxPendingTasksExceeded, got {:?}", other),
+            }
+        }
+
+        // Replica / stale reads may legitimately target followers: keep
+        // MaxPendingTasksExceeded.
+        match cop_pool_full_reject_error(Some(&not_leader_hint), false, region_id) {
+            Error::MaxPendingTasksExceeded => {}
+            other => panic!("expected MaxPendingTasksExceeded, got {:?}", other),
+        }
     }
 }

--- a/src/server/raftkv/mod.rs
+++ b/src/server/raftkv/mod.rs
@@ -499,6 +499,10 @@ where
         }
     }
 
+    fn local_leader_hint(&self, region_id: u64) -> Option<bool> {
+        Some(self.region_leaders.read().unwrap().contains(&region_id))
+    }
+
     type WriteRes = impl Stream<Item = WriteEvent> + Send + Unpin;
     fn async_write(
         &self,

--- a/src/server/raftkv2/mod.rs
+++ b/src/server/raftkv2/mod.rs
@@ -384,6 +384,10 @@ impl<EK: KvEngine, ER: RaftEngine> tikv_kv::Engine for RaftKv2<EK, ER> {
         }
     }
 
+    fn local_leader_hint(&self, region_id: u64) -> Option<bool> {
+        Some(self.region_leaders.read().unwrap().contains(&region_id))
+    }
+
     #[inline]
     fn schedule_txn_extra(&self, txn_extra: TxnExtra) {
         if let Some(tx) = self.txn_extra_scheduler.as_ref() {

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -685,6 +685,7 @@ mod tests {
             ResourceTagFactory::new_for_test(),
             Arc::new(QuotaLimiter::default()),
             None,
+            None,
         );
         let copr_v2 = coprocessor_v2::Endpoint::new(&coprocessor_v2::Config::default());
         let debug_thread_pool = Arc::new(

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -894,11 +894,18 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
         // Unset the TLS tracker because the future below does not belong to any
         // specific request
         clear_tls_tracker_token();
+        // The pool-full rejection applies to the whole batch, so only convert
+        // it to NotLeader when every request is a leader read of the same
+        // region. `ReqBatcher` does not enforce same-region batching (it only
+        // filters by priority), so mixed batches fall back to SchedTooBusy.
+        let region_id = requests[0].get_context().get_region_id();
+        let uniform_leader_read = requests.iter().all(|r| {
+            let ctx = r.get_context();
+            ctx.get_region_id() == region_id && !ctx.get_replica_read() && !ctx.get_stale_read()
+        });
         self.read_pool_spawn_with_busy_check(
-            // All requests in a batch share the same region and read type.
-            requests[0].get_context().get_region_id(),
-            !requests[0].get_context().get_replica_read()
-                && !requests[0].get_context().get_stale_read(),
+            region_id,
+            uniform_leader_read,
             busy_threshold,
             async move {
                 KV_COMMAND_COUNTER_VEC_STATIC.get(CMD).inc();
@@ -2198,10 +2205,18 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
             .resource_tag_factory
             .new_tag_with_key_ranges(rand_ctx, vec![(rand_key.clone(), rand_key)]);
 
+        // The pool-full rejection applies to the whole batch, so only convert
+        // it to NotLeader when every request is a leader read of the same
+        // region. `ReqBatcher` does not enforce same-region batching (it only
+        // filters by priority), so mixed batches fall back to SchedTooBusy.
+        let region_id = gets[0].get_context().get_region_id();
+        let uniform_leader_read = gets.iter().all(|r| {
+            let ctx = r.get_context();
+            ctx.get_region_id() == region_id && !ctx.get_replica_read() && !ctx.get_stale_read()
+        });
         self.read_pool_spawn_with_busy_check(
-            // All requests in a batch share the same region and read type.
-            gets[0].get_context().get_region_id(),
-            !gets[0].get_context().get_replica_read() && !gets[0].get_context().get_stale_read(),
+            region_id,
+            uniform_leader_read,
             busy_threshold,
             async move {
                 KV_COMMAND_COUNTER_VEC_STATIC.get(CMD).inc();

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -857,7 +857,9 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
         begin_instant: Instant,
     ) -> impl Future<Output = Result<()>> {
         const CMD: CommandKind = CommandKind::batch_get_command;
-        // all requests in a batch have the same region, epoch, term, replica_read
+        // Requests in a batch are expected to share the same region, epoch,
+        // term and read type. Note `ReqBatcher` does not enforce this (it only
+        // filters by priority), so do not rely on it for correctness.
         let priority = requests[0].get_context().get_priority();
         let metadata =
             TaskMetadata::from_ctx(requests[0].get_context().get_resource_control_context());
@@ -2172,7 +2174,9 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
         consumer: P,
     ) -> impl Future<Output = Result<()>> {
         const CMD: CommandKind = CommandKind::raw_batch_get_command;
-        // all requests in a batch have the same region, epoch, term, replica_read
+        // Requests in a batch are expected to share the same region, epoch,
+        // term and read type. Note `ReqBatcher` does not enforce this (it only
+        // filters by priority), so do not rely on it for correctness.
         let priority = gets[0].get_context().get_priority();
         let metadata = TaskMetadata::from_ctx(gets[0].get_context().get_resource_control_context());
         let resource_group_name = gets[0]

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -268,6 +268,33 @@ impl<E: Engine, L: LockManager, F: KvFormat> Drop for Storage<E, L, F> {
     }
 }
 
+/// Builds the error for a request rejected because the read pool cannot
+/// accept more tasks.
+///
+/// The rejection happens before the request reaches the raft layer, so the
+/// client would never learn about a stale cached leader from it. When this
+/// store locally knows it is no longer the leader of the region (e.g. leaders
+/// have been evicted from this half-dead store), a `NotLeader` region error
+/// is returned instead of `ServerIsBusy`, so that the client refreshes its
+/// route instead of retrying this store until it becomes unreachable.
+///
+/// Only applies to leader reads: replica / stale reads may legitimately
+/// target followers, and engines that cannot provide the hint (e.g. raftstore
+/// v2 or test engines) keep the previous `SchedTooBusy` behavior.
+fn pool_full_reject_error(
+    local_leader_hint: Option<bool>,
+    is_leader_read: bool,
+    region_id: u64,
+) -> Error {
+    if is_leader_read && local_leader_hint == Some(false) {
+        let mut err = kvproto::errorpb::Error::default();
+        err.mut_not_leader().set_region_id(region_id);
+        Error::from(ErrorInner::Kv(err.into()))
+    } else {
+        Error::from(ErrorInner::SchedTooBusy)
+    }
+}
+
 impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
     /// Create a `Storage` from given engine.
     pub fn from_engine<R: FlowStatsReporter>(
@@ -660,6 +687,8 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
 
         let stage_begin_ts = Instant::now();
         self.read_pool_spawn_with_busy_check(
+            ctx.get_region_id(),
+            !ctx.get_replica_read() && !ctx.get_stale_read(),
             busy_threshold,
             async move {
                 let stage_scheduled_ts = Instant::now();
@@ -866,6 +895,10 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
         // specific request
         clear_tls_tracker_token();
         self.read_pool_spawn_with_busy_check(
+            // All requests in a batch share the same region and read type.
+            requests[0].get_context().get_region_id(),
+            !requests[0].get_context().get_replica_read()
+                && !requests[0].get_context().get_stale_read(),
             busy_threshold,
             async move {
                 KV_COMMAND_COUNTER_VEC_STATIC.get(CMD).inc();
@@ -1085,6 +1118,8 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
         });
         let stage_begin_ts = Instant::now();
         self.read_pool_spawn_with_busy_check(
+            ctx.get_region_id(),
+            !ctx.get_replica_read() && !ctx.get_stale_read(),
             busy_threshold,
             async move {
                 let stage_scheduled_ts = Instant::now();
@@ -1298,6 +1333,8 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
         });
         let stage_begin_ts = Instant::now();
         self.read_pool_spawn_with_busy_check(
+            ctx.get_region_id(),
+            !ctx.get_replica_read() && !ctx.get_stale_read(),
             busy_threshold,
             async move {
                 let stage_scheduled_ts = Instant::now();
@@ -1521,6 +1558,8 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
         let busy_threshold = Duration::from_millis(ctx.busy_threshold_ms as u64);
 
         self.read_pool_spawn_with_busy_check(
+            ctx.get_region_id(),
+            !ctx.get_replica_read() && !ctx.get_stale_read(),
             busy_threshold,
             async move {
                 {
@@ -2052,6 +2091,8 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
         let busy_threshold = Duration::from_millis(ctx.busy_threshold_ms as u64);
 
         self.read_pool_spawn_with_busy_check(
+            ctx.get_region_id(),
+            !ctx.get_replica_read() && !ctx.get_stale_read(),
             busy_threshold,
             async move {
                 KV_COMMAND_COUNTER_VEC_STATIC.get(CMD).inc();
@@ -2158,6 +2199,9 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
             .new_tag_with_key_ranges(rand_ctx, vec![(rand_key.clone(), rand_key)]);
 
         self.read_pool_spawn_with_busy_check(
+            // All requests in a batch share the same region and read type.
+            gets[0].get_context().get_region_id(),
+            !gets[0].get_context().get_replica_read() && !gets[0].get_context().get_stale_read(),
             busy_threshold,
             async move {
                 KV_COMMAND_COUNTER_VEC_STATIC.get(CMD).inc();
@@ -2300,6 +2344,8 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
         let busy_threshold = Duration::from_millis(ctx.busy_threshold_ms as u64);
 
         self.read_pool_spawn_with_busy_check(
+            ctx.get_region_id(),
+            !ctx.get_replica_read() && !ctx.get_stale_read(),
             busy_threshold,
             async move {
                 let mut key_ranges = vec![];
@@ -2803,6 +2849,8 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
         let busy_threshold = Duration::from_millis(ctx.busy_threshold_ms as u64);
 
         self.read_pool_spawn_with_busy_check(
+            ctx.get_region_id(),
+            !ctx.get_replica_read() && !ctx.get_stale_read(),
             busy_threshold,
             async move {
                 KV_COMMAND_COUNTER_VEC_STATIC.get(CMD).inc();
@@ -2947,6 +2995,8 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
         let busy_threshold = Duration::from_millis(ctx.busy_threshold_ms as u64);
 
         self.read_pool_spawn_with_busy_check(
+            ctx.get_region_id(),
+            !ctx.get_replica_read() && !ctx.get_stale_read(),
             busy_threshold,
             async move {
                 KV_COMMAND_COUNTER_VEC_STATIC.get(CMD).inc();
@@ -3106,6 +3156,8 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
         let busy_threshold = Duration::from_millis(ctx.busy_threshold_ms as u64);
 
         self.read_pool_spawn_with_busy_check(
+            ctx.get_region_id(),
+            !ctx.get_replica_read() && !ctx.get_stale_read(),
             busy_threshold,
             async move {
                 KV_COMMAND_COUNTER_VEC_STATIC.get(CMD).inc();
@@ -3367,6 +3419,8 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
 
     fn read_pool_spawn_with_busy_check<Fut, T>(
         &self,
+        region_id: u64,
+        is_leader_read: bool,
         busy_threshold: Duration,
         future: Fut,
         priority: CommandPri,
@@ -3384,12 +3438,25 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
             return FuturesEither::Left(future::err(Error::from(ErrorInner::Kv(err.into()))));
         }
 
+        let engine = self.engine.clone();
         let metadata = metadata.deep_clone();
         let read_pool = self.read_pool.clone();
         FuturesEither::Right(async move {
             read_pool
                 .spawn_handle(future, priority, task_id, metadata, resource_limiter)
-                .map_err(|_| Error::from(ErrorInner::SchedTooBusy))
+                .map_err(move |_| {
+                    // The request is rejected at the read pool gate, before
+                    // reaching the raft layer. If the local store is no longer
+                    // the leader of the region (e.g. leaders have been evicted
+                    // from this half-dead store), report `NotLeader` instead
+                    // of `ServerIsBusy` so that the client refreshes its route
+                    // instead of retrying this store endlessly.
+                    pool_full_reject_error(
+                        engine.local_leader_hint(region_id),
+                        is_leader_read,
+                        region_id,
+                    )
+                })
                 .await?
         })
     }
@@ -12603,5 +12670,34 @@ mod tests {
             assert_eq!(shared_lock.get_lock_type(), op);
             assert_eq!(shared_lock.get_lock_for_update_ts(), for_update_ts);
         }
+    }
+
+    #[test]
+    fn test_pool_full_reject_error() {
+        use crate::storage::errors::extract_region_error_from_error;
+
+        let region_id = 42;
+
+        // Leader read on a store that is known not to be the leader: report
+        // NotLeader so that the client refreshes its stale route instead of
+        // retrying this store.
+        let err = pool_full_reject_error(Some(false), true, region_id);
+        let region_err = extract_region_error_from_error(&err).expect("region error");
+        assert!(region_err.has_not_leader());
+        assert_eq!(region_err.get_not_leader().get_region_id(), region_id);
+
+        // The store is still the leader, or the hint is unavailable: keep the
+        // previous SchedTooBusy (ServerIsBusy) behavior.
+        for hint in [Some(true), None] {
+            let err = pool_full_reject_error(hint, true, region_id);
+            let region_err = extract_region_error_from_error(&err).expect("region error");
+            assert!(region_err.has_server_is_busy());
+        }
+
+        // Replica / stale reads may legitimately target followers: keep
+        // SchedTooBusy.
+        let err = pool_full_reject_error(Some(false), false, region_id);
+        let region_err = extract_region_error_from_error(&err).expect("region error");
+        assert!(region_err.has_server_is_busy());
     }
 }

--- a/tests/integrations/resource_metering/test_cpu.rs
+++ b/tests/integrations/resource_metering/test_cpu.rs
@@ -234,6 +234,7 @@ fn setup_test_suite() -> (TestSuite, Store<RocksEngine>, Endpoint<RocksEngine>) 
         test_suite.get_tag_factory(),
         Arc::new(QuotaLimiter::default()),
         Some(Arc::new(ResourceGroupManager::default())),
+        None,
     );
     (test_suite, store, endpoint)
 }

--- a/tests/integrations/resource_metering/test_read_keys.rs
+++ b/tests/integrations/resource_metering/test_read_keys.rs
@@ -233,6 +233,7 @@ fn init_coprocessor_with_data(
         tag_factory,
         Arc::new(QuotaLimiter::default()),
         None,
+        None,
     )
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #18491, ref tikv/client-go#2028

Problem Summary:

When the unified read pool cannot accept a new task, the request is rejected at the pool gate with `ServerIsBusy` (reason `"scheduler is busy"`, no `estimated_wait_ms`) **before reaching the raft layer**. If the store is half-dead (e.g. EBS/disk stuck so read-pool tasks never finish, tikv/tikv#18491) and PD has already evicted its leaders, the store keeps answering gRPC and returns `ServerIsBusy` instead of `NotLeader`. client-go's `replicaSelectorV2`/`replicaSelector` treats this error as transient: it neither invalidates the region cache nor switches replicas (tikv/client-go#2028), so TiDB keeps sending leader reads to the half-dead store until it becomes fully unreachable (observed ~25 minutes of latency in a production incident).

### What is changed and how it works?

When rejecting a **leader read** at the read-pool-full gate, if the local store already knows (via the `region_leaders` set maintained by `RegionInfoAccessor`, the same mechanism as the write-path `precheck_write_with_ctx`) that it is **no longer the leader** of the requested region, return `NotLeader` for the region instead of `ServerIsBusy`. `NotLeader` is routing-corrective on all existing client-go versions: the client refreshes its route (re-resolves the leader from PD) instead of retrying this store.

- `tikv_kv::Engine`: new `local_leader_hint(region_id) -> Option<bool>` with a default `None`.
- `RaftKv` (v1) and `RaftKv2` (v2): implement the hint via the existing `region_leaders` set.
- `Storage::read_pool_spawn_with_busy_check`: on pool-full rejection, build the error via `pool_full_reject_error(...)`, which returns `NotLeader` only for leader reads (`!replica_read && !stale_read`) when the hint is `Some(false)`; otherwise the behavior is unchanged (`SchedTooBusy` → `ServerIsBusy`).
- The hint is only evaluated on the rejection path; the hot path is unchanged.

Scope notes:

- The busy-threshold gate (`check_busy_threshold`, requires client-set `busy_threshold_ms`) is unchanged: it already carries `estimated_wait_ms` and client-go can fail over on it when enabled.
- Coprocessor endpoint (`MaxPendingTasksExceeded`) is not covered yet: `Endpoint` does not hold an engine instance, so plumbing the hint there is a follow-up.
- Engines without leader knowledge (test engines, `MockEngine`, etc.) keep `None` → unchanged behavior.

Why this is safe:

- False positive direction is benign: if the hint is stale and we wrongly claim `NotLeader`, the client re-resolves from PD and gets the correct leader (possibly this store again), costing one extra PD lookup.
- False negative direction degrades to today's behavior (`ServerIsBusy`).
- No client-side change is required.

### Related changes

- ref tikv/tikv#18491 (read pool wedge; the permanent-timeout fix is orthogonal and should still be done)
- ref tikv/client-go#2028 (client-side escalation; defense in depth)

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
When a leader read is rejected because the unified read pool is full, TiKV now returns `NotLeader` instead of `ServerIsBusy` if the local store already knows it is no longer the leader of the region, allowing clients to fail over to the new leader immediately instead of retrying a half-dead store.
```
