### PR TITLE
[DNM]*: port #19935 race-window debug changes onto latest master

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4492,7 +4492,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git#1c17b59dcb506302ed4684b3628c4a7165e0b86d"
+source = "git+https://github.com/LykxSassinator/rust-rocksdb?branch=debug_for_19906#7d29f50b9312891d23895253381e639b7dd8d390"
 dependencies = [
  "bindgen 0.65.1",
  "bzip2-sys",
@@ -4511,7 +4511,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/tikv/rust-rocksdb.git#1c17b59dcb506302ed4684b3628c4a7165e0b86d"
+source = "git+https://github.com/LykxSassinator/rust-rocksdb?branch=debug_for_19906#7d29f50b9312891d23895253381e639b7dd8d390"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -6708,7 +6708,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git#1c17b59dcb506302ed4684b3628c4a7165e0b86d"
+source = "git+https://github.com/LykxSassinator/rust-rocksdb?branch=debug_for_19906#7d29f50b9312891d23895253381e639b7dd8d390"
 dependencies = [
  "libc 0.2.176",
  "librocksdb_sys",
@@ -9215,7 +9215,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "static_assertions",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -231,6 +231,8 @@ sysinfo = { git = "https://github.com/tikv/sysinfo", branch = "0.26-fix-cpu" }
 # After the PR to rust-rocksdb is merged, remember to comment this out and run `cargo update -p rocksdb`.
 # [patch.'https://github.com/tikv/rust-rocksdb']
 # rocksdb = { git = "https://github.com/your_github_id/rust-rocksdb", branch = "your_branch" }
+[patch.'https://github.com/tikv/rust-rocksdb']
+rocksdb = { git = "https://github.com/LykxSassinator/rust-rocksdb", branch = "debug_for_19906" }
 
 [workspace]
 # See https://github.com/rust-lang/rfcs/blob/master/text/2957-cargo-features2.md

--- a/components/raftstore/src/store/peer_storage.rs
+++ b/components/raftstore/src/store/peer_storage.rs
@@ -1297,7 +1297,8 @@ where
                 storage_error(format!("could not load raft state of region {}", region_id))
             })
         })?;
-    assert_eq!(apply_state, last_applied_state);
+    // Annotate for debugging.
+    // assert_eq!(apply_state, last_applied_state);
 
     let key = SnapKey::new(
         region_id,


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: ref #19891

What's Changed:

```commit-message
Port the race-window amplification from #19935 onto the latest master,
which already contains the #19906 fix.

Use the debug rust-rocksdb branch that sleeps for 10 ms after reading the
last sequence number and before updating VersionSet sequence numbers. This
makes the original ingestion/write race window wider so E2E testing can
verify that the fix remains effective under forced contention.

Also keep the snapshot apply-state assertion disabled as in #19935 so the
debug build can continue collecting reproduction evidence.
```

Based on master commit `29766869c86f4a65de2ec0a9ef04dd0992832c24`.

Reference debug PR: #19935  
Fix under verification: #19906

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Manual checks performed:

- Confirmed merge commit of #19906 is an ancestor of this branch.
- `cargo fmt --all -- --check`
- `cargo metadata --locked --no-deps --format-version 1`
- `git diff --check`

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

This is a DNM debug-only change. The intentional 10 ms sleep affects external SST ingestion and must not be merged into production.

### Release note

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved snapshot handling to prevent unnecessary failures during snapshot generation.
* **Chores**
  * Updated the underlying storage component to incorporate a targeted upstream fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->