### PR TITLE
codec: fix Stacked Borrows UB in encode_all_in_place

### DIFF
--- a/components/codec/src/byte.rs
+++ b/components/codec/src/byte.rs
@@ -128,8 +128,13 @@ impl MemComparableByteCodec {
         let padding_marker = !(padding_size as u8);
 
         unsafe {
-            let mut src_ptr = src.as_ptr().add(src_len - last_group_size);
-            let mut dest_ptr = src.as_mut_ptr().add(dest_len - (MEMCMP_GROUP_SIZE + 1));
+            // Derive both pointers from the same unique mutable reborrow so that
+            // Stacked/Tree Borrows provenance stays valid when src and dest alias
+            // (in-place encode). Calling as_ptr() then as_mut_ptr() invalidates the
+            // shared-derived pointer under Stacked Borrows; using it later is UB.
+            let base = src.as_mut_ptr();
+            let mut src_ptr = base.add(src_len - last_group_size);
+            let mut dest_ptr = base.add(dest_len - (MEMCMP_GROUP_SIZE + 1));
 
             std::ptr::copy(src_ptr, dest_ptr, last_group_size);
             std::ptr::write_bytes(dest_ptr.add(last_group_size), MEMCMP_PAD_BYTE, padding_size);


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: N/A (discovered via Miri; can open a tracking issue if preferred)

What's Changed:

```commit-message
codec: fix Stacked Borrows UB in encode_all_in_place

Derive both src and dest raw pointers from a single `as_mut_ptr()` in the
in-place encode path so provenance remains valid when src and dest alias.
```

### Summary

`MemComparableByteCodec::encode_all_in_place` (and
`encode_all_in_place_desc`, which calls it) expands encoded bytes
**in place** inside a single buffer: data is written backward so unencoded
bytes are not overwritten too early.

The previous setup was:

```rust
unsafe {
    let mut src_ptr = src.as_ptr().add(src_len - last_group_size);
    let mut dest_ptr = src.as_mut_ptr().add(dest_len - (MEMCMP_GROUP_SIZE + 1));
    std::ptr::copy(src_ptr, dest_ptr, last_group_size);
    // ...
}
```

Under **Stacked Borrows**:

1. `src.as_ptr()` creates a `SharedReadOnly` tag.
2. `src.as_mut_ptr()` re-tags the allocation as `Unique` and **invalidates** the
   shared tag.
3. `ptr::copy` then reads via the invalidated `src_ptr` → **undefined behavior**.

The public function is **safe** (`&mut [u8]` + length). Any correct safe
caller of the in-place encode API can trigger this — classic **API
unsoundness**, not caller misuse.

### Miri reproduction

```
test byte::tests::test_memcmp_encode_all ... error:
Undefined Behavior: attempting a read access using <tag> at alloc[0x0],
but that tag does not exist in the borrow stack for this location
   --> encode_all_in_place: std::ptr::copy(src_ptr, dest_ptr, last_group_size)
help: <tag> was created by a SharedReadOnly retag at:
   --> src.as_ptr()
help: <tag> was later invalidated by a Unique retag at:
   --> src.as_mut_ptr()
```

### Fix

```rust
let base = src.as_mut_ptr();
let mut src_ptr = base.add(src_len - last_group_size);
let mut dest_ptr = base.add(dest_len - (MEMCMP_GROUP_SIZE + 1));
```

One Unique provenance for both pointers. Encoding algorithm and
backward-write order are unchanged; only derivation is fixed.

`encode_all_in_place_desc` is fixed transitively (it calls
`encode_all_in_place` then flips bytes).

### Sibling PR

Same class of bug as in-place **decode**
(`try_decode_first_in_place` / `try_decode_first_in_place_desc`) —
filed separately so each fix can land independently.

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests

- [x] Unit test (`test_memcmp_encode_all` and related panic tests)
- [ ] Integration test
- [x] Manual test (Miri on isolated codec extract; encode-all tests pass after fix)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note

```release-note
codec: fix undefined behavior (Stacked Borrows) in mem-comparable in-place encode
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved memory handling during in-place encoding, including scenarios where source and destination buffers overlap.
  * Preserved existing encoding behavior and public APIs.
* **Bug Fixes**
  * Improved pointer handling to support safer buffer aliasing without changing user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->