### PR TITLE
engine_rocks: check ingest write stall by stop-writes-trigger

### DIFF
--- a/components/engine_rocks/src/misc.rs
+++ b/components/engine_rocks/src/misc.rs
@@ -326,12 +326,15 @@ impl MiscExt for RocksEngine {
         let handle = util::get_cf_handle(self.as_inner(), cf)?;
         if let Some(n) = util::get_cf_num_files_at_level(self.as_inner(), handle, 0) {
             let options = self.as_inner().get_options_cf(handle);
-            let slowdown_trigger = options.get_level_zero_slowdown_writes_trigger();
+            // Use level0_stop_writes_trigger instead of level0_slowdown_writes_trigger
+            // to integrate with flow control while preserving RocksDB's compaction
+            // speed-up mechanism. See `fill_cf_opts` in src/config/mod.rs.
+            let stop_trigger = options.get_level_zero_stop_writes_trigger();
             let compaction_trigger = options.get_level_zero_file_num_compaction_trigger() as u64;
             // Leave enough buffer to tolerate heavy write workload,
             // which may flush some memtables in a short time.
             let worse_case_l0_file_count = n + inflight_ingest_cnt;
-            if worse_case_l0_file_count > u64::from(slowdown_trigger) / 2
+            if worse_case_l0_file_count > u64::from(stop_trigger) / 2
                 && worse_case_l0_file_count >= compaction_trigger
             {
                 return Ok(true);
@@ -503,7 +506,8 @@ impl MiscExt for RocksEngine {
 #[cfg(test)]
 mod tests {
     use engine_traits::{
-        ALL_CFS, DeleteStrategy, Iterable, Iterator, Mutable, SyncMutable, WriteBatchExt,
+        ALL_CFS, CF_DEFAULT, DeleteStrategy, Iterable, Iterator, Mutable, SyncMutable,
+        WriteBatchExt,
     };
     use tempfile::Builder;
 
@@ -805,5 +809,40 @@ mod tests {
         assert_eq!(db.get_total_sst_files_size_cf("write").unwrap().unwrap(), 0);
         assert_eq!(db.get_total_sst_files_size_cf("lock").unwrap().unwrap(), 0);
         assert!(db.get_total_sst_files_size_cf("default").unwrap().unwrap() > 0);
+    }
+
+    #[test]
+    fn test_ingest_maybe_slowdown_writes_follows_stop_writes_trigger() {
+        let path = Builder::new()
+            .prefix("test_ingest_maybe_slowdown_writes")
+            .tempdir()
+            .unwrap();
+        let path_str = path.path().to_str().unwrap();
+
+        // Mimic the config after `fill_cf_opts` when flow control raises
+        // `l0-files-threshold`: the stop trigger follows it while the slowdown
+        // trigger stays low so that RocksDB speeds up compaction early.
+        let mut cf_opts = RocksCfOptions::default();
+        cf_opts.set_level_zero_file_num_compaction_trigger(2);
+        cf_opts.set_level_zero_slowdown_writes_trigger(4);
+        cf_opts.set_level_zero_stop_writes_trigger(20);
+        cf_opts.set_disable_auto_compactions(true);
+        let db = new_engine_opt(
+            path_str,
+            RocksDbOptions::default(),
+            vec![(CF_DEFAULT, cf_opts)],
+        )
+        .unwrap();
+
+        // Build 3 L0 files, which is above half the slowdown trigger but well
+        // below half the stop trigger.
+        for i in 0..3u8 {
+            db.put_cf(CF_DEFAULT, &[b'k', i], b"v").unwrap();
+            db.flush_cf(CF_DEFAULT, true).unwrap();
+        }
+
+        assert!(!db.ingest_maybe_slowdown_writes(CF_DEFAULT, 0).unwrap());
+        // 3 existing files plus 8 inflight ones exceed half the stop trigger.
+        assert!(db.ingest_maybe_slowdown_writes(CF_DEFAULT, 8).unwrap());
     }
 }


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: ref #18708

`ingest_maybe_slowdown_writes` reads `level0-slowdown-writes-trigger` to
decide whether an SST ingest may cause a write stall. After #18710 that is
the wrong knob.

#18710 decoupled `level0-slowdown-writes-trigger` from
`storage.flow-control.l0-files-threshold`: the slowdown trigger now keeps its
own default (20) and is only lowered when it exceeds the flow control
threshold, so RocksDB can start speeding up compaction early.
`level0-stop-writes-trigger` is the one that still follows
`l0-files-threshold` — `fill_cf_opts` fills it with that value when unset.

#18710 was supposed to move the ingest check over to the stop trigger. That
change was in the branch from the first commit, but its last commit
(78ff1e13b, "fix unit test") reverted the one-line switch while moving some
test config around. The PR description and the comments left in
`src/config/mod.rs`, `components/raftstore/src/store/worker/region.rs` and
`tests/integrations/import/test_sst_service.rs` all still describe the
intended behavior, so the code and the comments disagree today.

Impact: raising `l0-files-threshold` makes SST ingest and snapshot apply back
off much earlier than intended, which is the opposite of what raising the
threshold is for. With `l0-files-threshold = 60` the slowdown trigger stays
at 20 and the stop trigger becomes 60, so the gate fires at 10 L0 files
instead of 30. Default settings are unaffected because all three values are
20 there, which is why CI stayed green.

`level0-stop-writes-trigger` is the right knob in both modes. With flow
control off, `disable-write-stall` is off too, so RocksDB really does stop
writes at that value. With flow control on, RocksDB never stalls and the
value carries `l0-files-threshold`, which is where flow control starts to
throttle. The slowdown trigger answers neither question after #18710.

Ideally the gate would read the flow control config directly, as raised in
the review of #18710. `engine_rocks` cannot see it today because flow control
lives in the upper `storage` module, so this keeps borrowing the stop trigger
as the carrier.

What's Changed:

```commit-message
engine_rocks: check ingest write stall by stop-writes-trigger

#18710 decoupled `level0-slowdown-writes-trigger` from
`storage.flow-control.l0-files-threshold`, so the slowdown trigger now
keeps its own default (20) and is only lowered when it exceeds the flow
control threshold. `level0-stop-writes-trigger` is the one that still
follows `l0-files-threshold`.

`ingest_maybe_slowdown_writes` was meant to switch to the stop trigger in
that PR, but the change was reverted by mistake in its last commit, so
the function still reads the slowdown trigger. This commit restores it.

Without this, raising `l0-files-threshold` makes SST ingest and snapshot
apply back off far earlier than intended. With `l0-files-threshold` set
to 60, the gate fires at 10 L0 files instead of 30, which is the opposite
of what raising the threshold is supposed to do. Defaults are unaffected
because all three values are 20 there.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [x] Need to cherry-pick to the release branch: release-8.5, which took
      #18710 as #18994.

### Check List

Tests

- [x] Unit test

`test_ingest_maybe_slowdown_writes_follows_stop_writes_trigger` sets a low
slowdown trigger (4) and a high stop trigger (20), builds 3 L0 files, and
asserts the gate stays open. It fails before this change and passes after.
The second assertion feeds 8 inflight ingests to show the gate does close
once the stop trigger is actually crossed.

The existing tests could not catch the revert: they set the slowdown and the
stop trigger to the same value, so reading either one gives the same answer.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note

```release-note
Fix a problem where raising storage.flow-control.l0-files-threshold made SST
ingest and snapshot apply back off earlier instead of later.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved write-throttling behavior during ingestion by using a more appropriate projected file-count threshold.
  * Added coverage for ingestion scenarios with files still in progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->