### PR TITLE
[release-8.5] *: upgrade vulnerable Rust dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,7 +36,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c80b57a86234ee3e9238f5f2d33d37f8fd5c7ff168c07f2d5147d410e86db33"
 dependencies = [
  "home",
- "libc 0.2.186",
+ "libc 0.2.176",
  "rustc_version 0.4.0",
  "xdg",
 ]
@@ -94,7 +94,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
- "libc 0.2.186",
+ "libc 0.2.176",
 ]
 
 [[package]]
@@ -259,7 +259,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -270,7 +270,7 @@ checksum = "7b2d0f03b3640e3a630367e40c468cb7f309529c708ed1d88597047b0e7c6ef7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -294,7 +294,7 @@ version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
 dependencies = [
- "libc 0.2.186",
+ "libc 0.2.176",
  "winapi 0.3.9",
 ]
 
@@ -365,8 +365,8 @@ dependencies = [
  "aws-smithy-types",
  "aws-types",
  "bytes",
- "fastrand 2.4.1",
- "http 1.4.2",
+ "fastrand 2.3.0",
+ "http 1.4.0",
  "time 0.3.47",
  "tokio",
  "tracing",
@@ -439,9 +439,9 @@ dependencies = [
  "aws-types",
  "bytes",
  "bytes-utils",
- "fastrand 2.4.1",
+ "fastrand 2.3.0",
  "http 0.2.12",
- "http 1.4.2",
+ "http 1.4.0",
  "http-body 0.4.6",
  "http-body 1.0.1",
  "percent-encoding",
@@ -467,9 +467,9 @@ dependencies = [
  "aws-smithy-types",
  "aws-types",
  "bytes",
- "fastrand 2.4.1",
+ "fastrand 2.3.0",
  "http 0.2.12",
- "http 1.4.2",
+ "http 1.4.0",
  "regex-lite",
  "tracing",
 ]
@@ -495,11 +495,11 @@ dependencies = [
  "aws-smithy-xml",
  "aws-types",
  "bytes",
- "fastrand 2.4.1",
+ "fastrand 2.3.0",
  "hex 0.4.3",
  "hmac",
  "http 0.2.12",
- "http 1.4.2",
+ "http 1.4.0",
  "http-body 1.0.1",
  "lru",
  "percent-encoding",
@@ -527,9 +527,9 @@ dependencies = [
  "aws-smithy-types",
  "aws-smithy-xml",
  "aws-types",
- "fastrand 2.4.1",
+ "fastrand 2.3.0",
  "http 0.2.12",
- "http 1.4.2",
+ "http 1.4.0",
  "regex-lite",
  "tracing",
 ]
@@ -550,7 +550,7 @@ dependencies = [
  "hex 0.4.3",
  "hmac",
  "http 0.2.12",
- "http 1.4.2",
+ "http 1.4.0",
  "percent-encoding",
  "sha2",
  "time 0.3.47",
@@ -579,7 +579,7 @@ dependencies = [
  "bytes",
  "crc-fast",
  "hex 0.4.3",
- "http 1.4.2",
+ "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
  "md-5",
@@ -613,7 +613,7 @@ dependencies = [
  "bytes-utils",
  "futures-core",
  "futures-util",
- "http 1.4.2",
+ "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
  "percent-encoding",
@@ -636,7 +636,7 @@ dependencies = [
  "h2 0.3.26",
  "h2 0.4.13",
  "http 0.2.12",
- "http 1.4.2",
+ "http 1.4.0",
  "http-body 0.4.6",
  "http-body 1.0.1",
  "hyper 0.14.28",
@@ -708,9 +708,9 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
- "fastrand 2.4.1",
+ "fastrand 2.3.0",
  "http 0.2.12",
- "http 1.4.2",
+ "http 1.4.0",
  "http-body 0.4.6",
  "http-body 1.0.1",
  "http-body-util",
@@ -731,7 +731,7 @@ dependencies = [
  "aws-smithy-types",
  "bytes",
  "http 0.2.12",
- "http 1.4.2",
+ "http 1.4.0",
  "pin-project-lite",
  "tokio",
  "tracing",
@@ -749,12 +749,12 @@ dependencies = [
  "bytes-utils",
  "futures-core",
  "http 0.2.12",
- "http 1.4.2",
+ "http 1.4.0",
  "http-body 0.4.6",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 0.14.28",
- "itoa 1.0.18",
+ "itoa 1.0.17",
  "num-integer",
  "pin-project-lite",
  "pin-utils",
@@ -944,7 +944,7 @@ dependencies = [
  "addr2line",
  "cc",
  "cfg-if 1.0.0",
- "libc 0.2.186",
+ "libc 0.2.176",
  "miniz_oxide 0.4.4",
  "object",
  "rustc-demangle",
@@ -1124,7 +1124,7 @@ dependencies = [
  "bcc-sys",
  "bitflags 1.3.2",
  "byteorder",
- "libc 0.2.186",
+ "libc 0.2.176",
  "regex",
  "thiserror 1.0.40",
 ]
@@ -1176,7 +1176,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.0.1",
  "shlex",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1196,7 +1196,7 @@ dependencies = [
  "regex",
  "rustc-hash 2.1.2",
  "shlex",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1269,7 +1269,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1343,7 +1343,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
 dependencies = [
  "cc",
- "libc 0.2.186",
+ "libc 0.2.176",
  "pkg-config",
 ]
 
@@ -1369,7 +1369,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7f788eaf239475a3c1e1acf89951255a46c4b9b46cf3e866fc4d0707b4b9e36"
 dependencies = [
- "libc 0.2.186",
+ "libc 0.2.176",
  "valgrind_request",
 ]
 
@@ -1449,7 +1449,7 @@ checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
- "libc 0.2.186",
+ "libc 0.2.176",
  "shlex",
 ]
 
@@ -1582,7 +1582,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f54d78e30b388d4815220c8dd03fea5656b6c6d32adb59e89061552a102f8da1"
 dependencies = [
  "glob",
- "libc 0.2.186",
+ "libc 0.2.176",
  "libloading",
 ]
 
@@ -1668,7 +1668,7 @@ version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71367d3385c716342014ad17e3d19f7788ae514885a1f4c24f500260fb365e1a"
 dependencies = [
- "libc 0.2.186",
+ "libc 0.2.176",
  "once_cell",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
@@ -1681,7 +1681,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "error_code",
- "libc 0.2.186",
+ "libc 0.2.176",
  "panic_hook",
  "protobuf 2.8.0",
  "rand 0.8.5",
@@ -1806,7 +1806,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a89e2ae426ea83155dccf10c0fa6b1463ef6d5fcb44cee0b224a408fa640a62"
 dependencies = [
  "core-foundation-sys",
- "libc 0.2.186",
+ "libc 0.2.176",
 ]
 
 [[package]]
@@ -1816,7 +1816,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
- "libc 0.2.186",
+ "libc 0.2.176",
 ]
 
 [[package]]
@@ -1831,7 +1831,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9e393a7668fe1fad3075085b86c781883000b4ede868f43627b34a87c8b7ded"
 dependencies = [
- "libc 0.2.186",
+ "libc 0.2.176",
  "winapi 0.3.9",
 ]
 
@@ -1841,7 +1841,7 @@ version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
 dependencies = [
- "libc 0.2.186",
+ "libc 0.2.176",
 ]
 
 [[package]]
@@ -1855,9 +1855,9 @@ dependencies = [
 
 [[package]]
 name = "crc-catalog"
-version = "2.5.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
 name = "crc-fast"
@@ -1954,7 +1954,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63aaaf47e457badbcb376c65a49d0f182c317ebd97dc6d1ced94c8e1d09c0f3a"
 dependencies = [
  "criterion 0.3.5",
- "libc 0.2.186",
+ "libc 0.2.176",
 ]
 
 [[package]]
@@ -2167,7 +2167,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2180,7 +2180,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2202,7 +2202,7 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2213,7 +2213,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core 0.23.0",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2244,12 +2244,12 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.8"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+checksum = "d630bccd429a5bb5a64b5e94f693bfc48c9f8566418fda4c494cc94f911f87cc"
 dependencies = [
  "powerfmt",
- "serde_core",
+ "serde",
 ]
 
 [[package]]
@@ -2307,7 +2307,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
- "libc 0.2.186",
+ "libc 0.2.176",
  "redox_users",
  "winapi 0.3.9",
 ]
@@ -2326,7 +2326,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2589,7 +2589,7 @@ checksum = "3bf679796c0322556351f287a51b49e48f7c4986e727b5dd78c972d30e2e16cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2604,7 +2604,7 @@ version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
- "libc 0.2.186",
+ "libc 0.2.176",
  "windows-sys 0.61.0",
 ]
 
@@ -2729,9 +2729,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "file_system"
@@ -2744,7 +2744,7 @@ dependencies = [
  "fail",
  "fs2",
  "lazy_static",
- "libc 0.2.186",
+ "libc 0.2.176",
  "online_config",
  "openssl",
  "parking_lot 0.12.1",
@@ -2766,7 +2766,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed3d8a5e20435ff00469e51a0d82049bae66504b5c429920dadf9bb54d47b3f"
 dependencies = [
- "libc 0.2.186",
+ "libc 0.2.176",
  "thiserror 1.0.40",
  "winapi 0.3.9",
 ]
@@ -2778,7 +2778,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d34cfa13a63ae058bfa601fe9e313bbdb3746427c1459185464ce0fcf62e1e8"
 dependencies = [
  "cfg-if 1.0.0",
- "libc 0.2.186",
+ "libc 0.2.176",
  "redox_syscall 0.2.11",
  "winapi 0.3.9",
 ]
@@ -2797,7 +2797,7 @@ checksum = "d691fdb3f817632d259d09220d4cf0991dbb2c9e59e044a02a59194bf6e14484"
 dependencies = [
  "cc",
  "lazy_static",
- "libc 0.2.186",
+ "libc 0.2.176",
  "winapi 0.3.9",
 ]
 
@@ -2808,7 +2808,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2adaffba6388640136149e18ed080b77a78611c1e1d6de75aedcdf78df5d4682"
 dependencies = [
  "crc32fast",
- "libc 0.2.186",
+ "libc 0.2.176",
  "libz-sys",
  "miniz_oxide 0.3.7",
 ]
@@ -2860,7 +2860,7 @@ name = "fs2"
 version = "0.4.3"
 source = "git+https://github.com/tikv/fs2-rs?branch=tikv#cd503764a19a99d74c1ab424dd13d6bcd093fcae"
 dependencies = [
- "libc 0.2.186",
+ "libc 0.2.176",
  "winapi 0.3.9",
 ]
 
@@ -2886,7 +2886,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f41b048a94555da0f42f1d632e2e19510084fb8e303b0daa2816e733fb3644a0"
 dependencies = [
- "libc 0.2.186",
+ "libc 0.2.176",
 ]
 
 [[package]]
@@ -2983,7 +2983,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3160,7 +3160,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "473a1265acc8ff1e808cd0a1af8cee3c2ee5200916058a2ca113c29f2d903571"
 dependencies = [
  "cfg-if 0.1.10",
- "libc 0.2.186",
+ "libc 0.2.176",
  "wasi 0.7.0",
 ]
 
@@ -3172,7 +3172,7 @@ checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
- "libc 0.2.186",
+ "libc 0.2.176",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
@@ -3185,7 +3185,7 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
- "libc 0.2.186",
+ "libc 0.2.176",
  "r-efi",
  "wasip2",
  "wasm-bindgen",
@@ -3225,7 +3225,7 @@ dependencies = [
  "base64 0.22.1",
  "bon",
  "google-cloud-gax",
- "http 1.4.2",
+ "http 1.4.0",
  "reqwest 0.12.28",
  "rustc_version 0.4.0",
  "rustls",
@@ -3248,7 +3248,7 @@ dependencies = [
  "futures 0.3.15",
  "google-cloud-rpc",
  "google-cloud-wkt",
- "http 1.4.2",
+ "http 1.4.0",
  "pin-project",
  "rand 0.9.4",
  "serde",
@@ -3268,7 +3268,7 @@ dependencies = [
  "google-cloud-gax",
  "google-cloud-rpc",
  "google-cloud-wkt",
- "http 1.4.2",
+ "http 1.4.0",
  "http-body-util",
  "percent-encoding",
  "prost",
@@ -3412,7 +3412,7 @@ dependencies = [
  "google-cloud-rpc",
  "google-cloud-type",
  "google-cloud-wkt",
- "http 1.4.2",
+ "http 1.4.0",
  "http-body 1.0.1",
  "hyper 1.9.0",
  "lazy_static",
@@ -3482,7 +3482,7 @@ dependencies = [
  "futures-executor",
  "futures-util",
  "grpcio-sys",
- "libc 0.2.186",
+ "libc 0.2.176",
  "log",
  "parking_lot 0.11.1",
  "protobuf 2.8.0",
@@ -3519,7 +3519,7 @@ dependencies = [
  "bindgen 0.59.2",
  "cc",
  "cmake",
- "libc 0.2.186",
+ "libc 0.2.176",
  "libz-sys",
  "openssl-sys",
  "pkg-config",
@@ -3556,7 +3556,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.4.2",
+ "http 1.4.0",
  "indexmap 2.11.1",
  "slab",
  "tokio",
@@ -3655,7 +3655,7 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
- "libc 0.2.186",
+ "libc 0.2.176",
 ]
 
 [[package]]
@@ -3713,17 +3713,17 @@ checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
 dependencies = [
  "bytes",
  "fnv",
- "itoa 1.0.18",
+ "itoa 1.0.17",
 ]
 
 [[package]]
 name = "http"
-version = "1.4.2"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
 dependencies = [
  "bytes",
- "itoa 1.0.18",
+ "itoa 1.0.17",
 ]
 
 [[package]]
@@ -3744,7 +3744,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.4.2",
+ "http 1.4.0",
 ]
 
 [[package]]
@@ -3755,7 +3755,7 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.2",
+ "http 1.4.0",
  "http-body 1.0.1",
  "pin-project-lite",
 ]
@@ -3840,7 +3840,7 @@ dependencies = [
  "http-body 0.4.6",
  "httparse",
  "httpdate",
- "itoa 1.0.18",
+ "itoa 1.0.17",
  "pin-project-lite",
  "socket2 0.5.7",
  "tokio",
@@ -3860,10 +3860,10 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "h2 0.4.13",
- "http 1.4.2",
+ "http 1.4.0",
  "http-body 1.0.1",
  "httparse",
- "itoa 1.0.18",
+ "itoa 1.0.17",
  "pin-project-lite",
  "smallvec",
  "tokio",
@@ -3894,7 +3894,7 @@ version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http 1.4.2",
+ "http 1.4.0",
  "hyper 1.9.0",
  "hyper-util",
  "rustls",
@@ -3940,11 +3940,11 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.4.2",
+ "http 1.4.0",
  "http-body 1.0.1",
  "hyper 1.9.0",
  "ipnet",
- "libc 0.2.186",
+ "libc 0.2.176",
  "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.3",
@@ -4091,7 +4091,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4146,7 +4146,7 @@ dependencies = [
  "keys",
  "kvproto",
  "lazy_static",
- "libc 0.2.186",
+ "libc 0.2.176",
  "log_wrappers",
  "online_config",
  "parking_lot 0.12.1",
@@ -4217,7 +4217,7 @@ dependencies = [
  "ahash 0.7.8",
  "atty",
  "indexmap 1.9.3",
- "itoa 1.0.18",
+ "itoa 1.0.17",
  "lazy_static",
  "log",
  "num-format",
@@ -4234,7 +4234,7 @@ checksum = "4816c66d2c8ae673df83366c18341538f234a26d65a9ecea5c348b453ac1d02f"
 dependencies = [
  "bitflags 1.3.2",
  "inotify-sys",
- "libc 0.2.186",
+ "libc 0.2.176",
 ]
 
 [[package]]
@@ -4243,7 +4243,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
 dependencies = [
- "libc 0.2.186",
+ "libc 0.2.176",
 ]
 
 [[package]]
@@ -4270,7 +4270,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7d6c6f8c91b4b9ed43484ad1a938e393caf35960fce7f82a040497207bd8e9e"
 dependencies = [
- "libc 0.2.186",
+ "libc 0.2.176",
  "windows-sys 0.42.0",
 ]
 
@@ -4280,7 +4280,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
 dependencies = [
- "libc 0.2.186",
+ "libc 0.2.176",
 ]
 
 [[package]]
@@ -4346,9 +4346,9 @@ checksum = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 
 [[package]]
 name = "itoa"
-version = "1.0.18"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jobserver"
@@ -4356,7 +4356,7 @@ version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
 dependencies = [
- "libc 0.2.186",
+ "libc 0.2.176",
 ]
 
 [[package]]
@@ -4434,9 +4434,9 @@ checksum = "e32a70cf75e5846d53a673923498228bbec6a8624708a9ea5645f075d6276122"
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.176"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -4482,7 +4482,7 @@ dependencies = [
  "bzip2-sys",
  "cc",
  "cmake",
- "libc 0.2.186",
+ "libc 0.2.176",
  "libtitan_sys",
  "libz-sys",
  "lz4-sys",
@@ -4500,7 +4500,7 @@ dependencies = [
  "bzip2-sys",
  "cc",
  "cmake",
- "libc 0.2.186",
+ "libc 0.2.176",
  "libz-sys",
  "lz4-sys",
  "snappy-sys",
@@ -4514,7 +4514,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b70e7a7df205e92a1a4cd9aaae7898dac0aa555503cc0a649494d0d60e7651d"
 dependencies = [
  "cc",
- "libc 0.2.186",
+ "libc 0.2.176",
  "pkg-config",
  "vcpkg",
 ]
@@ -4603,7 +4603,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9764018d143cc854c9f17f0b907de70f14393b1f502da6375dce70f00514eb3"
 dependencies = [
  "cc",
- "libc 0.2.186",
+ "libc 0.2.176",
 ]
 
 [[package]]
@@ -4666,7 +4666,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
 dependencies = [
- "libc 0.2.186",
+ "libc 0.2.176",
  "winapi 0.3.9",
 ]
 
@@ -4676,7 +4676,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45fd3a57831bf88bc63f8cebc0cf956116276e97fef3966103e96416209f7c92"
 dependencies = [
- "libc 0.2.186",
+ "libc 0.2.176",
 ]
 
 [[package]]
@@ -4766,7 +4766,7 @@ dependencies = [
  "fuchsia-zircon-sys",
  "iovec",
  "kernel32-sys",
- "libc 0.2.186",
+ "libc 0.2.176",
  "log",
  "miow",
  "net2",
@@ -4776,11 +4776,11 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
 dependencies = [
- "libc 0.2.186",
+ "libc 0.2.176",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.61.0",
 ]
@@ -4842,7 +4842,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4872,7 +4872,7 @@ version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
 dependencies = [
- "libc 0.2.186",
+ "libc 0.2.176",
  "log",
  "openssl",
  "openssl-probe 0.1.2",
@@ -4890,7 +4890,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "391630d12b68002ae1e25e8f974306474966550ad82dac6886fb8910c19568ae"
 dependencies = [
  "cfg-if 0.1.10",
- "libc 0.2.186",
+ "libc 0.2.176",
  "winapi 0.3.9",
 ]
 
@@ -4902,7 +4902,7 @@ checksum = "8f17df307904acd05aa8e32e97bb20f2a0df1728bbc2d771ae8f9a90463441e9"
 dependencies = [
  "bitflags 1.3.2",
  "cfg-if 1.0.0",
- "libc 0.2.186",
+ "libc 0.2.176",
  "memoffset 0.6.4",
 ]
 
@@ -4914,7 +4914,7 @@ checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
 dependencies = [
  "bitflags 1.3.2",
  "cfg-if 1.0.0",
- "libc 0.2.186",
+ "libc 0.2.176",
  "memoffset 0.7.1",
  "pin-utils",
  "static_assertions",
@@ -4973,7 +4973,7 @@ dependencies = [
  "fsevent",
  "fsevent-sys",
  "inotify",
- "libc 0.2.186",
+ "libc 0.2.176",
  "mio 0.6.23",
  "mio-extras",
  "walkdir",
@@ -5033,9 +5033,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
 name = "num-derive"
@@ -5045,7 +5045,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5119,7 +5119,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
  "hermit-abi 0.3.9",
- "libc 0.2.186",
+ "libc 0.2.176",
 ]
 
 [[package]]
@@ -5128,7 +5128,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
 dependencies = [
- "libc 0.2.186",
+ "libc 0.2.176",
 ]
 
 [[package]]
@@ -5199,7 +5199,7 @@ dependencies = [
  "bitflags 2.11.1",
  "cfg-if 1.0.0",
  "foreign-types",
- "libc 0.2.186",
+ "libc 0.2.176",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -5212,7 +5212,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5243,7 +5243,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
- "libc 0.2.186",
+ "libc 0.2.176",
  "openssl-src",
  "pkg-config",
  "vcpkg",
@@ -5279,7 +5279,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eebde548fbbf1ea81a99b128872779c437752fb99f217c45245e1a61dcd9edcd"
 dependencies = [
- "libc 0.2.186",
+ "libc 0.2.176",
  "winapi 0.3.9",
 ]
 
@@ -5322,7 +5322,7 @@ checksum = "fa7a782938e745763fe6907fc6ba86946d72f49fe7e21de074e08128a99fb018"
 dependencies = [
  "cfg-if 1.0.0",
  "instant",
- "libc 0.2.186",
+ "libc 0.2.176",
  "redox_syscall 0.2.11",
  "smallvec",
  "winapi 0.3.9",
@@ -5335,7 +5335,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28141e0cc4143da2443301914478dc976a61ffdb3f043058310c70df2fed8954"
 dependencies = [
  "cfg-if 1.0.0",
- "libc 0.2.186",
+ "libc 0.2.176",
  "redox_syscall 0.2.11",
  "smallvec",
  "windows-sys 0.32.0",
@@ -5411,7 +5411,7 @@ checksum = "b8f94885300e262ef461aa9fd1afbf7df3caf9e84e271a74925d1c6c8b24830f"
 dependencies = [
  "bitflags 1.3.2",
  "byteorder",
- "libc 0.2.186",
+ "libc 0.2.176",
  "mmap",
  "nom 4.2.3",
  "phf",
@@ -5544,7 +5544,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d27361d7578b410d0eb5fe815c2b2105b01ab770a7c738cb9a231457a809fcc7"
 dependencies = [
  "ipnetwork",
- "libc 0.2.186",
+ "libc 0.2.176",
  "pnet_base",
  "pnet_sys",
  "winapi 0.2.8",
@@ -5556,7 +5556,7 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82f881a6d75ac98c5541db6144682d1773bb14c6fc50c6ebac7086c8f7f23c29"
 dependencies = [
- "libc 0.2.186",
+ "libc 0.2.176",
  "winapi 0.2.8",
  "ws2_32-sys",
 ]
@@ -5577,7 +5577,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "findshlibs",
  "inferno",
- "libc 0.2.186",
+ "libc 0.2.176",
  "log",
  "nix 0.26.2",
  "once_cell",
@@ -5601,7 +5601,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "findshlibs",
  "inferno",
- "libc 0.2.186",
+ "libc 0.2.176",
  "log",
  "nix 0.26.2",
  "once_cell",
@@ -5666,7 +5666,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6837b9e10d61f45f987d50808f83d1ee3d206c66acf650c3e4ae2e1f6ddedf55"
 dependencies = [
  "proc-macro2",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5718,7 +5718,7 @@ dependencies = [
  "byteorder",
  "hex 0.4.3",
  "lazy_static",
- "libc 0.2.186",
+ "libc 0.2.176",
 ]
 
 [[package]]
@@ -5727,7 +5727,7 @@ version = "0.4.2"
 source = "git+https://github.com/tikv/procinfo-rs?rev=7693954bd1dd86eb1709572fd7b62fd5f7ff2ea1#7693954bd1dd86eb1709572fd7b62fd5f7ff2ea1"
 dependencies = [
  "byteorder",
- "libc 0.2.186",
+ "libc 0.2.176",
  "nom 2.2.1",
  "rustc_version 0.2.3",
 ]
@@ -5752,7 +5752,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "fnv",
  "lazy_static",
- "libc 0.2.186",
+ "libc 0.2.176",
  "memchr",
  "parking_lot 0.11.1",
  "protobuf 2.8.0",
@@ -5812,7 +5812,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6001,9 +6001,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
 dependencies = [
  "cfg_aliases",
- "libc 0.2.186",
+ "libc 0.2.176",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.7",
  "tracing",
  "windows-sys 0.52.0",
 ]
@@ -6051,7 +6051,7 @@ dependencies = [
  "hex 0.4.3",
  "if_chain",
  "lazy_static",
- "libc 0.2.186",
+ "libc 0.2.176",
  "log",
  "lz4-sys",
  "memmap2",
@@ -6237,7 +6237,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
  "getrandom 0.1.12",
- "libc 0.2.186",
+ "libc 0.2.176",
  "rand_chacha 0.2.1",
  "rand_core 0.5.1",
  "rand_hc",
@@ -6249,7 +6249,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
- "libc 0.2.186",
+ "libc 0.2.176",
  "rand_chacha 0.3.0",
  "rand_core 0.6.4",
 ]
@@ -6426,7 +6426,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6523,7 +6523,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http 1.4.2",
+ "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.9.0",
@@ -6693,7 +6693,7 @@ dependencies = [
  "cc",
  "cfg-if 1.0.0",
  "getrandom 0.2.11",
- "libc 0.2.186",
+ "libc 0.2.176",
  "untrusted",
  "windows-sys 0.52.0",
 ]
@@ -6703,7 +6703,7 @@ name = "rocksdb"
 version = "0.3.0"
 source = "git+https://github.com/tikv/rust-rocksdb.git#1c17b59dcb506302ed4684b3628c4a7165e0b86d"
 dependencies = [
- "libc 0.2.186",
+ "libc 0.2.176",
  "librocksdb_sys",
 ]
 
@@ -6782,7 +6782,7 @@ dependencies = [
  "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
- "libc 0.2.186",
+ "libc 0.2.176",
  "linux-raw-sys 0.1.4",
  "windows-sys 0.45.0",
 ]
@@ -6795,7 +6795,7 @@ checksum = "745ecfa778e66b2b63c88a61cb36e0eea109e803b0b86bf9879fbc77c70e86ed"
 dependencies = [
  "bitflags 2.11.1",
  "errno",
- "libc 0.2.186",
+ "libc 0.2.176",
  "linux-raw-sys 0.4.12",
  "windows-sys 0.48.0",
 ]
@@ -6959,7 +6959,7 @@ dependencies = [
  "bitflags 1.3.2",
  "core-foundation 0.9.1",
  "core-foundation-sys",
- "libc 0.2.186",
+ "libc 0.2.176",
  "security-framework-sys",
 ]
 
@@ -6972,7 +6972,7 @@ dependencies = [
  "bitflags 2.11.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
- "libc 0.2.186",
+ "libc 0.2.176",
  "security-framework-sys",
 ]
 
@@ -6983,7 +6983,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
- "libc 0.2.186",
+ "libc 0.2.176",
 ]
 
 [[package]]
@@ -7043,9 +7043,9 @@ checksum = "f97841a747eef040fcd2e7b3b9a220a7205926e60488e673d9e4926d27772ce5"
 
 [[package]]
 name = "serde"
-version = "1.0.229"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -7063,22 +7063,22 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.229"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.229"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7092,12 +7092,12 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.151"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "indexmap 2.11.1",
- "itoa 1.0.18",
+ "itoa 1.0.17",
  "memchr",
  "serde",
  "serde_core",
@@ -7142,7 +7142,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa 1.0.18",
+ "itoa 1.0.17",
  "ryu",
  "serde",
 ]
@@ -7176,7 +7176,7 @@ dependencies = [
  "darling 0.23.0",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7208,7 +7208,7 @@ dependencies = [
  "in_memory_engine",
  "keys",
  "kvproto",
- "libc 0.2.186",
+ "libc 0.2.176",
  "log_wrappers",
  "pd_client",
  "prometheus",
@@ -7302,7 +7302,7 @@ version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a253b5e89e2698464fc26b545c9edceb338e18a89effeeecfea192c3025be29d"
 dependencies = [
- "libc 0.2.186",
+ "libc 0.2.176",
  "signal-hook-registry",
 ]
 
@@ -7312,7 +7312,7 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
 dependencies = [
- "libc 0.2.186",
+ "libc 0.2.176",
 ]
 
 [[package]]
@@ -7443,7 +7443,7 @@ version = "0.1.0"
 source = "git+https://github.com/tikv/rust-snappy.git?branch=static-link#8c12738bad811397600455d6982aff754ea2ac44"
 dependencies = [
  "cmake",
- "libc 0.2.186",
+ "libc 0.2.176",
  "pkg-config",
 ]
 
@@ -7471,7 +7471,7 @@ version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
 dependencies = [
- "libc 0.2.186",
+ "libc 0.2.176",
  "windows-sys 0.52.0",
 ]
 
@@ -7481,7 +7481,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
- "libc 0.2.186",
+ "libc 0.2.176",
  "windows-sys 0.61.0",
 ]
 
@@ -7681,7 +7681,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7725,20 +7725,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.101"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
-version = "3.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7768,7 +7757,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7778,7 +7767,7 @@ source = "git+https://github.com/tikv/sysinfo?branch=0.26-fix-cpu#5a1bcf08816979
 dependencies = [
  "cfg-if 1.0.0",
  "core-foundation-sys",
- "libc 0.2.186",
+ "libc 0.2.176",
  "ntapi",
  "once_cell",
  "rayon",
@@ -7803,7 +7792,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
 dependencies = [
  "core-foundation-sys",
- "libc 0.2.186",
+ "libc 0.2.176",
 ]
 
 [[package]]
@@ -7877,7 +7866,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
 dependencies = [
  "cfg-if 1.0.0",
- "fastrand 2.4.1",
+ "fastrand 2.3.0",
  "redox_syscall 0.3.5",
  "rustix 0.38.19",
  "windows-sys 0.48.0",
@@ -8276,7 +8265,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8287,7 +8276,7 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8509,7 +8498,7 @@ dependencies = [
  "keys",
  "kvproto",
  "lazy_static",
- "libc 0.2.186",
+ "libc 0.2.176",
  "libloading",
  "log",
  "log_wrappers",
@@ -8635,7 +8624,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "661f1f6a57b3a36dc9174a2c10f19513b4866816e13425d3e418b11cc37bc24c"
 dependencies = [
- "libc 0.2.186",
+ "libc 0.2.176",
  "paste",
  "tikv-jemalloc-sys",
 ]
@@ -8647,7 +8636,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
 dependencies = [
  "cc",
- "libc 0.2.186",
+ "libc 0.2.176",
 ]
 
 [[package]]
@@ -8656,7 +8645,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
 dependencies = [
- "libc 0.2.186",
+ "libc 0.2.176",
  "tikv-jemalloc-sys",
 ]
 
@@ -8683,7 +8672,7 @@ version = "0.1.0"
 dependencies = [
  "fxhash",
  "lazy_static",
- "libc 0.2.186",
+ "libc 0.2.176",
  "mimalloc",
  "snmalloc-rs",
  "tcmalloc",
@@ -8751,7 +8740,7 @@ dependencies = [
  "http 0.2.12",
  "kvproto",
  "lazy_static",
- "libc 0.2.186",
+ "libc 0.2.176",
  "log",
  "log_wrappers",
  "nix 0.24.1",
@@ -8799,7 +8788,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4752a97f8eebd6854ff91f1c1824cd6160626ac4bd44287f7f4ea2035a02a242"
 dependencies = [
  "const_fn",
- "libc 0.2.186",
+ "libc 0.2.176",
  "standback",
  "stdweb",
  "time-macros 0.1.1",
@@ -8814,9 +8803,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
- "itoa 1.0.18",
+ "itoa 1.0.17",
  "js-sys",
- "libc 0.2.186",
+ "libc 0.2.176",
  "num-conv",
  "num_threads",
  "powerfmt",
@@ -8921,13 +8910,13 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
- "libc 0.2.186",
- "mio 1.2.1",
+ "libc 0.2.176",
+ "mio 1.1.0",
  "parking_lot 0.12.1",
  "pin-project-lite",
  "signal-hook-registry",
@@ -8947,13 +8936,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -9042,7 +9031,7 @@ checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "http 1.4.2",
+ "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.9.0",
@@ -9100,7 +9089,7 @@ dependencies = [
  "bitflags 2.11.1",
  "bytes",
  "futures-util",
- "http 1.4.2",
+ "http 1.4.0",
  "http-body 1.0.1",
  "iri-string",
  "pin-project-lite",
@@ -9154,7 +9143,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -9414,7 +9403,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
 dependencies = [
- "libc 0.2.186",
+ "libc 0.2.176",
 ]
 
 [[package]]
@@ -9488,7 +9477,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -9523,7 +9512,7 @@ checksum = "9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -9600,7 +9589,7 @@ checksum = "2a5a7e487e921cf220206864a94a89b6c6905bfc19f1057fa26a4cb360e5c1d2"
 dependencies = [
  "either",
  "lazy_static",
- "libc 0.2.186",
+ "libc 0.2.176",
 ]
 
 [[package]]
@@ -10034,7 +10023,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -10064,7 +10053,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -10075,7 +10064,7 @@ checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -10095,7 +10084,7 @@ checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -10124,7 +10113,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -10138,9 +10127,9 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.23"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zstd"
@@ -10166,7 +10155,7 @@ version = "5.0.2+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
 dependencies = [
- "libc 0.2.186",
+ "libc 0.2.176",
  "zstd-sys",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,7 +36,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c80b57a86234ee3e9238f5f2d33d37f8fd5c7ff168c07f2d5147d410e86db33"
 dependencies = [
  "home",
- "libc 0.2.176",
+ "libc 0.2.186",
  "rustc_version 0.4.0",
  "xdg",
 ]
@@ -94,7 +94,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
- "libc 0.2.176",
+ "libc 0.2.186",
 ]
 
 [[package]]
@@ -162,11 +162,10 @@ dependencies = [
 
 [[package]]
 name = "assert-json-diff"
-version = "1.1.0"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4259cbe96513d2f1073027a259fc2ca917feb3026a5a8d984e3628e490255cc0"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
 dependencies = [
- "extend",
  "serde",
  "serde_json",
 ]
@@ -295,7 +294,7 @@ version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
 dependencies = [
- "libc 0.2.176",
+ "libc 0.2.186",
  "winapi 0.3.9",
 ]
 
@@ -351,9 +350,9 @@ dependencies = [
 
 [[package]]
 name = "aws-config"
-version = "1.5.5"
+version = "1.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e95816a168520d72c0e7680c405a5a8c1fb6a035b4bc4b9d7b0de8e1a941697"
+checksum = "11493b0bad143270fb8ad284a096dd529ba91924c5409adeac856cc1bf047dbc"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -366,9 +365,9 @@ dependencies = [
  "aws-smithy-types",
  "aws-types",
  "bytes",
- "fastrand 2.0.1",
- "http 0.2.12",
- "time 0.3.44",
+ "fastrand 2.4.1",
+ "http 1.4.2",
+ "time 0.3.47",
  "tokio",
  "tracing",
  "url",
@@ -376,9 +375,9 @@ dependencies = [
 
 [[package]]
 name = "aws-credential-types"
-version = "1.2.1"
+version = "1.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60e8f6b615cb5fc60a98132268508ad104310f0cfb25a1c22eee76efdf9154da"
+checksum = "8f20799b373a1be121fe3005fba0c2090af9411573878f224df44b42727fcaf7"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -425,23 +424,26 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.4.0"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f42c2d4218de4dcd890a109461e2f799a1a2ba3bcd2cde9af88360f5df9266c6"
+checksum = "5fc0651c57e384202e47153c1260b84a9936e19803d747615edf199dc3b98d17"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
  "aws-smithy-async",
  "aws-smithy-eventstream",
  "aws-smithy-http",
+ "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "aws-types",
  "bytes",
- "fastrand 2.0.1",
+ "bytes-utils",
+ "fastrand 2.4.1",
  "http 0.2.12",
- "http-body 0.4.5",
- "once_cell",
+ "http 1.4.2",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
  "percent-encoding",
  "pin-project-lite",
  "tracing",
@@ -450,33 +452,34 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-kms"
-version = "1.40.0"
+version = "1.103.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ebbbc319551583b9233a74b359ede7349102e779fc12371d2478e80b50d218"
+checksum = "8e6bfd8dfb5a562f9a605bbd5c3aef09db9231c826a1e0488ce3f4338c70dbbb"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http",
  "aws-smithy-json",
+ "aws-smithy-observability",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "aws-types",
  "bytes",
+ "fastrand 2.4.1",
  "http 0.2.12",
- "once_cell",
+ "http 1.4.2",
  "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.40.0"
+version = "1.126.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8367c403fdf27690684b926a46ed9524099a69dd5dfcef62028bf4096b5b809f"
+checksum = "7878050a2321d215eec9db8be09f8db59418b53860ae86cc7042b4094d6cb2bb"
 dependencies = [
- "ahash 0.8.11",
  "aws-credential-types",
  "aws-runtime",
  "aws-sigv4",
@@ -485,19 +488,20 @@ dependencies = [
  "aws-smithy-eventstream",
  "aws-smithy-http",
  "aws-smithy-json",
+ "aws-smithy-observability",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "aws-smithy-xml",
  "aws-types",
  "bytes",
- "fastrand 2.0.1",
+ "fastrand 2.4.1",
  "hex 0.4.3",
  "hmac",
  "http 0.2.12",
- "http-body 0.4.5",
+ "http 1.4.2",
+ "http-body 1.0.1",
  "lru",
- "once_cell",
  "percent-encoding",
  "regex-lite",
  "sha2",
@@ -507,32 +511,34 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.37.0"
+version = "1.100.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e52dc3fd7dfa6c01a69cf3903e00aa467261639138a05b06cd92314d2c8fb07"
+checksum = "fafbdda43b93f57f699c5dfe8328db590b967b8a820a13ccdd6687355dfcc7ca"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http",
  "aws-smithy-json",
+ "aws-smithy-observability",
  "aws-smithy-query",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "aws-smithy-xml",
  "aws-types",
+ "fastrand 2.4.1",
  "http 0.2.12",
- "once_cell",
+ "http 1.4.2",
  "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sigv4"
-version = "1.2.4"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc8db6904450bafe7473c6ca9123f88cc11089e41a025408f992db4e22d3be68"
+checksum = "b0b660013a6683ab23797778e21f1f854744fdf05f68204b4cca4c8c04b5d1f4"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
@@ -544,19 +550,18 @@ dependencies = [
  "hex 0.4.3",
  "hmac",
  "http 0.2.12",
- "http 1.1.0",
- "once_cell",
+ "http 1.4.2",
  "percent-encoding",
  "sha2",
- "time 0.3.44",
+ "time 0.3.47",
  "tracing",
 ]
 
 [[package]]
 name = "aws-smithy-async"
-version = "1.2.1"
+version = "1.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62220bc6e97f946ddd51b5f1361f78996e704677afc518a4ff66b7a72ea1378c"
+checksum = "2ffcaf626bdda484571968400c326a244598634dc75fd451325a54ad1a59acfc"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -565,18 +570,18 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.60.12"
+version = "0.64.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "598b1689d001c4d4dc3cb386adb07d37786783aee3ac4b324bcadac116bf3d23"
+checksum = "6750f3dd509b0694a4377f0293ed2f9630d710b1cebe281fa8bac8f099f88bc6"
 dependencies = [
  "aws-smithy-http",
  "aws-smithy-types",
  "bytes",
- "crc32c",
- "crc32fast",
+ "crc-fast",
  "hex 0.4.3",
- "http 0.2.12",
- "http-body 0.4.5",
+ "http 1.4.2",
+ "http-body 1.0.1",
+ "http-body-util",
  "md-5",
  "pin-project-lite",
  "sha1 0.10.6",
@@ -586,9 +591,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-eventstream"
-version = "0.60.5"
+version = "0.60.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cef7d0a272725f87e51ba2bf89f8c21e4df61b9e49ae1ac367a6d69916ef7c90"
+checksum = "faf09d74e5e32f76b8762da505a3cd59303e367a664ca67295387baa8c1d7548"
 dependencies = [
  "aws-smithy-types",
  "bytes",
@@ -597,9 +602,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.60.11"
+version = "0.63.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8bc3e8fdc6b8d07d976e301c02fe553f72a39b7a9fea820e023268467d7ab6"
+checksum = "ba1ab2dc1c2c3749ead27180d333c42f11be8b0e934058fb4b2258ee8dbe5231"
 dependencies = [
  "aws-smithy-eventstream",
  "aws-smithy-runtime-api",
@@ -607,9 +612,10 @@ dependencies = [
  "bytes",
  "bytes-utils",
  "futures-core",
- "http 0.2.12",
- "http-body 0.4.5",
- "once_cell",
+ "futures-util",
+ "http 1.4.2",
+ "http-body 1.0.1",
+ "http-body-util",
  "percent-encoding",
  "pin-project-lite",
  "pin-utils",
@@ -617,19 +623,54 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-smithy-json"
-version = "0.60.7"
+name = "aws-smithy-http-client"
+version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4683df9469ef09468dad3473d129960119a0d3593617542b7d52086c8486f2d6"
+checksum = "6a2f165a7feee6f263028b899d0a181987f4fa7179a6411a32a439fba7c5f769"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-protocol-test",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "h2 0.3.26",
+ "h2 0.4.13",
+ "http 0.2.12",
+ "http 1.4.2",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "hyper 0.14.28",
+ "indexmap 2.11.1",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.62.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9648b0bb82a2eedd844052c6ad2a1a822d1f8e3adee5fbf668366717e428856a"
 dependencies = [
  "aws-smithy-types",
 ]
 
 [[package]]
-name = "aws-smithy-protocol-test"
-version = "0.63.0"
+name = "aws-smithy-observability"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b92b62199921f10685c6b588fdbeb81168ae4e7950ae3e5f50145a01bb5f1ad"
+checksum = "a06c2315d173edbf1920da8ba3a7189695827002e4c0fc961973ab1c54abca9c"
+dependencies = [
+ "aws-smithy-runtime-api",
+]
+
+[[package]]
+name = "aws-smithy-protocol-test"
+version = "0.63.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b227aa94af99a8e5ee52551cc7e3ee30a217019ef99207b6f0b7a1527685941"
 dependencies = [
  "assert-json-diff",
  "aws-smithy-runtime-api",
@@ -641,14 +682,14 @@ dependencies = [
  "regex-lite",
  "roxmltree",
  "serde_json",
- "thiserror 1.0.40",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "aws-smithy-query"
-version = "0.60.7"
+version = "0.60.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2fbd61ceb3fe8a1cb7352e42689cec5335833cd9f94103a61e98f9bb61c64bb"
+checksum = "1a56d79744fb3edb5d722ef79d86081e121d3b9422cb209eb03aea6aa4f21ebd"
 dependencies = [
  "aws-smithy-types",
  "urlencoding",
@@ -656,29 +697,25 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.7.2"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a065c0fe6fdbdf9f11817eb68582b2ab4aff9e9c39e986ae48f7ec576c6322db"
+checksum = "028999056d2d2fd58a697232f9eec4a643cf73a71cf327690a7edad1d2af2110"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
- "aws-smithy-protocol-test",
+ "aws-smithy-http-client",
+ "aws-smithy-observability",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
- "fastrand 2.0.1",
- "h2 0.3.26",
+ "fastrand 2.4.1",
  "http 0.2.12",
- "http-body 0.4.5",
- "http-body 1.0.0",
- "httparse",
- "hyper 0.14.28",
- "indexmap 2.11.1",
- "once_cell",
+ "http 1.4.2",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
  "pin-project-lite",
  "pin-utils",
- "serde",
- "serde_json",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -686,15 +723,15 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.7.2"
+version = "1.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e086682a53d3aa241192aa110fa8dfce98f2f5ac2ead0de84d41582c7e8fdb96"
+checksum = "876ab3c9c29791ba4ba02b780a3049e21ec63dabda09268b175272c3733a79e6"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-types",
  "bytes",
  "http 0.2.12",
- "http 1.1.0",
+ "http 1.4.2",
  "pin-project-lite",
  "tokio",
  "tracing",
@@ -703,45 +740,45 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.2.7"
+version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147100a7bea70fa20ef224a6bad700358305f5dc0f84649c53769761395b355b"
+checksum = "d2b1117b3b2bbe166d11199b540ceed0d0f7676e36e7b962b5a437a9971eac75"
 dependencies = [
  "base64-simd",
  "bytes",
  "bytes-utils",
  "futures-core",
  "http 0.2.12",
- "http 1.1.0",
- "http-body 0.4.5",
- "http-body 1.0.0",
+ "http 1.4.2",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
  "http-body-util",
  "hyper 0.14.28",
- "itoa 1.0.1",
+ "itoa 1.0.18",
  "num-integer",
  "pin-project-lite",
  "pin-utils",
  "ryu",
  "serde",
- "time 0.3.44",
+ "time 0.3.47",
  "tokio",
  "tokio-util",
 ]
 
 [[package]]
 name = "aws-smithy-xml"
-version = "0.60.8"
+version = "0.60.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d123fbc2a4adc3c301652ba8e149bf4bc1d1725affb9784eb20c953ace06bf55"
+checksum = "0ce02add1aa3677d022f8adf81dcbe3046a95f17a1b1e8979c145cd21d3d22b3"
 dependencies = [
  "xmlparser",
 ]
 
 [[package]]
 name = "aws-types"
-version = "1.3.3"
+version = "1.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5221b91b3e441e6675310829fd8984801b772cb1546ef6c0e54dec9f1ac13fef"
+checksum = "47c8323699dd9b3c8d5b3c13051ae9cdef58fd179957c882f8374dd8725962d9"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
@@ -773,7 +810,7 @@ dependencies = [
  "slog",
  "slog-global",
  "tikv_util",
- "time 0.3.44",
+ "time 0.3.47",
  "tokio",
  "url",
  "uuid 1.7.0",
@@ -803,7 +840,7 @@ dependencies = [
  "rustc_version 0.4.0",
  "serde",
  "serde_json",
- "time 0.3.44",
+ "time 0.3.47",
  "url",
  "uuid 1.7.0",
 ]
@@ -822,7 +859,7 @@ dependencies = [
  "oauth2",
  "pin-project",
  "serde",
- "time 0.3.44",
+ "time 0.3.47",
  "tz-rs",
  "url",
  "uuid 1.7.0",
@@ -839,7 +876,7 @@ dependencies = [
  "futures 0.3.15",
  "serde",
  "serde_json",
- "time 0.3.44",
+ "time 0.3.47",
 ]
 
 [[package]]
@@ -856,7 +893,7 @@ dependencies = [
  "log",
  "serde",
  "serde_derive",
- "time 0.3.44",
+ "time 0.3.47",
  "url",
  "uuid 1.7.0",
 ]
@@ -877,7 +914,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "time 0.3.44",
+ "time 0.3.47",
  "url",
  "uuid 1.7.0",
 ]
@@ -895,7 +932,7 @@ dependencies = [
  "once_cell",
  "serde",
  "serde_json",
- "time 0.3.44",
+ "time 0.3.47",
 ]
 
 [[package]]
@@ -907,7 +944,7 @@ dependencies = [
  "addr2line",
  "cc",
  "cfg-if 1.0.0",
- "libc 0.2.176",
+ "libc 0.2.186",
  "miniz_oxide 0.4.4",
  "object",
  "rustc-demangle",
@@ -1087,7 +1124,7 @@ dependencies = [
  "bcc-sys",
  "bitflags 1.3.2",
  "byteorder",
- "libc 0.2.176",
+ "libc 0.2.186",
  "regex",
  "thiserror 1.0.40",
 ]
@@ -1306,7 +1343,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
 dependencies = [
  "cc",
- "libc 0.2.176",
+ "libc 0.2.186",
  "pkg-config",
 ]
 
@@ -1332,7 +1369,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7f788eaf239475a3c1e1acf89951255a46c4b9b46cf3e866fc4d0707b4b9e36"
 dependencies = [
- "libc 0.2.176",
+ "libc 0.2.186",
  "valgrind_request",
 ]
 
@@ -1412,7 +1449,7 @@ checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
- "libc 0.2.176",
+ "libc 0.2.186",
  "shlex",
 ]
 
@@ -1545,7 +1582,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f54d78e30b388d4815220c8dd03fea5656b6c6d32adb59e89061552a102f8da1"
 dependencies = [
  "glob",
- "libc 0.2.176",
+ "libc 0.2.186",
  "libloading",
 ]
 
@@ -1631,7 +1668,7 @@ version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71367d3385c716342014ad17e3d19f7788ae514885a1f4c24f500260fb365e1a"
 dependencies = [
- "libc 0.2.176",
+ "libc 0.2.186",
  "once_cell",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
@@ -1644,7 +1681,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "error_code",
- "libc 0.2.176",
+ "libc 0.2.186",
  "panic_hook",
  "protobuf 2.8.0",
  "rand 0.8.5",
@@ -1769,7 +1806,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a89e2ae426ea83155dccf10c0fa6b1463ef6d5fcb44cee0b224a408fa640a62"
 dependencies = [
  "core-foundation-sys",
- "libc 0.2.176",
+ "libc 0.2.186",
 ]
 
 [[package]]
@@ -1779,7 +1816,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
- "libc 0.2.176",
+ "libc 0.2.186",
 ]
 
 [[package]]
@@ -1794,7 +1831,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9e393a7668fe1fad3075085b86c781883000b4ede868f43627b34a87c8b7ded"
 dependencies = [
- "libc 0.2.176",
+ "libc 0.2.186",
  "winapi 0.3.9",
 ]
 
@@ -1804,7 +1841,34 @@ version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
 dependencies = [
- "libc 0.2.176",
+ "libc 0.2.186",
+]
+
+[[package]]
+name = "crc"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
+name = "crc-fast"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fd92aca2c6001b1bf5ba0ff84ee74ec8501b52bbef0cac80bf25a6c1d87a83d"
+dependencies = [
+ "crc",
+ "digest",
+ "rustversion",
+ "spin",
 ]
 
 [[package]]
@@ -1890,7 +1954,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63aaaf47e457badbcb376c65a49d0f182c317ebd97dc6d1ced94c8e1d09c0f3a"
 dependencies = [
  "criterion 0.3.5",
- "libc 0.2.176",
+ "libc 0.2.186",
 ]
 
 [[package]]
@@ -2069,6 +2133,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
 name = "darling_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2097,6 +2171,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.11.1",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2114,6 +2201,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.101",
 ]
@@ -2146,12 +2244,12 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.3"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d630bccd429a5bb5a64b5e94f693bfc48c9f8566418fda4c494cc94f911f87cc"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2209,7 +2307,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
- "libc 0.2.176",
+ "libc 0.2.186",
  "redox_users",
  "winapi 0.3.9",
 ]
@@ -2502,33 +2600,12 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
-dependencies = [
- "errno-dragonfly",
- "libc 0.2.176",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
- "libc 0.2.176",
+ "libc 0.2.186",
  "windows-sys 0.61.0",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc 0.2.176",
 ]
 
 [[package]]
@@ -2582,18 +2659,6 @@ name = "example_coprocessor_plugin"
 version = "0.1.0"
 dependencies = [
  "coprocessor_plugin_api",
-]
-
-[[package]]
-name = "extend"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f47da3a72ec598d9c8937a7ebca8962a5c7a1f28444e38c2b33c771ba3f55f05"
-dependencies = [
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.103",
 ]
 
 [[package]]
@@ -2664,9 +2729,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.0.1"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "file_system"
@@ -2679,7 +2744,7 @@ dependencies = [
  "fail",
  "fs2",
  "lazy_static",
- "libc 0.2.176",
+ "libc 0.2.186",
  "online_config",
  "openssl",
  "parking_lot 0.12.1",
@@ -2701,7 +2766,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed3d8a5e20435ff00469e51a0d82049bae66504b5c429920dadf9bb54d47b3f"
 dependencies = [
- "libc 0.2.176",
+ "libc 0.2.186",
  "thiserror 1.0.40",
  "winapi 0.3.9",
 ]
@@ -2713,7 +2778,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d34cfa13a63ae058bfa601fe9e313bbdb3746427c1459185464ce0fcf62e1e8"
 dependencies = [
  "cfg-if 1.0.0",
- "libc 0.2.176",
+ "libc 0.2.186",
  "redox_syscall 0.2.11",
  "winapi 0.3.9",
 ]
@@ -2732,7 +2797,7 @@ checksum = "d691fdb3f817632d259d09220d4cf0991dbb2c9e59e044a02a59194bf6e14484"
 dependencies = [
  "cc",
  "lazy_static",
- "libc 0.2.176",
+ "libc 0.2.186",
  "winapi 0.3.9",
 ]
 
@@ -2743,7 +2808,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2adaffba6388640136149e18ed080b77a78611c1e1d6de75aedcdf78df5d4682"
 dependencies = [
  "crc32fast",
- "libc 0.2.176",
+ "libc 0.2.186",
  "libz-sys",
  "miniz_oxide 0.3.7",
 ]
@@ -2756,9 +2821,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
@@ -2795,7 +2860,7 @@ name = "fs2"
 version = "0.4.3"
 source = "git+https://github.com/tikv/fs2-rs?branch=tikv#cd503764a19a99d74c1ab424dd13d6bcd093fcae"
 dependencies = [
- "libc 0.2.176",
+ "libc 0.2.186",
  "winapi 0.3.9",
 ]
 
@@ -2821,7 +2886,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f41b048a94555da0f42f1d632e2e19510084fb8e303b0daa2816e733fb3644a0"
 dependencies = [
- "libc 0.2.176",
+ "libc 0.2.186",
 ]
 
 [[package]]
@@ -3095,7 +3160,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "473a1265acc8ff1e808cd0a1af8cee3c2ee5200916058a2ca113c29f2d903571"
 dependencies = [
  "cfg-if 0.1.10",
- "libc 0.2.176",
+ "libc 0.2.186",
  "wasi 0.7.0",
 ]
 
@@ -3107,7 +3172,7 @@ checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
- "libc 0.2.176",
+ "libc 0.2.186",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
@@ -3120,7 +3185,7 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
- "libc 0.2.176",
+ "libc 0.2.186",
  "r-efi",
  "wasip2",
  "wasm-bindgen",
@@ -3160,7 +3225,7 @@ dependencies = [
  "base64 0.22.1",
  "bon",
  "google-cloud-gax",
- "http 1.1.0",
+ "http 1.4.2",
  "reqwest 0.12.28",
  "rustc_version 0.4.0",
  "rustls",
@@ -3168,7 +3233,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.12",
- "time 0.3.44",
+ "time 0.3.47",
  "tokio",
 ]
 
@@ -3183,7 +3248,7 @@ dependencies = [
  "futures 0.3.15",
  "google-cloud-rpc",
  "google-cloud-wkt",
- "http 1.1.0",
+ "http 1.4.2",
  "pin-project",
  "rand 0.9.4",
  "serde",
@@ -3203,7 +3268,7 @@ dependencies = [
  "google-cloud-gax",
  "google-cloud-rpc",
  "google-cloud-wkt",
- "http 1.1.0",
+ "http 1.4.2",
  "http-body-util",
  "percent-encoding",
  "prost",
@@ -3234,7 +3299,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
- "serde_with 3.14.1",
+ "serde_with",
  "tracing",
 ]
 
@@ -3257,7 +3322,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
- "serde_with 3.14.1",
+ "serde_with",
  "tracing",
 ]
 
@@ -3276,7 +3341,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
- "serde_with 3.14.1",
+ "serde_with",
  "tracing",
 ]
 
@@ -3296,7 +3361,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
- "serde_with 3.14.1",
+ "serde_with",
  "tracing",
 ]
 
@@ -3324,7 +3389,7 @@ dependencies = [
  "google-cloud-wkt",
  "serde",
  "serde_json",
- "serde_with 3.14.1",
+ "serde_with",
 ]
 
 [[package]]
@@ -3347,8 +3412,8 @@ dependencies = [
  "google-cloud-rpc",
  "google-cloud-type",
  "google-cloud-wkt",
- "http 1.1.0",
- "http-body 1.0.0",
+ "http 1.4.2",
+ "http-body 1.0.1",
  "hyper 1.9.0",
  "lazy_static",
  "md5 0.8.0",
@@ -3359,7 +3424,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
- "serde_with 3.14.1",
+ "serde_with",
  "sha2",
  "thiserror 2.0.12",
  "tokio",
@@ -3378,7 +3443,7 @@ dependencies = [
  "google-cloud-wkt",
  "serde",
  "serde_json",
- "serde_with 3.14.1",
+ "serde_with",
 ]
 
 [[package]]
@@ -3391,9 +3456,9 @@ dependencies = [
  "bytes",
  "serde",
  "serde_json",
- "serde_with 3.14.1",
+ "serde_with",
  "thiserror 2.0.12",
- "time 0.3.44",
+ "time 0.3.47",
  "url",
 ]
 
@@ -3417,7 +3482,7 @@ dependencies = [
  "futures-executor",
  "futures-util",
  "grpcio-sys",
- "libc 0.2.176",
+ "libc 0.2.186",
  "log",
  "parking_lot 0.11.1",
  "protobuf 2.8.0",
@@ -3454,7 +3519,7 @@ dependencies = [
  "bindgen 0.59.2",
  "cc",
  "cmake",
- "libc 0.2.176",
+ "libc 0.2.186",
  "libz-sys",
  "openssl-sys",
  "pkg-config",
@@ -3491,7 +3556,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.1.0",
+ "http 1.4.2",
  "indexmap 2.11.1",
  "slab",
  "tokio",
@@ -3536,6 +3601,12 @@ name = "hashbrown"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -3584,7 +3655,7 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
- "libc 0.2.176",
+ "libc 0.2.186",
 ]
 
 [[package]]
@@ -3642,25 +3713,24 @@ checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
 dependencies = [
  "bytes",
  "fnv",
- "itoa 1.0.1",
+ "itoa 1.0.18",
 ]
 
 [[package]]
 name = "http"
-version = "1.1.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
- "fnv",
- "itoa 1.0.1",
+ "itoa 1.0.18",
 ]
 
 [[package]]
 name = "http-body"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
  "http 0.2.12",
@@ -3669,12 +3739,12 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.1.0",
+ "http 1.4.2",
 ]
 
 [[package]]
@@ -3685,8 +3755,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.1.0",
- "http-body 1.0.0",
+ "http 1.4.2",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -3767,10 +3837,10 @@ dependencies = [
  "futures-util",
  "h2 0.3.26",
  "http 0.2.12",
- "http-body 0.4.5",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
- "itoa 1.0.1",
+ "itoa 1.0.18",
  "pin-project-lite",
  "socket2 0.5.7",
  "tokio",
@@ -3790,10 +3860,10 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "h2 0.4.13",
- "http 1.1.0",
- "http-body 1.0.0",
+ "http 1.4.2",
+ "http-body 1.0.1",
  "httparse",
- "itoa 1.0.1",
+ "itoa 1.0.18",
  "pin-project-lite",
  "smallvec",
  "tokio",
@@ -3824,7 +3894,7 @@ version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http 1.1.0",
+ "http 1.4.2",
  "hyper 1.9.0",
  "hyper-util",
  "rustls",
@@ -3870,11 +3940,11 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.1.0",
- "http-body 1.0.0",
+ "http 1.4.2",
+ "http-body 1.0.1",
  "hyper 1.9.0",
  "ipnet",
- "libc 0.2.176",
+ "libc 0.2.186",
  "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.3",
@@ -4076,7 +4146,7 @@ dependencies = [
  "keys",
  "kvproto",
  "lazy_static",
- "libc 0.2.176",
+ "libc 0.2.186",
  "log_wrappers",
  "online_config",
  "parking_lot 0.12.1",
@@ -4147,7 +4217,7 @@ dependencies = [
  "ahash 0.7.8",
  "atty",
  "indexmap 1.9.3",
- "itoa 1.0.1",
+ "itoa 1.0.18",
  "lazy_static",
  "log",
  "num-format",
@@ -4164,7 +4234,7 @@ checksum = "4816c66d2c8ae673df83366c18341538f234a26d65a9ecea5c348b453ac1d02f"
 dependencies = [
  "bitflags 1.3.2",
  "inotify-sys",
- "libc 0.2.176",
+ "libc 0.2.186",
 ]
 
 [[package]]
@@ -4173,7 +4243,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
 dependencies = [
- "libc 0.2.176",
+ "libc 0.2.186",
 ]
 
 [[package]]
@@ -4200,7 +4270,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7d6c6f8c91b4b9ed43484ad1a938e393caf35960fce7f82a040497207bd8e9e"
 dependencies = [
- "libc 0.2.176",
+ "libc 0.2.186",
  "windows-sys 0.42.0",
 ]
 
@@ -4210,7 +4280,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
 dependencies = [
- "libc 0.2.176",
+ "libc 0.2.186",
 ]
 
 [[package]]
@@ -4246,7 +4316,7 @@ checksum = "28dfb6c8100ccc63462345b67d1bbc3679177c75ee4bf59bf29c8b1d110b8189"
 dependencies = [
  "hermit-abi 0.2.6",
  "io-lifetimes",
- "rustix 0.36.7",
+ "rustix 0.36.16",
  "windows-sys 0.42.0",
 ]
 
@@ -4276,9 +4346,9 @@ checksum = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 
 [[package]]
 name = "itoa"
-version = "1.0.1"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jobserver"
@@ -4286,7 +4356,7 @@ version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
 dependencies = [
- "libc 0.2.176",
+ "libc 0.2.186",
 ]
 
 [[package]]
@@ -4364,9 +4434,9 @@ checksum = "e32a70cf75e5846d53a673923498228bbec6a8624708a9ea5645f075d6276122"
 
 [[package]]
 name = "libc"
-version = "0.2.176"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -4412,7 +4482,7 @@ dependencies = [
  "bzip2-sys",
  "cc",
  "cmake",
- "libc 0.2.176",
+ "libc 0.2.186",
  "libtitan_sys",
  "libz-sys",
  "lz4-sys",
@@ -4430,7 +4500,7 @@ dependencies = [
  "bzip2-sys",
  "cc",
  "cmake",
- "libc 0.2.176",
+ "libc 0.2.186",
  "libz-sys",
  "lz4-sys",
  "snappy-sys",
@@ -4444,7 +4514,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b70e7a7df205e92a1a4cd9aaae7898dac0aa555503cc0a649494d0d60e7651d"
 dependencies = [
  "cc",
- "libc 0.2.176",
+ "libc 0.2.186",
  "pkg-config",
  "vcpkg",
 ]
@@ -4513,11 +4583,11 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.12.5"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
 dependencies = [
- "hashbrown 0.15.1",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -4533,7 +4603,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9764018d143cc854c9f17f0b907de70f14393b1f502da6375dce70f00514eb3"
 dependencies = [
  "cc",
- "libc 0.2.176",
+ "libc 0.2.186",
 ]
 
 [[package]]
@@ -4596,7 +4666,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
 dependencies = [
- "libc 0.2.176",
+ "libc 0.2.186",
  "winapi 0.3.9",
 ]
 
@@ -4606,7 +4676,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45fd3a57831bf88bc63f8cebc0cf956116276e97fef3966103e96416209f7c92"
 dependencies = [
- "libc 0.2.176",
+ "libc 0.2.186",
 ]
 
 [[package]]
@@ -4696,7 +4766,7 @@ dependencies = [
  "fuchsia-zircon-sys",
  "iovec",
  "kernel32-sys",
- "libc 0.2.176",
+ "libc 0.2.186",
  "log",
  "miow",
  "net2",
@@ -4706,13 +4776,13 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.11"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
- "libc 0.2.176",
+ "libc 0.2.186",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -4802,7 +4872,7 @@ version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
 dependencies = [
- "libc 0.2.176",
+ "libc 0.2.186",
  "log",
  "openssl",
  "openssl-probe 0.1.2",
@@ -4820,7 +4890,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "391630d12b68002ae1e25e8f974306474966550ad82dac6886fb8910c19568ae"
 dependencies = [
  "cfg-if 0.1.10",
- "libc 0.2.176",
+ "libc 0.2.186",
  "winapi 0.3.9",
 ]
 
@@ -4832,7 +4902,7 @@ checksum = "8f17df307904acd05aa8e32e97bb20f2a0df1728bbc2d771ae8f9a90463441e9"
 dependencies = [
  "bitflags 1.3.2",
  "cfg-if 1.0.0",
- "libc 0.2.176",
+ "libc 0.2.186",
  "memoffset 0.6.4",
 ]
 
@@ -4844,7 +4914,7 @@ checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
 dependencies = [
  "bitflags 1.3.2",
  "cfg-if 1.0.0",
- "libc 0.2.176",
+ "libc 0.2.186",
  "memoffset 0.7.1",
  "pin-utils",
  "static_assertions",
@@ -4903,7 +4973,7 @@ dependencies = [
  "fsevent",
  "fsevent-sys",
  "inotify",
- "libc 0.2.176",
+ "libc 0.2.186",
  "mio 0.6.23",
  "mio-extras",
  "walkdir",
@@ -4963,9 +5033,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-derive"
@@ -5049,7 +5119,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
  "hermit-abi 0.3.9",
- "libc 0.2.176",
+ "libc 0.2.186",
 ]
 
 [[package]]
@@ -5058,7 +5128,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
 dependencies = [
- "libc 0.2.176",
+ "libc 0.2.186",
 ]
 
 [[package]]
@@ -5122,15 +5192,14 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "openssl"
-version = "0.10.73"
+version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if 1.0.0",
  "foreign-types",
- "libc 0.2.176",
- "once_cell",
+ "libc 0.2.186",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -5169,12 +5238,12 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.109"
+version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
- "libc 0.2.176",
+ "libc 0.2.186",
  "openssl-src",
  "pkg-config",
  "vcpkg",
@@ -5210,7 +5279,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eebde548fbbf1ea81a99b128872779c437752fb99f217c45245e1a61dcd9edcd"
 dependencies = [
- "libc 0.2.176",
+ "libc 0.2.186",
  "winapi 0.3.9",
 ]
 
@@ -5253,7 +5322,7 @@ checksum = "fa7a782938e745763fe6907fc6ba86946d72f49fe7e21de074e08128a99fb018"
 dependencies = [
  "cfg-if 1.0.0",
  "instant",
- "libc 0.2.176",
+ "libc 0.2.186",
  "redox_syscall 0.2.11",
  "smallvec",
  "winapi 0.3.9",
@@ -5266,7 +5335,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28141e0cc4143da2443301914478dc976a61ffdb3f043058310c70df2fed8954"
 dependencies = [
  "cfg-if 1.0.0",
- "libc 0.2.176",
+ "libc 0.2.186",
  "redox_syscall 0.2.11",
  "smallvec",
  "windows-sys 0.32.0",
@@ -5342,7 +5411,7 @@ checksum = "b8f94885300e262ef461aa9fd1afbf7df3caf9e84e271a74925d1c6c8b24830f"
 dependencies = [
  "bitflags 1.3.2",
  "byteorder",
- "libc 0.2.176",
+ "libc 0.2.186",
  "mmap",
  "nom 4.2.3",
  "phf",
@@ -5475,7 +5544,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d27361d7578b410d0eb5fe815c2b2105b01ab770a7c738cb9a231457a809fcc7"
 dependencies = [
  "ipnetwork",
- "libc 0.2.176",
+ "libc 0.2.186",
  "pnet_base",
  "pnet_sys",
  "winapi 0.2.8",
@@ -5487,7 +5556,7 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82f881a6d75ac98c5541db6144682d1773bb14c6fc50c6ebac7086c8f7f23c29"
 dependencies = [
- "libc 0.2.176",
+ "libc 0.2.186",
  "winapi 0.2.8",
  "ws2_32-sys",
 ]
@@ -5508,7 +5577,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "findshlibs",
  "inferno",
- "libc 0.2.176",
+ "libc 0.2.186",
  "log",
  "nix 0.26.2",
  "once_cell",
@@ -5532,7 +5601,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "findshlibs",
  "inferno",
- "libc 0.2.176",
+ "libc 0.2.186",
  "log",
  "nix 0.26.2",
  "once_cell",
@@ -5649,7 +5718,7 @@ dependencies = [
  "byteorder",
  "hex 0.4.3",
  "lazy_static",
- "libc 0.2.176",
+ "libc 0.2.186",
 ]
 
 [[package]]
@@ -5658,7 +5727,7 @@ version = "0.4.2"
 source = "git+https://github.com/tikv/procinfo-rs?rev=7693954bd1dd86eb1709572fd7b62fd5f7ff2ea1#7693954bd1dd86eb1709572fd7b62fd5f7ff2ea1"
 dependencies = [
  "byteorder",
- "libc 0.2.176",
+ "libc 0.2.186",
  "nom 2.2.1",
  "rustc_version 0.2.3",
 ]
@@ -5683,7 +5752,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "fnv",
  "lazy_static",
- "libc 0.2.176",
+ "libc 0.2.186",
  "memchr",
  "parking_lot 0.11.1",
  "protobuf 2.8.0",
@@ -5906,9 +5975,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",
@@ -5932,7 +6001,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
 dependencies = [
  "cfg_aliases",
- "libc 0.2.176",
+ "libc 0.2.186",
  "once_cell",
  "socket2 0.6.3",
  "tracing",
@@ -5982,7 +6051,7 @@ dependencies = [
  "hex 0.4.3",
  "if_chain",
  "lazy_static",
- "libc 0.2.176",
+ "libc 0.2.186",
  "log",
  "lz4-sys",
  "memmap2",
@@ -6092,7 +6161,7 @@ dependencies = [
  "resource_metering",
  "serde",
  "serde_derive",
- "serde_with 1.4.0",
+ "serde_with",
  "service",
  "slog",
  "slog-global",
@@ -6168,7 +6237,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
  "getrandom 0.1.12",
- "libc 0.2.176",
+ "libc 0.2.186",
  "rand_chacha 0.2.1",
  "rand_core 0.5.1",
  "rand_hc",
@@ -6180,7 +6249,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
- "libc 0.2.176",
+ "libc 0.2.186",
  "rand_chacha 0.3.0",
  "rand_core 0.6.4",
 ]
@@ -6417,7 +6486,7 @@ dependencies = [
  "futures-util",
  "h2 0.3.26",
  "http 0.2.12",
- "http-body 0.4.5",
+ "http-body 0.4.6",
  "hyper 0.14.28",
  "hyper-tls",
  "ipnet",
@@ -6454,8 +6523,8 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http 1.1.0",
- "http-body 1.0.0",
+ "http 1.4.2",
+ "http-body 1.0.1",
  "http-body-util",
  "hyper 1.9.0",
  "hyper-rustls",
@@ -6624,7 +6693,7 @@ dependencies = [
  "cc",
  "cfg-if 1.0.0",
  "getrandom 0.2.11",
- "libc 0.2.176",
+ "libc 0.2.186",
  "untrusted",
  "windows-sys 0.52.0",
 ]
@@ -6634,7 +6703,7 @@ name = "rocksdb"
 version = "0.3.0"
 source = "git+https://github.com/tikv/rust-rocksdb.git#1c17b59dcb506302ed4684b3628c4a7165e0b86d"
 dependencies = [
- "libc 0.2.176",
+ "libc 0.2.186",
  "librocksdb_sys",
 ]
 
@@ -6706,27 +6775,27 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.7"
+version = "0.36.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4fdebc4b395b7fbb9ab11e462e20ed9051e7b16e42d24042c776eca0ac81b03"
+checksum = "6da3636faa25820d8648e0e31c5d519bbb01f72fdf57131f0f5f7da5fed36eab"
 dependencies = [
  "bitflags 1.3.2",
- "errno 0.2.8",
+ "errno",
  "io-lifetimes",
- "libc 0.2.176",
+ "libc 0.2.186",
  "linux-raw-sys 0.1.4",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
 name = "rustix"
-version = "0.38.3"
+version = "0.38.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac5ffa1efe7548069688cd7028f32591853cd7b5b756d41bcffd2353e4fc75b4"
+checksum = "745ecfa778e66b2b63c88a61cb36e0eea109e803b0b86bf9879fbc77c70e86ed"
 dependencies = [
  "bitflags 2.11.1",
- "errno 0.3.14",
- "libc 0.2.176",
+ "errno",
+ "libc 0.2.186",
  "linux-raw-sys 0.4.12",
  "windows-sys 0.48.0",
 ]
@@ -6810,9 +6879,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.17"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -6890,7 +6959,7 @@ dependencies = [
  "bitflags 1.3.2",
  "core-foundation 0.9.1",
  "core-foundation-sys",
- "libc 0.2.176",
+ "libc 0.2.186",
  "security-framework-sys",
 ]
 
@@ -6903,7 +6972,7 @@ dependencies = [
  "bitflags 2.11.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
- "libc 0.2.176",
+ "libc 0.2.186",
  "security-framework-sys",
 ]
 
@@ -6914,7 +6983,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
- "libc 0.2.176",
+ "libc 0.2.186",
 ]
 
 [[package]]
@@ -6974,10 +7043,11 @@ checksum = "f97841a747eef040fcd2e7b3b9a220a7205926e60488e673d9e4926d27772ce5"
 
 [[package]]
 name = "serde"
-version = "1.0.194"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b114498256798c94a0689e1a15fec6005dee8ac1f41de56404b67afc2a4b773"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
+ "serde_core",
  "serde_derive",
 ]
 
@@ -6992,14 +7062,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.194"
+name = "serde_core"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3385e45322e8f9931410f01b3031ec534c3947d0e94c18049af4d9f9907d4e0"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -7013,15 +7092,16 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.143"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "indexmap 2.11.1",
- "itoa 1.0.1",
+ "itoa 1.0.18",
  "memchr",
- "ryu",
  "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -7062,59 +7142,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa 1.0.1",
+ "itoa 1.0.18",
  "ryu",
  "serde",
 ]
 
 [[package]]
 name = "serde_with"
-version = "1.4.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d3d595d64120bbbc70b7f6d5ae63298b62a3d9f373ec2f56acf5365ca8a444"
-dependencies = [
- "serde",
- "serde_with_macros 1.1.0",
-]
-
-[[package]]
-name = "serde_with"
-version = "3.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c522100790450cf78eeac1507263d0a350d4d5b30df0c8e1fe051a10c22b376e"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
  "base64 0.22.1",
+ "bs58",
  "chrono",
  "hex 0.4.3",
  "indexmap 1.9.3",
  "indexmap 2.11.1",
  "schemars 0.9.0",
  "schemars 1.0.3",
- "serde",
- "serde_derive",
+ "serde_core",
  "serde_json",
- "serde_with_macros 3.14.1",
- "time 0.3.44",
+ "serde_with_macros",
+ "time 0.3.47",
 ]
 
 [[package]]
 name = "serde_with_macros"
-version = "1.1.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4070d2c9b9d258465ad1d82aabb985b84cd9a3afa94da25ece5a9938ba5f1606"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.103",
-]
-
-[[package]]
-name = "serde_with_macros"
-version = "3.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327ada00f7d64abaac1e55a6911e90cf665aa051b9a561c7006c157f4633135e"
-dependencies = [
- "darling 0.21.3",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -7149,7 +7208,7 @@ dependencies = [
  "in_memory_engine",
  "keys",
  "kvproto",
- "libc 0.2.176",
+ "libc 0.2.186",
  "log_wrappers",
  "pd_client",
  "prometheus",
@@ -7243,7 +7302,7 @@ version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a253b5e89e2698464fc26b545c9edceb338e18a89effeeecfea192c3025be29d"
 dependencies = [
- "libc 0.2.176",
+ "libc 0.2.186",
  "signal-hook-registry",
 ]
 
@@ -7253,7 +7312,7 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
 dependencies = [
- "libc 0.2.176",
+ "libc 0.2.186",
 ]
 
 [[package]]
@@ -7384,7 +7443,7 @@ version = "0.1.0"
 source = "git+https://github.com/tikv/rust-snappy.git?branch=static-link#8c12738bad811397600455d6982aff754ea2ac44"
 dependencies = [
  "cmake",
- "libc 0.2.176",
+ "libc 0.2.186",
  "pkg-config",
 ]
 
@@ -7412,7 +7471,7 @@ version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
 dependencies = [
- "libc 0.2.176",
+ "libc 0.2.186",
  "windows-sys 0.52.0",
 ]
 
@@ -7422,7 +7481,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
- "libc 0.2.176",
+ "libc 0.2.186",
  "windows-sys 0.61.0",
 ]
 
@@ -7676,6 +7735,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7708,7 +7778,7 @@ source = "git+https://github.com/tikv/sysinfo?branch=0.26-fix-cpu#5a1bcf08816979
 dependencies = [
  "cfg-if 1.0.0",
  "core-foundation-sys",
- "libc 0.2.176",
+ "libc 0.2.186",
  "ntapi",
  "once_cell",
  "rayon",
@@ -7733,7 +7803,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
 dependencies = [
  "core-foundation-sys",
- "libc 0.2.176",
+ "libc 0.2.186",
 ]
 
 [[package]]
@@ -7807,9 +7877,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
 dependencies = [
  "cfg-if 1.0.0",
- "fastrand 2.0.1",
+ "fastrand 2.4.1",
  "redox_syscall 0.3.5",
- "rustix 0.38.3",
+ "rustix 0.38.19",
  "windows-sys 0.48.0",
 ]
 
@@ -8439,7 +8509,7 @@ dependencies = [
  "keys",
  "kvproto",
  "lazy_static",
- "libc 0.2.176",
+ "libc 0.2.186",
  "libloading",
  "log",
  "log_wrappers",
@@ -8565,7 +8635,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "661f1f6a57b3a36dc9174a2c10f19513b4866816e13425d3e418b11cc37bc24c"
 dependencies = [
- "libc 0.2.176",
+ "libc 0.2.186",
  "paste",
  "tikv-jemalloc-sys",
 ]
@@ -8577,7 +8647,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
 dependencies = [
  "cc",
- "libc 0.2.176",
+ "libc 0.2.186",
 ]
 
 [[package]]
@@ -8586,7 +8656,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
 dependencies = [
- "libc 0.2.176",
+ "libc 0.2.186",
  "tikv-jemalloc-sys",
 ]
 
@@ -8613,7 +8683,7 @@ version = "0.1.0"
 dependencies = [
  "fxhash",
  "lazy_static",
- "libc 0.2.176",
+ "libc 0.2.186",
  "mimalloc",
  "snmalloc-rs",
  "tcmalloc",
@@ -8681,7 +8751,7 @@ dependencies = [
  "http 0.2.12",
  "kvproto",
  "lazy_static",
- "libc 0.2.176",
+ "libc 0.2.186",
  "log",
  "log_wrappers",
  "nix 0.24.1",
@@ -8729,7 +8799,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4752a97f8eebd6854ff91f1c1824cd6160626ac4bd44287f7f4ea2035a02a242"
 dependencies = [
  "const_fn",
- "libc 0.2.176",
+ "libc 0.2.186",
  "standback",
  "stdweb",
  "time-macros 0.1.1",
@@ -8739,27 +8809,27 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.44"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
- "itoa 1.0.1",
+ "itoa 1.0.18",
  "js-sys",
- "libc 0.2.176",
+ "libc 0.2.186",
  "num-conv",
  "num_threads",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
- "time-macros 0.2.24",
+ "time-macros 0.2.27",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
@@ -8773,9 +8843,9 @@ dependencies = [
 
 [[package]]
 name = "time-macros"
-version = "0.2.24"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
@@ -8851,21 +8921,19 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.38.2"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68722da18b0fc4a05fdc1120b302b82051265792a1e1b399086e9b204b10ad3d"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
- "backtrace",
  "bytes",
- "libc 0.2.176",
- "mio 0.8.11",
- "num_cpus",
+ "libc 0.2.186",
+ "mio 1.2.1",
  "parking_lot 0.12.1",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.7",
+ "socket2 0.6.3",
  "tokio-macros",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -8879,9 +8947,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.3.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8944,16 +9012,15 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.12"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-io",
  "futures-sink",
  "futures-util",
- "hashbrown 0.14.0",
  "pin-project-lite",
  "tokio",
 ]
@@ -8975,8 +9042,8 @@ checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "http 1.1.0",
- "http-body 1.0.0",
+ "http 1.4.2",
+ "http-body 1.0.1",
  "http-body-util",
  "hyper 1.9.0",
  "hyper-timeout",
@@ -9033,8 +9100,8 @@ dependencies = [
  "bitflags 2.11.1",
  "bytes",
  "futures-util",
- "http 1.1.0",
- "http-body 1.0.0",
+ "http 1.4.2",
+ "http-body 1.0.1",
  "iri-string",
  "pin-project-lite",
  "tower",
@@ -9056,9 +9123,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -9081,9 +9148,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9092,9 +9159,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.34"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -9123,9 +9190,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.20"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -9168,7 +9235,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "static_assertions",
 ]
 
@@ -9347,7 +9414,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
 dependencies = [
- "libc 0.2.176",
+ "libc 0.2.186",
 ]
 
 [[package]]
@@ -9533,7 +9600,7 @@ checksum = "2a5a7e487e921cf220206864a94a89b6c6905bfc19f1057fa26a4cb360e5c1d2"
 dependencies = [
  "either",
  "lazy_static",
- "libc 0.2.176",
+ "libc 0.2.186",
 ]
 
 [[package]]
@@ -9613,13 +9680,22 @@ version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
- "windows_aarch64_gnullvm 0.42.0",
- "windows_aarch64_msvc 0.42.0",
- "windows_i686_gnu 0.42.0",
- "windows_i686_msvc 0.42.0",
- "windows_x86_64_gnu 0.42.0",
- "windows_x86_64_gnullvm 0.42.0",
- "windows_x86_64_msvc 0.42.0",
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
 ]
 
 [[package]]
@@ -9647,6 +9723,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e201184e40b2ede64bc2ea34968b28e33622acdbbf37104f0e4a33f7abe657aa"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -9681,9 +9772,9 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -9705,9 +9796,9 @@ checksum = "d8e92753b1c443191654ec532f14c199742964a061be25d77d7a96f09db20bf5"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -9729,9 +9820,9 @@ checksum = "6a711c68811799e017b6038e0922cb27a5e2f43a2ddb609fe0b6f3eeda9de615"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -9753,9 +9844,9 @@ checksum = "146c11bb1a02615db74680b32a68e2d61f553cc24c4eb5b4ca10311740e44172"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -9777,9 +9868,9 @@ checksum = "c912b12f7454c6620635bbff3450962753834be2a594819bd5e945af18ec64bc"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -9795,9 +9886,9 @@ checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -9819,9 +9910,9 @@ checksum = "504a2476202769977a040c6364301a3f65d0cc9e3fb08600b2bda150a0488316"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -10046,6 +10137,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
+
+[[package]]
 name = "zstd"
 version = "0.11.2+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10069,7 +10166,7 @@ version = "5.0.2+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
 dependencies = [
- "libc 0.2.176",
+ "libc 0.2.186",
  "zstd-sys",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -454,7 +454,7 @@ tracing = { version = "0.1.39", default-features = false, features = [
   "attributes",
   "std",
 ] }
-openssl = "0.10"
+openssl = "0.10.80"
 openssl-sys = "0.9"
 compact-log-backup = { path = "components/compact-log-backup" }
 heck = "0.3"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,3 +1,5 @@
+avoid-breaking-exported-api = false
+
 [[disallowed-methods]]
 path = "std::thread::Builder::spawn"
 reason = """
@@ -78,23 +80,6 @@ reason = """
 openssl::asn1::Asn1GeneralizedTimeRef may call openssl::bio::MemBio::get_buf, \
 see RUSTSEC-2024-0357
 """
-
-# See more about RUSTSEC-2025-0022 in deny.toml.
-[[disallowed-types]]
-path = "openssl::cipher::Cipher::fetch"
-reason = """
-When a Some(...) value was passed to the properties argument of openssl::cipher::Cipher::fetch, \
-a use-after-free would result. See RUSTSEC-2025-0022
-"""
-[[disallowed-types]]
-path = "openssl::md::Md::fetch"
-reason = """
-When a Some(...) value was passed to the properties argument of openssl::md::Md::fetch, \
-a use-after-free would result. See RUSTSEC-2025-0022
-"""
-
-avoid-breaking-exported-api = false
-upper-case-acronyms-aggressive = true
 
 [[await-holding-invalid-types]]
 path = "dashmap::mapref::one::Ref"

--- a/cmd/tikv-ctl/Cargo.toml
+++ b/cmd/tikv-ctl/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tikv-ctl"
 version = "0.0.1"
 license = "Apache-2.0"
-edition = "2021"
+edition = "2024"
 publish = false
 
 [features]

--- a/cmd/tikv-ctl/src/executor.rs
+++ b/cmd/tikv-ctl/src/executor.rs
@@ -1319,14 +1319,14 @@ where
 
 fn handle_engine_error(err: EngineError) -> ! {
     error!("error while open kvdb: {}", err);
-    if let EngineError::Engine(s) = err {
-        if s.state().contains(LOCK_FILE_ERROR) {
-            error!(
-                "LOCK file conflict indicates TiKV process is running. \
+    if let EngineError::Engine(s) = err
+        && s.state().contains(LOCK_FILE_ERROR)
+    {
+        error!(
+            "LOCK file conflict indicates TiKV process is running. \
                 Do NOT delete the LOCK file and force the command to run. \
                 Doing so could cause data corruption."
-            );
-        }
+        );
     }
 
     tikv_util::logger::exit_process_gracefully(-1);

--- a/cmd/tikv-ctl/src/main.rs
+++ b/cmd/tikv-ctl/src/main.rs
@@ -1,7 +1,5 @@
 // Copyright 2016 TiKV Project Authors. Licensed under Apache-2.0.
 
-#![feature(let_chains)]
-
 #[macro_use]
 extern crate log;
 

--- a/cmd/tikv-ctl/src/util.rs
+++ b/cmd/tikv-ctl/src/util.rs
@@ -50,7 +50,7 @@ pub fn convert_gbmb(mut bytes: u64) -> String {
     if bytes < MIB {
         return format!("{}B", bytes);
     }
-    let mb = if bytes % GIB == 0 {
+    let mb = if bytes.is_multiple_of(GIB) {
         String::from("")
     } else {
         format!("{:.3}MiB", (bytes % GIB) as f64 / MIB as f64)

--- a/components/backup-stream/src/checkpoint_manager.rs
+++ b/components/backup-stream/src/checkpoint_manager.rs
@@ -609,7 +609,6 @@ where
 #[cfg(test)]
 pub mod tests {
     use std::{
-        assert_matches,
         collections::HashMap,
         sync::{Arc, Mutex, RwLock},
         time::Duration,
@@ -777,16 +776,20 @@ pub mod tests {
         mgr.do_update(region(2, 35, 8), TimeStamp::new(16));
         mgr.do_update(region(2, 35, 8), TimeStamp::new(14));
         let r = mgr.get_from_region(RegionIdWithVersion::new(1, 32));
-        assert_matches::assert_matches!(r, GetCheckpointResult::NotFound { .. });
+        assert!(matches!(r, GetCheckpointResult::NotFound { .. }));
 
         mgr.freeze_and_flush();
         let r = mgr.get_from_region(RegionIdWithVersion::new(1, 32));
-        assert_matches::assert_matches!(r, GetCheckpointResult::Ok { checkpoint , .. } if checkpoint.into_inner() == 8);
+        assert!(
+            matches!(r, GetCheckpointResult::Ok { checkpoint , .. } if checkpoint.into_inner() == 8)
+        );
         let r = mgr.get_from_region(RegionIdWithVersion::new(2, 35));
-        assert_matches::assert_matches!(r, GetCheckpointResult::Ok { checkpoint , .. } if checkpoint.into_inner() == 16);
+        assert!(
+            matches!(r, GetCheckpointResult::Ok { checkpoint , .. } if checkpoint.into_inner() == 16)
+        );
         mgr.freeze_and_flush();
         let r = mgr.get_from_region(RegionIdWithVersion::new(1, 32));
-        assert_matches::assert_matches!(r, GetCheckpointResult::NotFound { .. });
+        assert!(matches!(r, GetCheckpointResult::NotFound { .. }));
     }
 
     #[test]
@@ -795,25 +798,35 @@ pub mod tests {
         mgr.update_region_checkpoint(&region(1, 32, 8), TimeStamp::new(8));
         mgr.update_region_checkpoint(&region(2, 34, 8), TimeStamp::new(15));
         let r = mgr.get_from_region(RegionIdWithVersion::new(1, 32));
-        assert_matches::assert_matches!(r, GetCheckpointResult::Ok{checkpoint, ..} if checkpoint.into_inner() == 8);
+        assert!(
+            matches!(r, GetCheckpointResult::Ok{checkpoint, ..} if checkpoint.into_inner() == 8)
+        );
         let r = mgr.get_from_region(RegionIdWithVersion::new(2, 33));
-        assert_matches::assert_matches!(r, GetCheckpointResult::EpochNotMatch { .. });
+        assert!(matches!(r, GetCheckpointResult::EpochNotMatch { .. }));
         let r = mgr.get_from_region(RegionIdWithVersion::new(3, 44));
-        assert_matches::assert_matches!(r, GetCheckpointResult::NotFound { .. });
+        assert!(matches!(r, GetCheckpointResult::NotFound { .. }));
 
         mgr.update_region_checkpoint(&region(1, 30, 8), TimeStamp::new(16));
         let r = mgr.get_from_region(RegionIdWithVersion::new(1, 32));
-        assert_matches::assert_matches!(r, GetCheckpointResult::Ok{checkpoint, ..} if checkpoint.into_inner() == 8);
+        assert!(
+            matches!(r, GetCheckpointResult::Ok{checkpoint, ..} if checkpoint.into_inner() == 8)
+        );
 
         mgr.update_region_checkpoint(&region(1, 30, 8), TimeStamp::new(16));
         let r = mgr.get_from_region(RegionIdWithVersion::new(1, 32));
-        assert_matches::assert_matches!(r, GetCheckpointResult::Ok{checkpoint, ..} if checkpoint.into_inner() == 8);
+        assert!(
+            matches!(r, GetCheckpointResult::Ok{checkpoint, ..} if checkpoint.into_inner() == 8)
+        );
         mgr.update_region_checkpoint(&region(1, 32, 8), TimeStamp::new(16));
         let r = mgr.get_from_region(RegionIdWithVersion::new(1, 32));
-        assert_matches::assert_matches!(r, GetCheckpointResult::Ok{checkpoint, ..} if checkpoint.into_inner() == 16);
+        assert!(
+            matches!(r, GetCheckpointResult::Ok{checkpoint, ..} if checkpoint.into_inner() == 16)
+        );
         mgr.update_region_checkpoint(&region(1, 33, 8), TimeStamp::new(24));
         let r = mgr.get_from_region(RegionIdWithVersion::new(1, 33));
-        assert_matches::assert_matches!(r, GetCheckpointResult::Ok{checkpoint, ..} if checkpoint.into_inner() == 24);
+        assert!(
+            matches!(r, GetCheckpointResult::Ok{checkpoint, ..} if checkpoint.into_inner() == 24)
+        );
     }
 
     #[test]
@@ -835,9 +848,9 @@ pub mod tests {
         // Freezed
         mgr.freeze();
         let r = mgr.get_from_region(RegionIdWithVersion::new(1, 32));
-        assert_matches::assert_matches!(r, GetCheckpointResult::NotFound { .. });
+        assert!(matches!(r, GetCheckpointResult::NotFound { .. }));
         let r = mgr.get_from_region(RegionIdWithVersion::new(2, 34));
-        assert_matches::assert_matches!(r, GetCheckpointResult::NotFound { .. });
+        assert!(matches!(r, GetCheckpointResult::NotFound { .. }));
         // Shouldn't be recorded to resolved ts.
         mgr.resolve_regions(vec![ResolveResult {
             region: region(1, 32, 8),
@@ -853,9 +866,13 @@ pub mod tests {
         }]);
 
         let r = mgr.get_from_region(RegionIdWithVersion::new(1, 32));
-        assert_matches::assert_matches!(r, GetCheckpointResult::Ok{checkpoint, ..} if checkpoint.into_inner() == 8);
+        assert!(
+            matches!(r, GetCheckpointResult::Ok{checkpoint, ..} if checkpoint.into_inner() == 8)
+        );
         let r = mgr.get_from_region(RegionIdWithVersion::new(2, 34));
-        assert_matches::assert_matches!(r, GetCheckpointResult::Ok{checkpoint, ..} if checkpoint.into_inner() == 17);
+        assert!(
+            matches!(r, GetCheckpointResult::Ok{checkpoint, ..} if checkpoint.into_inner() == 17)
+        );
     }
 
     pub struct MockPdClient {

--- a/components/backup-stream/src/lib.rs
+++ b/components/backup-stream/src/lib.rs
@@ -1,7 +1,5 @@
 // Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
 #![feature(trait_alias)]
-#![feature(result_flattening)]
-#![feature(assert_matches)]
 #![feature(test)]
 
 mod checkpoint_manager;

--- a/components/backup-stream/src/observer.rs
+++ b/components/backup-stream/src/observer.rs
@@ -186,7 +186,7 @@ impl RegionChangeObserver for BackupStreamObserver {
 
 #[cfg(test)]
 mod tests {
-    use std::{assert_matches::assert_matches, sync::Arc, time::Duration};
+    use std::{sync::Arc, time::Duration};
 
     use dashmap::DashMap;
     use engine_panic::PanicEngine;
@@ -272,9 +272,9 @@ mod tests {
         let mut cmd_batches = vec![cb];
         o.on_flush_applied_cmd_batch(ObserveLevel::All, &mut cmd_batches, &mock_engine);
         let task = rx.recv_timeout(Duration::from_secs(0)).unwrap().unwrap();
-        assert_matches!(task, Task::BatchEvent(batches) if
+        assert!(matches!(task, Task::BatchEvent(batches) if
             batches.len() == 1 && batches[0].region_id == 42 && batches[0].cdc_id == handle.id
-        );
+        ));
 
         // Test event from other region should not be send.
         let observe_info = CmdObserveInfo::from_handle(
@@ -310,10 +310,10 @@ mod tests {
         let mut ctx = ObserverContext::new(&r);
         o.on_role_change(&mut ctx, &RoleChange::new_for_test(StateRole::Follower));
         let task = rx.recv_timeout(Duration::from_millis(20));
-        assert_matches!(
+        assert!(matches!(
             task,
             Ok(Some(Task::ModifyObserve(ObserveOp::Stop { region, .. }))) if region.id == 42
-        );
+        ));
     }
 
     #[test]

--- a/components/backup-stream/src/router.rs
+++ b/components/backup-stream/src/router.rs
@@ -877,7 +877,7 @@ impl TempFileKey {
     fn format_date_time(ts: u64, t: FormatType) -> impl Display {
         use chrono::prelude::*;
         let millis = TimeStamp::physical(ts.into());
-        let dt = Utc.timestamp_millis(millis as _);
+        let dt = Utc.timestamp_millis_opt(millis as _).unwrap();
         match t {
             FormatType::Date => dt.format("%Y%m%d"),
             FormatType::Hour => dt.format("%H"),
@@ -2918,7 +2918,7 @@ mod tests {
         let kv_event = build_kv_event(1, 1);
         let tmp_key = TempFileKey::of(&kv_event.events[0], 1);
         data_file.inner.done().await?;
-        let mut files = vec![(tmp_key, data_file, info)];
+        let mut files = [(tmp_key, data_file, info)];
 
         let stream_task = StreamTask {
             info: StreamBackupTaskInfo::default(),

--- a/components/backup-stream/src/tempfiles.rs
+++ b/components/backup-stream/src/tempfiles.rs
@@ -630,6 +630,7 @@ impl AsyncRead for ForRead {
         defer! {
             TEMP_FILE_READ_POLL_DURATION.observe(begin.elapsed().as_secs_f64())
         }
+        #[allow(clippy::unnecessary_unwrap)]
         if this.read == 0 && this.myfile.is_some() {
             let old = buf.remaining();
             let ext_file = Pin::new(this.myfile.as_mut().unwrap());

--- a/components/backup-stream/tests/suite.rs
+++ b/components/backup-stream/tests/suite.rs
@@ -552,7 +552,7 @@ impl Suite {
         for sn in (from..(from + n)).map(|x| x * 2) {
             let sn = sn as u64;
             let key = make_record_key(for_table, sn);
-            let value = if sn % 4 == 0 {
+            let value = if sn.is_multiple_of(4) {
                 Self::PROMISED_SHORT_VALUE.to_vec()
             } else {
                 Self::PROMISED_LONG_VALUE.to_vec()

--- a/components/cdc/src/channel.rs
+++ b/components/cdc/src/channel.rs
@@ -484,7 +484,6 @@ where
 #[cfg(test)]
 mod tests {
     use std::{
-        assert_matches::assert_matches,
         sync::{Arc, mpsc},
         time::Duration,
     };
@@ -527,7 +526,10 @@ mod tests {
 
             let memory_quota = rx.memory_quota.clone();
             let mut drain = rx.drain();
-            assert_matches!(block_on(drain.next()), Some((CdcEvent::Event(_), _)));
+            assert!(matches!(
+                block_on(drain.next()),
+                Some((CdcEvent::Event(_), _))
+            ));
             assert_eq!(memory_quota.in_use(), size);
         }
         {
@@ -564,15 +566,27 @@ mod tests {
         let mut drain = rx.drain();
         brx1.recv_timeout(Duration::from_millis(100)).unwrap_err();
         brx2.recv_timeout(Duration::from_millis(100)).unwrap_err();
-        assert_matches!(block_on(drain.next()), Some((CdcEvent::Event(_), _)));
+        assert!(matches!(
+            block_on(drain.next()),
+            Some((CdcEvent::Event(_), _))
+        ));
         brx1.recv_timeout(Duration::from_millis(100)).unwrap_err();
         brx2.recv_timeout(Duration::from_millis(100)).unwrap_err();
-        assert_matches!(block_on(drain.next()), Some((CdcEvent::Barrier(_), _)));
+        assert!(matches!(
+            block_on(drain.next()),
+            Some((CdcEvent::Barrier(_), _))
+        ));
         brx1.recv_timeout(Duration::from_millis(100)).unwrap();
         brx2.recv_timeout(Duration::from_millis(100)).unwrap_err();
-        assert_matches!(block_on(drain.next()), Some((CdcEvent::ResolvedTs(_), _)));
+        assert!(matches!(
+            block_on(drain.next()),
+            Some((CdcEvent::ResolvedTs(_), _))
+        ));
         brx2.recv_timeout(Duration::from_millis(100)).unwrap_err();
-        assert_matches!(block_on(drain.next()), Some((CdcEvent::Barrier(_), _)));
+        assert!(matches!(
+            block_on(drain.next()),
+            Some((CdcEvent::Barrier(_), _))
+        ));
         brx2.recv_timeout(Duration::from_millis(100)).unwrap();
         brx1.recv_timeout(Duration::from_millis(100)).unwrap_err();
         brx2.recv_timeout(Duration::from_millis(100)).unwrap_err();
@@ -615,7 +629,10 @@ mod tests {
         for _ in 0..buffer {
             send(CdcEvent::Event(e.clone())).unwrap();
         }
-        assert_matches!(send(CdcEvent::Event(e)).unwrap_err(), SendError::Congested);
+        assert!(matches!(
+            send(CdcEvent::Event(e)).unwrap_err(),
+            SendError::Congested
+        ));
     }
 
     #[test]
@@ -636,10 +653,10 @@ mod tests {
                 send(CdcEvent::Event(e.clone())).unwrap();
             }
 
-            assert_matches!(
+            assert!(matches!(
                 send(CdcEvent::Event(e.clone())).unwrap_err(),
                 SendError::Congested
-            );
+            ));
 
             let memory_quota = rx.memory_quota.clone();
             assert_eq!(memory_quota.capacity(), 1024);
@@ -664,7 +681,10 @@ mod tests {
 
             let new_capacity = 1024 - event.size();
             memory_quota.set_capacity(new_capacity as usize);
-            assert_matches!(send(CdcEvent::Event(e)).unwrap_err(), SendError::Congested);
+            assert!(matches!(
+                send(CdcEvent::Event(e)).unwrap_err(),
+                SendError::Congested
+            ));
             assert_eq!(memory_quota.capacity(), new_capacity as usize);
         }
     }
@@ -684,11 +704,11 @@ mod tests {
             tx.unbounded_send(CdcEvent::Event(e.clone()), false)
                 .unwrap();
         }
-        assert_matches!(
+        assert!(matches!(
             tx.unbounded_send(CdcEvent::Event(e.clone()), false)
                 .unwrap_err(),
             SendError::Congested
-        );
+        ));
         tx.unbounded_send(CdcEvent::Event(e), true).unwrap();
     }
 
@@ -709,7 +729,7 @@ mod tests {
                 match send(CdcEvent::Event(e.clone())) {
                     Ok(_) => (),
                     Err(e) => {
-                        assert_matches!(e, SendError::Congested);
+                        assert!(matches!(e, SendError::Congested));
                         break;
                     }
                 }
@@ -726,7 +746,7 @@ mod tests {
                 match send(CdcEvent::Event(e.clone())) {
                     Ok(_) => (),
                     Err(e) => {
-                        assert_matches!(e, SendError::Congested);
+                        assert!(matches!(e, SendError::Congested));
                         break;
                     }
                 }

--- a/components/cdc/src/delegate.rs
+++ b/components/cdc/src/delegate.rs
@@ -69,9 +69,10 @@ impl Default for DownstreamId {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
 pub enum DownstreamState {
     /// It's just created and rejects change events and resolved timestamps.
+    #[default]
     Uninitialized,
     /// It has got a snapshot for incremental scan, and change events will be
     /// accepted. However, it still rejects resolved timestamps.
@@ -80,12 +81,6 @@ pub enum DownstreamState {
     /// now.
     Normal,
     Stopped,
-}
-
-impl Default for DownstreamState {
-    fn default() -> Self {
-        Self::Uninitialized
-    }
 }
 
 /// Should only be called when it's uninitialized or stopped. Return false if
@@ -962,6 +957,7 @@ impl Delegate {
                 }
                 // lock_heap initialized and there is lock_modified_counts, update the lock_heap
                 // to avoid the resolved-ts stuck.
+                #[allow(clippy::unnecessary_unwrap)]
                 if !lock_modified_counts.is_empty() && downstream.lock_heap.is_some() {
                     let lock_heap = downstream.lock_heap.as_mut().unwrap();
                     lock_modified_counts.iter().for_each(|modified| {
@@ -1649,7 +1645,7 @@ mod tests {
 
     #[test]
     fn test_observed_range() {
-        for case in vec![
+        for case in [
             (b"".as_slice(), b"".as_slice(), false),
             (b"a", b"", false),
             (b"", b"b", false),

--- a/components/cdc/src/lib.rs
+++ b/components/cdc/src/lib.rs
@@ -1,7 +1,6 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
 #![feature(box_patterns)]
-#![feature(assert_matches)]
 
 mod channel;
 mod config;

--- a/components/cdc/src/old_value.rs
+++ b/components/cdc/src/old_value.rs
@@ -352,7 +352,7 @@ mod tests {
         let new_capacity = 256;
         // The memory usage that needs to be removed because of the capacity reduction.
         let dropped = old_value_cache.cache.size() - new_capacity;
-        let dropped_count = if dropped % size != 0 {
+        let dropped_count = if !dropped.is_multiple_of(size) {
             (dropped / size) + 1
         } else {
             dropped / size

--- a/components/cdc/tests/integrations/mod.rs
+++ b/components/cdc/tests/integrations/mod.rs
@@ -1,7 +1,5 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-#![feature(assert_matches)]
-
 mod test_cdc;
 mod test_flow_control;
 

--- a/components/cloud/aws/Cargo.toml
+++ b/components/cloud/aws/Cargo.toml
@@ -11,12 +11,11 @@ failpoints = ["fail/failpoints"]
 [dependencies]
 async-trait = "0.1"
 
-aws-config = { version = "1", features = [], default-features = false }
+aws-config = { version = "=1.8.15", features = [], default-features = false }
 aws-credential-types = { version = "1", features = ["hardcoded-credentials"] }
-# Note: sts@1.40.0, s3@1.47.0 and kms@1.41.0 is the latest version that supports rustc 1.77...
-# We may update this after we update our rustc.
-aws-sdk-kms = { version = "=1.40.0", features = [], default-features = false }
-aws-sdk-s3 = { version = "=1.40.0", features = ["rt-tokio"], default-features = false }
+# Keep the AWS SDK family pinned so Cargo resolves fixed transitive versions.
+aws-sdk-kms = { version = "=1.103.0", features = [], default-features = false }
+aws-sdk-s3 = { version = "=1.126.0", features = ["rt-tokio"], default-features = false }
 
 aws-smithy-runtime = { version = "1", features = [ "client", "connector-hyper-0-14-x" ], default-features = false }
 aws-smithy-runtime-api = { version = "1", features = [], default-features = false }

--- a/components/cloud/aws/src/lib.rs
+++ b/components/cloud/aws/src/lib.rs
@@ -1,6 +1,4 @@
 // Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
-#![feature(assert_matches)]
-
 mod kms;
 pub use kms::{AwsKms, ENCRYPTION_VENDOR_NAME_AWS_KMS};
 

--- a/components/cloud/aws/src/s3.rs
+++ b/components/cloud/aws/src/s3.rs
@@ -519,7 +519,7 @@ impl<'client> S3Uploader<'client> {
         } else {
             // Otherwise, use multipart upload to improve robustness.
             self.upload_id = retry_and_count(|| self.begin(), "begin_upload").await?;
-            let upload_res = async {
+            let upload_res = Box::pin(async {
                 let mut buf = vec![0; effective_part_size];
                 let mut part_number = 1;
                 loop {
@@ -527,16 +527,16 @@ impl<'client> S3Uploader<'client> {
                     if data_size == 0 {
                         break;
                     }
-                    let part = retry_and_count(
+                    let part = Box::pin(retry_and_count(
                         || self.upload_part(part_number, &buf[..data_size]),
                         "upload_part",
-                    )
+                    ))
                     .await?;
                     self.parts.push(part);
                     part_number += 1;
                 }
                 Ok(())
-            }
+            })
             .await;
 
             if upload_res.is_ok() {
@@ -874,7 +874,7 @@ impl IterableStorage for S3Storage {
 
 #[cfg(test)]
 mod tests {
-    use std::{assert_matches::assert_matches, ffi::OsString};
+    use std::ffi::OsString;
 
     use aws_sdk_s3::{config::Credentials, primitives::SdkBody};
     use aws_smithy_runtime::{
@@ -1553,11 +1553,11 @@ mod tests {
 
         let mut data = AllowStdIo::new(ThrottleRead(Cursor::new(b"muthologia.")));
         let mut buf = vec![0u8; 6];
-        assert_matches!(try_read_exact(&mut data, &mut buf).await, Ok(6));
+        assert!(matches!(try_read_exact(&mut data, &mut buf).await, Ok(6)));
         assert_eq!(buf, b"muthol");
-        assert_matches!(try_read_exact(&mut data, &mut buf).await, Ok(5));
+        assert!(matches!(try_read_exact(&mut data, &mut buf).await, Ok(5)));
         assert_eq!(&buf[..5], b"ogia.");
-        assert_matches!(try_read_exact(&mut data, &mut buf).await, Ok(0));
+        assert!(matches!(try_read_exact(&mut data, &mut buf).await, Ok(0)));
     }
 
     #[test]

--- a/components/compact-log-backup/src/compaction/collector.rs
+++ b/components/compact-log-backup/src/compaction/collector.rs
@@ -293,7 +293,7 @@ mod test {
         };
         let t = with_ts;
 
-        let items = vec![
+        let items = [
             // should be filtered out.
             t(log_file("1", 999, r(1)), 40, 49),
             t(log_file("11", 456, r(1)), 201, 288),

--- a/components/compact-log-backup/src/compaction/exec.rs
+++ b/components/compact-log-backup/src/compaction/exec.rs
@@ -259,7 +259,6 @@ where
         let items = super::util::execute_all_ext(
             c.inputs
                 .iter()
-                .cloned()
                 .map(|f| {
                     let source = &self.source;
                     Box::pin(async move {
@@ -267,7 +266,7 @@ where
                         let mut out = vec![];
                         let mut stat = LoadStatistic::default();
                         source
-                            .load(f, Some(&mut stat), |k, v| {
+                            .load(f.clone(), Some(&mut stat), |k, v| {
                                 fail::fail_point!("compact_log_backup_omit_key", |_| {});
                                 out.push(Record {
                                     key: k.to_owned(),
@@ -398,6 +397,7 @@ where
         Ok(meta)
     }
 
+    #[allow(unused_assignments)]
     #[tracing::instrument(skip_all, fields(c=%c))]
     pub async fn run(
         mut self,

--- a/components/compact-log-backup/src/storage.rs
+++ b/components/compact-log-backup/src/storage.rs
@@ -762,10 +762,11 @@ impl<'a> MigrationStorageWrapper<'a> {
         // future.
         let name = name_of_migration(id + 1, &migration);
         let bytes = migration.write_to_bytes()?;
+        let full_name = format!("{}/{}", self.migrations_prefix, name);
         retry_expr!(
             self.storage
                 .write(
-                    &format!("{}/{}", self.migrations_prefix, name),
+                    &full_name,
                     UnpinReader(Box::new(Cursor::new(&bytes))),
                     bytes.len() as u64
                 )

--- a/components/compact-log-backup/src/util.rs
+++ b/components/compact-log-backup/src/util.rs
@@ -171,6 +171,7 @@ pub fn redact(k: &[u8]) -> log_wrappers::Value<'_> {
     log_wrappers::Value::key(k)
 }
 
+#[allow(dead_code)]
 #[derive(Eq, PartialEq)]
 pub struct EndKey<'a>(pub &'a [u8]);
 

--- a/components/crossbeam-skiplist/src/base.rs
+++ b/components/crossbeam-skiplist/src/base.rs
@@ -2105,7 +2105,7 @@ impl<K, V> Drop for IntoIter<K, V> {
             unsafe {
                 // Unprotected loads are okay because this function is the only one currently using
                 // the skip list.
-                let next = (*self.node).tower[0].load(Ordering::Relaxed, epoch::unprotected());
+                let next = (&(*self.node).tower)[0].load(Ordering::Relaxed, epoch::unprotected());
 
                 // We can safely do this without deferring because references to
                 // keys & values that we give out never outlive the SkipList.
@@ -2136,7 +2136,7 @@ impl<K, V> Iterator for IntoIter<K, V> {
                 //
                 // Unprotected loads are okay because this function is the only one currently using
                 // the skip list.
-                let next = (*self.node).tower[0].load(Ordering::Relaxed, epoch::unprotected());
+                let next = (&(*self.node).tower)[0].load(Ordering::Relaxed, epoch::unprotected());
 
                 // Deallocate the current node and move to the next one.
                 Node::dealloc(self.node);

--- a/components/encryption/Cargo.toml
+++ b/components/encryption/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "encryption"
 version = "0.0.1"
-edition = "2021"
+edition = "2024"
 publish = false
 license = "Apache-2.0"
 

--- a/components/encryption/src/lib.rs
+++ b/components/encryption/src/lib.rs
@@ -1,7 +1,5 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
-#![feature(let_chains)]
-
 mod backup;
 mod config;
 mod crypter;

--- a/components/encryption/src/test_utils.rs
+++ b/components/encryption/src/test_utils.rs
@@ -13,6 +13,6 @@ pub fn create_master_key_file_test_only(val: &str) -> (PathBuf, TempDir) {
 }
 
 pub fn generate_random_master_key() -> String {
-    let master_key: [u8; 32] = rand::thread_rng().gen();
+    let master_key: [u8; 32] = rand::thread_rng().r#gen();
     hex::encode(master_key)
 }

--- a/components/engine_rocks/Cargo.toml
+++ b/components/engine_rocks/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "engine_rocks"
 version = "0.0.1"
-edition = "2021"
+edition = "2024"
 publish = false
 license = "Apache-2.0"
 

--- a/components/engine_rocks/src/compact_listener.rs
+++ b/components/engine_rocks/src/compact_listener.rs
@@ -234,10 +234,10 @@ impl rocksdb::EventListener for CompactionListener {
             return;
         }
 
-        if let Some(ref f) = self.filter {
-            if !f(info) {
-                return;
-            }
+        if let Some(ref f) = self.filter
+            && !f(info)
+        {
+            return;
         }
 
         let mut input_files = hash_set_with_capacity(info.input_file_count());

--- a/components/engine_rocks/src/lib.rs
+++ b/components/engine_rocks/src/lib.rs
@@ -16,8 +16,6 @@
 //! Please read the engine_trait crate docs before hacking.
 
 #![cfg_attr(test, feature(test))]
-#![feature(let_chains)]
-#![feature(path_file_prefix)]
 
 #[allow(unused_extern_crates)]
 extern crate tikv_alloc;

--- a/components/engine_rocks/src/logger.rs
+++ b/components/engine_rocks/src/logger.rs
@@ -9,12 +9,12 @@ pub struct RocksdbLogger;
 impl Logger for RocksdbLogger {
     fn logv(&self, log_level: InfoLogLevel, log: &str) {
         match log_level {
-            InfoLogLevel::Header => info!(#"rocksdb_log_header", "{}", log),
-            InfoLogLevel::Debug => debug!(#"rocksdb_log", "{}", log),
-            InfoLogLevel::Info => info!(#"rocksdb_log", "{}", log),
-            InfoLogLevel::Warn => warn!(#"rocksdb_log", "{}", log),
-            InfoLogLevel::Error => error!(#"rocksdb_log", "{}", log),
-            InfoLogLevel::Fatal => crit!(#"rocksdb_log", "{}", log),
+            InfoLogLevel::Header => info!(# "rocksdb_log_header", "{}", log),
+            InfoLogLevel::Debug => debug!(# "rocksdb_log", "{}", log),
+            InfoLogLevel::Info => info!(# "rocksdb_log", "{}", log),
+            InfoLogLevel::Warn => warn!(# "rocksdb_log", "{}", log),
+            InfoLogLevel::Error => error!(# "rocksdb_log", "{}", log),
+            InfoLogLevel::Fatal => crit!(# "rocksdb_log", "{}", log),
             _ => {}
         }
     }
@@ -33,12 +33,12 @@ impl TabletLogger {
 impl Logger for TabletLogger {
     fn logv(&self, log_level: InfoLogLevel, log: &str) {
         match log_level {
-            InfoLogLevel::Header => info!(#"rocksdb_log_header", "[{}]{}", self.tablet_name, log),
-            InfoLogLevel::Debug => debug!(#"rocksdb_log", "[{}]{}", self.tablet_name, log),
-            InfoLogLevel::Info => info!(#"rocksdb_log", "[{}]{}", self.tablet_name, log),
-            InfoLogLevel::Warn => warn!(#"rocksdb_log", "[{}]{}", self.tablet_name, log),
-            InfoLogLevel::Error => error!(#"rocksdb_log", "[{}]{}", self.tablet_name, log),
-            InfoLogLevel::Fatal => crit!(#"rocksdb_log", "[{}]{}", self.tablet_name, log),
+            InfoLogLevel::Header => info!(# "rocksdb_log_header", "[{}]{}", self.tablet_name, log),
+            InfoLogLevel::Debug => debug!(# "rocksdb_log", "[{}]{}", self.tablet_name, log),
+            InfoLogLevel::Info => info!(# "rocksdb_log", "[{}]{}", self.tablet_name, log),
+            InfoLogLevel::Warn => warn!(# "rocksdb_log", "[{}]{}", self.tablet_name, log),
+            InfoLogLevel::Error => error!(# "rocksdb_log", "[{}]{}", self.tablet_name, log),
+            InfoLogLevel::Fatal => crit!(# "rocksdb_log", "[{}]{}", self.tablet_name, log),
             _ => {}
         }
     }
@@ -50,12 +50,12 @@ pub struct RaftDbLogger;
 impl Logger for RaftDbLogger {
     fn logv(&self, log_level: InfoLogLevel, log: &str) {
         match log_level {
-            InfoLogLevel::Header => info!(#"raftdb_log_header", "{}", log),
-            InfoLogLevel::Debug => debug!(#"raftdb_log", "{}", log),
-            InfoLogLevel::Info => info!(#"raftdb_log", "{}", log),
-            InfoLogLevel::Warn => warn!(#"raftdb_log", "{}", log),
-            InfoLogLevel::Error => error!(#"raftdb_log", "{}", log),
-            InfoLogLevel::Fatal => crit!(#"raftdb_log", "{}", log),
+            InfoLogLevel::Header => info!(# "raftdb_log_header", "{}", log),
+            InfoLogLevel::Debug => debug!(# "raftdb_log", "{}", log),
+            InfoLogLevel::Info => info!(# "raftdb_log", "{}", log),
+            InfoLogLevel::Warn => warn!(# "raftdb_log", "{}", log),
+            InfoLogLevel::Error => error!(# "raftdb_log", "{}", log),
+            InfoLogLevel::Fatal => crit!(# "raftdb_log", "{}", log),
             _ => {}
         }
     }

--- a/components/engine_rocks/src/options.rs
+++ b/components/engine_rocks/src/options.rs
@@ -120,24 +120,22 @@ impl TableFilter for TsFilter {
         if let Some(hint_min_ts) = self.hint_min_ts {
             // TODO avoid hard code after refactor MvccProperties from
             // tikv/src/raftstore/coprocessor/ into some component about engine.
-            if let Some(mut p) = user_props.get("tikv.max_ts") {
-                if let Ok(get_max) = number::decode_u64(&mut p) {
-                    if get_max < hint_min_ts {
-                        return false;
-                    }
-                }
+            if let Some(mut p) = user_props.get("tikv.max_ts")
+                && let Ok(get_max) = number::decode_u64(&mut p)
+                && get_max < hint_min_ts
+            {
+                return false;
             }
         }
 
         if let Some(hint_max_ts) = self.hint_max_ts {
             // TODO avoid hard code after refactor MvccProperties from
             // tikv/src/raftstore/coprocessor/ into some component about engine.
-            if let Some(mut p) = user_props.get("tikv.min_ts") {
-                if let Ok(get_min) = number::decode_u64(&mut p) {
-                    if get_min > hint_max_ts {
-                        return false;
-                    }
-                }
+            if let Some(mut p) = user_props.get("tikv.min_ts")
+                && let Ok(get_min) = number::decode_u64(&mut p)
+                && get_min > hint_max_ts
+            {
+                return false;
             }
         }
 

--- a/components/engine_rocks/src/util.rs
+++ b/components/engine_rocks/src/util.rs
@@ -215,12 +215,12 @@ pub fn get_engine_compression_ratio_at_level(
     level: usize,
 ) -> Option<f64> {
     let prop = format!("{}{}", ROCKSDB_COMPRESSION_RATIO_AT_LEVEL, level);
-    if let Some(v) = engine.get_property_value_cf(handle, &prop) {
-        if let Ok(f) = f64::from_str(&v) {
-            // RocksDB returns -1.0 if the level is empty.
-            if f >= 0.0 {
-                return Some(f);
-            }
+    if let Some(v) = engine.get_property_value_cf(handle, &prop)
+        && let Ok(f) = f64::from_str(&v)
+    {
+        // RocksDB returns -1.0 if the level is empty.
+        if f >= 0.0 {
+            return Some(f);
         }
     }
     None

--- a/components/engine_test/Cargo.toml
+++ b/components/engine_test/Cargo.toml
@@ -2,7 +2,7 @@
 name = "engine_test"
 version = "0.0.1"
 description = "A single engine that masquerades as all other engines, for testing"
-edition = "2021"
+edition = "2024"
 publish = false
 license = "Apache-2.0"
 

--- a/components/engine_test/src/lib.rs
+++ b/components/engine_test/src/lib.rs
@@ -55,8 +55,6 @@
 //! storage engines, and that it be extracted into its own crate for use in
 //! TiKV, once the full requirements are better understood.
 
-#![feature(let_chains)]
-
 /// Types and constructors for the "raft" engine
 pub mod raft {
     #[cfg(feature = "test-engine-raft-panic")]

--- a/components/engine_traits/src/lib.rs
+++ b/components/engine_traits/src/lib.rs
@@ -250,9 +250,7 @@
 //!   Likewise `engine_rocks` can temporarily call code from inside `engine`.
 #![cfg_attr(test, feature(test))]
 #![feature(min_specialization)]
-#![feature(assert_matches)]
 #![feature(linked_list_cursors)]
-#![feature(let_chains)]
 #![feature(str_split_remainder)]
 
 #[macro_use(fail_point)]

--- a/components/hybrid_engine/Cargo.toml
+++ b/components/hybrid_engine/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hybrid_engine"
 version = "0.0.1"
-edition = "2021"
+edition = "2024"
 publish = false
 license = "Apache-2.0"
 

--- a/components/hybrid_engine/src/lib.rs
+++ b/components/hybrid_engine/src/lib.rs
@@ -3,8 +3,6 @@
 // `HybridEngineSnapshot` and `HybridEngineIterator` into in_memory_engine
 // crate.
 
-#![feature(let_chains)]
-
 mod db_vector;
 mod engine;
 mod engine_iterator;

--- a/components/in_memory_engine/Cargo.toml
+++ b/components/in_memory_engine/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "in_memory_engine"
 version = "0.0.1"
-edition = "2021"
+edition = "2024"
 publish = false
 license = "Apache-2.0"
 

--- a/components/in_memory_engine/src/background.rs
+++ b/components/in_memory_engine/src/background.rs
@@ -752,16 +752,15 @@ impl BackgroundRunnerCore {
             regions_to_delete.extend(deletable_regions);
         }
 
-        if !regions_to_delete.is_empty() {
-            if let Err(e) = delete_range_scheduler
+        if !regions_to_delete.is_empty()
+            && let Err(e) = delete_range_scheduler
                 .schedule_force(BackgroundTask::DeleteRegions(regions_to_delete))
-            {
-                error!(
-                    "ime schedule delete range failed";
-                    "err" => ?e,
-                );
-                assert!(tikv_util::thread_group::is_shutdown(!cfg!(test)));
-            }
+        {
+            error!(
+                "ime schedule delete range failed";
+                "err" => ?e,
+            );
+            assert!(tikv_util::thread_group::is_shutdown(!cfg!(test)));
         }
         for _ in 0..evict_count {
             if rx.recv().await.is_none() {

--- a/components/in_memory_engine/src/config.rs
+++ b/components/in_memory_engine/src/config.rs
@@ -130,6 +130,7 @@ impl InMemoryEngineConfig {
             );
         }
 
+        #[allow(clippy::unnecessary_unwrap)]
         if self.evict_threshold.is_none() {
             let capacity = self.capacity.unwrap().0;
             let delta = std::cmp::min(
@@ -146,6 +147,7 @@ impl InMemoryEngineConfig {
             .into());
         }
 
+        #[allow(clippy::unnecessary_unwrap)]
         if self.stop_load_threshold.is_none() {
             let delta = std::cmp::min(
                 self.capacity.unwrap().0 * 15 / 100,

--- a/components/in_memory_engine/src/engine.rs
+++ b/components/in_memory_engine/src/engine.rs
@@ -470,8 +470,8 @@ impl RegionCacheMemoryEngine {
         get_tikv_safe_point: Box<dyn Fn() -> Option<u64> + Send>,
     ) {
         let cross_check_interval = self.config.value().cross_check_interval;
-        if !cross_check_interval.is_zero() {
-            if let Err(e) =
+        if !cross_check_interval.is_zero()
+            && let Err(e) =
                 self.bg_worker_manager()
                     .schedule_task(BackgroundTask::TurnOnCrossCheck((
                         self.clone(),
@@ -480,13 +480,12 @@ impl RegionCacheMemoryEngine {
                         cross_check_interval.0,
                         get_tikv_safe_point,
                     )))
-            {
-                error!(
-                    "schedule TurnOnCrossCheck failed";
-                    "err" => ?e,
-                );
-                assert!(tikv_util::thread_group::is_shutdown(!cfg!(test)));
-            }
+        {
+            error!(
+                "schedule TurnOnCrossCheck failed";
+                "err" => ?e,
+            );
+            assert!(tikv_util::thread_group::is_shutdown(!cfg!(test)));
         }
     }
 }

--- a/components/in_memory_engine/src/keys.rs
+++ b/components/in_memory_engine/src/keys.rs
@@ -1,6 +1,5 @@
 // Copyright 2023 TiKV Project Authors. Licensed under Apache-2.0.
 
-use core::slice::SlicePattern;
 use std::{
     cmp::{self, Ordering},
     fmt,

--- a/components/in_memory_engine/src/lib.rs
+++ b/components/in_memory_engine/src/lib.rs
@@ -1,10 +1,9 @@
 // Copyright 2023 TiKV Project Authors. Licensed under Apache-2.0.
 
-#![feature(assert_matches)]
-#![feature(let_chains)]
 #![allow(internal_features)]
 #![feature(core_intrinsics)]
 #![feature(slice_pattern)]
+#![feature(str_as_str)]
 
 use std::sync::Arc;
 

--- a/components/in_memory_engine/src/read.rs
+++ b/components/in_memory_engine/src/read.rs
@@ -1,6 +1,5 @@
 // Copyright 2024 TiKV Project Authors. Licensed under Apache-2.0.
 
-use core::slice::SlicePattern;
 use std::{fmt::Debug, ops::Deref, result, sync::Arc};
 
 use bytes::Bytes;
@@ -97,18 +96,17 @@ impl Drop for RegionCacheSnapshot {
             .core
             .region_manager
             .remove_region_snapshot(&self.snapshot_meta);
-        if !regions_removable.is_empty() {
-            if let Err(e) = self
+        if !regions_removable.is_empty()
+            && let Err(e) = self
                 .engine
                 .bg_worker_manager()
                 .schedule_task(BackgroundTask::DeleteRegions(regions_removable))
-            {
-                error!(
-                    "ime schedule delete range failed";
-                    "err" => ?e,
-                );
-                assert!(tikv_util::thread_group::is_shutdown(!cfg!(test)));
-            }
+        {
+            error!(
+                "ime schedule delete range failed";
+                "err" => ?e,
+            );
+            assert!(tikv_util::thread_group::is_shutdown(!cfg!(test)));
         }
     }
 }
@@ -298,11 +296,11 @@ impl RegionCacheIterator {
                 break;
             }
 
-            if let Some(ref prefix) = self.prefix {
-                if prefix != self.prefix_extractor.as_mut().unwrap().transform(user_key) {
-                    // stop iterating due to unmatched prefix
-                    break;
-                }
+            if let Some(ref prefix) = self.prefix
+                && prefix != self.prefix_extractor.as_mut().unwrap().transform(user_key)
+            {
+                // stop iterating due to unmatched prefix
+                break;
             }
 
             if self.is_visible(sequence) {
@@ -369,11 +367,11 @@ impl RegionCacheIterator {
                 break;
             }
 
-            if let Some(ref prefix) = self.prefix {
-                if prefix != self.prefix_extractor.as_mut().unwrap().transform(user_key) {
-                    // stop iterating due to unmatched prefix
-                    break;
-                }
+            if let Some(ref prefix) = self.prefix
+                && prefix != self.prefix_extractor.as_mut().unwrap().transform(user_key)
+            {
+                // stop iterating due to unmatched prefix
+                break;
             }
 
             if !self.find_value_for_current_key(guard) {

--- a/components/in_memory_engine/src/region_manager.rs
+++ b/components/in_memory_engine/src/region_manager.rs
@@ -1,7 +1,6 @@
 // Copyright 2024 TiKV Project Authors. Licensed under Apache-2.0.
 
 use std::{
-    assert_matches::assert_matches,
     collections::{
         BTreeMap,
         Bound::{self, Excluded, Unbounded},
@@ -239,8 +238,8 @@ impl CacheRegionMeta {
         on_evict_finished: Option<OnEvictFinishedCallback>,
     ) {
         use RegionState::*;
-        assert_matches!(self.state, Loading | Active | LoadingCanceled);
-        assert_matches!(state, PendingEvict | Evicting);
+        assert!(matches!(self.state, Loading | Active | LoadingCanceled));
+        assert!(matches!(state, PendingEvict | Evicting));
         self.set_state(state);
         self.evict_info = Some(EvictInfo {
             start: Instant::now_coarse(),

--- a/components/in_memory_engine/src/write_batch.rs
+++ b/components/in_memory_engine/src/write_batch.rs
@@ -311,18 +311,17 @@ impl RegionCacheWriteBatch {
         if self.memory_controller.memory_checking() {
             return;
         }
-        if !self.memory_controller.set_memory_checking(true) {
-            if let Err(e) = self
+        if !self.memory_controller.set_memory_checking(true)
+            && let Err(e) = self
                 .engine
                 .bg_worker_manager()
                 .schedule_task(BackgroundTask::MemoryCheckAndEvict)
-            {
-                error!(
-                    "ime schedule memory check failed";
-                    "err" => ?e,
-                );
-                assert!(tikv_util::thread_group::is_shutdown(!cfg!(test)));
-            }
+        {
+            error!(
+                "ime schedule memory check failed";
+                "err" => ?e,
+            );
+            assert!(tikv_util::thread_group::is_shutdown(!cfg!(test)));
         }
     }
 

--- a/components/pd_client/src/client.rs
+++ b/components/pd_client/src/client.rs
@@ -164,7 +164,7 @@ impl RpcClient {
                     return Ok(rpc_client);
                 }
                 Err(e) => {
-                    if i as usize % cfg.retry_log_every == 0 {
+                    if (i as usize).is_multiple_of(cfg.retry_log_every) {
                         warn!("validate PD endpoints failed"; "err" => ?e);
                     }
                     let _ = GLOBAL_TIMER_HANDLE

--- a/components/pd_client/src/client_v2.rs
+++ b/components/pd_client/src/client_v2.rs
@@ -100,7 +100,7 @@ impl RawClient {
                     });
                 }
                 Err(e) => {
-                    if i as usize % ctx.cfg.retry_log_every == 0 {
+                    if (i as usize).is_multiple_of(ctx.cfg.retry_log_every) {
                         warn!("validate PD endpoints failed"; "err" => ?e);
                     }
                     let _ = GLOBAL_TIMER_HANDLE

--- a/components/pd_client/src/lib.rs
+++ b/components/pd_client/src/lib.rs
@@ -1,7 +1,5 @@
 // Copyright 2016 TiKV Project Authors. Licensed under Apache-2.0.
 
-#![feature(let_chains)]
-
 #[allow(unused_extern_crates)]
 extern crate tikv_alloc;
 

--- a/components/pd_client/src/util.rs
+++ b/components/pd_client/src/util.rs
@@ -686,7 +686,7 @@ impl PdConnector {
         for m in members
             .iter()
             .filter(|m| *m != previous_leader)
-            .chain(&[previous_leader.clone()])
+            .chain(std::slice::from_ref(previous_leader))
         {
             for ep in m.get_client_urls() {
                 match self.connect(ep.as_str()).await {

--- a/components/raft_log_engine/src/engine.rs
+++ b/components/raft_log_engine/src/engine.rs
@@ -811,7 +811,6 @@ fn transfer_error(e: RaftEngineError) -> engine_traits::Error {
 
 #[cfg(test)]
 mod tests {
-    use std::assert_matches::assert_matches;
 
     use engine_traits::ALL_CFS;
 
@@ -825,10 +824,10 @@ mod tests {
             ..Default::default()
         };
         let engine = RaftLogEngine::new(cfg, None, None).unwrap();
-        assert_matches!(engine.get_region_state(2, u64::MAX), Ok(None));
-        assert_matches!(engine.get_apply_state(2, u64::MAX), Ok(None));
+        assert!(matches!(engine.get_region_state(2, u64::MAX), Ok(None)));
+        assert!(matches!(engine.get_apply_state(2, u64::MAX), Ok(None)));
         for cf in ALL_CFS {
-            assert_matches!(engine.get_flushed_index(2, cf), Ok(None));
+            assert!(matches!(engine.get_flushed_index(2, cf), Ok(None)));
         }
 
         let mut wb = engine.log_batch(10);
@@ -844,10 +843,10 @@ mod tests {
         engine.consume(&mut wb, false).unwrap();
 
         for cf in ALL_CFS.iter().take(2) {
-            assert_matches!(engine.get_flushed_index(2, cf), Ok(Some(4)));
+            assert!(matches!(engine.get_flushed_index(2, cf), Ok(Some(4))));
         }
         for cf in ALL_CFS.iter().skip(2) {
-            assert_matches!(engine.get_flushed_index(2, cf), Ok(None));
+            assert!(matches!(engine.get_flushed_index(2, cf), Ok(None)));
         }
 
         let mut region_state2 = region_state.clone();
@@ -861,14 +860,14 @@ mod tests {
         }
         engine.consume(&mut wb, false).unwrap();
 
-        assert_matches!(engine.get_region_state(2, 0), Ok(None));
-        assert_matches!(engine.get_region_state(2, 1), Ok(Some(s)) if s == region_state);
-        assert_matches!(engine.get_region_state(2, 4), Ok(Some(s)) if s == region_state2);
-        assert_matches!(engine.get_apply_state(2, 0), Ok(None));
-        assert_matches!(engine.get_apply_state(2, 3), Ok(Some(s)) if s == apply_state);
-        assert_matches!(engine.get_apply_state(2, 5), Ok(Some(s)) if s == apply_state2);
+        assert!(matches!(engine.get_region_state(2, 0), Ok(None)));
+        assert!(matches!(engine.get_region_state(2, 1), Ok(Some(s)) if s == region_state));
+        assert!(matches!(engine.get_region_state(2, 4), Ok(Some(s)) if s == region_state2));
+        assert!(matches!(engine.get_apply_state(2, 0), Ok(None)));
+        assert!(matches!(engine.get_apply_state(2, 3), Ok(Some(s)) if s == apply_state));
+        assert!(matches!(engine.get_apply_state(2, 5), Ok(Some(s)) if s == apply_state2));
         for cf in ALL_CFS {
-            assert_matches!(engine.get_flushed_index(2, cf), Ok(Some(5)));
+            assert!(matches!(engine.get_flushed_index(2, cf), Ok(Some(5))));
         }
     }
 }

--- a/components/raft_log_engine/src/lib.rs
+++ b/components/raft_log_engine/src/lib.rs
@@ -16,7 +16,6 @@
 //! Please read the engine_trait crate docs before hacking.
 
 #![cfg_attr(test, feature(test))]
-#![feature(assert_matches)]
 
 #[macro_use]
 extern crate tikv_util;

--- a/components/raftstore-v2/src/batch/store.rs
+++ b/components/raftstore-v2/src/batch/store.rs
@@ -767,18 +767,20 @@ impl<EK: KvEngine, ER: RaftEngine> StoreSystem<EK, ER> {
                         if to_flush == 0 {
                             break;
                         }
-                        if let Some(mut t) = registry.get(r)
-                            && let Some(t) = t.latest()
-                        {
-                            match t.flush_oldest_cf(true, Some(threshold)) {
-                                Err(e) => warn!(logger, "failed to flush oldest cf"; "err" => %e),
-                                Ok(true) => {
-                                    to_flush -= 1;
-                                    let time =
-                                        std::time::Instant::now() + limiter.consume_duration(1);
-                                    let _ = GLOBAL_TIMER_HANDLE.delay(time).compat().await;
+                        if let Some(mut t) = registry.get(r) {
+                            if let Some(t) = t.latest() {
+                                match t.flush_oldest_cf(true, Some(threshold)) {
+                                    Err(e) => {
+                                        warn!(logger, "failed to flush oldest cf"; "err" => %e)
+                                    }
+                                    Ok(true) => {
+                                        to_flush -= 1;
+                                        let time =
+                                            std::time::Instant::now() + limiter.consume_duration(1);
+                                        let _ = GLOBAL_TIMER_HANDLE.delay(time).compat().await;
+                                    }
+                                    _ => (),
                                 }
-                                _ => (),
                             }
                         }
                     }

--- a/components/raftstore-v2/src/fsm/store.rs
+++ b/components/raftstore-v2/src/fsm/store.rs
@@ -63,29 +63,29 @@ impl<EK> StoreMeta<EK> {
             .regions
             .insert(region_id, (region.clone(), initialized));
         // `prev` only makes sense when it's initialized.
-        if let Some((prev, prev_init)) = prev
-            && prev_init
-        {
-            assert!(initialized, "{} region corrupted", SlogFormat(logger));
-            if prev.get_region_epoch().get_version() != version {
-                let prev_id = self.region_ranges.remove(&(
-                    data_end_key(prev.get_end_key()),
-                    prev.get_region_epoch().get_version(),
-                ));
-                assert_eq!(
-                    prev_id,
-                    Some(region_id),
-                    "{} region corrupted",
-                    SlogFormat(logger)
-                );
-            } else {
-                assert!(
-                    self.region_ranges
-                        .contains_key(&(data_end_key(prev.get_end_key()), version)),
-                    "{} region corrupted",
-                    SlogFormat(logger)
-                );
-                return;
+        if let Some((prev, prev_init)) = prev {
+            if prev_init {
+                assert!(initialized, "{} region corrupted", SlogFormat(logger));
+                if prev.get_region_epoch().get_version() != version {
+                    let prev_id = self.region_ranges.remove(&(
+                        data_end_key(prev.get_end_key()),
+                        prev.get_region_epoch().get_version(),
+                    ));
+                    assert_eq!(
+                        prev_id,
+                        Some(region_id),
+                        "{} region corrupted",
+                        SlogFormat(logger)
+                    );
+                } else {
+                    assert!(
+                        self.region_ranges
+                            .contains_key(&(data_end_key(prev.get_end_key()), version)),
+                        "{} region corrupted",
+                        SlogFormat(logger)
+                    );
+                    return;
+                }
             }
         }
         if initialized {

--- a/components/raftstore-v2/src/lib.rs
+++ b/components/raftstore-v2/src/lib.rs
@@ -21,10 +21,7 @@
 // Functionalities like read, write, etc should be implemented in [`operation`]
 // using a standalone modules.
 
-#![feature(let_chains)]
-#![feature(array_windows)]
 #![feature(box_into_inner)]
-#![feature(assert_matches)]
 
 mod batch;
 mod bootstrap;

--- a/components/raftstore-v2/src/operation/command/admin/compact_log.rs
+++ b/components/raftstore-v2/src/operation/command/admin/compact_log.rs
@@ -468,16 +468,16 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         mut res: CompactLogResult,
     ) {
         let first_index = self.entry_storage().first_index();
-        if let Some(i) = self.merge_context().and_then(|c| c.max_compact_log_index())
-            && res.compact_index > i
-        {
-            info!(
-                self.logger,
-                "in merging mode, adjust compact index";
-                "old_index" => res.compact_index,
-                "new_index" => i,
-            );
-            res.compact_index = i;
+        if let Some(i) = self.merge_context().and_then(|c| c.max_compact_log_index()) {
+            if res.compact_index > i {
+                info!(
+                    self.logger,
+                    "in merging mode, adjust compact index";
+                    "old_index" => res.compact_index,
+                    "new_index" => i,
+                );
+                res.compact_index = i;
+            }
         }
         if res.compact_index <= first_index {
             debug!(
@@ -529,19 +529,19 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
 
         // All logs < persisted_apply will be deleted.
         let prev_first_index = first_index;
-        if prev_first_index < self.storage().apply_trace().persisted_apply_index()
-            && let Some(index) = self.compact_log_index()
-        {
-            // Raft Engine doesn't care about first index.
-            if let Err(e) =
-                store_ctx
-                    .engine
-                    .gc(self.region_id(), 0, index, self.state_changes_mut())
-            {
-                error!(self.logger, "failed to compact raft logs"; "err" => ?e);
+        if prev_first_index < self.storage().apply_trace().persisted_apply_index() {
+            if let Some(index) = self.compact_log_index() {
+                // Raft Engine doesn't care about first index.
+                if let Err(e) =
+                    store_ctx
+                        .engine
+                        .gc(self.region_id(), 0, index, self.state_changes_mut())
+                {
+                    error!(self.logger, "failed to compact raft logs"; "err" => ?e);
+                }
+                self.compact_log_context_mut().set_last_compacted_idx(index);
+                // Extra write set right above.
             }
-            self.compact_log_context_mut().set_last_compacted_idx(index);
-            // Extra write set right above.
         }
 
         let context = self.compact_log_context_mut();
@@ -574,16 +574,15 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
                 error!(self.logger, "failed to delete raft states"; "err" => ?e);
             }
             // If it's snapshot, logs are gc already.
-            if !task.has_snapshot
-                && old_persisted < self.entry_storage().truncated_index() + 1
-                && let Some(index) = self.compact_log_index()
-            {
-                let batch = task
-                    .extra_write
-                    .ensure_v2(|| self.entry_storage().raft_engine().log_batch(0));
-                // Raft Engine doesn't care about first index.
-                if let Err(e) = store_ctx.engine.gc(self.region_id(), 0, index, batch) {
-                    error!(self.logger, "failed to compact raft logs"; "err" => ?e);
+            if !task.has_snapshot && old_persisted < self.entry_storage().truncated_index() + 1 {
+                if let Some(index) = self.compact_log_index() {
+                    let batch = task
+                        .extra_write
+                        .ensure_v2(|| self.entry_storage().raft_engine().log_batch(0));
+                    // Raft Engine doesn't care about first index.
+                    if let Err(e) = store_ctx.engine.gc(self.region_id(), 0, index, batch) {
+                        error!(self.logger, "failed to compact raft logs"; "err" => ?e);
+                    }
                 }
             }
             if self.remove_tombstone_tablets(new_persisted) {

--- a/components/raftstore-v2/src/operation/command/admin/merge/prepare.rs
+++ b/components/raftstore-v2/src/operation/command/admin/merge/prepare.rs
@@ -415,69 +415,72 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         resp: &ExtraMessage,
     ) {
         let region_id = self.region_id();
-        if self.merge_context().is_some()
-            && let Some(PrepareStatus::WaitForTrimStatus {
+        if self.merge_context().is_some() {
+            if let Some(PrepareStatus::WaitForTrimStatus {
                 pending_peers, req, ..
             }) = self.merge_context_mut().prepare_status.as_mut()
-            && req.is_some()
-        {
-            assert!(resp.has_availability_context());
-            let from_region = resp.get_availability_context().get_from_region_id();
-            let from_epoch = resp.get_availability_context().get_from_region_epoch();
-            let trimmed = resp.get_availability_context().get_trimmed();
-            if let Some(epoch) = pending_peers.get(&from_peer)
-                && util::is_region_epoch_equal(from_epoch, epoch)
             {
-                if !trimmed {
-                    info!(
-                        self.logger,
-                        "cancel merge because source peer is not trimmed";
-                        "region_id" => from_region,
-                        "peer_id" => from_peer,
-                    );
-                    self.take_merge_context();
-                    return;
-                } else {
-                    pending_peers.remove(&from_peer);
+                if req.is_some() {
+                    assert!(resp.has_availability_context());
+                    let from_region = resp.get_availability_context().get_from_region_id();
+                    let from_epoch = resp.get_availability_context().get_from_region_epoch();
+                    let trimmed = resp.get_availability_context().get_trimmed();
+                    if let Some(epoch) = pending_peers.get(&from_peer) {
+                        if util::is_region_epoch_equal(from_epoch, epoch) {
+                            if !trimmed {
+                                info!(
+                                    self.logger,
+                                    "cancel merge because source peer is not trimmed";
+                                    "region_id" => from_region,
+                                    "peer_id" => from_peer,
+                                );
+                                self.take_merge_context();
+                                return;
+                            } else {
+                                pending_peers.remove(&from_peer);
+                            }
+                        }
+                    }
+                    if pending_peers.is_empty() {
+                        let mailbox = match store_ctx.router.mailbox(region_id) {
+                            Some(mailbox) => mailbox,
+                            None => {
+                                assert!(
+                                    store_ctx.router.is_shutdown(),
+                                    "{} router should have been closed",
+                                    SlogFormat(&self.logger)
+                                );
+                                return;
+                            }
+                        };
+                        let mut req = req.take().unwrap();
+                        req.mut_header()
+                            .set_flags(WriteBatchFlags::PRE_FLUSH_FINISHED.bits());
+                        let logger = self.logger.clone();
+                        let on_flush_finish = move || {
+                            let (ch, _) = CmdResChannel::pair();
+                            if let Err(e) =
+                                mailbox.force_send(PeerMsg::AdminCommand(RaftRequest::new(req, ch)))
+                            {
+                                error!(
+                                    logger,
+                                    "send PrepareMerge request failed after pre-flush finished";
+                                    "err" => ?e,
+                                );
+                                // We rely on
+                                // `maybe_clean_up_stale_merge_context` to
+                                // clean this up.
+                            }
+                        };
+                        self.start_pre_flush(
+                            store_ctx,
+                            "prepare_merge",
+                            false,
+                            &self.region().clone(),
+                            Box::new(on_flush_finish),
+                        );
+                    }
                 }
-            }
-            if pending_peers.is_empty() {
-                let mailbox = match store_ctx.router.mailbox(region_id) {
-                    Some(mailbox) => mailbox,
-                    None => {
-                        assert!(
-                            store_ctx.router.is_shutdown(),
-                            "{} router should have been closed",
-                            SlogFormat(&self.logger)
-                        );
-                        return;
-                    }
-                };
-                let mut req = req.take().unwrap();
-                req.mut_header()
-                    .set_flags(WriteBatchFlags::PRE_FLUSH_FINISHED.bits());
-                let logger = self.logger.clone();
-                let on_flush_finish = move || {
-                    let (ch, _) = CmdResChannel::pair();
-                    if let Err(e) =
-                        mailbox.force_send(PeerMsg::AdminCommand(RaftRequest::new(req, ch)))
-                    {
-                        error!(
-                            logger,
-                            "send PrepareMerge request failed after pre-flush finished";
-                            "err" => ?e,
-                        );
-                        // We rely on `maybe_clean_up_stale_merge_context` to
-                        // clean this up.
-                    }
-                };
-                self.start_pre_flush(
-                    store_ctx,
-                    "prepare_merge",
-                    false,
-                    &self.region().clone(),
-                    Box::new(on_flush_finish),
-                );
             }
         }
     }
@@ -608,10 +611,11 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
             .merge_context()
             .as_ref()
             .and_then(|c| c.prepare_status.as_ref())
-            && start_time.saturating_elapsed() > TRIM_CHECK_TIMEOUT
         {
-            info!(self.logger, "cancel merge because trim check timed out");
-            self.take_merge_context();
+            if start_time.saturating_elapsed() > TRIM_CHECK_TIMEOUT {
+                info!(self.logger, "cancel merge because trim check timed out");
+                self.take_merge_context();
+            }
         }
     }
 

--- a/components/raftstore-v2/src/operation/command/admin/merge/rollback.rs
+++ b/components/raftstore-v2/src/operation/command/admin/merge/rollback.rs
@@ -58,14 +58,14 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
         request.set_admin_request(admin);
         let (ch, res) = CmdResChannel::pair();
         self.on_admin_command(store_ctx, request, ch);
-        if let Some(res) = res.take_result()
-            && res.get_header().has_error()
-        {
-            error!(
-                self.logger,
-                "failed to propose rollback merge";
-                "res" => ?res,
-            );
+        if let Some(res) = res.take_result() {
+            if res.get_header().has_error() {
+                error!(
+                    self.logger,
+                    "failed to propose rollback merge";
+                    "res" => ?res,
+                );
+            }
         }
     }
 }

--- a/components/raftstore-v2/src/operation/command/write/ingest.rs
+++ b/components/raftstore-v2/src/operation/command/write/ingest.rs
@@ -65,8 +65,10 @@ impl Store {
             if let Err(TrySendError::Disconnected(msg)) = ctx
                 .router
                 .send(region_id, PeerMsg::CleanupImportSst(ssts.into()))
-                && !ctx.router.is_shutdown()
             {
+                if ctx.router.is_shutdown() {
+                    continue;
+                }
                 let PeerMsg::CleanupImportSst(ssts) = msg else {
                     unreachable!()
                 };

--- a/components/raftstore-v2/src/operation/life.rs
+++ b/components/raftstore-v2/src/operation/life.rs
@@ -241,10 +241,10 @@ fn check_if_to_peer_destroyed<ER: RaftEngine>(
     if util::is_epoch_stale(msg.get_region_epoch(), local_epoch) {
         return Ok(true);
     }
-    if let Some(local_peer) = find_peer(local_state.get_region(), store_id)
-        && to_peer.id <= local_peer.get_id()
-    {
-        return Ok(true);
+    if let Some(local_peer) = find_peer(local_state.get_region(), store_id) {
+        if to_peer.id <= local_peer.get_id() {
+            return Ok(true);
+        }
     }
     // If the peer is destroyed by conf change, all above checks will pass.
     if local_state

--- a/components/raftstore-v2/src/operation/misc.rs
+++ b/components/raftstore-v2/src/operation/misc.rs
@@ -41,8 +41,10 @@ impl Store {
         for (region_id, keys) in region_keys {
             if let Err(TrySendError::Disconnected(msg)) =
                 ctx.router.send(region_id, PeerMsg::SnapGc(keys.into()))
-                && !ctx.router.is_shutdown()
             {
+                if ctx.router.is_shutdown() {
+                    continue;
+                }
                 let PeerMsg::SnapGc(keys) = msg else {
                     unreachable!()
                 };

--- a/components/raftstore-v2/src/operation/query/capture.rs
+++ b/components/raftstore-v2/src/operation/query/capture.rs
@@ -54,12 +54,12 @@ impl<EK: KvEngine, ER: RaftEngine, T: raftstore::store::Transport> PeerFsmDelega
         let id = self.fsm.peer().region_id();
         let term = self.fsm.peer().term();
         let (ch, _) = QueryResChannel::with_callback(Box::new(move |res| {
-            if let QueryResult::Response(resp) = res
-                && resp.get_header().has_error()
-            {
-                // Return error
-                capture_change.snap_cb.report_error(resp.clone());
-                return;
+            if let QueryResult::Response(resp) = res {
+                if resp.get_header().has_error() {
+                    // Return error
+                    capture_change.snap_cb.report_error(resp.clone());
+                    return;
+                }
             }
             if let Some(scheduler) = apply_scheduler {
                 scheduler.send(ApplyTask::CaptureApply(capture_change))

--- a/components/raftstore-v2/src/operation/ready/apply_trace.rs
+++ b/components/raftstore-v2/src/operation/ready/apply_trace.rs
@@ -289,15 +289,13 @@ impl ApplyTrace {
                 }
             })
             .max();
-        if let Some(m) = last_modified
-            && m >= self.admin.flushed + 4096000
-            && m >= self.last_flush_trigger + 4096000
-        {
-            self.last_flush_trigger = m;
-            true
-        } else {
-            false
+        if let Some(m) = last_modified {
+            if m >= self.admin.flushed + 4096000 && m >= self.last_flush_trigger + 4096000 {
+                self.last_flush_trigger = m;
+                return true;
+            }
         }
+        false
     }
 
     // All events before `mem_index` must be consumed before calling this function.

--- a/components/raftstore-v2/src/operation/unsafe_recovery/create.rs
+++ b/components/raftstore-v2/src/operation/unsafe_recovery/create.rs
@@ -110,15 +110,15 @@ impl Store {
 
 impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
     pub fn on_unsafe_recovery_wait_initialized(&mut self, syncer: UnsafeRecoveryExecutePlanSyncer) {
-        if let Some(state) = self.unsafe_recovery_state()
-            && !state.is_abort()
-        {
-            warn!(self.logger,
-                "Unsafe recovery, can't wait initialize, another plan is executing in progress";
-                "state" => ?state,
-            );
-            syncer.abort();
-            return;
+        if let Some(state) = self.unsafe_recovery_state() {
+            if !state.is_abort() {
+                warn!(self.logger,
+                    "Unsafe recovery, can't wait initialize, another plan is executing in progress";
+                    "state" => ?state,
+                );
+                syncer.abort();
+                return;
+            }
         }
 
         *self.unsafe_recovery_state_mut() = Some(UnsafeRecoveryState::WaitInitialize(syncer));

--- a/components/raftstore-v2/src/operation/unsafe_recovery/demote.rs
+++ b/components/raftstore-v2/src/operation/unsafe_recovery/demote.rs
@@ -40,14 +40,14 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
             let exit_joint = exit_joint_request(self.region(), self.peer());
             let (ch, sub) = CmdResChannel::pair();
             self.on_admin_command(ctx, exit_joint, ch);
-            if let Some(resp) = sub.try_result()
-                && resp.get_header().has_error()
-            {
-                error!(self.logger,
-                    "Unsafe recovery, fail to exit residual joint state";
-                    "err" => ?resp.get_header().get_error(),
-                );
-                return;
+            if let Some(resp) = sub.try_result() {
+                if resp.get_header().has_error() {
+                    error!(self.logger,
+                        "Unsafe recovery, fail to exit residual joint state";
+                        "err" => ?resp.get_header().get_error(),
+                    );
+                    return;
+                }
             }
             *self.unsafe_recovery_state_mut() = Some(UnsafeRecoveryState::DemoteFailedVoters {
                 syncer,
@@ -72,15 +72,15 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
                 "req" => ?req);
             let (ch, sub) = CmdResChannel::pair();
             self.on_admin_command(ctx, req, ch);
-            if let Some(resp) = sub.try_result()
-                && resp.get_header().has_error()
-            {
-                error!(self.logger,
-                    "Unsafe recovery, fail to finish demotion";
-                    "err" => ?resp.get_header().get_error(),
-                );
-                *self.unsafe_recovery_state_mut() = Some(UnsafeRecoveryState::Failed);
-                return;
+            if let Some(resp) = sub.try_result() {
+                if resp.get_header().has_error() {
+                    error!(self.logger,
+                        "Unsafe recovery, fail to finish demotion";
+                        "err" => ?resp.get_header().get_error(),
+                    );
+                    *self.unsafe_recovery_state_mut() = Some(UnsafeRecoveryState::Failed);
+                    return;
+                }
             }
             *self.unsafe_recovery_state_mut() = Some(UnsafeRecoveryState::DemoteFailedVoters {
                 syncer,
@@ -132,14 +132,14 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
                     let exit_joint = exit_joint_request(self.region(), self.peer());
                     let (ch, sub) = CmdResChannel::pair();
                     self.on_admin_command(ctx, exit_joint, ch);
-                    if let Some(resp) = sub.try_result()
-                        && resp.get_header().has_error()
-                    {
-                        error!(self.logger,
-                            "Unsafe recovery, fail to exit joint state";
-                            "err" => ?resp.get_header().get_error(),
-                        );
-                        *self.unsafe_recovery_state_mut() = Some(UnsafeRecoveryState::Failed);
+                    if let Some(resp) = sub.try_result() {
+                        if resp.get_header().has_error() {
+                            error!(self.logger,
+                                "Unsafe recovery, fail to exit joint state";
+                                "err" => ?resp.get_header().get_error(),
+                            );
+                            *self.unsafe_recovery_state_mut() = Some(UnsafeRecoveryState::Failed);
+                        }
                     }
                 } else {
                     error!(self.logger,

--- a/components/raftstore-v2/src/operation/unsafe_recovery/destroy.rs
+++ b/components/raftstore-v2/src/operation/unsafe_recovery/destroy.rs
@@ -8,15 +8,15 @@ use crate::raft::Peer;
 
 impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
     pub fn on_unsafe_recovery_destroy_peer(&mut self, syncer: UnsafeRecoveryExecutePlanSyncer) {
-        if let Some(state) = self.unsafe_recovery_state()
-            && !state.is_abort()
-        {
-            warn!(self.logger,
-                "Unsafe recovery, can't destroy, another plan is executing in progress";
-                "state" => ?state,
-            );
-            syncer.abort();
-            return;
+        if let Some(state) = self.unsafe_recovery_state() {
+            if !state.is_abort() {
+                warn!(self.logger,
+                    "Unsafe recovery, can't destroy, another plan is executing in progress";
+                    "state" => ?state,
+                );
+                syncer.abort();
+                return;
+            }
         }
         // Syncer will be dropped after peer finishing destroy process.
         *self.unsafe_recovery_state_mut() = Some(UnsafeRecoveryState::Destroy(syncer));

--- a/components/raftstore-v2/src/operation/unsafe_recovery/force_leader.rs
+++ b/components/raftstore-v2/src/operation/unsafe_recovery/force_leader.rs
@@ -191,13 +191,13 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
             return;
         }
 
-        if let Some(UnsafeRecoveryState::Failed) = self.unsafe_recovery_state()
-            && !force
-        {
-            // Skip force leader if the plan failed, so wait for the next retry of plan with
-            // force leader state holding
-            info!(self.logger, "skip exiting force leader state");
-            return;
+        if !force {
+            if let Some(UnsafeRecoveryState::Failed) = self.unsafe_recovery_state() {
+                // Skip force leader if the plan failed, so wait for the next retry of plan with
+                // force leader state holding
+                info!(self.logger, "skip exiting force leader state");
+                return;
+            }
         }
 
         info!(self.logger, "exit force leader state");

--- a/components/raftstore-v2/src/operation/unsafe_recovery/report.rs
+++ b/components/raftstore-v2/src/operation/unsafe_recovery/report.rs
@@ -27,15 +27,15 @@ impl Store {
 
 impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
     pub fn on_unsafe_recovery_wait_apply(&mut self, syncer: UnsafeRecoveryWaitApplySyncer) {
-        if let Some(state) = self.unsafe_recovery_state()
-            && !state.is_abort()
-        {
-            warn!(self.logger,
-                "Unsafe recovery, can't wait apply, another plan is executing in progress";
-                "state" => ?state,
-            );
-            syncer.abort();
-            return;
+        if let Some(state) = self.unsafe_recovery_state() {
+            if !state.is_abort() {
+                warn!(self.logger,
+                    "Unsafe recovery, can't wait apply, another plan is executing in progress";
+                    "state" => ?state,
+                );
+                syncer.abort();
+                return;
+            }
         }
         let target_index = if self.has_force_leader() {
             // For regions that lose quorum (or regions have force leader), whatever has

--- a/components/raftstore-v2/src/raft/storage.rs
+++ b/components/raftstore-v2/src/raft/storage.rs
@@ -109,7 +109,7 @@ impl<EK: KvEngine, ER> Storage<EK, ER> {
         let mut task = self.gen_snap_task.borrow_mut();
         if let Some(t) = &**task {
             if to == t.to_peer() {
-                *task = Box::new(None);
+                **task = None;
             };
         }
     }

--- a/components/raftstore-v2/src/router/response_channel.rs
+++ b/components/raftstore-v2/src/router/response_channel.rs
@@ -728,7 +728,6 @@ pub use flush_channel::{FlushChannel, FlushSubscriber};
 
 #[cfg(test)]
 mod tests {
-    use std::assert_matches::assert_matches;
 
     use futures::{StreamExt, executor::block_on};
 
@@ -791,7 +790,9 @@ mod tests {
         let (chan, sub) = builder.build();
         let mut stream = CmdResStream::new(sub);
         chan.set_result(RaftCmdResponse::default());
-        assert_matches!(block_on(stream.next()), Some(CmdResEvent::Finished(res)) if res.get_header().get_current_term() == 6);
+        assert!(
+            matches!(block_on(stream.next()), Some(CmdResEvent::Finished(res)) if res.get_header().get_current_term() == 6)
+        );
 
         // When using builder, no event is subscribed by default.
         let (mut chan, sub) = CmdResChannelBuilder::default().build();
@@ -799,7 +800,7 @@ mod tests {
         chan.notify_proposed();
         chan.notify_committed();
         drop(chan);
-        assert_matches!(block_on(stream.next()), None);
+        assert!(block_on(stream.next()).is_none());
 
         let mut builder = CmdResChannelBuilder::default();
         builder.subscribe_proposed();
@@ -807,9 +808,12 @@ mod tests {
         let mut stream = CmdResStream::new(sub);
         chan.notify_proposed();
         chan.notify_committed();
-        assert_matches!(block_on(stream.next()), Some(CmdResEvent::Proposed));
+        assert!(matches!(
+            block_on(stream.next()),
+            Some(CmdResEvent::Proposed)
+        ));
         drop(chan);
-        assert_matches!(block_on(stream.next()), None);
+        assert!(block_on(stream.next()).is_none());
 
         let mut builder = CmdResChannelBuilder::default();
         builder.subscribe_committed();
@@ -817,8 +821,11 @@ mod tests {
         let mut stream = CmdResStream::new(sub);
         chan.notify_proposed();
         chan.notify_committed();
-        assert_matches!(block_on(stream.next()), Some(CmdResEvent::Committed));
+        assert!(matches!(
+            block_on(stream.next()),
+            Some(CmdResEvent::Committed)
+        ));
         drop(chan);
-        assert_matches!(block_on(stream.next()), None);
+        assert!(block_on(stream.next()).is_none());
     }
 }

--- a/components/raftstore-v2/src/worker/pd/store.rs
+++ b/components/raftstore-v2/src/worker/pd/store.rs
@@ -462,7 +462,7 @@ where
         // make the statistics of slowness percepted by PD timely.
         (interval_second > store_heartbeat_interval)
             && (interval_second <= STORE_HEARTBEAT_DELAY_LIMIT)
-            && (interval_second % store_heartbeat_interval == 0)
+            && interval_second.is_multiple_of(store_heartbeat_interval)
     }
 
     pub fn handle_inspect_latency(&self, send_time: TiInstant, inspector: LatencyInspector) {

--- a/components/raftstore-v2/src/worker/tablet.rs
+++ b/components/raftstore-v2/src/worker/tablet.rs
@@ -658,8 +658,10 @@ where
     fn on_timeout(&mut self) {
         self.pending_destroy_tasks.retain_mut(|(path, cb)| {
             let r = Self::process_destroy_task(&self.logger, &self.tablet_registry, path);
-            if r && let Some(cb) = cb.take() {
-                cb();
+            if r {
+                if let Some(cb) = cb.take() {
+                    cb();
+                }
             }
             !r
         });

--- a/components/raftstore-v2/tests/failpoints/mod.rs
+++ b/components/raftstore-v2/tests/failpoints/mod.rs
@@ -1,7 +1,6 @@
 // Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
 
 #![feature(test)]
-#![feature(assert_matches)]
 #![feature(custom_test_frameworks)]
 #![test_runner(test_util::run_failpoint_tests)]
 

--- a/components/raftstore-v2/tests/failpoints/test_basic_write.rs
+++ b/components/raftstore-v2/tests/failpoints/test_basic_write.rs
@@ -1,6 +1,6 @@
 // Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::{assert_matches::assert_matches, time::Duration};
+use std::time::Duration;
 
 use engine_traits::{
     CF_DEFAULT, CF_RAFT, CF_WRITE, CompactExt, DbOptionsExt, ManualCompactionOptions, MiscExt,
@@ -57,7 +57,7 @@ fn test_write_batch_rollback() {
     assert!(!resp.get_header().has_error(), "{:?}", resp);
 
     let snap = router.stale_snapshot(2);
-    assert_matches!(snap.get_value(b"key"), Ok(None));
+    assert!(matches!(snap.get_value(b"key"), Ok(None)));
     assert_eq!(snap.get_value(b"key1").unwrap().unwrap(), b"value");
 
     fail::cfg("APPLY_COMMITTED_ENTRIES", "pause").unwrap();
@@ -93,7 +93,7 @@ fn test_write_batch_rollback() {
     let resp = block_on(sub1.result()).unwrap();
     assert!(!resp.get_header().has_error(), "{:?}", resp);
     let snap = router.stale_snapshot(2);
-    assert_matches!(snap.get_value(b"key2"), Ok(None));
+    assert!(matches!(snap.get_value(b"key2"), Ok(None)));
     assert_eq!(snap.get_value(b"key3").unwrap().unwrap(), b"value");
 }
 

--- a/components/raftstore-v2/tests/failpoints/test_bootstrap.rs
+++ b/components/raftstore-v2/tests/failpoints/test_bootstrap.rs
@@ -1,7 +1,5 @@
 // Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::assert_matches::assert_matches;
-
 use engine_traits::RaftEngineReadOnly;
 use kvproto::metapb::Store;
 use raftstore_v2::Bootstrap;
@@ -32,7 +30,10 @@ fn test_bootstrap_half_way_failure() {
     fail::cfg("node_after_bootstrap_store", "return").unwrap();
     let s = format!("{}", bootstrap().unwrap_err());
     assert!(s.contains("node_after_bootstrap_store"), "{}", s);
-    assert_matches!(engines.raft.get_prepare_bootstrap_region(), Ok(None));
+    assert!(matches!(
+        engines.raft.get_prepare_bootstrap_region(),
+        Ok(None)
+    ));
 
     let ident = engines.raft.get_store_ident().unwrap().unwrap();
     assert_ne!(ident.get_store_id(), 0);
@@ -42,20 +43,32 @@ fn test_bootstrap_half_way_failure() {
     fail::cfg("node_after_prepare_bootstrap_cluster", "return").unwrap();
     let s = format!("{}", bootstrap().unwrap_err());
     assert!(s.contains("node_after_prepare_bootstrap_cluster"), "{}", s);
-    assert_matches!(engines.raft.get_prepare_bootstrap_region(), Ok(Some(_)));
+    assert!(matches!(
+        engines.raft.get_prepare_bootstrap_region(),
+        Ok(Some(_))
+    ));
 
     fail::remove("node_after_prepare_bootstrap_cluster");
     fail::cfg("node_after_bootstrap_cluster", "return").unwrap();
     let s = format!("{}", bootstrap().unwrap_err());
     assert!(s.contains("node_after_bootstrap_cluster"), "{}", s);
-    assert_matches!(engines.raft.get_prepare_bootstrap_region(), Ok(Some(_)));
+    assert!(matches!(
+        engines.raft.get_prepare_bootstrap_region(),
+        Ok(Some(_))
+    ));
 
     // Although aborted by error, rebootstrap should continue.
     bootstrap().unwrap().unwrap();
-    assert_matches!(engines.raft.get_prepare_bootstrap_region(), Ok(None));
+    assert!(matches!(
+        engines.raft.get_prepare_bootstrap_region(),
+        Ok(None)
+    ));
 
     // Second bootstrap should be noop.
     assert_eq!(bootstrap().unwrap(), None);
 
-    assert_matches!(engines.raft.get_prepare_bootstrap_region(), Ok(None));
+    assert!(matches!(
+        engines.raft.get_prepare_bootstrap_region(),
+        Ok(None)
+    ));
 }

--- a/components/raftstore-v2/tests/integrations/cluster.rs
+++ b/components/raftstore-v2/tests/integrations/cluster.rs
@@ -944,7 +944,6 @@ pub mod merge_helper {
 }
 
 pub mod life_helper {
-    use std::assert_matches::assert_matches;
 
     use engine_traits::RaftEngineDebug;
     use kvproto::raft_serverpb::{ExtraMessageType, PeerState};
@@ -985,13 +984,16 @@ pub mod life_helper {
         let mut buf = vec![];
         raft_engine.get_all_entries_to(region_id, &mut buf).unwrap();
         assert!(buf.is_empty(), "{:?}", buf);
-        assert_matches!(raft_engine.get_raft_state(region_id), Ok(None));
-        assert_matches!(raft_engine.get_apply_state(region_id, u64::MAX), Ok(None));
+        assert!(matches!(raft_engine.get_raft_state(region_id), Ok(None)));
+        assert!(matches!(
+            raft_engine.get_apply_state(region_id, u64::MAX),
+            Ok(None)
+        ));
         let region_state = raft_engine
             .get_region_state(region_id, u64::MAX)
             .unwrap()
             .unwrap();
-        assert_matches!(region_state.get_state(), PeerState::Tombstone);
+        assert!(matches!(region_state.get_state(), PeerState::Tombstone));
         assert!(
             region_state.get_region().get_peers().contains(peer),
             "{:?}",

--- a/components/raftstore-v2/tests/integrations/mod.rs
+++ b/components/raftstore-v2/tests/integrations/mod.rs
@@ -1,7 +1,6 @@
 // Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
 
 #![feature(test)]
-#![feature(assert_matches)]
 #![feature(custom_test_frameworks)]
 #![test_runner(test_util::run_tests)]
 

--- a/components/raftstore-v2/tests/integrations/test_basic_write.rs
+++ b/components/raftstore-v2/tests/integrations/test_basic_write.rs
@@ -1,6 +1,6 @@
 // Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::{assert_matches::assert_matches, time::Duration};
+use std::time::Duration;
 
 use engine_traits::{CF_DEFAULT, Peekable};
 use futures::executor::block_on;
@@ -123,7 +123,7 @@ fn test_put_delete() {
     let resp = block_on(sub.result()).unwrap();
     assert!(!resp.get_header().has_error(), "{:?}", resp);
     let snap = router.stale_snapshot(2);
-    assert_matches!(snap.get_value(b"key"), Ok(None));
+    assert!(matches!(snap.get_value(b"key"), Ok(None)));
 
     // Check if WAL is skipped for basic writes.
     let mut cached = cluster.node(0).tablet_registry().get(2).unwrap();

--- a/components/raftstore-v2/tests/integrations/test_transfer_leader.rs
+++ b/components/raftstore-v2/tests/integrations/test_transfer_leader.rs
@@ -1,6 +1,6 @@
 // Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::{assert_matches::assert_matches, time::Duration};
+use std::time::Duration;
 
 use engine_traits::{CF_DEFAULT, Peekable};
 use futures::executor::block_on;
@@ -30,7 +30,7 @@ fn put_data(
 
     // router.wait_applied_to_current_term(2, Duration::from_secs(3));
     let snap = router.stale_snapshot(region_id);
-    assert_matches!(snap.get_value(key), Ok(None));
+    assert!(matches!(snap.get_value(key), Ok(None)));
 
     let header = Box::new(router.new_request_for(region_id).take_header());
     let mut put = SimpleWriteEncoder::with_capacity(64);
@@ -57,7 +57,7 @@ fn put_data(
     // Because of skip bcast commit, the data should not be applied yet.
     router = &mut cluster.routers[node_off_for_verify];
     let snap = router.stale_snapshot(region_id);
-    assert_matches!(snap.get_value(key), Ok(None));
+    assert!(matches!(snap.get_value(key), Ok(None)));
     // Trigger heartbeat explicitly to commit on follower.
     router = &mut cluster.routers[node_off];
     for _ in 0..2 {

--- a/components/raftstore/Cargo.toml
+++ b/components/raftstore/Cargo.toml
@@ -66,7 +66,7 @@ resource_control = { workspace = true }
 resource_metering = { workspace = true }
 serde = "1.0"
 serde_derive = "1.0"
-serde_with = "1.4"
+serde_with = "3.21"
 service = { workspace = true }
 slog = { workspace = true }
 slog-global = { workspace = true }

--- a/components/raftstore/src/coprocessor/config.rs
+++ b/components/raftstore/src/coprocessor/config.rs
@@ -203,16 +203,18 @@ impl Config {
         let res = self.validate_bucket_size();
         // If it's OK to enable bucket, we will prefer to enable it if useful for
         // raftstore-v2.
-        if let Ok(()) = res
-            && self.enable_region_bucket.is_none()
-            && raft_kv_v2
-        {
-            let useful = self.region_split_size() >= self.region_bucket_size * 2;
-            self.enable_region_bucket = Some(useful);
-        } else if let Err(e) = res
-            && self.enable_region_bucket()
-        {
-            return Err(e);
+        match res {
+            Ok(()) => {
+                if self.enable_region_bucket.is_none() && raft_kv_v2 {
+                    let useful = self.region_split_size() >= self.region_bucket_size * 2;
+                    self.enable_region_bucket = Some(useful);
+                }
+            }
+            Err(e) => {
+                if self.enable_region_bucket() {
+                    return Err(e);
+                }
+            }
         }
         Ok(())
     }

--- a/components/raftstore/src/coprocessor/region_info_accessor.rs
+++ b/components/raftstore/src/coprocessor/region_info_accessor.rs
@@ -737,11 +737,11 @@ impl RegionCollector {
                 // epoch is properly set and an Update message was sent.
                 return;
             }
-            if let RaftStoreEvent::RoleChange { initialized, .. } = &event
-                && !initialized
-            {
-                // Ignore uninitialized peers.
-                return;
+            if let RaftStoreEvent::RoleChange { initialized, .. } = &event {
+                if !initialized {
+                    // Ignore uninitialized peers.
+                    return;
+                }
             }
             if !self.check_region_range(region, true) {
                 debug!(
@@ -982,11 +982,11 @@ impl RegionInfoProvider for RegionInfoAccessor {
         self.seek_region(
             key,
             Box::new(move |iter| {
-                if let Some(info) = iter.next()
-                    && info.region.get_start_key() <= key_in_vec.as_slice()
-                {
-                    if let Err(e) = tx.send(info.region.clone()) {
-                        warn!("failed to send find_region_by_key result: {:?}", e);
+                if let Some(info) = iter.next() {
+                    if info.region.get_start_key() <= key_in_vec.as_slice() {
+                        if let Err(e) = tx.send(info.region.clone()) {
+                            warn!("failed to send find_region_by_key result: {:?}", e);
+                        }
                     }
                 }
             }),

--- a/components/raftstore/src/coprocessor/split_check/keys.rs
+++ b/components/raftstore/src/coprocessor/split_check/keys.rs
@@ -518,11 +518,7 @@ mod tests {
             let split_count =
                 calc_split_keys_count(region_size.0, split_size.0, max_region_size.0, split_limit);
             let avg_split_size = region_size.0 / (split_count + 1);
-            let diff = if avg_split_size >= split_size.0 {
-                avg_split_size - split_size.0
-            } else {
-                split_size.0 - avg_split_size
-            };
+            let diff = avg_split_size.abs_diff(split_size.0);
             // the diff of actual split size and split_size is less than 1/3 split_size
             assert!(
                 diff <= split_size.0 / 3,

--- a/components/raftstore/src/coprocessor/split_check/size.rs
+++ b/components/raftstore/src/coprocessor/split_check/size.rs
@@ -234,7 +234,7 @@ pub fn get_approximate_split_keys(
 
 #[cfg(test)]
 pub mod tests {
-    use std::{assert_matches::assert_matches, iter, sync::mpsc};
+    use std::{iter, sync::mpsc};
 
     use collections::HashSet;
     use engine_test::{
@@ -474,7 +474,9 @@ pub mod tests {
             None,
         ));
         // size has not reached the max_size 100 yet.
-        assert_matches!(rx.try_recv(), Ok(SchedTask::UpdateApproximateSize { region_id, .. }) if region_id == region.get_id());
+        assert!(
+            matches!(rx.try_recv(), Ok(SchedTask::UpdateApproximateSize { region_id, .. }) if region_id == region.get_id())
+        );
 
         for i in 7..11 {
             let s = keys::data_key(format!("{:04}", i).as_bytes());

--- a/components/raftstore/src/coprocessor/split_check/table.rs
+++ b/components/raftstore/src/coprocessor/split_check/table.rs
@@ -36,11 +36,8 @@ where
 
         let current_encoded_key = keys::origin_key(entry.key());
 
-        let split_key = if self.first_encoded_table_prefix.is_some() {
-            if !is_same_table(
-                self.first_encoded_table_prefix.as_ref().unwrap(),
-                current_encoded_key,
-            ) {
+        let split_key = if let Some(first_encoded_table_prefix) = &self.first_encoded_table_prefix {
+            if !is_same_table(first_encoded_table_prefix, current_encoded_key) {
                 // Different tables.
                 Some(current_encoded_key)
             } else {

--- a/components/raftstore/src/lib.rs
+++ b/components/raftstore/src/lib.rs
@@ -1,11 +1,8 @@
 // Copyright 2016 TiKV Project Authors. Licensed under Apache-2.0.
 
 #![cfg_attr(test, feature(test))]
-#![feature(cell_update)]
 #![feature(min_specialization)]
 #![feature(box_patterns)]
-#![feature(let_chains)]
-#![feature(assert_matches)]
 #![feature(type_alias_impl_trait)]
 #![feature(impl_trait_in_assoc_type)]
 #![recursion_limit = "256"]

--- a/components/raftstore/src/store/async_io/write.rs
+++ b/components/raftstore/src/store/async_io/write.rs
@@ -572,13 +572,14 @@ where
             )
             .unwrap();
 
-        if let Some(raft_state) = task.raft_state.take()
-            && self
+        if let Some(raft_state) = task.raft_state.take() {
+            if self
                 .raft_states
                 .insert(task.region_id, raft_state)
                 .is_none()
-        {
-            self.state_size += std::mem::size_of::<RaftLocalState>();
+            {
+                self.state_size += std::mem::size_of::<RaftLocalState>();
+            }
         }
         self.extra_batch_write.merge(&mut task.extra_write);
 

--- a/components/raftstore/src/store/entry_storage.rs
+++ b/components/raftstore/src/store/entry_storage.rs
@@ -188,9 +188,8 @@ impl EntryCache {
             let first_index = entries[0].get_index();
             if cache_last_index >= first_index {
                 let cache_len = self.cache.len();
-                let truncate_to = cache_len
-                    .checked_sub((cache_last_index - first_index + 1) as usize)
-                    .unwrap_or_default();
+                let truncate_to =
+                    cache_len.saturating_sub((cache_last_index - first_index + 1) as usize);
                 let trunc_to_idx = self.cache[truncate_to].index;
                 for e in self.cache.drain(truncate_to..) {
                     mem_size_change -=
@@ -1291,7 +1290,7 @@ impl<EK: KvEngine, ER: RaftEngine> EntryStorage<EK, ER> {
 
 #[cfg(test)]
 pub mod tests {
-    use std::{assert_matches::assert_matches, sync::mpsc};
+    use std::sync::mpsc;
 
     use engine_test::{kv::KvTestEngine, raft::RaftTestEngine};
     use engine_traits::RaftEngineReadOnly;
@@ -1850,14 +1849,14 @@ pub mod tests {
         assert_eq!(store.entry_cache_first_index().unwrap(), 6);
 
         // The return value should be None when it is already warmed up.
-        assert_matches!(store.async_warm_up_entry_cache(6), None);
+        assert!(store.async_warm_up_entry_cache(6).is_none());
 
         // The high index should be equal to the entry_cache_first_index.
-        assert_matches!(store.async_warm_up_entry_cache(5), Some((5, 6)));
+        assert!(matches!(store.async_warm_up_entry_cache(5), Some((5, 6))));
 
         store.cache.compact_to(7); // Clean cache.
         // The high index should be equal to the last_index + 1.
-        assert_matches!(store.async_warm_up_entry_cache(5), Some((5, 7)));
+        assert!(matches!(store.async_warm_up_entry_cache(5), Some((5, 7))));
     }
 
     #[test]

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -787,20 +787,21 @@ where
         } else {
             if self.fsm.batch_req_builder.has_proposed_cb
                 && self.fsm.batch_req_builder.propose_checked.is_none()
-                && let Some(cmd) = self.fsm.batch_req_builder.request.take()
             {
-                // We are delaying these requests to next loop. Try to fulfill their
-                // proposed callback early.
-                self.fsm.batch_req_builder.propose_checked = Some(false);
-                if let Ok(None) = self.pre_propose_raft_command(&cmd) {
-                    if self.fsm.peer.will_likely_propose(&cmd) {
-                        self.fsm.batch_req_builder.propose_checked = Some(true);
-                        for cb in &mut self.fsm.batch_req_builder.callbacks {
-                            cb.invoke_proposed();
+                if let Some(cmd) = self.fsm.batch_req_builder.request.take() {
+                    // We are delaying these requests to next loop. Try to fulfill their
+                    // proposed callback early.
+                    self.fsm.batch_req_builder.propose_checked = Some(false);
+                    if let Ok(None) = self.pre_propose_raft_command(&cmd) {
+                        if self.fsm.peer.will_likely_propose(&cmd) {
+                            self.fsm.batch_req_builder.propose_checked = Some(true);
+                            for cb in &mut self.fsm.batch_req_builder.callbacks {
+                                cb.invoke_proposed();
+                            }
                         }
                     }
+                    self.fsm.batch_req_builder.request = Some(cmd);
                 }
-                self.fsm.batch_req_builder.request = Some(cmd);
             }
             if self.fsm.batch_req_builder.request.is_some() {
                 self.ctx.raft_metrics.ready.propose_delay.inc();
@@ -840,17 +841,17 @@ where
         syncer: UnsafeRecoveryExecutePlanSyncer,
         failed_voters: Vec<metapb::Peer>,
     ) {
-        if let Some(state) = &self.fsm.peer.unsafe_recovery_state
-            && !state.is_abort()
-        {
-            warn!(
-                "Unsafe recovery, demote failed voters has already been initiated";
-                "region_id" => self.region().get_id(),
-                "peer_id" => self.fsm.peer.peer.get_id(),
-                "state" => ?state,
-            );
-            syncer.abort();
-            return;
+        if let Some(state) = &self.fsm.peer.unsafe_recovery_state {
+            if !state.is_abort() {
+                warn!(
+                    "Unsafe recovery, demote failed voters has already been initiated";
+                    "region_id" => self.region().get_id(),
+                    "peer_id" => self.fsm.peer.peer.get_id(),
+                    "state" => ?state,
+                );
+                syncer.abort();
+                return;
+            }
         }
 
         if !self.fsm.peer.is_in_force_leader() {
@@ -948,17 +949,17 @@ where
     }
 
     fn on_unsafe_recovery_destroy(&mut self, syncer: UnsafeRecoveryExecutePlanSyncer) {
-        if let Some(state) = &self.fsm.peer.unsafe_recovery_state
-            && !state.is_abort()
-        {
-            warn!(
-                "Unsafe recovery, can't destroy, another plan is executing in progress";
-                "region_id" => self.region_id(),
-                "peer_id" => self.fsm.peer_id(),
-                "state" => ?state,
-            );
-            syncer.abort();
-            return;
+        if let Some(state) = &self.fsm.peer.unsafe_recovery_state {
+            if !state.is_abort() {
+                warn!(
+                    "Unsafe recovery, can't destroy, another plan is executing in progress";
+                    "region_id" => self.region_id(),
+                    "peer_id" => self.fsm.peer_id(),
+                    "state" => ?state,
+                );
+                syncer.abort();
+                return;
+            }
         }
         self.fsm.peer.unsafe_recovery_state = Some(UnsafeRecoveryState::Destroy(syncer));
         self.handle_destroy_peer(DestroyPeerJob {
@@ -969,17 +970,17 @@ where
     }
 
     fn on_unsafe_recovery_wait_apply(&mut self, syncer: UnsafeRecoveryWaitApplySyncer) {
-        if let Some(state) = &self.fsm.peer.unsafe_recovery_state
-            && !state.is_abort()
-        {
-            warn!(
-                "Unsafe recovery, can't wait apply, another plan is executing in progress";
-                "region_id" => self.region_id(),
-                "peer_id" => self.fsm.peer_id(),
-                "state" => ?state,
-            );
-            syncer.abort();
-            return;
+        if let Some(state) = &self.fsm.peer.unsafe_recovery_state {
+            if !state.is_abort() {
+                warn!(
+                    "Unsafe recovery, can't wait apply, another plan is executing in progress";
+                    "region_id" => self.region_id(),
+                    "peer_id" => self.fsm.peer_id(),
+                    "state" => ?state,
+                );
+                syncer.abort();
+                return;
+            }
         }
         let target_index = if self.fsm.peer.force_leader.is_some() {
             // For regions that lose quorum (or regions have force leader), whatever has
@@ -1896,17 +1897,17 @@ where
         if self.fsm.peer.force_leader.is_none() {
             return;
         }
-        if let Some(UnsafeRecoveryState::Failed) = self.fsm.peer.unsafe_recovery_state
-            && !force
-        {
-            // Skip force leader if the plan failed, so wait for the next retry of plan with
-            // force leader state holding
-            info!(
-                "skip exiting force leader state";
-                "region_id" => self.fsm.region_id(),
-                "peer_id" => self.fsm.peer_id(),
-            );
-            return;
+        if !force {
+            if let Some(UnsafeRecoveryState::Failed) = self.fsm.peer.unsafe_recovery_state {
+                // Skip force leader if the plan failed, so wait for the next retry of plan with
+                // force leader state holding
+                info!(
+                    "skip exiting force leader state";
+                    "region_id" => self.fsm.region_id(),
+                    "peer_id" => self.fsm.peer_id(),
+                );
+                return;
+            }
         }
 
         info!(

--- a/components/raftstore/src/store/local_metrics.rs
+++ b/components/raftstore/src/store/local_metrics.rs
@@ -89,7 +89,11 @@ impl LocalHealthStatistics {
     #[inline]
     fn avg(&self) -> Duration {
         if self.count > 0 {
-            Duration::from_micros(self.duration_sum.as_micros() as u64 / self.count)
+            Duration::from_micros(
+                (self.duration_sum.as_micros() as u64)
+                    .checked_div(self.count)
+                    .unwrap_or(0),
+            )
         } else {
             Duration::default()
         }

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -6796,6 +6796,7 @@ mod tests {
                 }
             }
         }
+        #[allow(unused_assignments)]
         fn must_call() -> ExtCallback {
             let mut d = DropPanic(true);
             Box::new(move || {

--- a/components/raftstore/src/store/simple_write.rs
+++ b/components/raftstore/src/store/simple_write.rs
@@ -1,7 +1,5 @@
 // Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::assert_matches::debug_assert_matches;
-
 use engine_traits::{CF_DEFAULT, CF_LOCK, CF_WRITE};
 use kvproto::{
     import_sstpb::SstMeta,
@@ -170,30 +168,30 @@ impl SimpleWriteEncoder {
 
     #[inline]
     pub fn put(&mut self, cf: &str, key: &[u8], value: &[u8]) {
-        debug_assert_matches!(
+        debug_assert!(matches!(
             self.write_type,
             WriteType::Unspecified | WriteType::PutDelete
-        );
+        ));
         encode(SimpleWrite::Put(Put { cf, key, value }), &mut self.buf);
         self.write_type = WriteType::PutDelete;
     }
 
     #[inline]
     pub fn delete(&mut self, cf: &str, key: &[u8]) {
-        debug_assert_matches!(
+        debug_assert!(matches!(
             self.write_type,
             WriteType::Unspecified | WriteType::PutDelete
-        );
+        ));
         encode(SimpleWrite::Delete(Delete { cf, key }), &mut self.buf);
         self.write_type = WriteType::PutDelete;
     }
 
     #[inline]
     pub fn delete_range(&mut self, cf: &str, start_key: &[u8], end_key: &[u8], notify_only: bool) {
-        debug_assert_matches!(
+        debug_assert!(matches!(
             self.write_type,
             WriteType::Unspecified | WriteType::DeleteRange
-        );
+        ));
         encode(
             SimpleWrite::DeleteRange(DeleteRange {
                 cf,
@@ -208,7 +206,10 @@ impl SimpleWriteEncoder {
 
     #[inline]
     pub fn ingest(&mut self, sst: Vec<SstMeta>) {
-        debug_assert_matches!(self.write_type, WriteType::Unspecified | WriteType::Ingest);
+        debug_assert!(matches!(
+            self.write_type,
+            WriteType::Unspecified | WriteType::Ingest
+        ));
         encode(SimpleWrite::Ingest(sst), &mut self.buf);
         self.write_type = WriteType::Ingest;
     }
@@ -527,7 +528,6 @@ fn decode<'a>(buf: &mut &'a [u8]) -> Option<SimpleWrite<'a>> {
 
 #[cfg(test)]
 mod tests {
-    use std::assert_matches::assert_matches;
 
     use kvproto::raft_cmdpb::{CmdType, Request};
     use slog::o;
@@ -585,7 +585,7 @@ mod tests {
         };
         assert_eq!(delete.cf, CF_WRITE);
         assert_eq!(delete.key, &delete_key);
-        assert_matches!(decoder.next(), None);
+        assert!(decoder.next().is_none());
 
         let (bytes, _) = req_encoder2.encode();
         decoder =
@@ -631,7 +631,7 @@ mod tests {
             panic!("should be ingest")
         };
         assert_eq!(exp, ssts);
-        assert_matches!(decoder.next(), None);
+        assert!(decoder.next().is_none());
     }
 
     #[test]

--- a/components/raftstore/src/store/snap.rs
+++ b/components/raftstore/src/store/snap.rs
@@ -1386,10 +1386,8 @@ impl Write for Snapshot {
             written_bytes += write_len;
 
             let file = &mut file_for_recving.file;
-            let encrypt_buffer = if file_for_recving.encrypter.is_none() {
-                Cow::Borrowed(&next_buf[0..write_len])
-            } else {
-                let (cipher, crypter) = file_for_recving.encrypter.as_mut().unwrap();
+            let encrypt_buffer = if let Some(encrypter) = &mut file_for_recving.encrypter {
+                let (cipher, crypter) = encrypter;
                 let mut encrypt_buffer = vec![0; write_len + cipher.block_size()];
                 let mut bytes = crypter.update(&next_buf[0..write_len], &mut encrypt_buffer)?;
                 if switch {
@@ -1397,6 +1395,8 @@ impl Write for Snapshot {
                 }
                 encrypt_buffer.truncate(bytes);
                 Cow::Owned(encrypt_buffer)
+            } else {
+                Cow::Borrowed(&next_buf[0..write_len])
             };
             let encrypt_len = encrypt_buffer.len();
 
@@ -3013,8 +3013,7 @@ pub mod tests {
         let mut res = Vec::new();
         let read_dir = file_system::read_dir(dir_path).unwrap();
         for p in read_dir {
-            if p.is_ok() {
-                let e = p.as_ref().unwrap();
+            if let Ok(e) = &p {
                 if e.file_name()
                     .into_string()
                     .unwrap()
@@ -3059,8 +3058,7 @@ pub mod tests {
         let dir_path = dir.into();
         let read_dir = file_system::read_dir(dir_path).unwrap();
         for p in read_dir {
-            if p.is_ok() {
-                let e = p.as_ref().unwrap();
+            if let Ok(e) = &p {
                 if e.file_name()
                     .into_string()
                     .unwrap()

--- a/components/raftstore/src/store/util.rs
+++ b/components/raftstore/src/store/util.rs
@@ -361,10 +361,10 @@ pub fn check_flashback_state(
     skip_not_prepared: bool,
 ) -> Result<()> {
     // The admin flashback cmd could be proposed/applied under any state.
-    if let Some(ty) = admin_type
-        && (ty == AdminCmdType::PrepareFlashback || ty == AdminCmdType::FinishFlashback)
-    {
-        return Ok(());
+    if let Some(ty) = admin_type {
+        if ty == AdminCmdType::PrepareFlashback || ty == AdminCmdType::FinishFlashback {
+            return Ok(());
+        }
     }
     // TODO: only use `flashback_start_ts` to check flashback state.
     let is_in_flashback = is_in_flashback || flashback_start_ts > 0;
@@ -1298,8 +1298,8 @@ impl RegionReadProgressRegistry {
         self.registry
             .lock()
             .unwrap()
-            .iter()
-            .map(|(_, rrp)| rrp.resolved_ts())
+            .values()
+            .map(| rrp| rrp.resolved_ts())
             //TODO: the uninitialized peer should be taken into consideration instead of skipping it(https://github.com/tikv/tikv/issues/15506).
             .filter(|ts| *ts != 0) // ts == 0 means the peer is uninitialized,
             .min()
@@ -1399,10 +1399,10 @@ impl RegionReadProgress {
     }
 
     pub fn notify_advance_resolved_ts(&self) {
-        if let Ok(core) = self.core.try_lock()
-            && let Some(advance_notify) = &core.advance_notify
-        {
-            advance_notify.notify_waiters();
+        if let Ok(core) = self.core.try_lock() {
+            if let Some(advance_notify) = &core.advance_notify {
+                advance_notify.notify_waiters();
+            }
         }
     }
 

--- a/components/raftstore/src/store/worker/check_leader.rs
+++ b/components/raftstore/src/store/worker/check_leader.rs
@@ -74,8 +74,8 @@ where
             // Fast path to get the min `safe_ts` of all regions in this store
             self.region_read_progress.with(|registry| {
                 registry
-                .iter()
-                .map(|(_, rrp)| rrp.safe_ts())
+                .values()
+                .map(|rrp| rrp.safe_ts())
                 .filter(|ts| *ts != 0) // ts == 0 means the peer is uninitialized
                 .min()
                 .unwrap_or(0)

--- a/components/raftstore/src/store/worker/consistency_check.rs
+++ b/components/raftstore/src/store/worker/consistency_check.rs
@@ -114,7 +114,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::{assert_matches::assert_matches, sync::mpsc, time::Duration};
+    use std::{sync::mpsc, time::Duration};
 
     use byteorder::{BigEndian, WriteBytesExt};
     use engine_test::kv::{KvTestEngine, new_engine};
@@ -168,8 +168,10 @@ mod tests {
         checksum_bytes.write_u32::<BigEndian>(sum).unwrap();
 
         let res = rx.recv_timeout(Duration::from_secs(3)).unwrap();
-        assert_matches!(res, SchedTask::UpdateComputeHashResult { region_id, index, hash, context} if
-            region_id == region.get_id() && index == 10 && context == vec![0] && hash == checksum_bytes
+        assert!(
+            matches!(res, SchedTask::UpdateComputeHashResult { region_id, index, hash, context} if
+                region_id == region.get_id() && index == 10 && context == vec![0] && hash == checksum_bytes
+            )
         );
     }
 }

--- a/components/raftstore/src/store/worker/pd.rs
+++ b/components/raftstore/src/store/worker/pd.rs
@@ -757,7 +757,7 @@ where
         let props = tikv_util::thread_group::current_properties();
 
         fn is_enable_tick(timer_cnt: u64, interval: u64) -> bool {
-            interval != 0 && timer_cnt % interval == 0
+            interval != 0 && timer_cnt.is_multiple_of(interval)
         }
         let h = Builder::new()
             .name(thd_name!("stats-monitor"))
@@ -2626,7 +2626,9 @@ where
                         // Try to split the region on half within the given key
                         // range if there is no `split_key` been given.
                         } else if split_info.start_key.is_some() && split_info.end_key.is_some() {
+                            #[allow(clippy::unnecessary_unwrap)]
                             let start_key = split_info.start_key.unwrap();
+                            #[allow(clippy::unnecessary_unwrap)]
                             let end_key = split_info.end_key.unwrap();
                             let region_id = region.get_id();
                             let msg = Box::new(CasualMessage::HalfSplitRegion {

--- a/components/raftstore/src/store/worker/read.rs
+++ b/components/raftstore/src/store/worker/read.rs
@@ -246,9 +246,9 @@ where
         // before and the `cached_read_id` of it is None because only a consecutive
         // requests will have the same cache and the cache will be cleared after the
         // last request of the batch.
-        if self.read_id.is_some() {
+        if let Some(read_id) = &self.read_id {
             if self.snap_cache.cached_read_id == self.read_id
-                && self.read_id.as_ref().unwrap().create_time >= delegate_last_valid_ts
+                && read_id.create_time >= delegate_last_valid_ts
             {
                 // Cache hit
                 return false;

--- a/components/raftstore/src/store/worker/split_check.rs
+++ b/components/raftstore/src/store/worker/split_check.rs
@@ -253,17 +253,22 @@ impl BucketStatsInfo {
         // The bucket ranges is none when the region buckets is also none.
         // So this condition indicates that the region buckets needs to refresh not
         // renew.
-        if let Some(bucket_ranges) = bucket_ranges
-            && self.bucket_stat.is_some()
-        {
-            assert_eq!(buckets.len(), bucket_ranges.len());
-            change_bucket_version = self.update_buckets(
-                cfg,
-                next_bucket_version,
-                buckets,
-                region_epoch,
-                &bucket_ranges,
-            );
+        if let Some(bucket_ranges) = bucket_ranges {
+            if self.bucket_stat.is_some() {
+                assert_eq!(buckets.len(), bucket_ranges.len());
+                change_bucket_version = self.update_buckets(
+                    cfg,
+                    next_bucket_version,
+                    buckets,
+                    region_epoch,
+                    &bucket_ranges,
+                );
+            } else {
+                change_bucket_version = true;
+                // when the region buckets is none, the exclusive buckets includes all the
+                // bucket keys.
+                self.init_buckets(cfg, next_bucket_version, buckets, region_epoch, region);
+            }
         } else {
             change_bucket_version = true;
             // when the region buckets is none, the exclusive buckets includes all the

--- a/components/raftstore/src/store/worker/split_controller.rs
+++ b/components/raftstore/src/store/worker/split_controller.rs
@@ -464,27 +464,27 @@ impl ReadStats {
         region_info.cop_detail.add(write_cf_cop_detail);
         // the bucket of the follower only have the version info and not needs to be
         // recorded the hot bucket.
-        if let Some(buckets) = buckets
-            && !buckets.sizes.is_empty()
-        {
-            let bucket_stat = self
-                .region_buckets
-                .entry(region_id)
-                .and_modify(|current| {
-                    if current.meta < *buckets {
-                        let mut new = BucketStat::from_meta(buckets.clone());
-                        std::mem::swap(current, &mut new);
-                        current.merge(&new);
-                    }
-                })
-                .or_insert_with(|| BucketStat::from_meta(buckets.clone()));
-            let mut delta = metapb::BucketStats::default();
-            delta.set_read_bytes(vec![(write.read_bytes + data.read_bytes) as u64]);
-            delta.set_read_keys(vec![(write.read_keys + data.read_keys) as u64]);
-            bucket_stat.add_flows(
-                &[start.unwrap_or_default(), end.unwrap_or_default()],
-                &delta,
-            );
+        if let Some(buckets) = buckets {
+            if !buckets.sizes.is_empty() {
+                let bucket_stat = self
+                    .region_buckets
+                    .entry(region_id)
+                    .and_modify(|current| {
+                        if current.meta < *buckets {
+                            let mut new = BucketStat::from_meta(buckets.clone());
+                            std::mem::swap(current, &mut new);
+                            current.merge(&new);
+                        }
+                    })
+                    .or_insert_with(|| BucketStat::from_meta(buckets.clone()));
+                let mut delta = metapb::BucketStats::default();
+                delta.set_read_bytes(vec![(write.read_bytes + data.read_bytes) as u64]);
+                delta.set_read_keys(vec![(write.read_keys + data.read_keys) as u64]);
+                bucket_stat.add_flows(
+                    &[start.unwrap_or_default(), end.unwrap_or_default()],
+                    &delta,
+                );
+            }
         }
     }
 
@@ -922,23 +922,18 @@ impl AutoSplitController {
                 });
                 let region_id = top_cpu_usage[0];
                 let recorder = self.recorders.get_mut(&region_id).unwrap();
-                if recorder.hottest_key_range.is_some() {
+                if let Some(hottest_key_range) = recorder.hottest_key_range.as_ref() {
                     split_infos.push(SplitInfo::with_start_end_key(
                         region_id,
                         recorder.peer.clone(),
-                        recorder
-                            .hottest_key_range
-                            .as_ref()
-                            .unwrap()
-                            .start_key
-                            .clone(),
-                        recorder.hottest_key_range.as_ref().unwrap().end_key.clone(),
+                        hottest_key_range.start_key.clone(),
+                        hottest_key_range.end_key.clone(),
                     ));
                     LOAD_BASE_SPLIT_EVENT.ready_to_split_cpu_top.inc();
                     info!("load base split region";
                         "region_id" => region_id,
-                        "start_key" => log_wrappers::Value::key(&recorder.hottest_key_range.as_ref().unwrap().start_key),
-                        "end_key" => log_wrappers::Value::key(&recorder.hottest_key_range.as_ref().unwrap().end_key),
+                        "start_key" => log_wrappers::Value::key(&hottest_key_range.start_key),
+                        "end_key" => log_wrappers::Value::key(&hottest_key_range.end_key),
                         "cpu_usage" => recorder.cpu_usage,
                     );
                 } else {

--- a/components/resolved_ts/src/lib.rs
+++ b/components/resolved_ts/src/lib.rs
@@ -13,8 +13,6 @@
 //!   its term.
 
 #![feature(box_patterns)]
-#![feature(result_flattening)]
-#![feature(let_chains)]
 
 #[macro_use]
 extern crate tikv_util;

--- a/components/resource_control/Cargo.toml
+++ b/components/resource_control/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "resource_control"
 version = "0.0.1"
-edition = "2021"
+edition = "2024"
 publish = false
 license = "Apache-2.0"
 

--- a/components/resource_control/src/lib.rs
+++ b/components/resource_control/src/lib.rs
@@ -1,6 +1,5 @@
 // Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
 #![feature(test)]
-#![feature(let_chains)]
 
 use std::sync::{Arc, atomic::AtomicU32};
 

--- a/components/resource_control/src/service.rs
+++ b/components/resource_control/src/service.rs
@@ -263,10 +263,10 @@ impl ResourceManagerService {
 
             all_reqs.push(bucket_req);
 
-            if !all_reqs.is_empty() {
-                if let Err(e) = self.pd_client.report_ru_metrics(req).await {
-                    error!("report ru metrics failed"; "err" => ?e);
-                }
+            if !all_reqs.is_empty()
+                && let Err(e) = self.pd_client.report_ru_metrics(req).await
+            {
+                error!("report ru metrics failed"; "err" => ?e);
             }
 
             let dur = if cfg!(feature = "failpoints") {

--- a/components/resource_metering/src/lib.rs
+++ b/components/resource_metering/src/lib.rs
@@ -2,7 +2,6 @@
 
 // TODO(mornyx): crate doc.
 
-#![feature(hash_extract_if)]
 #![allow(internal_features)]
 #![feature(core_intrinsics)]
 

--- a/components/server/Cargo.toml
+++ b/components/server/Cargo.toml
@@ -2,7 +2,7 @@
 name = "server"
 version = "0.0.1"
 license = "Apache-2.0"
-edition = "2021"
+edition = "2024"
 publish = false
 
 [features]

--- a/components/server/src/common.rs
+++ b/components/server/src/common.rs
@@ -375,10 +375,7 @@ impl TikvServerCore {
                     } else {
                         cputime_limit / 1000_f64
                     };
-                    let cpu_usage = match proc_stats.cpu_usage() {
-                        Ok(r) => r,
-                        Err(_e) => 0.0,
-                    };
+                    let cpu_usage = proc_stats.cpu_usage().unwrap_or(0.0);
                     // Try tuning quota when cpu_usage is correctly collected.
                     // rule based tuning:
                     // - if instance is busy, shrink cpu quota for analyze by one quota pace until
@@ -578,7 +575,9 @@ impl EnginesResourceInfo {
             if evict_threshold > 0 {
                 normalized_pending_bytes = cmp::max(
                     normalized_pending_bytes,
-                    (*pending * EnginesResourceInfo::SCALE_FACTOR / evict_threshold) as u32,
+                    (*pending * EnginesResourceInfo::SCALE_FACTOR)
+                        .checked_div(evict_threshold)
+                        .unwrap_or(0) as u32,
                 );
                 let base = self.base_max_compactions[i];
                 if base > 0 {
@@ -1054,9 +1053,7 @@ impl DiskUsageChecker {
                     }
                 };
                 let raft_disk_available = cmp::min(
-                    raft_disk_cap
-                        .checked_sub(raft_used_size)
-                        .unwrap_or_default(),
+                    raft_disk_cap.saturating_sub(raft_used_size),
                     raft_disk_avail,
                 );
                 if raft_disk_available <= raft_already_full_thd {
@@ -1091,10 +1088,7 @@ impl DiskUsageChecker {
         } else {
             self.config_disk_capacity
         };
-        let available = cmp::min(
-            capacity.checked_sub(kvdb_used_size).unwrap_or_default(),
-            disk_avail,
-        );
+        let available = cmp::min(capacity.saturating_sub(kvdb_used_size), disk_avail);
         let cur_kv_disk_status = if available <= kvdb_already_full_thd {
             disk::DiskUsage::AlreadyFull
         } else if available <= self.kvdb_almost_full_thd {

--- a/components/server/src/lib.rs
+++ b/components/server/src/lib.rs
@@ -2,7 +2,6 @@
 
 #![allow(incomplete_features)]
 #![feature(specialization)]
-#![feature(let_chains)]
 
 #[macro_use]
 extern crate tikv_util;

--- a/components/server/src/signal_handler.rs
+++ b/components/server/src/signal_handler.rs
@@ -42,27 +42,27 @@ mod imp {
                 SIGTERM => {
                     if enable_graceful_shutdown {
                         info!("receive signal {}, starting graceful shutdown...", signal);
-                        if let Some(tx) = service_event_tx {
-                            if let Err(e) = tx.send(ServiceEvent::GracefulShutdown) {
-                                warn!("failed to notify graceful shutdown, {:?}", e);
-                            }
+                        if let Some(tx) = service_event_tx
+                            && let Err(e) = tx.send(ServiceEvent::GracefulShutdown)
+                        {
+                            warn!("failed to notify graceful shutdown, {:?}", e);
                         }
                     } else {
                         info!("receive signal {}, stopping server...", signal);
-                        if let Some(tx) = service_event_tx {
-                            if let Err(e) = tx.send(ServiceEvent::Exit) {
-                                warn!("failed to notify grpc server exit, {:?}", e);
-                            }
+                        if let Some(tx) = service_event_tx
+                            && let Err(e) = tx.send(ServiceEvent::Exit)
+                        {
+                            warn!("failed to notify grpc server exit, {:?}", e);
                         }
                     }
                     break;
                 }
                 SIGINT | SIGHUP => {
                     info!("receive signal {}, stopping server...", signal);
-                    if let Some(tx) = service_event_tx {
-                        if let Err(e) = tx.send(ServiceEvent::Exit) {
-                            warn!("failed to notify grpc server exit, {:?}", e);
-                        }
+                    if let Some(tx) = service_event_tx
+                        && let Err(e) = tx.send(ServiceEvent::Exit)
+                    {
+                        warn!("failed to notify grpc server exit, {:?}", e);
                     }
                     break;
                 }

--- a/components/test_raftstore-v2/src/lib.rs
+++ b/components/test_raftstore-v2/src/lib.rs
@@ -1,7 +1,6 @@
 // Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
 #![allow(incomplete_features)]
 #![feature(type_alias_impl_trait)]
-#![feature(let_chains)]
 
 mod cluster;
 mod node;

--- a/components/test_raftstore/src/cluster.rs
+++ b/components/test_raftstore/src/cluster.rs
@@ -1362,9 +1362,10 @@ impl<T: Simulator> Cluster<T> {
                     &keys::region_state_key(region_id),
                 )
                 .unwrap()
-                && state.get_state() == peer_state
             {
-                return;
+                if state.get_state() == peer_state {
+                    return;
+                }
             }
             sleep_ms(10);
         }

--- a/components/test_raftstore/src/lib.rs
+++ b/components/test_raftstore/src/lib.rs
@@ -1,6 +1,5 @@
 // Copyright 2018 TiKV Project Authors. Licensed under Apache-2.0.
 
-#![feature(let_chains)]
 #![feature(trait_alias)]
 
 #[macro_use]

--- a/components/test_raftstore/src/util.rs
+++ b/components/test_raftstore/src/util.rs
@@ -437,6 +437,8 @@ pub fn make_cb_rocks(
     make_cb(cmd)
 }
 
+#[allow(unused_assignments)]
+#[allow(unused_variables)]
 pub fn make_cb(
     cmd: &RaftCmdRequest,
 ) -> (Callback<RocksSnapshot>, future::Receiver<RaftCmdResponse>) {
@@ -459,7 +461,7 @@ pub fn make_cb(
     (cb, rx)
 }
 
-pub fn make_cb_ext<EK: KvEngine>(
+pub fn make_cb_ext(
     cmd: &RaftCmdRequest,
     proposed: Option<ExtCallback>,
     committed: Option<ExtCallback>,

--- a/components/tikv_alloc/src/jemalloc.rs
+++ b/components/tikv_alloc/src/jemalloc.rs
@@ -52,8 +52,11 @@ impl<T: Copy> PeekableRemoteStat<T> {
     /// The pointer should not be dangling. (i.e. the thread to be traced should
     /// be accessible.)
     unsafe fn peek(&self) -> Option<T> {
-        self.0
-            .map(|nlp| unsafe { core::intrinsics::atomic_load_seqcst(nlp.as_ptr()) })
+        self.0.map(|nlp| unsafe {
+            core::intrinsics::atomic_load::<T, { core::intrinsics::AtomicOrdering::SeqCst }>(
+                nlp.as_ptr(),
+            )
+        })
     }
 
     fn from_raw(ptr: *mut T) -> Self {

--- a/components/tikv_util/Cargo.toml
+++ b/components/tikv_util/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tikv_util"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 publish = false
 license = "Apache-2.0"
 

--- a/components/tikv_util/src/buffer_vec.rs
+++ b/components/tikv_util/src/buffer_vec.rs
@@ -341,12 +341,12 @@ impl<'a> Extend<&'a u8> for WithConcatExtend<'_> {
 
 impl BufferWriter for WithConcatExtend<'_> {
     unsafe fn bytes_mut(&mut self, size: usize) -> &mut [u8] {
-        self.0.data.bytes_mut(size)
+        unsafe { self.0.data.bytes_mut(size) }
     }
 
     #[inline]
     unsafe fn advance_mut(&mut self, count: usize) {
-        self.0.data.advance_mut(count)
+        unsafe { self.0.data.advance_mut(count) }
     }
 
     #[inline]

--- a/components/tikv_util/src/callback.rs
+++ b/components/tikv_util/src/callback.rs
@@ -44,10 +44,9 @@ where
 {
     fn drop(&mut self) {
         if let (Some(callback), Some(arg_on_drop)) = (self.callback.take(), self.arg_on_drop.take())
+            && !crate::thread_group::is_shutdown(!cfg!(test))
         {
-            if !crate::thread_group::is_shutdown(!cfg!(test)) {
-                callback(arg_on_drop());
-            }
+            callback(arg_on_drop());
         }
     }
 }

--- a/components/tikv_util/src/codec/stream_event.rs
+++ b/components/tikv_util/src/codec/stream_event.rs
@@ -228,7 +228,7 @@ mod tests {
         let count = 20;
 
         for _i in 0..count {
-            let should_rewrite = rng.gen::<bool>();
+            let should_rewrite = rng.gen_bool(0.5);
             let mut key: Vec<u8> = std::iter::once(if should_rewrite { b'k' } else { b'l' })
                 .chain((0..100).map(|_| rng.gen_range(0..255)))
                 .collect();

--- a/components/tikv_util/src/config.rs
+++ b/components/tikv_util/src/config.rs
@@ -150,15 +150,15 @@ impl fmt::Display for ReadableSize {
         let size = self.0;
         if size == 0 {
             write!(f, "{}KiB", size)
-        } else if size % PIB == 0 {
+        } else if size.is_multiple_of(PIB) {
             write!(f, "{}PiB", size / PIB)
-        } else if size % TIB == 0 {
+        } else if size.is_multiple_of(TIB) {
             write!(f, "{}TiB", size / TIB)
-        } else if size % GIB == 0 {
+        } else if size.is_multiple_of(GIB) {
             write!(f, "{}GiB", size / GIB)
-        } else if size % MIB == 0 {
+        } else if size.is_multiple_of(MIB) {
             write!(f, "{}MiB", size / MIB)
-        } else if size % KIB == 0 {
+        } else if size.is_multiple_of(KIB) {
             write!(f, "{}KiB", size / KIB)
         } else {
             write!(f, "{}B", size)

--- a/components/tikv_util/src/lib.rs
+++ b/components/tikv_util/src/lib.rs
@@ -3,8 +3,6 @@
 #![cfg_attr(test, feature(test))]
 #![feature(thread_id_value)]
 #![feature(box_patterns)]
-#![feature(vec_into_raw_parts)]
-#![feature(let_chains)]
 #![feature(iterator_try_collect)]
 
 #[cfg(test)]
@@ -524,7 +522,9 @@ pub fn set_panic_hook(panic_abort: bool, data_dir: &str) {
 /// Checks environment variables that affect TiKV.
 pub fn check_environment_variables() {
     if cfg!(unix) && env::var("TZ").is_err() {
-        env::set_var("TZ", ":/etc/localtime");
+        unsafe {
+            env::set_var("TZ", ":/etc/localtime");
+        }
         warn!("environment variable `TZ` is missing, using `/etc/localtime`");
     }
 

--- a/components/tikv_util/src/logger/file_log.rs
+++ b/components/tikv_util/src/logger/file_log.rs
@@ -255,10 +255,10 @@ impl Runner {
         let mut logs = Vec::new();
         for f in fs::read_dir(&self.log_dir)? {
             let f = f?;
-            if f.file_type()?.is_file() {
-                if let Some(dt) = dt_from_file_name(f.path().as_path(), &self.file_name) {
-                    logs.push(LogInfo { f, dt });
-                }
+            if f.file_type()?.is_file()
+                && let Some(dt) = dt_from_file_name(f.path().as_path(), &self.file_name)
+            {
+                logs.push(LogInfo { f, dt });
             }
         }
         logs.sort_by(|l1, l2| l2.dt.cmp(&l1.dt));

--- a/components/tikv_util/src/logger/mod.rs
+++ b/components/tikv_util/src/logger/mod.rs
@@ -475,11 +475,11 @@ where
             let mut s = SlowCostSerializer { cost: None };
             let kv = record.kv();
             let _ = kv.serialize(record, &mut s);
-            if let Some(cost) = s.cost {
-                if cost <= self.threshold {
-                    // Filter slow logs which are actually not that slow
-                    return Ok(());
-                }
+            if let Some(cost) = s.cost
+                && cost <= self.threshold
+            {
+                // Filter slow logs which are actually not that slow
+                return Ok(());
             }
         }
         self.inner.log(record, values)
@@ -579,8 +579,10 @@ where
 
     fn log(&self, record: &Record<'_>, values: &OwnedKVList) -> Result<Self::Ok, Self::Err> {
         let tag = record.tag();
-        if self.slow.is_some() && tag.starts_with("slow_log") {
-            self.slow.as_ref().unwrap().log(record, values)
+        if let Some(slow) = self.slow.as_ref()
+            && tag.starts_with("slow_log")
+        {
+            slow.log(record, values)
         } else if tag.starts_with("rocksdb_log") {
             self.rocksdb.log(record, values)
         } else if tag.starts_with("raftdb_log") {
@@ -1090,13 +1092,13 @@ mod tests {
         .fuse();
         let logger = slog::Logger::root_typed(drain, slog_o!());
         slog_info!(logger, "Hello World");
-        slog_info!(logger, #"slow_log", "nothing");
-        slog_info!(logger, #"slow_log", "🆗"; "takes" => LogCost(30));
-        slog_info!(logger, #"slow_log", "🐢"; "takes" => LogCost(200));
-        slog_info!(logger, #"slow_log", "🐢🐢"; "takes" => LogCost(201));
-        slog_info!(logger, #"slow_log", "without cost"; "a" => "b");
-        slog_info!(logger, #"slow_log_by_timer", "⏰");
-        slog_info!(logger, #"slow_log_by_timer", "⏰"; "takes" => LogCost(1000));
+        slog_info!(logger, # "slow_log", "nothing");
+        slog_info!(logger, # "slow_log", "🆗"; "takes" => LogCost(30));
+        slog_info!(logger, # "slow_log", "🐢"; "takes" => LogCost(200));
+        slog_info!(logger, # "slow_log", "🐢🐢"; "takes" => LogCost(201));
+        slog_info!(logger, # "slow_log", "without cost"; "a" => "b");
+        slog_info!(logger, # "slow_log_by_timer", "⏰");
+        slog_info!(logger, # "slow_log_by_timer", "⏰"; "takes" => LogCost(1000));
         let re = Regex::new(r"(?P<datetime>\[.*?\])\s(?P<level>\[.*?\])\s(?P<source_file>\[.*?\])\s(?P<msg>\[.*?\])\s?(?P<kvs>\[.*\])?").unwrap();
         NORMAL_BUFFER.with(|buffer| {
             let buffer = buffer.borrow_mut();

--- a/components/tikv_util/src/lru.rs
+++ b/components/tikv_util/src/lru.rs
@@ -28,13 +28,15 @@ struct Trace<K> {
 
 #[inline]
 unsafe fn suture<K>(mut leading: NonNull<Record<K>>, mut following: NonNull<Record<K>>) {
-    leading.as_mut().next = following;
-    following.as_mut().prev = leading;
+    unsafe {
+        leading.as_mut().next = following;
+        following.as_mut().prev = leading;
+    }
 }
 
 #[inline]
 unsafe fn cut_out<K>(record: NonNull<Record<K>>) {
-    suture(record.as_ref().prev, record.as_ref().next)
+    unsafe { suture(record.as_ref().prev, record.as_ref().next) }
 }
 
 impl<K> Trace<K> {

--- a/components/tikv_util/src/macros.rs
+++ b/components/tikv_util/src/macros.rs
@@ -32,11 +32,11 @@ macro_rules! box_try {
 macro_rules! slow_log {
     (T $t:expr, $($arg:tt)*) => {{
         if $t.is_slow() {
-            warn!(#"slow_log_by_timer", $($arg)*; "takes" => $crate::logger::LogCost($crate::time::duration_to_ms($t.saturating_elapsed())));
+            warn!(# "slow_log_by_timer", $($arg)*; "takes" => $crate::logger::LogCost($crate::time::duration_to_ms($t.saturating_elapsed())));
         }
     }};
     ($n:expr, $($arg:tt)*) => {{
-        warn!(#"slow_log", $($arg)*; "takes" => $crate::logger::LogCost($crate::time::duration_to_ms($n)));
+        warn!(# "slow_log", $($arg)*; "takes" => $crate::logger::LogCost($crate::time::duration_to_ms($n)));
     }}
 
 }

--- a/components/tikv_util/src/memory.rs
+++ b/components/tikv_util/src/memory.rs
@@ -36,7 +36,7 @@ pub unsafe fn vec_transmute<F, T>(from: Vec<F>) -> Vec<T> {
     debug_assert!(mem::size_of::<F>() == mem::size_of::<T>());
     debug_assert!(mem::align_of::<F>() == mem::align_of::<T>());
     let (ptr, len, cap) = from.into_raw_parts();
-    Vec::from_raw_parts(ptr as _, len, cap)
+    unsafe { Vec::from_raw_parts(ptr as _, len, cap) }
 }
 
 /// Query the number of bytes of an object.

--- a/components/tikv_util/src/metrics/process_linux.rs
+++ b/components/tikv_util/src/metrics/process_linux.rs
@@ -62,11 +62,10 @@ impl ProcessCollector {
         .unwrap();
         descs.extend(start_time.desc().into_iter().cloned());
         // proc_start_time init once because it is immutable
-        if let Ok(boot_time) = procfs::boot_time_secs() {
-            if let Ok(p) = procfs::process::Process::myself() {
-                start_time
-                    .set(p.stat.starttime as i64 / thread::ticks_per_second() + boot_time as i64);
-            }
+        if let Ok(boot_time) = procfs::boot_time_secs()
+            && let Ok(p) = procfs::process::Process::myself()
+        {
+            start_time.set(p.stat.starttime as i64 / thread::ticks_per_second() + boot_time as i64);
         }
 
         Self {

--- a/components/tikv_util/src/metrics/threads_linux.rs
+++ b/components/tikv_util/src/metrics/threads_linux.rs
@@ -579,36 +579,36 @@ mod tests {
         let pid = thread::process_id();
         let tids: Vec<_> = thread::thread_ids(pid).unwrap();
         for tid in tids {
-            if let Ok(stat) = thread::full_thread_stat(pid, tid) {
-                if stat.command.starts_with(s1) {
-                    rx1.recv().unwrap();
-                    thread_info.record();
-                    {
-                        let write_io = thread_info
-                            .metrics_total
-                            .write_ios
-                            .entry(tid)
-                            .or_insert(0.0);
-                        assert_eq!(*write_io as u64, page_size);
-                    }
-
-                    tx.send(()).unwrap();
-
-                    rx1.recv().unwrap();
-                    thread_info.record();
-                    {
-                        let write_io = thread_info
-                            .metrics_total
-                            .write_ios
-                            .entry(tid)
-                            .or_insert(0.0);
-                        assert_eq!(*write_io as u64, page_size * 2);
-                    }
-
-                    tx.send(()).unwrap();
-                    rx1.recv().unwrap();
-                    return;
+            if let Ok(stat) = thread::full_thread_stat(pid, tid)
+                && stat.command.starts_with(s1)
+            {
+                rx1.recv().unwrap();
+                thread_info.record();
+                {
+                    let write_io = thread_info
+                        .metrics_total
+                        .write_ios
+                        .entry(tid)
+                        .or_insert(0.0);
+                    assert_eq!(*write_io as u64, page_size);
                 }
+
+                tx.send(()).unwrap();
+
+                rx1.recv().unwrap();
+                thread_info.record();
+                {
+                    let write_io = thread_info
+                        .metrics_total
+                        .write_ios
+                        .entry(tid)
+                        .or_insert(0.0);
+                    assert_eq!(*write_io as u64, page_size * 2);
+                }
+
+                tx.send(()).unwrap();
+                rx1.recv().unwrap();
+                return;
             }
         }
         panic!();
@@ -653,21 +653,21 @@ mod tests {
         let pid = thread::process_id();
         let tids: Vec<_> = thread::thread_ids(pid).unwrap();
         for tid in tids {
-            if let Ok(stat) = thread::full_thread_stat(pid, tid) {
-                if stat.command.starts_with(tn) {
-                    rx.recv().unwrap();
-                    thread_info.record();
+            if let Ok(stat) = thread::full_thread_stat(pid, tid)
+                && stat.command.starts_with(tn)
+            {
+                rx.recv().unwrap();
+                thread_info.record();
 
-                    let mut cpu_usages = thread_info.get_cpu_usages();
-                    let cpu_usage = cpu_usages.entry(stat.command).or_insert(0);
-                    assert!(*cpu_usage < 110); // Consider the error of statistics
-                    if *cpu_usage < 50 {
-                        panic!("the load must be heavy than 0.5, but got {}", *cpu_usage);
-                    }
-
-                    tx.send(()).unwrap();
-                    return;
+                let mut cpu_usages = thread_info.get_cpu_usages();
+                let cpu_usage = cpu_usages.entry(stat.command).or_insert(0);
+                assert!(*cpu_usage < 110); // Consider the error of statistics
+                if *cpu_usage < 50 {
+                    panic!("the load must be heavy than 0.5, but got {}", *cpu_usage);
                 }
+
+                tx.send(()).unwrap();
+                return;
             }
         }
         panic!();

--- a/components/tikv_util/src/sys/cpu_time.rs
+++ b/components/tikv_util/src/sys/cpu_time.rs
@@ -127,6 +127,7 @@ mod imp {
 }
 
 #[cfg(target_os = "macos")]
+#[allow(deprecated)]
 mod imp {
     use std::{io, ptr};
 

--- a/components/tikv_util/src/sys/thread.rs
+++ b/components/tikv_util/src/sys/thread.rs
@@ -140,10 +140,10 @@ mod imp {
             let ret = libc::getpriority(libc::PRIO_PROCESS, tid as u32);
             if ret == -1 {
                 let e = Error::last_os_error();
-                if let Some(errno) = e.raw_os_error() {
-                    if errno != 0 {
-                        return Err(e);
-                    }
+                if let Some(errno) = e.raw_os_error()
+                    && errno != 0
+                {
+                    return Err(e);
                 }
             }
             Ok(ret)
@@ -152,7 +152,7 @@ mod imp {
 
     // Sadly the std lib does not have any support for setting `errno`, so we
     // have to implement this ourselves.
-    extern "C" {
+    unsafe extern "C" {
         #[link_name = "__errno_location"]
         fn errno_location() -> *mut c_int;
     }
@@ -192,6 +192,7 @@ mod imp {
 
 #[cfg(target_os = "macos")]
 #[allow(bad_style)]
+#[allow(deprecated)]
 mod imp {
     use std::{io, iter::FromIterator, mem::size_of, ptr::null_mut, slice};
 
@@ -203,7 +204,7 @@ mod imp {
     type thread_act_t = mach_port_t;
     type thread_act_array_t = *mut thread_act_t;
 
-    extern "C" {
+    unsafe extern "C" {
         fn task_threads(
             target_task: task_inspect_t,
             act_list: *mut thread_act_array_t,

--- a/components/tikv_util/src/worker/mod.rs
+++ b/components/tikv_util/src/worker/mod.rs
@@ -64,6 +64,7 @@ mod tests {
         }
     }
 
+    #[allow(dead_code)]
     struct TickRunner {
         ch: mpsc::Sender<&'static str>,
     }

--- a/components/tikv_util/src/yatp_pool/future_pool.rs
+++ b/components/tikv_util/src/yatp_pool/future_pool.rs
@@ -291,7 +291,7 @@ mod tests {
         time::Duration,
     };
 
-    use futures::executor::block_on;
+    use futures::{channel::oneshot, executor::block_on};
 
     use super::{
         super::{DefaultTicker, PoolTicker, TICK_INTERVAL, YatpPoolBuilder as Builder},
@@ -477,14 +477,16 @@ mod tests {
     }
 
     fn spawn_long_time_future(
-        pool: &FuturePool,
+        pool: FuturePool,
         id: u64,
         future_duration_ms: u64,
     ) -> Result<impl Future<Output = Result<u64, Canceled>>, Full> {
-        pool.spawn_handle(async move {
+        let (tx, rx) = oneshot::channel();
+        pool.spawn(async move {
             thread::sleep(Duration::from_millis(future_duration_ms));
-            id
-        })
+            let _ = tx.send(id);
+        })?;
+        Ok(rx)
     }
 
     fn wait_on_new_thread<F>(sender: mpsc::Sender<F::Output>, future: F)
@@ -510,44 +512,44 @@ mod tests {
 
         wait_on_new_thread(
             tx.clone(),
-            spawn_long_time_future(&read_pool, 0, 5).unwrap(),
+            spawn_long_time_future(read_pool.clone(), 0, 5).unwrap(),
         );
         // not full
         assert_eq!(rx.recv().unwrap(), Ok(0));
 
         wait_on_new_thread(
             tx.clone(),
-            spawn_long_time_future(&read_pool, 1, 100).unwrap(),
+            spawn_long_time_future(read_pool.clone(), 1, 100).unwrap(),
         );
         wait_on_new_thread(
             tx.clone(),
-            spawn_long_time_future(&read_pool, 2, 200).unwrap(),
+            spawn_long_time_future(read_pool.clone(), 2, 200).unwrap(),
         );
         wait_on_new_thread(
             tx.clone(),
-            spawn_long_time_future(&read_pool, 3, 300).unwrap(),
+            spawn_long_time_future(read_pool.clone(), 3, 300).unwrap(),
         );
         wait_on_new_thread(
             tx.clone(),
-            spawn_long_time_future(&read_pool, 4, 400).unwrap(),
+            spawn_long_time_future(read_pool.clone(), 4, 400).unwrap(),
         );
         // no available results (running = 4)
         rx.recv_timeout(Duration::from_millis(50)).unwrap_err();
 
         // full
-        assert!(spawn_long_time_future(&read_pool, 5, 100).is_err());
+        assert!(spawn_long_time_future(read_pool.clone(), 5, 100).is_err());
 
         // full
-        assert!(spawn_long_time_future(&read_pool, 6, 100).is_err());
+        assert!(spawn_long_time_future(read_pool.clone(), 6, 100).is_err());
 
         // wait a future completes (running = 3)
         assert_eq!(rx.recv().unwrap(), Ok(1));
 
         // add new (running = 4)
-        wait_on_new_thread(tx, spawn_long_time_future(&read_pool, 7, 5).unwrap());
+        wait_on_new_thread(tx, spawn_long_time_future(read_pool.clone(), 7, 5).unwrap());
 
         // full
-        assert!(spawn_long_time_future(&read_pool, 8, 100).is_err());
+        assert!(spawn_long_time_future(read_pool.clone(), 8, 100).is_err());
 
         rx.recv().unwrap().unwrap();
         rx.recv().unwrap().unwrap();

--- a/deny.toml
+++ b/deny.toml
@@ -37,7 +37,8 @@ deny = [
     # Ban trait crates from RustCrypto.
     { name = "aead" },
     { name = "cipher" },
-    { name = "digest", wrappers = ["sha2", "md-5", "sha1", "hmac"] },
+    # aws-smithy-checksums reaches digest through crc-fast in newer releases.
+    { name = "digest", wrappers = ["sha2", "md-5", "sha1", "hmac", "crc-fast"] },
     { name = "password-hash" },
     { name = "signature" },
 ]
@@ -48,17 +49,6 @@ version = 2
 yanked = "deny"
 unmaintained = 'workspace'
 ignore = [
-    # Ignore RUSTSEC-2023-0072 as we ban the unsound `X509StoreRef::objects`.
-    #
-    # NB: Upgrading rust-openssl the latest version do fix the issue but it
-    # also upgrade the OpenSSL to v3.x which causes performance degradation.
-    # See https://github.com/openssl/openssl/issues/17064
-    "RUSTSEC-2023-0072",
-    # Ignore RUSTSEC-2024-0357 as there is no `MemBio::get_buf` in TiKV, also
-    # we ban all openssl (Rust) APIs that call `MemBio::get_buf`.
-    #
-    # See https://github.com/sfackler/rust-openssl/pull/2266
-    "RUSTSEC-2024-0357",
     # Ignore RUSTSEC-2021-0145 (unsound issue of "atty" crate) as it only
     # affects Windows plaform which is not supported offically by TiKV, and 2)
     # we have disabled the clap feature "color" so that the "atty" crate is not
@@ -75,20 +65,6 @@ ignore = [
     #
     # TODO: Upgrade shlex@0.1.1 to v1.3.x.
     "RUSTSEC-2024-0006",
-    # Ignore RUSTSEC-2025-0004, as it will trigger a recursive upgrade of OpenSSL
-    # to version 3.x.
-    #
-    # NB: Upgrading openssl the version >= 0.10.70 do fix the issue but it
-    # also upgrade the OpenSSL to v3.x which causes performance degradation.
-    # See https://github.com/openssl/openssl/issues/17064
-    "RUSTSEC-2025-0004",
-    # Ignore RUSTSEC-2025-0022, as it will trigger a recursive upgrade of OpenSSL
-    # to version 3.x.
-    #
-    # NB: Upgrading openssl the version >= 0.10.72 do fix the issue but it
-    # also upgrade the OpenSSL to v3.x which causes performance degradation.
-    # See https://github.com/openssl/openssl/issues/17064
-    "RUSTSEC-2025-0022",
     # Ignore following warnings/errors temporarily. We are evaluating alternatives
     # to replace them. Currently, these packages are stable and there are no known
     # exploitable vulnerabilities affecting our use case.
@@ -97,16 +73,6 @@ ignore = [
     "RUSTSEC-2023-0081",
     "RUSTSEC-2024-0388",
     "RUSTSEC-2024-0436",
-    # aws-sdk-s3 transitively depends on lru 0.12.x, which triggers
-    # RUSTSEC-2026-0002 (Stacked Borrows UB). Upstream dependency
-    # constraints prevent upgrading at the moment.
-    "RUSTSEC-2026-0002",
-    # Ignore RUSTSEC-2026-0009 temporarily. This advisory comes from the
-    # transitive cloud SDK dependency chain pulling in time 0.3.47. The fixed
-    # time release requires serde 1.0.220 through serde_core, but the current
-    # raft-engine revision in this workspace still hard-pins serde = 1.0.228,
-    # so this cannot be resolved with a lockfile-only update.
-    "RUSTSEC-2026-0009",
     # Ignore RUSTSEC-2026-0186 temporarily. memmap2 is pulled in transitively by
     # raft-engine and symbolic-common, so release-8.5 cannot resolve it with a
     # local code change in this PR.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,4 @@
 [toolchain]
-#WARN: Before upgrading to a new toolchain, please ensure https://github.com/rust-lang/rust/issues/141306 is fixed.
-channel = "nightly-2025-02-28"
+channel = "nightly-2026-01-30"
 components = ["rustfmt", "clippy", "rust-src", "rust-analyzer"]
 profile = "minimal"

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1566,26 +1566,27 @@ impl DbConfig {
         force_partition_range_mgr: ForcePartitionRangeManager,
     ) -> CfResources {
         let mut compaction_thread_limiters = HashMap::new();
-        if let Some(n) = self.defaultcf.max_compactions
-            && n > 0
-        {
-            compaction_thread_limiters
-                .insert(CF_DEFAULT, ConcurrentTaskLimiter::new(CF_DEFAULT, n));
+        if let Some(n) = self.defaultcf.max_compactions {
+            if n > 0 {
+                compaction_thread_limiters
+                    .insert(CF_DEFAULT, ConcurrentTaskLimiter::new(CF_DEFAULT, n));
+            }
         }
-        if let Some(n) = self.writecf.max_compactions
-            && n > 0
-        {
-            compaction_thread_limiters.insert(CF_WRITE, ConcurrentTaskLimiter::new(CF_WRITE, n));
+        if let Some(n) = self.writecf.max_compactions {
+            if n > 0 {
+                compaction_thread_limiters
+                    .insert(CF_WRITE, ConcurrentTaskLimiter::new(CF_WRITE, n));
+            }
         }
-        if let Some(n) = self.lockcf.max_compactions
-            && n > 0
-        {
-            compaction_thread_limiters.insert(CF_LOCK, ConcurrentTaskLimiter::new(CF_LOCK, n));
+        if let Some(n) = self.lockcf.max_compactions {
+            if n > 0 {
+                compaction_thread_limiters.insert(CF_LOCK, ConcurrentTaskLimiter::new(CF_LOCK, n));
+            }
         }
-        if let Some(n) = self.raftcf.max_compactions
-            && n > 0
-        {
-            compaction_thread_limiters.insert(CF_RAFT, ConcurrentTaskLimiter::new(CF_RAFT, n));
+        if let Some(n) = self.raftcf.max_compactions {
+            if n > 0 {
+                compaction_thread_limiters.insert(CF_RAFT, ConcurrentTaskLimiter::new(CF_RAFT, n));
+            }
         }
         let mut write_buffer_managers = HashMap::default();
         self.lockcf.write_buffer_limit.map(|limit| {
@@ -1774,10 +1775,12 @@ impl Default for RaftDefaultCfConfig {
 
 impl RaftDefaultCfConfig {
     pub fn build_opt(&self, cache: &Cache) -> RocksCfOptions {
-        let limiter = if let Some(n) = self.max_compactions
-            && n > 0
-        {
-            Some(ConcurrentTaskLimiter::new(CF_DEFAULT, n))
+        let limiter = if let Some(n) = self.max_compactions {
+            if n > 0 {
+                Some(ConcurrentTaskLimiter::new(CF_DEFAULT, n))
+            } else {
+                None
+            }
         } else {
             None
         };
@@ -2553,6 +2556,7 @@ macro_rules! readpool_config {
         mod $test_mod_name {
             use super::*;
 
+            #[allow(unused_assignments)]
             #[test]
             fn test_validate() {
                 let cfg = $struct_name::default();
@@ -4325,18 +4329,19 @@ impl TikvConfig {
         // When shared block cache is enabled, if its capacity is set, it overrides
         // individual block cache sizes. Otherwise use the sum of block cache
         // size of all column families as the shared cache size.
-        if let Some(a) = self.rocksdb.defaultcf.block_cache_size
-            && let Some(b) = self.rocksdb.writecf.block_cache_size
-            && let Some(c) = self.rocksdb.lockcf.block_cache_size
-        {
-            let d = self
-                .raftdb
-                .defaultcf
-                .block_cache_size
-                .map(|s| s.0)
-                .unwrap_or_default();
-            let sum = a.0 + b.0 + c.0 + d;
-            self.storage.block_cache.capacity = Some(ReadableSize(sum));
+        if let Some(a) = self.rocksdb.defaultcf.block_cache_size {
+            if let Some(b) = self.rocksdb.writecf.block_cache_size {
+                if let Some(c) = self.rocksdb.lockcf.block_cache_size {
+                    let d = self
+                        .raftdb
+                        .defaultcf
+                        .block_cache_size
+                        .map(|s| s.0)
+                        .unwrap_or_default();
+                    let sum = a.0 + b.0 + c.0 + d;
+                    self.storage.block_cache.capacity = Some(ReadableSize(sum));
+                }
+            }
         }
         if self.backup.sst_max_size.0 < default_coprocessor.region_max_size().0 / 10 {
             warn!(
@@ -5962,7 +5967,7 @@ mod tests {
 
         // update some configs on default cf
         let cf_opts = db.get_options_cf(CF_DEFAULT).unwrap();
-        assert_eq!(cf_opts.get_disable_auto_compactions(), false);
+        assert!(!cf_opts.get_disable_auto_compactions());
         assert_eq!(cf_opts.get_target_file_size_base(), ReadableSize::mb(64).0);
 
         let mut change = HashMap::new();
@@ -5977,7 +5982,7 @@ mod tests {
         cfg_controller.update(change).unwrap();
 
         let cf_opts = db.get_options_cf(CF_DEFAULT).unwrap();
-        assert_eq!(cf_opts.get_disable_auto_compactions(), true);
+        assert!(cf_opts.get_disable_auto_compactions());
         assert_eq!(cf_opts.get_target_file_size_base(), ReadableSize::mb(32).0);
     }
 
@@ -5991,18 +5996,12 @@ mod tests {
         let db = storage.get_engine().get_rocksdb();
 
         // update rate_limiter_auto_tuned
-        assert_eq!(
-            db.get_db_options().get_rate_limiter_auto_tuned().unwrap(),
-            true
-        );
+        assert!(db.get_db_options().get_rate_limiter_auto_tuned().unwrap());
 
         cfg_controller
             .update_config("rocksdb.rate_limiter_auto_tuned", "false")
             .unwrap();
-        assert_eq!(
-            db.get_db_options().get_rate_limiter_auto_tuned().unwrap(),
-            false
-        );
+        assert!(!db.get_db_options().get_rate_limiter_auto_tuned().unwrap());
     }
 
     #[test]
@@ -6467,7 +6466,7 @@ mod tests {
         let should_delay = block_on(quota_limiter.consume_sample(sample, false));
         assert_eq!(should_delay, Duration::from_millis(50));
 
-        assert_eq!(cfg.quota.enable_auto_tune, false);
+        assert!(!cfg.quota.enable_auto_tune);
         cfg_controller
             .update_config("quota.enable-auto-tune", "true")
             .unwrap();
@@ -7701,33 +7700,30 @@ mod tests {
             50
         );
 
-        assert_eq!(
+        assert!(
             db.get_options_cf(CF_DEFAULT)
                 .unwrap()
-                .get_disable_write_stall(),
-            true
+                .get_disable_write_stall()
         );
-        assert_eq!(flow_controller.enabled(), true);
+        assert!(flow_controller.enabled());
         cfg_controller
             .update_config("storage.flow-control.enable", "false")
             .unwrap();
-        assert_eq!(
-            db.get_options_cf(CF_DEFAULT)
+        assert!(
+            !db.get_options_cf(CF_DEFAULT)
                 .unwrap()
-                .get_disable_write_stall(),
-            false
+                .get_disable_write_stall()
         );
-        assert_eq!(flow_controller.enabled(), false);
+        assert!(!flow_controller.enabled());
         cfg_controller
             .update_config("storage.flow-control.enable", "true")
             .unwrap();
-        assert_eq!(
+        assert!(
             db.get_options_cf(CF_DEFAULT)
                 .unwrap()
-                .get_disable_write_stall(),
-            true
+                .get_disable_write_stall()
         );
-        assert_eq!(flow_controller.enabled(), true);
+        assert!(flow_controller.enabled());
     }
 
     #[test]

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -547,16 +547,17 @@ impl<E: Engine> Endpoint<E> {
 
         // Check if the buckets version is latest.
         // skip if request don't carry this bucket version.
-        if let Some(ref buckets) = latest_buckets
-            && buckets.version > tracker.req_ctx.context.buckets_version
-            && tracker.req_ctx.context.buckets_version != 0
-        {
-            let mut bucket_not_match = errorpb::BucketVersionNotMatch::default();
-            bucket_not_match.set_version(buckets.version);
-            bucket_not_match.set_keys(buckets.keys.clone().into());
-            let mut err = errorpb::Error::default();
-            err.set_bucket_version_not_match(bucket_not_match);
-            return Err(Error::Region(err));
+        if let Some(ref buckets) = latest_buckets {
+            if buckets.version > tracker.req_ctx.context.buckets_version
+                && tracker.req_ctx.context.buckets_version != 0
+            {
+                let mut bucket_not_match = errorpb::BucketVersionNotMatch::default();
+                bucket_not_match.set_version(buckets.version);
+                bucket_not_match.set_keys(buckets.keys.clone().into());
+                let mut err = errorpb::Error::default();
+                err.set_bucket_version_not_match(bucket_not_match);
+                return Err(Error::Region(err));
+            }
         }
         // When snapshot is retrieved, deadline may exceed.
         tracker.on_snapshot_finished();
@@ -1312,7 +1313,6 @@ impl<E: Engine> RegionStorageAccessor for ExtraSnapStoreAccessor<E> {
 #[cfg(test)]
 mod tests {
     use std::{
-        assert_matches::assert_matches,
         sync::{Mutex, atomic, mpsc},
         thread, vec,
     };
@@ -2784,7 +2784,7 @@ mod tests {
             let result =
                 block_on(unsafe { Endpoint::<RocksEngine>::get_snapshot_with_timeout(&req_ctx) });
             assert!(result.is_err());
-            assert_matches!(result, Err(Error::DeadlineExceeded));
+            assert!(matches!(result, Err(Error::DeadlineExceeded)));
         }
 
         // Test case 2: Snapshot retrieval delayed by failpoint, causing timeout
@@ -2827,7 +2827,7 @@ mod tests {
                     // In production yatp FuturePool environment, this would
                     // timeout correctly
                 } else {
-                    assert_matches!(result, Err(Error::DeadlineExceeded));
+                    assert!(matches!(result, Err(Error::DeadlineExceeded)));
                     // Verify that timeout happened before the full sleep duration
                     // The timeout should trigger around 100ms, not wait for the full 5000ms sleep
                     assert!(
@@ -3392,9 +3392,9 @@ mod tests {
         .map_err(Error::from)
         .err()
         .unwrap();
-        assert_matches!(err, Error::Locked(LockInfo { key, .. }) if {
+        assert!(matches!(err, Error::Locked(LockInfo { key, .. }) if {
             assert_eq!(key, b"key".to_vec());
             true
-        });
+        }));
     }
 }

--- a/src/coprocessor/statistics/analyze.rs
+++ b/src/coprocessor/statistics/analyze.rs
@@ -949,7 +949,7 @@ mod tests {
         for loop_i in 0..loop_cnt {
             let mut collector = ReservoirRowSampleCollector::new(sample_num, 1000, 1);
             for row in &nums {
-                collector.sampling(&[row.clone()]);
+                collector.sampling(std::slice::from_ref(row));
             }
             assert_eq!(collector.samples.len(), sample_num);
             for sample in &collector.samples {
@@ -997,7 +997,7 @@ mod tests {
             let mut collector =
                 BernoulliRowSampleCollector::new(sample_num as f64 / row_num as f64, 1000, 1);
             for row in &nums {
-                collector.sampling(&[row.clone()]);
+                collector.sampling(std::slice::from_ref(row));
             }
             for sample in &collector.samples {
                 *item_cnt.entry(sample[0].clone()).or_insert(0) += 1;
@@ -1042,7 +1042,7 @@ mod tests {
             // Test for ReservoirRowSampleCollector
             let mut collector = ReservoirRowSampleCollector::new(sample_num, 1000, 1);
             for row in &nums {
-                collector.sampling(&[row.clone()]);
+                collector.sampling(std::slice::from_ref(row));
             }
             assert_eq!(collector.samples.len(), 0);
         }
@@ -1051,7 +1051,7 @@ mod tests {
             let mut collector =
                 BernoulliRowSampleCollector::new(sample_num as f64 / row_num as f64, 1000, 1);
             for row in &nums {
-                collector.sampling(&[row.clone()]);
+                collector.sampling(std::slice::from_ref(row));
             }
             assert_eq!(collector.samples.len(), 0);
         }

--- a/src/coprocessor/statistics/cmsketch.rs
+++ b/src/coprocessor/statistics/cmsketch.rs
@@ -146,11 +146,7 @@ mod tests {
                 datum::encode_value(&mut EvalContext::default(), from_ref(&Datum::U64(*val)))
                     .unwrap();
             let estimate = c.query(&bytes);
-            let err = if *num > estimate {
-                *num - estimate
-            } else {
-                estimate - *num
-            };
+            let err = (*num).abs_diff(estimate);
             total += u64::from(err)
         }
         total / map.len() as u64

--- a/src/coprocessor_v2/endpoint.rs
+++ b/src/coprocessor_v2/endpoint.rs
@@ -126,7 +126,7 @@ fn extract_region_error(error: &PluginError) -> Option<kvproto::errorpb::Error> 
     match error {
         PluginError::Other(_, other_err) => other_err
             .downcast_ref::<storage::Result<()>>()
-            .and_then(|e| storage::errors::extract_region_error::<()>(e)),
+            .and_then(storage::errors::extract_region_error::<()>),
         _ => None,
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,18 +19,15 @@
 #![crate_type = "lib"]
 #![cfg_attr(test, feature(test))]
 #![recursion_limit = "400"]
-#![feature(cell_update)]
 #![feature(proc_macro_hygiene)]
 #![feature(min_specialization)]
 #![feature(box_patterns)]
 #![feature(deadline_api)]
-#![feature(let_chains)]
 #![feature(read_buf)]
 #![feature(type_alias_impl_trait)]
 #![feature(impl_trait_in_assoc_type)]
 #![allow(incomplete_features)]
 #![feature(core_io_borrowed_buf)]
-#![feature(assert_matches)]
 
 #[macro_use(fail_point)]
 extern crate fail;

--- a/src/server/debug.rs
+++ b/src/server/debug.rs
@@ -962,20 +962,20 @@ where
 
     fn dump_kv_stats(&self) -> Result<String> {
         let mut kv_str = box_try!(MiscExt::dump_stats(&self.engines.kv));
-        if let Some(s) = self.kv_statistics.as_ref()
-            && let Some(s) = s.to_string()
-        {
-            kv_str.push_str(&s);
+        if let Some(s) = self.kv_statistics.as_ref() {
+            if let Some(s) = s.to_string() {
+                kv_str.push_str(&s);
+            }
         }
         Ok(kv_str)
     }
 
     fn dump_raft_stats(&self) -> Result<String> {
         let mut raft_str = box_try!(RaftEngine::dump_stats(&self.engines.raft));
-        if let Some(s) = self.raft_statistics.as_ref()
-            && let Some(s) = s.to_string()
-        {
-            raft_str.push_str(&s);
+        if let Some(s) = self.raft_statistics.as_ref() {
+            if let Some(s) = s.to_string() {
+                raft_str.push_str(&s);
+            }
         }
         Ok(raft_str)
     }
@@ -1368,7 +1368,7 @@ impl MvccChecker {
 
     fn check_mvcc_key(&mut self, wb: &mut RocksWriteBatchVec, key: &[u8]) -> Result<()> {
         self.scan_count += 1;
-        if self.scan_count % 1_000_000 == 0 {
+        if self.scan_count.is_multiple_of(1_000_000) {
             info!(
                 "thread {}: scan {} rows",
                 self.thread_index, self.scan_count

--- a/src/server/engine_factory.rs
+++ b/src/server/engine_factory.rs
@@ -213,12 +213,16 @@ impl TabletFactory<RocksEngine> for KvEngineFactory {
         if let Some(listener) = &self.inner.flow_listener {
             db_opts.add_event_listener(listener.clone_with(ctx.id));
         }
-        if let Some(storage) = &self.inner.state_storage
-            && let Some(flush_state) = ctx.flush_state
-        {
-            let listener =
-                PersistenceListener::new(ctx.id, ctx.suffix.unwrap(), flush_state, storage.clone());
-            db_opts.add_event_listener(RocksPersistenceListener::new(listener));
+        if let Some(storage) = &self.inner.state_storage {
+            if let Some(flush_state) = ctx.flush_state {
+                let listener = PersistenceListener::new(
+                    ctx.id,
+                    ctx.suffix.unwrap(),
+                    flush_state,
+                    storage.clone(),
+                );
+                db_opts.add_event_listener(RocksPersistenceListener::new(listener));
+            }
         }
         let kv_engine =
             engine_rocks::util::new_engine_opt(path.to_str().unwrap(), db_opts, cf_opts);

--- a/src/server/gc_worker/gc_worker.rs
+++ b/src/server/gc_worker/gc_worker.rs
@@ -278,8 +278,7 @@ fn get_regions_for_range_of_keys(
 fn get_keys_in_region(keys: &mut Peekable<IntoIter<Key>>, region: &Region) -> Vec<Key> {
     let mut keys_in_region = Vec::new();
 
-    loop {
-        let Some(key) = keys.peek() else { break };
+    while let Some(key) = keys.peek() {
         let key = key.as_encoded().as_slice();
 
         if key < region.get_start_key() {
@@ -445,11 +444,7 @@ impl<E: Engine> GcRunnerCore<E> {
         let count = keys.len();
         let range_start_key = keys.first().unwrap().clone();
         let range_end_key = {
-            let mut k = keys
-                .last()
-                .unwrap()
-                .to_raw()
-                .map_err(|e| EngineError::Codec(e))?;
+            let mut k = keys.last().unwrap().to_raw().map_err(EngineError::Codec)?;
             k.push(0);
             Key::from_raw(&k)
         };
@@ -565,11 +560,7 @@ impl<E: Engine> GcRunnerCore<E> {
     ) -> Result<(usize, usize)> {
         let range_start_key = keys.first().unwrap().clone();
         let range_end_key = {
-            let mut k = keys
-                .last()
-                .unwrap()
-                .to_raw()
-                .map_err(|e| EngineError::Codec(e))?;
+            let mut k = keys.last().unwrap().to_raw().map_err(EngineError::Codec)?;
             k.push(0);
             Key::from_raw(&k)
         };
@@ -1581,6 +1572,7 @@ pub mod test_gc_worker {
         }
     }
 
+    #[allow(dead_code)]
     #[derive(Clone, Default)]
     pub struct MultiRocksEngine {
         pub engines: Arc<Mutex<HashMap<u64, PrefixedEngine>>>,

--- a/src/server/lock_manager/config.rs
+++ b/src/server/lock_manager/config.rs
@@ -173,8 +173,8 @@ mod tests {
         let config: Config = toml::from_str(conf).unwrap();
         assert_eq!(config.wait_for_lock_timeout.as_millis(), 10);
         assert_eq!(config.wake_up_delay_duration.as_millis(), 100);
-        assert_eq!(config.pipelined, false);
-        assert_eq!(config.in_memory, false);
+        assert!(!config.pipelined);
+        assert!(!config.in_memory);
         assert_eq!(config.in_memory_peer_size_limit.0, 512 << 10);
         assert_eq!(config.in_memory_instance_size_limit.0, 100 << 20);
     }

--- a/src/server/lock_manager/deadlock.rs
+++ b/src/server/lock_manager/deadlock.rs
@@ -1139,7 +1139,7 @@ pub mod tests {
             3
         );
         detect_table.clean_up(2.into());
-        assert_eq!(detect_table.wait_for_map.contains_key(&2.into()), false);
+        assert!(!detect_table.wait_for_map.contains_key(&2.into()));
 
         // After cycle is broken, no deadlock.
         assert_eq!(detect_table.detect(3.into(), 1.into(), 1, &[], &[]), None);
@@ -1233,7 +1233,7 @@ pub mod tests {
                 hash: 2,
             },
         );
-        assert_eq!(detect_table.wait_for_map.contains_key(&3.into()), false);
+        assert!(!detect_table.wait_for_map.contains_key(&3.into()));
 
         // Clean up non-exist entry
         detect_table.clean_up(3.into());

--- a/src/server/lock_manager/waiter_manager.rs
+++ b/src/server/lock_manager/waiter_manager.rs
@@ -554,13 +554,13 @@ impl WaiterManager {
                 continue;
             }
 
-            if let Some((previous_wait_info, diag_ctx)) = previous_wait_info
-                && previous_wait_info.allow_lock_with_conflict
-            {
-                self.detector_scheduler
-                    .clean_up_wait_for(event.start_ts, previous_wait_info);
-                self.detector_scheduler
-                    .detect(event.start_ts, event.wait_info, diag_ctx);
+            if let Some((previous_wait_info, diag_ctx)) = previous_wait_info {
+                if previous_wait_info.allow_lock_with_conflict {
+                    self.detector_scheduler
+                        .clean_up_wait_for(event.start_ts, previous_wait_info);
+                    self.detector_scheduler
+                        .detect(event.start_ts, event.wait_info, diag_ctx);
+                }
             }
         }
     }

--- a/src/server/raft_client.rs
+++ b/src/server/raft_client.rs
@@ -673,10 +673,9 @@ where
                     // local variables without return.
                     let mut transport_on_resolve_fp = || {
                         fail_point!(_ON_RESOLVE_FP, |sid| if let Some(sid) = sid {
-                            use std::mem;
                             let sid: u64 = sid.parse().unwrap();
                             if sid == store_id {
-                                mem::swap(&mut addr, &mut Err(box_err!("injected failure")));
+                                addr = Err(box_err!("injected failure"));
                                 // Sleep some time to avoid race between enqueuing message and
                                 // resolving address.
                                 std::thread::sleep(std::time::Duration::from_millis(10));

--- a/src/server/raftkv/raft_extension.rs
+++ b/src/server/raftkv/raft_extension.rs
@@ -64,10 +64,10 @@ where
         let region_id = msg.get_region_id();
         let msg_ty = msg.get_message().get_msg_type();
         // Channel full and region not found are ignored unless it's a key message.
-        if let Err(e) = self.router.send_raft_msg(msg)
-            && key_message
-        {
-            error!("failed to send raft message"; "region_id" => region_id, "msg_ty" => ?msg_ty, "err" => ?e);
+        if let Err(e) = self.router.send_raft_msg(msg) {
+            if key_message {
+                error!("failed to send raft message"; "region_id" => region_id, "msg_ty" => ?msg_ty, "err" => ?e);
+            }
         }
     }
 

--- a/src/server/raftkv2/raft_extension.rs
+++ b/src/server/raftkv2/raft_extension.rs
@@ -24,10 +24,10 @@ impl<EK: KvEngine, ER: RaftEngine> tikv_kv::RaftExtension for Extension<EK, ER> 
         let region_id = msg.get_region_id();
         let msg_ty = msg.get_message().get_msg_type();
         // Channel full and region not found are ignored unless it's a key message.
-        if let Err(e) = self.router.send_raft_message(Box::new(msg))
-            && key_message
-        {
-            error!("failed to send raft message"; "region_id" => region_id, "msg_ty" => ?msg_ty, "err" => ?e);
+        if let Err(e) = self.router.send_raft_message(Box::new(msg)) {
+            if key_message {
+                error!("failed to send raft message"; "region_id" => region_id, "msg_ty" => ?msg_ty, "err" => ?e);
+            }
         }
     }
 

--- a/src/server/service/diagnostics/sys.rs
+++ b/src/server/service/diagnostics/sys.rs
@@ -198,7 +198,7 @@ fn nic_load_info(prev_nic: HashMap<String, NicSnapshot>, collector: &mut Vec<Ser
 
 fn io_load_info(prev_io: HashMap<String, ioload::IoLoad>, collector: &mut Vec<ServerInfoItem>) {
     let current = ioload::IoLoad::snapshot();
-    let rate = |cur, prev| (cur - prev);
+    let rate = |cur, prev| cur - prev;
     for (name, cur) in current.into_iter() {
         let prev = match prev_io.get(&name) {
             Some(p) => p,

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -2695,10 +2695,10 @@ impl HealthFeedbackAttacher {
 
         let now = Instant::now_coarse();
 
-        if let Some(last_feedback_time) = self.last_feedback_time
-            && now - last_feedback_time < feedback_interval
-        {
-            return;
+        if let Some(last_feedback_time) = self.last_feedback_time {
+            if now - last_feedback_time < feedback_interval {
+                return;
+            }
         }
 
         self.attach(resp, now);

--- a/src/server/status_server/mod.rs
+++ b/src/server/status_server/mod.rs
@@ -1908,13 +1908,16 @@ mod tests {
         let resp = block_on(handle).unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
         let body_bytes = block_on(hyper::body::to_bytes(resp.into_body())).unwrap();
+        let resolved_symbol = String::from_utf8(body_bytes.as_ref().to_owned())
+            .unwrap()
+            .split(' ')
+            .next_back()
+            .unwrap()
+            .to_owned();
         assert!(
-            String::from_utf8(body_bytes.as_ref().to_owned())
-                .unwrap()
-                .split(' ')
-                .last()
-                .unwrap()
-                .starts_with("backtrace::backtrace")
+            resolved_symbol.contains("test_pprof_symbol_service"),
+            "resolved symbol: {}",
+            resolved_symbol
         );
         status_server.stop();
     }

--- a/src/server/tablet_snap.rs
+++ b/src/server/tablet_snap.rs
@@ -154,18 +154,17 @@ pub trait SnapCacheBuilder: Send + Sync {
 
 impl<EK: KvEngine> SnapCacheBuilder for TabletRegistry<EK> {
     fn build(&self, region_id: u64, path: &Path) -> Result<()> {
-        if let Some(mut c) = self.get(region_id)
-            && let Some(db) = c.latest()
-        {
-            let mut checkpointer = db.new_checkpointer()?;
-            // Avoid flush.
-            checkpointer.create_at(path, None, u64::MAX)?;
-            Ok(())
-        } else {
-            Err(Error::Other(
-                format!("region {} not found", region_id).into(),
-            ))
+        if let Some(mut c) = self.get(region_id) {
+            if let Some(db) = c.latest() {
+                let mut checkpointer = db.new_checkpointer()?;
+                // Avoid flush.
+                checkpointer.create_at(path, None, u64::MAX)?;
+                return Ok(());
+            }
         }
+        Err(Error::Other(
+            format!("region {} not found", region_id).into(),
+        ))
     }
 }
 
@@ -330,17 +329,17 @@ async fn cleanup_cache(
         };
         let mut buffer = Vec::with_capacity(PREVIEW_CHUNK_LEN);
         for meta in preview.take_metas().into_vec() {
-            if is_sst(&meta.file_name)
-                && let Some(p) = exists.remove(&meta.file_name)
-            {
-                if is_sst_match_preview(&meta, &p, &mut buffer, limiter, key_manager).await? {
-                    reused += meta.file_size;
-                    continue;
-                }
-                // We should not write to the file directly as it's hard linked.
-                fs::remove_file(&p)?;
-                if let Some(m) = key_manager {
-                    m.delete_file(p.to_str().unwrap(), None)?;
+            if is_sst(&meta.file_name) {
+                if let Some(p) = exists.remove(&meta.file_name) {
+                    if is_sst_match_preview(&meta, &p, &mut buffer, limiter, key_manager).await? {
+                        reused += meta.file_size;
+                        continue;
+                    }
+                    // We should not write to the file directly as it's hard linked.
+                    fs::remove_file(&p)?;
+                    if let Some(m) = key_manager {
+                        m.delete_file(p.to_str().unwrap(), None)?;
+                    }
                 }
             }
             missing.push(meta.file_name);
@@ -431,7 +430,7 @@ async fn accept_missing(
 ) -> Result<u64> {
     let mut digest = Digest::default();
     let mut received_bytes: u64 = 0;
-    let mut key_importer = key_manager.as_deref().map(|m| DataKeyImporter::new(m));
+    let mut key_importer = key_manager.as_deref().map(DataKeyImporter::new);
     for name in missing_ssts {
         let chunk = match stream.next().await {
             Some(Ok(mut req)) if req.has_chunk() => req.take_chunk(),
@@ -702,11 +701,11 @@ async fn send_missing(
         digest.write(chunk.file_name.as_bytes());
         chunk.file_size = file_size;
         total_sent += file_size;
-        if let Some(m) = key_manager
-            && let Some((iv, key)) = m.get_file_internal(file_path.to_str().unwrap())?
-        {
-            chunk.iv = iv;
-            chunk.set_key(key);
+        if let Some(m) = key_manager {
+            if let Some((iv, key)) = m.get_file_internal(file_path.to_str().unwrap())? {
+                chunk.iv = iv;
+                chunk.set_key(key);
+            }
         }
         if file_size == 0 {
             let mut req = TabletSnapshotRequest::default();
@@ -1027,18 +1026,18 @@ pub fn copy_tablet_snapshot(
     let mut key_importer = recver_snap_mgr
         .key_manager()
         .as_deref()
-        .map(|m| DataKeyImporter::new(m));
+        .map(DataKeyImporter::new);
     for path in files {
         let recv = recv_path.join(path.file_name().unwrap());
         std::fs::copy(&path, &recv)?;
-        if let Some(m) = sender_snap_mgr.key_manager()
-            && let Some((iv, key)) = m.get_file_internal(path.to_str().unwrap())?
-        {
-            key_importer
-                .as_mut()
-                .unwrap()
-                .add(recv.to_str().unwrap(), iv, key)
-                .unwrap();
+        if let Some(m) = sender_snap_mgr.key_manager() {
+            if let Some((iv, key)) = m.get_file_internal(path.to_str().unwrap())? {
+                key_importer
+                    .as_mut()
+                    .unwrap()
+                    .add(recv.to_str().unwrap(), iv, key)
+                    .unwrap();
+            }
         }
     }
     if let Some(i) = key_importer {

--- a/src/storage/kv/test_engine_builder.rs
+++ b/src/storage/kv/test_engine_builder.rs
@@ -343,7 +343,7 @@ mod tests {
             &mut statistics,
         )
         .unwrap();
-        assert_eq!(iter.valid().unwrap(), true);
+        assert!(iter.valid().unwrap());
         assert_eq!(perf_statistics.delta().internal_delete_skipped_count, 0);
 
         let perf_statistics = ReadPerfInstant::new();
@@ -352,7 +352,7 @@ mod tests {
             &mut statistics,
         )
         .unwrap();
-        assert_eq!(iter.valid().unwrap(), false);
+        assert!(!iter.valid().unwrap());
         assert_eq!(perf_statistics.delta().internal_delete_skipped_count, 1);
         let perf_statistics = ReadPerfInstant::new();
         iter.seek(
@@ -360,7 +360,7 @@ mod tests {
             &mut statistics,
         )
         .unwrap();
-        assert_eq!(iter.valid().unwrap(), false);
+        assert!(!iter.valid().unwrap());
         assert_eq!(perf_statistics.delta().internal_delete_skipped_count, 1);
         let perf_statistics = ReadPerfInstant::new();
         iter.seek(
@@ -368,18 +368,17 @@ mod tests {
             &mut statistics,
         )
         .unwrap();
-        assert_eq!(iter.valid().unwrap(), false);
+        assert!(!iter.valid().unwrap());
         assert_eq!(perf_statistics.delta().internal_delete_skipped_count, 1);
         let perf_statistics = ReadPerfInstant::new();
-        assert_eq!(
+        assert!(
             iter.seek(
                 &Key::from_raw(b"foo4").append_ts(TimeStamp::zero()),
                 &mut statistics
             )
-            .unwrap(),
-            true
+            .unwrap()
         );
-        assert_eq!(iter.valid().unwrap(), true);
+        assert!(iter.valid().unwrap());
         assert_eq!(
             iter.key(&mut statistics),
             Key::from_raw(b"foo4")

--- a/src/storage/lock_manager/lock_waiting_queue.rs
+++ b/src/storage/lock_manager/lock_waiting_queue.rs
@@ -327,6 +327,7 @@ impl<L: LockManager> LockWaitQueues<L> {
     /// queue while executing, and in this case the caller will be responsible
     /// to wake it up. When the head of the queue is a shared lock wait, all
     /// consecutive shared lock waits are returned together in the vector.
+    #[allow(clippy::vec_box)]
     pub fn pop_for_waking_up(
         &self,
         key: &Key,
@@ -986,12 +987,12 @@ mod tests {
     fn test_simple_push_pop() {
         let queues = LockWaitQueues::new(MockLockManager::new());
         assert_eq!(queues.entry_count(), 0);
-        assert_eq!(queues.is_empty(), true);
+        assert!(queues.is_empty());
 
         queues.mock_lock_wait(b"k1", 10, 5, false);
         queues.mock_lock_wait(b"k2", 11, 5, false);
         assert_eq!(queues.entry_count(), 2);
-        assert_eq!(queues.is_empty(), false);
+        assert!(!queues.is_empty());
 
         queues
             .must_pop(b"k1", 5, 6)
@@ -1000,7 +1001,7 @@ mod tests {
         queues.must_pop_none(b"k1", 5, 6);
         queues.must_not_contain_key(b"k1");
         assert_eq!(queues.entry_count(), 1);
-        assert_eq!(queues.is_empty(), false);
+        assert!(!queues.is_empty());
 
         queues
             .must_pop(b"k2", 5, 6)
@@ -1009,7 +1010,7 @@ mod tests {
         queues.must_pop_none(b"k2", 5, 6);
         queues.must_not_contain_key(b"k2");
         assert_eq!(queues.entry_count(), 0);
-        assert_eq!(queues.is_empty(), true);
+        assert!(queues.is_empty());
     }
 
     #[test]
@@ -1305,7 +1306,7 @@ mod tests {
             entry.check_shared(true);
             start_ts_set.push(entry.parameters.start_ts.into_inner());
         }
-        start_ts_set.sort_by(|a, b| a.cmp(b));
+        start_ts_set.sort();
         assert_eq!(start_ts_set, vec![10, 11, 12]);
         assert!(future.is_some());
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -61,7 +61,6 @@ mod read_pool;
 mod types;
 
 use std::{
-    assert_matches::assert_matches,
     borrow::Cow,
     iter,
     marker::PhantomData,
@@ -3369,7 +3368,10 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
                 if txn_status.is_completed {
                     // large_txn_cache is only for **ongoing** large txns, so remove it when
                     // completed.
-                    assert_matches!(txn_state, TxnState::Committed { .. } | TxnState::RolledBack);
+                    assert!(matches!(
+                        txn_state,
+                        TxnState::Committed { .. } | TxnState::RolledBack
+                    ));
                     cache.remove_large_txn(txn_status.start_ts.into());
                 }
                 cache.upsert(txn_status.start_ts.into(), txn_state, now);

--- a/src/storage/mvcc/reader/point_getter.rs
+++ b/src/storage/mvcc/reader/point_getter.rs
@@ -482,7 +482,6 @@ impl<S: Snapshot> PointGetter<S> {
 
 #[cfg(test)]
 mod tests {
-    use std::assert_matches::assert_matches;
 
     use engine_rocks::ReadPerfInstant;
     use kvproto::kvrpcpb::{Assertion, AssertionLevel, PrewriteRequestPessimisticAction::*};
@@ -1452,7 +1451,7 @@ mod tests {
         // When load_commit_ts is true, `access_locks` should be ignored and
         // the lock should be seen as conflict
         let err = must_get_entry_err(&mut getter, key, true);
-        assert_matches!(err.0, box ErrorInner::KeyIsLocked { .. });
+        assert!(matches!(err.0, box ErrorInner::KeyIsLocked { .. }));
     }
 
     #[test]

--- a/src/storage/mvcc/reader/reader.rs
+++ b/src/storage/mvcc/reader/reader.rs
@@ -1362,16 +1362,16 @@ pub mod tests {
 
             for (i, expect_ts) in res.iter().enumerate() {
                 if i == 0 {
-                    assert_eq!(iter.seek_to_first().unwrap(), true);
+                    assert!(iter.seek_to_first().unwrap());
                 } else {
-                    assert_eq!(iter.next().unwrap(), true);
+                    assert!(iter.next().unwrap());
                 }
 
                 let ts = Key::decode_ts_from(iter.key()).unwrap();
                 assert_eq!(ts.into_inner(), *expect_ts);
             }
 
-            assert_eq!(iter.next().unwrap(), false);
+            assert!(!iter.next().unwrap());
         }
     }
 
@@ -1409,7 +1409,7 @@ pub mod tests {
         let mut iter = snap.iter(CF_WRITE, iopt).unwrap();
 
         // Must not omit the latest deletion of key1 to prevent seeing outdated record.
-        assert_eq!(iter.seek_to_first().unwrap(), true);
+        assert!(iter.seek_to_first().unwrap());
         assert_eq!(
             Key::from_encoded_slice(iter.key())
                 .to_raw()
@@ -1417,7 +1417,7 @@ pub mod tests {
                 .as_slice(),
             key2
         );
-        assert_eq!(iter.next().unwrap(), false);
+        assert!(!iter.next().unwrap());
     }
 
     #[test]
@@ -2251,7 +2251,7 @@ pub mod tests {
             expect_is_remain: bool,
         }
 
-        let cases = vec![
+        let cases = [
             // Test the limit.
             Case {
                 start_key: None,

--- a/src/storage/mvcc/reader/scanner/backward.rs
+++ b/src/storage/mvcc/reader/scanner/backward.rs
@@ -77,21 +77,16 @@ impl<S: Snapshot> BackwardKvScanner<S> {
     /// Get the next key-value pair, in backward order.
     pub fn read_next(&mut self) -> Result<Option<(Key, ValueEntry)>> {
         if !self.is_started {
-            if self.cfg.upper_bound.is_some() {
+            if let Some(upper_bound) = &self.cfg.upper_bound {
                 // TODO: `seek_to_last` is better, however it has performance issues currently.
                 // TODO: We have no guarantee about whether or not the upper_bound has a
                 // timestamp suffix, so currently it is not safe to change write_cursor's
                 // reverse_seek to seek_for_prev. However in future, once we have different
                 // types for them, this can be done safely.
-                self.write_cursor.reverse_seek(
-                    self.cfg.upper_bound.as_ref().unwrap(),
-                    &mut self.statistics.write,
-                )?;
+                self.write_cursor
+                    .reverse_seek(upper_bound, &mut self.statistics.write)?;
                 if let Some(lock_cursor) = self.lock_cursor.as_mut() {
-                    lock_cursor.reverse_seek(
-                        self.cfg.upper_bound.as_ref().unwrap(),
-                        &mut self.statistics.lock,
-                    )?;
+                    lock_cursor.reverse_seek(upper_bound, &mut self.statistics.lock)?;
                 }
             } else {
                 self.write_cursor.seek_to_last(&mut self.statistics.write);

--- a/src/storage/mvcc/reader/scanner/forward.rs
+++ b/src/storage/mvcc/reader/scanner/forward.rs
@@ -171,17 +171,13 @@ impl<S: Snapshot, P: ScanPolicy<S>> ForwardScanner<S, P> {
     /// Get the next key-value pair, in forward order.
     pub fn read_next(&mut self) -> Result<Option<P::Output>> {
         if !self.is_started {
-            if self.cfg.lower_bound.is_some() {
+            if let Some(lower_bound) = &self.cfg.lower_bound {
                 // TODO: `seek_to_first` is better, however it has performance issues currently.
-                self.cursors.write.seek(
-                    self.cfg.lower_bound.as_ref().unwrap(),
-                    &mut self.statistics.write,
-                )?;
+                self.cursors
+                    .write
+                    .seek(lower_bound, &mut self.statistics.write)?;
                 if let Some(lock_cursor) = self.cursors.lock.as_mut() {
-                    lock_cursor.seek(
-                        self.cfg.lower_bound.as_ref().unwrap(),
-                        &mut self.statistics.lock,
-                    )?;
+                    lock_cursor.seek(lower_bound, &mut self.statistics.lock)?;
                 }
             } else {
                 self.cursors.write.seek_to_first(&mut self.statistics.write);

--- a/src/storage/mvcc/reader/scanner/mod.rs
+++ b/src/storage/mvcc/reader/scanner/mod.rs
@@ -346,8 +346,8 @@ impl<S: Snapshot> ScannerConfig<S> {
             .range(lower, upper)
             .fill_cache(self.fill_cache)
             .scan_mode(scan_mode)
-            .hint_min_ts(hint_min_ts.map(|ts| Bound::Included(ts)))
-            .hint_max_ts(hint_max_ts.map(|ts| Bound::Included(ts)))
+            .hint_min_ts(hint_min_ts.map(Bound::Included))
+            .hint_max_ts(hint_max_ts.map(Bound::Included))
             .build()?;
         Ok(cursor)
     }

--- a/src/storage/mvcc/txn.rs
+++ b/src/storage/mvcc/txn.rs
@@ -1381,7 +1381,7 @@ pub(crate) mod tests {
             .left()
             .unwrap();
         assert_eq!(lock.ts, TimeStamp::new(2));
-        assert_eq!(lock.use_async_commit, true);
+        assert!(lock.use_async_commit);
         assert_eq!(
             lock.secondaries,
             vec![b"key1".to_vec(), b"key2".to_vec(), b"key3".to_vec()]
@@ -1445,7 +1445,7 @@ pub(crate) mod tests {
             .left()
             .unwrap();
         assert_eq!(lock.ts, TimeStamp::new(2));
-        assert_eq!(lock.use_async_commit, true);
+        assert!(lock.use_async_commit);
         assert_eq!(
             lock.secondaries,
             vec![b"key1".to_vec(), b"key2".to_vec(), b"key3".to_vec()]

--- a/src/storage/raw/raw_mvcc.rs
+++ b/src/storage/raw/raw_mvcc.rs
@@ -362,6 +362,6 @@ mod tests {
         assert_eq!(pairs, ret_data);
 
         // two way direction scan is not supported.
-        assert_eq!(iter.next().is_err(), true);
+        iter.next().unwrap_err();
     }
 }

--- a/src/storage/txn/commands/flush.rs
+++ b/src/storage/txn/commands/flush.rs
@@ -219,7 +219,6 @@ impl Flush {
 
 #[cfg(test)]
 mod tests {
-    use std::assert_matches::assert_matches;
 
     use kvproto::kvrpcpb::{Assertion, Context};
     use tikv_kv::Engine;
@@ -362,10 +361,10 @@ mod tests {
         let v = b"value";
 
         // generation == 0 will be rejected
-        assert_matches!(
+        assert!(matches!(
             must_flush_put_err(&mut engine, k, *v, k, 1, 0),
             Error(box ErrorInner::Other(s)) if s.to_string().contains("generation should be greater than 0")
-        );
+        ));
 
         must_flush_put(&mut engine, k, *v, k, 1, 2);
         must_locked(&mut engine, k, 1);
@@ -385,17 +384,17 @@ mod tests {
         let v = b"value";
         must_flush_put(&mut engine, k, *v, k, 1, 1);
         must_locked(&mut engine, k, 1);
-        assert_matches!(
+        assert!(matches!(
             must_flush_insert_err(&mut engine, k, *v, k, 1, 2),
             Error(box ErrorInner::Mvcc(MvccError(box MvccErrorInner::AlreadyExist { key, existing_start_ts})))
             if key == k  && existing_start_ts == 1.into()
-        );
+        ));
         must_commit(&mut engine, k, 1, 2);
-        assert_matches!(
+        assert!(matches!(
             must_flush_insert_err(&mut engine, k, *v, k, 3, 1),
             Error(box ErrorInner::Mvcc(MvccError(box MvccErrorInner::AlreadyExist { key, existing_start_ts})))
             if key == k  && existing_start_ts == 1.into()
-        );
+        ));
     }
 
     #[test]

--- a/src/storage/txn/flow_controller/singleton_flow_controller.rs
+++ b/src/storage/txn/flow_controller/singleton_flow_controller.rs
@@ -734,10 +734,10 @@ impl<E: FlowControlFactorStore + Send + 'static> FlowChecker<E> {
             // pending bytes sample update it, so a less pressured CF does not
             // overwrite the ratio chosen by the current bottleneck.
             for checker in self.cf_checkers.values() {
-                if let Some(long_term_pending_bytes) = checker.long_term_pending_bytes.as_ref()
-                    && recent_pending_compaction_bytes_log2 < long_term_pending_bytes.get_recent()
-                {
-                    return;
+                if let Some(long_term_pending_bytes) = checker.long_term_pending_bytes.as_ref() {
+                    if recent_pending_compaction_bytes_log2 < long_term_pending_bytes.get_recent() {
+                        return;
+                    }
                 }
             }
 

--- a/src/storage/txn/latch.rs
+++ b/src/storage/txn/latch.rs
@@ -288,11 +288,11 @@ mod tests {
 
         // a acquire lock success
         let acquired_a = latches.acquire(&mut lock_a, cid_a);
-        assert_eq!(acquired_a, true);
+        assert!(acquired_a);
 
         // b acquire lock failed
         let mut acquired_b = latches.acquire(&mut lock_b, cid_b);
-        assert_eq!(acquired_b, false);
+        assert!(!acquired_b);
 
         // a release lock, and get wakeup list
         let wakeup = latches.release(&lock_a, cid_a, None);
@@ -300,7 +300,7 @@ mod tests {
 
         // b acquire lock success
         acquired_b = latches.acquire(&mut lock_b, cid_b);
-        assert_eq!(acquired_b, true);
+        assert!(acquired_b);
     }
 
     #[test]
@@ -319,15 +319,15 @@ mod tests {
 
         // a acquire lock success
         let acquired_a = latches.acquire(&mut lock_a, cid_a);
-        assert_eq!(acquired_a, true);
+        assert!(acquired_a);
 
         // b acquire lock success
         let acquired_b = latches.acquire(&mut lock_b, cid_b);
-        assert_eq!(acquired_b, true);
+        assert!(acquired_b);
 
         // c acquire lock failed, cause a occupied slot 3
         let mut acquired_c = latches.acquire(&mut lock_c, cid_c);
-        assert_eq!(acquired_c, false);
+        assert!(!acquired_c);
 
         // a release lock, and get wakeup list
         let wakeup = latches.release(&lock_a, cid_a, None);
@@ -335,7 +335,7 @@ mod tests {
 
         // c acquire lock failed again, cause b occupied slot 4
         acquired_c = latches.acquire(&mut lock_c, cid_c);
-        assert_eq!(acquired_c, false);
+        assert!(!acquired_c);
 
         // b release lock, and get wakeup list
         let wakeup = latches.release(&lock_b, cid_b, None);
@@ -343,7 +343,7 @@ mod tests {
 
         // finally c acquire lock success
         acquired_c = latches.acquire(&mut lock_c, cid_c);
-        assert_eq!(acquired_c, true);
+        assert!(acquired_c);
     }
 
     #[test]
@@ -364,19 +364,19 @@ mod tests {
         let cid_d: u64 = 4;
 
         let acquired_a = latches.acquire(&mut lock_a, cid_a);
-        assert_eq!(acquired_a, true);
+        assert!(acquired_a);
 
         // c acquire lock failed, cause a occupied slot 3
         let mut acquired_c = latches.acquire(&mut lock_c, cid_c);
-        assert_eq!(acquired_c, false);
+        assert!(!acquired_c);
 
         // b acquire lock success
         let acquired_b = latches.acquire(&mut lock_b, cid_b);
-        assert_eq!(acquired_b, true);
+        assert!(acquired_b);
 
         // d acquire lock failed, cause a occupied slot 7
         let mut acquired_d = latches.acquire(&mut lock_d, cid_d);
-        assert_eq!(acquired_d, false);
+        assert!(!acquired_d);
 
         // a release lock, and get wakeup list
         let wakeup = latches.release(&lock_a, cid_a, None);
@@ -384,7 +384,7 @@ mod tests {
 
         // c acquire lock success
         acquired_c = latches.acquire(&mut lock_c, cid_c);
-        assert_eq!(acquired_c, true);
+        assert!(acquired_c);
 
         // b release lock, and get wakeup list
         let wakeup = latches.release(&lock_b, cid_b, None);
@@ -392,7 +392,7 @@ mod tests {
 
         // finally d acquire lock success
         acquired_d = latches.acquire(&mut lock_d, cid_d);
-        assert_eq!(acquired_d, true);
+        assert!(acquired_d);
     }
 
     fn check_latch_holder(latches: &Latches, key: &[u8], expected_holder_cid: Option<u64>) {

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -2355,7 +2355,7 @@ impl SchedulerDetails {
 
 #[cfg(test)]
 mod tests {
-    use std::{assert_matches::assert_matches, thread};
+    use std::thread;
 
     use futures_executor::block_on;
     use kvproto::kvrpcpb::{
@@ -2910,8 +2910,8 @@ mod tests {
     fn test_run_cmd_memory_quota() {
         let key_a = Key::from_raw(&[b'a'; 64]);
         let key_b = Key::from_raw(&[b'b'; 64]);
-        let mut lock_a = Lock::new(&[key_a.clone()]);
-        let mut lock_b = Lock::new(&[key_b.clone()]);
+        let mut lock_a = Lock::new(std::slice::from_ref(&key_a));
+        let mut lock_b = Lock::new(std::slice::from_ref(&key_b));
         let build_cmd = || {
             let mut req = CheckSecondaryLocksRequest::default();
             req.set_keys(
@@ -2950,12 +2950,12 @@ mod tests {
             scheduler.run_cmd(cmd, StorageCallback::SecondaryLocksStatus(cb));
             if i >= max_request_count {
                 // If memory quota exceeds, scheduler returns SchedTooBusy.
-                assert_matches!(
+                assert!(matches!(
                     fut.try_recv(),
                     Ok(Some(Err(StorageError(box StorageErrorInner::SchedTooBusy))))
-                );
+                ));
             } else {
-                assert_matches!(fut.try_recv(), Ok(None));
+                assert!(matches!(fut.try_recv(), Ok(None)));
                 requests.push(fut);
             }
         }

--- a/src/storage/txn/store.rs
+++ b/src/storage/txn/store.rs
@@ -382,22 +382,19 @@ impl<S: Snapshot> Store for SnapshotStore<S> {
 
     #[inline]
     fn incremental_get_take_statistics(&mut self) -> Statistics {
-        if self.point_getter_cache.is_none() {
-            Statistics::default()
+        if let Some(cache) = &mut self.point_getter_cache {
+            cache.take_statistics()
         } else {
-            self.point_getter_cache.as_mut().unwrap().take_statistics()
+            Statistics::default()
         }
     }
 
     #[inline]
     fn incremental_get_met_newer_ts_data(&self) -> NewerTsCheckState {
-        if self.point_getter_cache.is_none() {
-            NewerTsCheckState::Unknown
+        if let Some(ref cache) = self.point_getter_cache {
+            cache.met_newer_ts_data()
         } else {
-            self.point_getter_cache
-                .as_ref()
-                .unwrap()
-                .met_newer_ts_data()
+            NewerTsCheckState::Unknown
         }
     }
 
@@ -1306,7 +1303,7 @@ mod tests {
 
         FixtureStore::new(
             data.into_iter()
-                .map(|(k, v)| (k, v.map(|val| ValueEntry::from_value(val))))
+                .map(|(k, v)| (k, v.map(ValueEntry::from_value)))
                 .collect(),
         )
     }

--- a/tests/failpoints/cases/test_cmd_epoch_checker.rs
+++ b/tests/failpoints/cases/test_cmd_epoch_checker.rs
@@ -5,7 +5,7 @@ use std::{
     time::Duration,
 };
 
-use engine_rocks::{RocksEngine, RocksSnapshot};
+use engine_rocks::RocksSnapshot;
 use kvproto::raft_cmdpb::{RaftCmdRequest, RaftCmdResponse};
 use raft::eraftpb::MessageType;
 use raftstore::store::msg::*;
@@ -61,7 +61,7 @@ impl CbReceivers {
 fn make_cb(cmd: &RaftCmdRequest) -> (Callback<RocksSnapshot>, CbReceivers) {
     let (proposed_tx, proposed_rx) = mpsc::channel();
     let (committed_tx, committed_rx) = mpsc::channel();
-    let (cb, applied_rx) = make_cb_ext::<RocksEngine>(
+    let (cb, applied_rx) = make_cb_ext(
         cmd,
         Some(Box::new(move || proposed_tx.send(()).unwrap())),
         Some(Box::new(move || committed_tx.send(()).unwrap())),

--- a/tests/integrations/coprocessor/test_select.rs
+++ b/tests/integrations/coprocessor/test_select.rs
@@ -2156,7 +2156,7 @@ fn test_batch_request() {
     // 2. The expected output results.
     // 3. Should the coprocessor request contain invalid region epoch.
     // 4. Should the scanned key be locked.
-    let cases = vec![
+    let cases = [
         // Basic valid case.
         (
             vec![

--- a/tests/integrations/import/test_sst_service.rs
+++ b/tests/integrations/import/test_sst_service.rs
@@ -642,7 +642,7 @@ fn test_suspend_import() {
         "{:?}",
         ingest_res
     );
-    let multi_ingest_res = multi_ingest(&[sst.clone()]).unwrap();
+    let multi_ingest_res = multi_ingest(std::slice::from_ref(&sst)).unwrap();
     assert!(
         multi_ingest_res.get_error().has_server_is_busy(),
         "{:?}",

--- a/tests/integrations/mod.rs
+++ b/tests/integrations/mod.rs
@@ -3,7 +3,6 @@
 #![feature(test)]
 #![feature(box_patterns)]
 #![feature(custom_test_frameworks)]
-#![feature(assert_matches)]
 #![test_runner(test_util::run_tests)]
 
 extern crate test;

--- a/tests/integrations/raftstore/test_hibernate.rs
+++ b/tests/integrations/raftstore/test_hibernate.rs
@@ -6,7 +6,7 @@ use std::{
     time::Duration,
 };
 
-use engine_rocks::{RocksEngine, RocksSnapshot};
+use engine_rocks::RocksSnapshot;
 use futures::executor::block_on;
 use kvproto::raft_cmdpb::RaftCmdRequest;
 use pd_client::PdClient;
@@ -822,7 +822,7 @@ fn test_hibernate_quorum_feature_voter_down_shortly() {
 
 fn make_cb(cmd: &RaftCmdRequest) -> (Callback<RocksSnapshot>, CbReceivers) {
     let (proposed_tx, proposed_rx) = mpsc::channel();
-    let (cb, _applied_rx) = make_cb_ext::<RocksEngine>(
+    let (cb, _applied_rx) = make_cb_ext(
         cmd,
         Some(Box::new(move || proposed_tx.send(()).unwrap())),
         None,

--- a/tests/integrations/raftstore/test_scale_pool.rs
+++ b/tests/integrations/raftstore/test_scale_pool.rs
@@ -623,8 +623,8 @@ fn test_increase_snap_generator_pool_size() {
     let t = Instant::now();
     while t.saturating_elapsed() < Duration::from_secs(1) {
         let val = engine.get_value(b"zkey0030").unwrap();
-        if val.is_some() {
-            assert_eq!(val.unwrap(), b"val");
+        if let Some(val) = val {
+            assert_eq!(val, b"val");
             break;
         }
     }

--- a/tests/integrations/raftstore/test_snap.rs
+++ b/tests/integrations/raftstore/test_snap.rs
@@ -1,7 +1,6 @@
 // Copyright 2016 TiKV Project Authors. Licensed under Apache-2.0.
 
 use std::{
-    assert_matches::assert_matches,
     fs,
     path::PathBuf,
     sync::{
@@ -1333,7 +1332,9 @@ fn test_extra_snapshot_override() {
         .snapshot(snap_ctx.clone())
         .err()
         .unwrap();
-    assert_matches!(err, Error(box ErrorInner::Request(header)) if header.stale_command.is_some());
+    assert!(
+        matches!(err, Error(box ErrorInner::Request(header)) if header.stale_command.is_some())
+    );
     snap_ctx.extra_region_override.as_mut().unwrap().check_term = None;
 
     // If `extra_snap_override`.`term` is set with a valid value, should return
@@ -1359,7 +1360,9 @@ fn test_extra_snapshot_override() {
         .snapshot(snap_ctx.clone())
         .err()
         .unwrap();
-    assert_matches!(err, Error(box ErrorInner::Request(header)) if header.epoch_not_match.is_some());
+    assert!(
+        matches!(err, Error(box ErrorInner::Request(header)) if header.epoch_not_match.is_some())
+    );
     snap_ctx
         .extra_region_override
         .as_mut()
@@ -1384,5 +1387,5 @@ fn test_extra_snapshot_override() {
         .snapshot(snap_ctx.clone())
         .err()
         .unwrap();
-    assert_matches!(err, Error(box ErrorInner::Request(header)) if header.not_leader.is_some());
+    assert!(matches!(err, Error(box ErrorInner::Request(header)) if header.not_leader.is_some()));
 }

--- a/tests/integrations/storage/test_raft_storage.rs
+++ b/tests/integrations/storage/test_raft_storage.rs
@@ -58,7 +58,7 @@ fn test_raft_storage() {
     ctx.set_region_id(region_id + 1);
     storage.get(ctx.clone(), &key, 20).unwrap_err();
     storage
-        .batch_get(ctx.clone(), &[key.clone()], 20)
+        .batch_get(ctx.clone(), std::slice::from_ref(&key), 20)
         .unwrap_err();
     storage
         .scan(ctx.clone(), key, None, 1, false, 20)
@@ -162,7 +162,7 @@ fn test_raft_storage_store_not_match() {
         panic!("expect store_not_match, but got {:?}", res);
     }
     storage
-        .batch_get(ctx.clone(), &[key.clone()], 20)
+        .batch_get(ctx.clone(), std::slice::from_ref(&key), 20)
         .unwrap_err();
     storage
         .scan(ctx.clone(), key, None, 1, false, 20)


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: close #19931

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Backport the dependency and toolchain updates used on master to release-8.5.

Upgrade the AWS SDK family, lru, OpenSSL, Quinn, Rustix, serde_with, and
time. Update the Rust nightly and carry over the required Rust 2024
compatibility changes. Remove resolved advisory exceptions and stale
OpenSSL Clippy guards.
```

#### 1. Security dependency upgrades

**Why this category is needed:** release-8.5 contains dependency versions
affected by the vulnerabilities listed below. These changes move each
dependency to the same fixed line selected on master.

**What the changes look like:** Cargo manifests and `Cargo.lock` are updated
for the AWS SDK family, lru, OpenSSL, quinn-proto, rustix, serde_with, and
time. Direct AWS SDK versions are pinned to keep their generated crates and
transitive dependencies on a compatible set. Every compatible transitive
package changed by this backport is locked to the version used by master PR
#19930. The only release-only additions are `rustix` 0.36.16 and its Windows
target metadata, required by release-8.5's older
`raft-engine-ctl -> env_logger -> is-terminal` dependency path. There is no
intended TiKV protocol, storage-format, or configuration-format change.

Vulnerabilities addressed:

- `aws-sdk-kms` 1.40.0 -> 1.103.0, `aws-sdk-s3` 1.40.0 -> 1.126.0,
  and `aws-sdk-sts` 1.37.0 -> 1.100.0: `GHSA-g59m-gf8j-gjf5`.
- `lru` 0.12.5 -> 0.16.3: `GHSA-rhfx-m35p-ff5j`.
- `openssl` 0.10.73 -> 0.10.80: `CVE-2026-41676`, `CVE-2026-41677`,
  `CVE-2026-41678`, `CVE-2026-41681`, `CVE-2026-41898`, `CVE-2026-42327`,
  `CVE-2026-44662`, and `CVE-2026-45784`.
- `quinn-proto` 0.11.14 -> 0.11.15: `CVE-2026-25800`.
- `rustix` 0.36.7/0.38.3 -> 0.36.16/0.38.19: `CVE-2024-43806`.
- `serde_with` 1.4.0 -> 3.21.0: `GHSA-7gcf-g7xr-8hxj`.
- `time` 0.3.44 -> 0.3.47: `CVE-2026-25727`.

The vendored OpenSSL source remains 3.5.2, so this does not introduce the
historical OpenSSL 1.1-to-3.x transition. The protobuf, quick-xml, and rand
dependency migrations are not included.

#### 2. Rust toolchain and language compatibility changes

**Why this category is needed:** the fixed AWS SDK and transitive dependency
versions require a newer Rust compiler than the nightly previously pinned by
release-8.5. Updating the compiler also requires source compatibility changes
for stabilized let chains and Rust 2024 unsafe-operation rules.

**What the changes look like:** `rust-toolchain.toml` moves from
`nightly-2025-02-28` to `nightly-2026-01-30`. Nine crates move to edition
2024. The remaining source changes are the same mechanical transformations
used on master: nested-condition/let-chain rewrites, explicit unsafe blocks
inside unsafe functions and extern blocks, stabilized feature cleanup, and
test assertion updates. These changes are not intended to alter TiKV control
flow or runtime behavior.

#### 3. AWS S3 compiler adaptation

**Why this category is needed:** after the AWS SDK upgrade, the multipart
upload async state becomes too large for the compiler unless the relevant
futures are boxed.

**What the changes look like:** the multipart upload future and each per-part
retry future are wrapped in `Box::pin`, following master PR #19458. Upload,
retry, completion, and abort semantics are unchanged. This adds a small heap
allocation for the outer multipart future and for each uploaded part.

#### 4. Security audit and lint cleanup

**Why this category is needed:** cargo-deny exceptions and OpenSSL API bans
that protected the old dependency versions become stale after the upgrades.
The new AWS checksum path also reaches `digest` through `crc-fast`.

**What the changes look like:** resolved OpenSSL, lru, and time advisory
exceptions are removed; obsolete OpenSSL Clippy bans are removed; and
`crc-fast` is added as an allowed `digest` wrapper. Remaining advisory
exceptions are unchanged.

#### Backport source

This follows the same approach as master PRs #19367, #19458, and #19930. The
large source diff comes from the toolchain compatibility backport rather than
from new release-8.5-specific application logic.

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Manual test:

```text
cargo check --all --locked
make format
cargo +1.92.0 deny check --disable-fetch --show-stats
./scripts/clippy-all
cargo test -p crypto -p security --lib --locked
```

`make clippy` completed the repository checks but could not fetch the online
RustSec advisory database. Its cached deny check and `clippy-all` stages passed
separately.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Upgrade vulnerable Rust dependencies used by TiKV release-8.5.
```