### PR TITLE
codec: fix Stacked Borrows UB in encode_all_in_place

### DIFF
--- a/components/codec/src/byte.rs
+++ b/components/codec/src/byte.rs
@@ -979,22 +979,25 @@ mod tests {
     /// std::ptr::copy(src_ptr, dest_ptr, ...);
     /// ```
     ///
-    /// Under Stacked Borrows, `as_mut_ptr()` invalidates the SharedReadOnly tag from
-    /// `as_ptr()`. The following `ptr::copy` reads via the invalidated pointer → UB.
-    /// Any safe caller with a valid buffer can trigger it (library unsoundness).
-    /// `encode_all_in_place_desc` is affected transitively.
+    /// Under Stacked Borrows, `as_mut_ptr()` invalidates the SharedReadOnly tag
+    /// from `as_ptr()`. The following `ptr::copy` reads via the invalidated
+    /// pointer → UB. Any safe caller with a valid buffer can trigger it
+    /// (library unsoundness). `encode_all_in_place_desc` is affected
+    /// transitively.
     ///
     /// # How this test proves it
     ///
     /// Under Miri with the pre-fix code this test fails with:
     /// `Undefined Behavior: ... tag does not exist in the borrow stack`
-    /// at `ptr::copy` in `encode_all_in_place`, with help tags created at `as_ptr()`
-    /// and invalidated at `as_mut_ptr()`.
+    /// at `ptr::copy` in `encode_all_in_place`, with help tags created at
+    /// `as_ptr()` and invalidated at `as_mut_ptr()`.
     ///
-    /// With the fix (both pointers from one `as_mut_ptr()` base), Miri accepts the
-    /// test and we assert bitwise equality with non-in-place `encode_all`.
+    /// With the fix (both pointers from one `as_mut_ptr()` base), Miri accepts
+    /// the test and we assert bitwise equality with non-in-place
+    /// `encode_all`.
     ///
-    /// Run: `cargo +nightly miri test -p codec -- miri_soundness_encode_all_in_place`
+    /// Run: `cargo +nightly miri test -p codec --
+    /// miri_soundness_encode_all_in_place`
     #[test]
     fn miri_soundness_encode_all_in_place() {
         let payloads: &[&[u8]] = &[
@@ -1020,7 +1023,8 @@ mod tests {
 
                 let mut buf = vec![0; enc_len];
                 buf[..payload.len()].copy_from_slice(payload);
-                let n = MemComparableByteCodec::encode_all_in_place(buf.as_mut_slice(), payload.len());
+                let n =
+                    MemComparableByteCodec::encode_all_in_place(buf.as_mut_slice(), payload.len());
                 assert_eq!(n, enc_len);
                 assert_eq!(&buf[..n], &expected[..n_exp]);
             }

--- a/components/codec/src/byte.rs
+++ b/components/codec/src/byte.rs
@@ -128,8 +128,13 @@ impl MemComparableByteCodec {
         let padding_marker = !(padding_size as u8);
 
         unsafe {
-            let mut src_ptr = src.as_ptr().add(src_len - last_group_size);
-            let mut dest_ptr = src.as_mut_ptr().add(dest_len - (MEMCMP_GROUP_SIZE + 1));
+            // Derive both pointers from the same unique mutable reborrow so that
+            // Stacked/Tree Borrows provenance stays valid when src and dest alias
+            // (in-place encode). Calling as_ptr() then as_mut_ptr() invalidates the
+            // shared-derived pointer under Stacked Borrows; using it later is UB.
+            let base = src.as_mut_ptr();
+            let mut src_ptr = base.add(src_len - last_group_size);
+            let mut dest_ptr = base.add(dest_len - (MEMCMP_GROUP_SIZE + 1));
 
             std::ptr::copy(src_ptr, dest_ptr, last_group_size);
             std::ptr::write_bytes(dest_ptr.add(last_group_size), MEMCMP_PAD_BYTE, padding_size);
@@ -958,6 +963,82 @@ mod tests {
                         &output_buffer[output_offset..output_offset + encoded_len],
                     );
                 }
+            }
+        }
+    }
+
+    /// Miri soundness regression for in-place encode aliasing UB.
+    ///
+    /// # Unsoundness (pre-fix)
+    ///
+    /// `encode_all_in_place` is a **safe** API. Pre-fix it did:
+    ///
+    /// ```ignore
+    /// let mut src_ptr = src.as_ptr().add(...);
+    /// let mut dest_ptr = src.as_mut_ptr().add(...);
+    /// std::ptr::copy(src_ptr, dest_ptr, ...);
+    /// ```
+    ///
+    /// Under Stacked Borrows, `as_mut_ptr()` invalidates the SharedReadOnly tag from
+    /// `as_ptr()`. The following `ptr::copy` reads via the invalidated pointer → UB.
+    /// Any safe caller with a valid buffer can trigger it (library unsoundness).
+    /// `encode_all_in_place_desc` is affected transitively.
+    ///
+    /// # How this test proves it
+    ///
+    /// Under Miri with the pre-fix code this test fails with:
+    /// `Undefined Behavior: ... tag does not exist in the borrow stack`
+    /// at `ptr::copy` in `encode_all_in_place`, with help tags created at `as_ptr()`
+    /// and invalidated at `as_mut_ptr()`.
+    ///
+    /// With the fix (both pointers from one `as_mut_ptr()` base), Miri accepts the
+    /// test and we assert bitwise equality with non-in-place `encode_all`.
+    ///
+    /// Run: `cargo +nightly miri test -p codec -- miri_soundness_encode_all_in_place`
+    #[test]
+    fn miri_soundness_encode_all_in_place() {
+        let payloads: &[&[u8]] = &[
+            b"",
+            b"\x00",
+            b"abc",
+            b"\x01\x02\x03\x04\x05\x06\x07",
+            b"\x00\x00\x00\x00\x00\x00\x00\x00",
+            b"\x01\x02\x03\x04\x05\x06\x07\x08",
+            b"\x01\x02\x03\x04\x05\x06\x07\x08\x09",
+            &[0xA5; 64],
+            &[0x3C; 100],
+        ];
+
+        for &payload in payloads {
+            let enc_len = MemComparableByteCodec::encoded_len(payload.len());
+
+            // ascending in-place vs non-in-place
+            {
+                let mut expected = vec![0; enc_len];
+                let n_exp = MemComparableByteCodec::encode_all(payload, expected.as_mut_slice());
+                assert_eq!(n_exp, enc_len);
+
+                let mut buf = vec![0; enc_len];
+                buf[..payload.len()].copy_from_slice(payload);
+                let n = MemComparableByteCodec::encode_all_in_place(buf.as_mut_slice(), payload.len());
+                assert_eq!(n, enc_len);
+                assert_eq!(&buf[..n], &expected[..n_exp]);
+            }
+            // descending in-place vs non-in-place
+            {
+                let mut expected = vec![0; enc_len];
+                let n_exp =
+                    MemComparableByteCodec::encode_all_desc(payload, expected.as_mut_slice());
+                assert_eq!(n_exp, enc_len);
+
+                let mut buf = vec![0; enc_len];
+                buf[..payload.len()].copy_from_slice(payload);
+                let n = MemComparableByteCodec::encode_all_in_place_desc(
+                    buf.as_mut_slice(),
+                    payload.len(),
+                );
+                assert_eq!(n, enc_len);
+                assert_eq!(&buf[..n], &expected[..n_exp]);
             }
         }
     }


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: close #19944

What's Changed:

```commit-message
Derive both src and dest raw pointers from a single as_mut_ptr() in the
in-place encode path so pointer provenance remains valid when src and
dest alias.
```

#### The problem

`MemComparableByteCodec::encode_all_in_place` (and `encode_all_in_place_desc`, which calls it) expands bytes **in place** inside a single buffer, writing backward so unencoded bytes are not overwritten too early. It built the aliasing src/dest pointer pair like this:

```rust
unsafe {
    let mut src_ptr = src.as_ptr().add(src_len - last_group_size);
    let mut dest_ptr = src.as_mut_ptr().add(dest_len - (MEMCMP_GROUP_SIZE + 1));
    std::ptr::copy(src_ptr, dest_ptr, last_group_size);
    // ...
}
```

Under the Stacked Borrows aliasing model, the unique retag performed by `as_mut_ptr()` invalidates the pointer previously derived from `as_ptr()`. The `ptr::copy` then reads through that invalidated source pointer, which is undefined behavior. Miri reports:

```
error: Undefined Behavior: attempting a read access using <tag>,
       but that tag does not exist in the borrow stack for this location
  --> std::ptr::copy(src_ptr, dest_ptr, last_group_size) in encode_all_in_place
help: <tag> was created by a SharedReadOnly retag at src.as_ptr()
help: <tag> was later invalidated by a Unique retag at src.as_mut_ptr()
```

Because the entry points are safe `pub fn`s, any safe caller can trigger this — it is library unsoundness rather than misuse of an `unsafe` API. To be precise about severity: no miscompilation is known on current toolchains; the risk of leaving the UB in place is that rustc/LLVM are allowed to exploit these aliasing rules more aggressively in future releases.

#### The fix

Derive both pointers from a single mutable reborrow, which is the pattern the aliasing models (Stacked Borrows and Tree Borrows) accept for intentionally-aliasing src/dest pairs:

```rust
let base = src.as_mut_ptr();
let mut src_ptr = base.add(src_len - last_group_size);
let mut dest_ptr = base.add(dest_len - (MEMCMP_GROUP_SIZE + 1));
```

The encoding algorithm and the backward-write order are untouched; only the pointer derivation changes. `encode_all_in_place_desc` is fixed transitively. Public API, observable behavior, and performance are unchanged.

Codegen impact: none — verified by diffing the emitted assembly of `encode_all_in_place` with and without this change (pinned nightly, `--release`, `-C codegen-units=1`); it is byte-identical. The trivial `as_ptr`/`as_mut_ptr` accessors collapse to the same SSA value after inlining, so today the provenance distinction never reaches LLVM. The UB is currently observable only in the Rust abstract machine (Miri); this fix removes the latent risk before a future rustc starts lowering provenance in a way that could exploit it.

#### Test

`miri_soundness_encode_all_in_place` encodes in place (ascending and descending) across empty, partial-group, exactly-one-group, multi-group, and larger payloads, asserting the returned length and bitwise equality with the non-in-place `encode_all` / `encode_all_desc` results.

- Against the pre-fix code, Miri fails this test with the Stacked Borrows error quoted above.
- With the fix, Miri passes.
- The test is also a valid plain unit test, so it runs in regular CI.

```bash
cargo +nightly miri test -p codec -- miri_soundness_encode_all_in_place
```

Sibling PR: #19939 fixes the same class of bug in the in-place **decode** path (`try_decode_first_in_place` / `_desc`); filed separately so each fix can land independently.

Supersedes #19940 — that PR was closed and its head branch was force-pushed afterwards (to fix the DCO sign-off and add the regression test), which permanently blocks reopening on GitHub, hence this fresh PR.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`: not needed (no user-facing change)
- Need to cherry-pick to the release branch: at the maintainers' discretion — the UB is real, but no miscompilation has been observed on current toolchains

### Check List

Tests

- [x] Unit test (`miri_soundness_encode_all_in_place`)
- [x] Manual test: `cargo +nightly miri test -p codec -- miri_soundness_encode_all_in_place` fails before the fix and passes after it

Side effects

- None expected: no API, behavior, or performance change.

### Release note

```release-note
codec: fix undefined behavior (Stacked Borrows aliasing violation) in the in-place mem-comparable encode functions
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed in-place encoding to produce correct results across different payload sizes and processing directions.

* **Tests**
  * Added regression coverage comparing in-place encoding with standard encoding to help prevent future issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->