### PR TITLE
codec: fix OOB pointer arithmetic in memcomparable naive bench

### DIFF
--- a/components/codec/src/byte.rs
+++ b/components/codec/src/byte.rs
@@ -1246,7 +1246,11 @@ mod benches {
             let src_ptr_end = src_ptr.add(src.len());
             let dest_ptr_end = dest_ptr.add(dest.len());
 
-            while src_ptr <= src_ptr_end {
+            // Process groups until the final (possibly empty) padded group, then
+            // stop. Unconditionally advancing src by MEMCMP_GROUP_SIZE after that
+            // group creates a pointer past one-past-the-end of the allocation,
+            // which is UB under Rust's pointer rules (same class as tikv#7751).
+            loop {
                 // We needs to write GROUP_SIZE + 1 bytes then, so we assert a bound.
                 assert!(
                     dest_ptr.add(super::MEMCMP_GROUP_SIZE + 1) <= dest_ptr_end,
@@ -1266,12 +1270,17 @@ mod benches {
                         padding_size,
                     );
                 }
-                src_ptr = src_ptr.add(super::MEMCMP_GROUP_SIZE);
                 dest_ptr = dest_ptr.add(super::MEMCMP_GROUP_SIZE);
 
                 let padding_marker = !(padding_size as u8);
                 dest_ptr.write(padding_marker);
                 dest_ptr = dest_ptr.add(1);
+
+                // Final group (remaining data <= one group, including empty src).
+                if remaining_size <= super::MEMCMP_GROUP_SIZE {
+                    break;
+                }
+                src_ptr = src_ptr.add(super::MEMCMP_GROUP_SIZE);
             }
 
             dest_ptr.offset_from(dest.as_mut_ptr()) as usize


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: N/A (discovered via Miri; can open a tracking issue if preferred)

What's Changed:

```commit-message
codec: fix OOB pointer arithmetic in memcomparable naive bench

Stop advancing src_ptr after the final padded group so ptr::add does not
produce a pointer past one-past-the-end of the allocation.
```

### Summary

The benchmark helper `mem_comparable_encode_all_naive` (in
`components/codec/src/byte.rs` benches) implements a simplified
mem-comparable encoder used only for performance comparison.

Previous loop structure (simplified):

```rust
while src_ptr <= src_ptr_end {
    // encode one group (possibly the final padded group)
    ...
    src_ptr = src_ptr.add(MEMCMP_GROUP_SIZE); // always advances
    dest_ptr = dest_ptr.add(MEMCMP_GROUP_SIZE);
    dest_ptr.write(padding_marker);
    dest_ptr = dest_ptr.add(1);
}
```

When `src.len()` is a multiple of `MEMCMP_GROUP_SIZE` (e.g. 1000 with group
size 8), after the final group `src_ptr` is already at **one-past-the-end**
of the allocation. The next unconditional `src_ptr.add(8)` creates a
pointer **beyond** one-past-the-end → **undefined behavior** under Rust's
in-bounds pointer arithmetic rules (same family as LLVM `getelementptr
inbounds`).

Miri message (excerpt):

```
Undefined Behavior: in-bounds pointer arithmetic failed: attempting to
offset pointer by 8 bytes, but got alloc+0x3e8 which is at or beyond the
end of the allocation of size 1000 bytes
   --> mem_comparable_encode_all_naive: src_ptr = src_ptr.add(MEMCMP_GROUP_SIZE)
```

### Scope

- **Production encode** (`encode_all` / `encode_all_in_place`) is **not**
  changed by this PR.
- This is the **naive benchmark helper only**, but it still runs under
  `#[cfg(test)]` benches and can fail Miri when benches are included.

Same class of bug as historical Miri findings (e.g. PR #7751 on codec
pointer arithmetic): intermediate OOB pointers are UB even without a
subsequent load/store through them.

### Fix

Restructure to a `loop` that **breaks after the final group**
(`remaining_size <= MEMCMP_GROUP_SIZE`, including the empty-source /
all-padding case) and only advances `src_ptr` when more full groups remain:

```rust
loop {
    let remaining_size = src_ptr_end.offset_from(src_ptr) as usize;
    // ... write group ...
    if remaining_size <= MEMCMP_GROUP_SIZE {
        break;
    }
    src_ptr = src_ptr.add(MEMCMP_GROUP_SIZE);
}
```

Encoded output is unchanged; only pointer motion is constrained to stay
in-bounds / at most one-past-the-end.

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests

- [x] Unit test / benches (existing memcmp encode naive benches)
- [ ] Integration test
- [x] Manual test (Miri: `bench_memcmp_encode_all_*_naive` no longer UB)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note

```release-note
None
```

(Bench-only helper; no production behavior change.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an encoder test helper so it stops safely after processing the final padded group.
  * Preserved existing encoded output behavior while preventing out-of-bounds source pointer advancement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->