### PR TITLE
codec: fix Stacked Borrows UB in try_decode_first_in_place

### DIFF
--- a/components/codec/src/byte.rs
+++ b/components/codec/src/byte.rs
@@ -1176,26 +1176,30 @@ mod tests {
     ///
     /// # Unsoundness (pre-fix)
     ///
-    /// `try_decode_first_in_place` / `_desc` are **safe** APIs. Pre-fix they did:
+    /// `try_decode_first_in_place` / `_desc` are **safe** APIs. Pre-fix they
+    /// did:
     ///
     /// ```ignore
     /// try_decode_first_internal(buffer.as_ptr(), len, buffer.as_mut_ptr(), len)
     /// ```
     ///
-    /// Under Stacked Borrows, `as_mut_ptr()` invalidates the SharedReadOnly tag from
-    /// `as_ptr()`. The internal `ptr::copy` then reads via the invalidated pointer → UB.
-    /// Any safe caller of this public API could trigger it (library unsoundness).
+    /// Under Stacked Borrows, `as_mut_ptr()` invalidates the SharedReadOnly tag
+    /// from `as_ptr()`. The internal `ptr::copy` then reads via the
+    /// invalidated pointer → UB. Any safe caller of this public API could
+    /// trigger it (library unsoundness).
     ///
     /// # How this test proves it
     ///
     /// Under Miri with the pre-fix code this test fails with:
     /// `Undefined Behavior: ... tag does not exist in the borrow stack`
-    /// pointing at `ptr::copy` in `try_decode_first_internal`, with help tags created
-    /// at `as_ptr()` and invalidated at `as_mut_ptr()`.
+    /// pointing at `ptr::copy` in `try_decode_first_internal`, with help tags
+    /// created at `as_ptr()` and invalidated at `as_mut_ptr()`.
     ///
-    /// With the fix (both pointers from one `as_mut_ptr()`), Miri accepts the test.
+    /// With the fix (both pointers from one `as_mut_ptr()`), Miri accepts the
+    /// test.
     ///
-    /// Run: `cargo +nightly miri test -p codec -- miri_soundness_try_decode_first_in_place`
+    /// Run: `cargo +nightly miri test -p codec --
+    /// miri_soundness_try_decode_first_in_place`
     #[test]
     fn miri_soundness_try_decode_first_in_place() {
         // Cover empty, partial group, full group(s), multi-group — all in-place.

--- a/components/codec/src/byte.rs
+++ b/components/codec/src/byte.rs
@@ -293,12 +293,13 @@ impl MemComparableByteCodec {
     ///
     /// When there is an error, `dest` may contain partially written data.
     pub fn try_decode_first_in_place(buffer: &mut [u8]) -> Result<(usize, usize)> {
-        Self::try_decode_first_internal::<Ascending>(
-            buffer.as_ptr(),
-            buffer.len(),
-            buffer.as_mut_ptr(),
-            buffer.len(),
-        )
+        // Derive both pointers from the same unique mutable reborrow so that
+        // Stacked/Tree Borrows provenance stays valid when src and dest alias
+        // (in-place decode). Calling as_ptr() then as_mut_ptr() invalidates the
+        // shared-derived pointer under Stacked Borrows; using it later is UB.
+        let ptr = buffer.as_mut_ptr();
+        let len = buffer.len();
+        Self::try_decode_first_internal::<Ascending>(ptr, len, ptr, len)
     }
 
     /// Decodes bytes in descending memory-comparable format in place, i.e.
@@ -321,12 +322,11 @@ impl MemComparableByteCodec {
     ///
     /// When there is an error, `dest` may contain partially written data.
     pub fn try_decode_first_in_place_desc(buffer: &mut [u8]) -> Result<(usize, usize)> {
-        let (read_bytes, written_bytes) = Self::try_decode_first_internal::<Descending>(
-            buffer.as_ptr(),
-            buffer.len(),
-            buffer.as_mut_ptr(),
-            buffer.len(),
-        )?;
+        // Same provenance fix as try_decode_first_in_place (see comment there).
+        let ptr = buffer.as_mut_ptr();
+        let len = buffer.len();
+        let (read_bytes, written_bytes) =
+            Self::try_decode_first_internal::<Descending>(ptr, len, ptr, len)?;
         Self::flip_bytes_in_place(buffer, written_bytes);
         Ok((read_bytes, written_bytes))
     }
@@ -1168,6 +1168,76 @@ mod tests {
                 let mut dest = vec![0; src.len()];
                 MemComparableByteCodec::try_decode_first(src.as_slice(), dest.as_mut_slice())
                     .unwrap();
+            }
+        }
+    }
+
+    /// Miri soundness regression for in-place decode aliasing UB.
+    ///
+    /// # Unsoundness (pre-fix)
+    ///
+    /// `try_decode_first_in_place` / `_desc` are **safe** APIs. Pre-fix they did:
+    ///
+    /// ```ignore
+    /// try_decode_first_internal(buffer.as_ptr(), len, buffer.as_mut_ptr(), len)
+    /// ```
+    ///
+    /// Under Stacked Borrows, `as_mut_ptr()` invalidates the SharedReadOnly tag from
+    /// `as_ptr()`. The internal `ptr::copy` then reads via the invalidated pointer → UB.
+    /// Any safe caller of this public API could trigger it (library unsoundness).
+    ///
+    /// # How this test proves it
+    ///
+    /// Under Miri with the pre-fix code this test fails with:
+    /// `Undefined Behavior: ... tag does not exist in the borrow stack`
+    /// pointing at `ptr::copy` in `try_decode_first_internal`, with help tags created
+    /// at `as_ptr()` and invalidated at `as_mut_ptr()`.
+    ///
+    /// With the fix (both pointers from one `as_mut_ptr()`), Miri accepts the test.
+    ///
+    /// Run: `cargo +nightly miri test -p codec -- miri_soundness_try_decode_first_in_place`
+    #[test]
+    fn miri_soundness_try_decode_first_in_place() {
+        // Cover empty, partial group, full group(s), multi-group — all in-place.
+        let payloads: &[&[u8]] = &[
+            b"",
+            b"\x00",
+            b"abc",
+            b"\x01\x02\x03\x04\x05\x06\x07",
+            b"\x00\x00\x00\x00\x00\x00\x00\x00", // exactly one group of data
+            b"\x01\x02\x03\x04\x05\x06\x07\x08",
+            b"\x01\x02\x03\x04\x05\x06\x07\x08\x09",
+            &[0xA5; 64],
+            &[0x3C; 100],
+        ];
+
+        for &payload in payloads {
+            // ascending in-place
+            {
+                let mut encoded = vec![0; MemComparableByteCodec::encoded_len(payload.len())];
+                let n = MemComparableByteCodec::encode_all(payload, encoded.as_mut_slice());
+                assert_eq!(n, encoded.len());
+
+                let mut buf = encoded.clone();
+                let (read, written) =
+                    MemComparableByteCodec::try_decode_first_in_place(buf.as_mut_slice()).unwrap();
+                assert_eq!(read, encoded.len());
+                assert_eq!(written, payload.len());
+                assert_eq!(&buf[..written], payload);
+            }
+            // descending in-place
+            {
+                let mut encoded = vec![0; MemComparableByteCodec::encoded_len(payload.len())];
+                let n = MemComparableByteCodec::encode_all_desc(payload, encoded.as_mut_slice());
+                assert_eq!(n, encoded.len());
+
+                let mut buf = encoded.clone();
+                let (read, written) =
+                    MemComparableByteCodec::try_decode_first_in_place_desc(buf.as_mut_slice())
+                        .unwrap();
+                assert_eq!(read, encoded.len());
+                assert_eq!(written, payload.len());
+                assert_eq!(&buf[..written], payload);
             }
         }
     }


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: close #19943

What's Changed:

```commit-message
Derive both src and dest raw pointers from a single as_mut_ptr() in the
in-place decode path so pointer provenance remains valid when src and
dest alias.
```

#### The problem

`MemComparableByteCodec::try_decode_first_in_place` and `try_decode_first_in_place_desc` are safe public APIs that decode a mem-comparable value in place. They built the aliasing src/dest pointer pair like this:

```rust
Self::try_decode_first_internal::<Ascending>(
    buffer.as_ptr(),     // pointer derived from a shared borrow
    buffer.len(),
    buffer.as_mut_ptr(), // unique retag: invalidates the pointer above
    buffer.len(),
)
```

Under the Stacked Borrows aliasing model, the unique retag performed by `as_mut_ptr()` invalidates the pointer previously derived from `as_ptr()`. When `try_decode_first_internal` later reads through that source pointer (in `ptr::copy`), the read uses an invalidated tag, which is undefined behavior. Miri reports:

```
error: Undefined Behavior: attempting a read access using <tag>,
       but that tag does not exist in the borrow stack for this location
  --> ptr::copy inside try_decode_first_internal
help: <tag> was created by a SharedReadOnly retag at buffer.as_ptr()
help: <tag> was later invalidated by a Unique retag at buffer.as_mut_ptr()
```

Because both entry points are safe `pub fn`s, any safe caller can trigger this — it is library unsoundness rather than misuse of an `unsafe` API. To be precise about severity: no miscompilation is known on current toolchains; the risk of leaving the UB in place is that rustc/LLVM are allowed to exploit these aliasing rules more aggressively in future releases.

#### The fix

Derive both pointers from a single mutable reborrow, which is the pattern the aliasing models (Stacked Borrows and Tree Borrows) accept for intentionally-aliasing src/dest pairs:

```rust
let ptr = buffer.as_mut_ptr();
let len = buffer.len();
Self::try_decode_first_internal::<Ascending>(ptr, len, ptr, len)
```

The descending variant receives the same change; its byte flipping after decoding is untouched. Public API, observable behavior, and performance are unchanged — same pointer values and lengths, only the provenance of the source pointer differs.

Codegen impact: none — verified by diffing the emitted assembly of both functions with and without this change (pinned nightly, `--release`, `-C codegen-units=1`); they are byte-identical. In the emitted LLVM IR, both versions already pass the same SSA value for src and dest (the trivial `as_ptr`/`as_mut_ptr` accessors collapse after inlining), so today the provenance distinction never reaches LLVM. The UB is currently observable only in the Rust abstract machine (Miri); this fix removes the latent risk before a future rustc starts lowering provenance in a way that could exploit it.

#### Test

`miri_soundness_try_decode_first_in_place` decodes in place (ascending and descending) across empty, partial-group, exactly-one-group, multi-group, and larger payloads, asserting the consumed length, the written length, and the round-tripped contents.

- Against the pre-fix code, Miri fails this test with the Stacked Borrows error quoted above.
- With the fix, Miri passes.
- The test is also a valid plain unit test, so it runs in regular CI.

```bash
cargo +nightly miri test -p codec -- miri_soundness_try_decode_first_in_place
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`: not needed (no user-facing change)
- Need to cherry-pick to the release branch: at the maintainers' discretion — the UB is real, but no miscompilation has been observed on current toolchains

### Check List

Tests

- [x] Unit test (`miri_soundness_try_decode_first_in_place`)
- [x] Manual test: `cargo +nightly miri test -p codec -- miri_soundness_try_decode_first_in_place` fails before the fix and passes after it

Side effects

- None expected: no API, behavior, or performance change.

### Release note

```release-note
codec: fix undefined behavior (Stacked Borrows aliasing violation) in the in-place mem-comparable decode functions
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved in-place ascending and descending decoding when input and output share the same buffer.
  * Preserved decoding results and return values for empty, partial, multi-group, and larger payloads.
  * Improved reliability and memory safety for supported in-place decoding scenarios.

* **Tests**
  * Added regression coverage across a range of payload sizes and decoding modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
