### PR TITLE
codec: fix OOB pointer arithmetic in memcomparable naive bench

### DIFF
--- a/components/codec/src/byte.rs
+++ b/components/codec/src/byte.rs
@@ -1246,7 +1246,10 @@ mod benches {
             let src_ptr_end = src_ptr.add(src.len());
             let dest_ptr_end = dest_ptr.add(dest.len());
 
-            while src_ptr <= src_ptr_end {
+            // Same group loop as before, but never advance src after the empty
+            // terminator group (remaining==0). That advance was past one-past-the-end
+            // and is UB (same class as tikv#7751). See break conditions below.
+            loop {
                 // We needs to write GROUP_SIZE + 1 bytes then, so we assert a bound.
                 assert!(
                     dest_ptr.add(super::MEMCMP_GROUP_SIZE + 1) <= dest_ptr_end,
@@ -1266,15 +1269,89 @@ mod benches {
                         padding_size,
                     );
                 }
-                src_ptr = src_ptr.add(super::MEMCMP_GROUP_SIZE);
                 dest_ptr = dest_ptr.add(super::MEMCMP_GROUP_SIZE);
 
                 let padding_marker = !(padding_size as u8);
                 dest_ptr.write(padding_marker);
                 dest_ptr = dest_ptr.add(1);
+
+                // Termination rules for mem-comparable groups:
+                // - remaining == 0: we just wrote the empty all-padding terminator → done
+                // - remaining < GROUP_SIZE: last data group had padding > 0 → done
+                // - remaining == GROUP_SIZE: last data group had padding 0 (marker 0xFF); still
+                //   need one more iteration for the empty terminator. Advance to end
+                //   (one-past-the-end is allowed); do NOT advance again after remaining==0.
+                // - remaining > GROUP_SIZE: more full groups remain
+                //
+                // Pre-fix always did src_ptr.add(GROUP_SIZE) after every group, including
+                // after remaining==0, which steps past one-past-the-end → UB under Miri.
+                if remaining_size == 0 || remaining_size < super::MEMCMP_GROUP_SIZE {
+                    break;
+                }
+                src_ptr = src_ptr.add(super::MEMCMP_GROUP_SIZE);
             }
 
             dest_ptr.offset_from(dest.as_mut_ptr()) as usize
+        }
+    }
+
+    /// Miri soundness regression for OOB `ptr::add` in the naive encode helper.
+    ///
+    /// # Unsoundness (pre-fix)
+    ///
+    /// The naive loop always advanced `src_ptr` by `MEMCMP_GROUP_SIZE` after
+    /// every group, including the final padded group:
+    ///
+    /// ```ignore
+    /// while src_ptr <= src_ptr_end {
+    ///     // encode group ...
+    ///     src_ptr = src_ptr.add(MEMCMP_GROUP_SIZE); // can go past one-past-the-end
+    /// }
+    /// ```
+    ///
+    /// The unconditional advance is UB for **every** input length: after the
+    /// final group (empty terminator or padded partial group) `add(8)` steps
+    /// past one-past-the-end of the source allocation, and for the empty input
+    /// it offsets a dangling pointer. Both violate Rust's in-bounds pointer
+    /// arithmetic rules (same class as historical codec Miri bugs / #7751).
+    /// Intermediate OOB pointers are UB even without a later load/store.
+    ///
+    /// # How this test proves it
+    ///
+    /// Under Miri with the pre-fix code this test fails at
+    /// `src_ptr.add(MEMCMP_GROUP_SIZE)` with
+    /// `Undefined Behavior: in-bounds pointer arithmetic failed`
+    /// (a dangling-pointer offset for the empty input, or a pointer
+    /// "at or beyond the end of the allocation" for non-empty inputs).
+    ///
+    /// Multiples of `MEMCMP_GROUP_SIZE` (8) additionally exercise the empty
+    /// terminator group that follows a full final data group; every case
+    /// asserts equality with production `encode_all`.
+    ///
+    /// Run: `cargo +nightly miri test -p codec --
+    /// miri_soundness_mem_comparable_encode_all_naive`
+    #[test]
+    fn miri_soundness_mem_comparable_encode_all_naive() {
+        // Every length triggers the pre-fix OOB advance (0 via a dangling
+        // pointer, the rest by stepping past one-past-the-end). Multiples of 8
+        // also exercise the empty terminator group, non-multiples the final
+        // padded partial group.
+        for len in [0usize, 1, 7, 8, 9, 15, 16, 64, 1000] {
+            let src = vec![0xABu8; len];
+            let enc_len = super::MemComparableByteCodec::encoded_len(len);
+            let mut dest = vec![0u8; enc_len];
+            let n = mem_comparable_encode_all_naive(src.as_slice(), dest.as_mut_slice());
+
+            let mut expected = vec![0u8; enc_len];
+            let e =
+                super::MemComparableByteCodec::encode_all(src.as_slice(), expected.as_mut_slice());
+            assert_eq!(n, e, "naive encoded length mismatch for len={}", len);
+            assert_eq!(
+                &dest[..n],
+                &expected[..e],
+                "naive encoded bytes mismatch for len={}",
+                len
+            );
         }
     }
 


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: close #19946

What's Changed:

```commit-message
Restructure the group loop in mem_comparable_encode_all_naive so src_ptr
only advances when more full groups remain. The old loop did
ptr::add(MEMCMP_GROUP_SIZE) after every group, including the final one;
that advance steps past one-past-the-end of the source allocation (or
offsets a dangling pointer for the empty input), which is UB under
Rust's pointer rules even without a subsequent dereference. Encoded
output is unchanged, including the empty terminator group emitted when
len is a multiple of the group size.
```

#### The problem

The benchmark helper `mem_comparable_encode_all_naive` (in `#[cfg(test)] mod benches` of `components/codec/src/byte.rs`) is a simplified encoder used only as a performance baseline. Its group loop advanced the source pointer unconditionally after every group:

```rust
while src_ptr <= src_ptr_end {
    // encode one group (possibly the final padded/terminator group)
    src_ptr = src_ptr.add(MEMCMP_GROUP_SIZE); // always advances
    // ...
}
```

After the final group this advance produces a pointer **beyond** one-past-the-end of the source allocation — and for the empty input it offsets a dangling pointer. Creating such a pointer with `ptr::add` is undefined behavior even if it is never dereferenced. This affects every input length, not just a corner case. Miri reports:

```
error: Undefined Behavior: in-bounds pointer arithmetic failed: attempting
       to offset pointer by 8 bytes, but got 0x1[noalloc] which is a
       dangling pointer (it has no provenance)
  --> src_ptr = src_ptr.add(MEMCMP_GROUP_SIZE)
```

(the message for non-empty inputs is a pointer "at or beyond the end of the allocation")

Scope: this is **bench-only code** — production `encode_all` / `encode_all_in_place` are untouched by this PR, nothing here ships in a release build, and there is no behavior or performance impact. The value of fixing it is that `cargo miri test -p codec` runs clean, so real soundness regressions (e.g. #19943, #19944) are not drowned out by a known bench failure. Same class of bug as the historical codec Miri fixes in #7751.

#### The fix

Restructure the loop so the pointer only advances when more full groups remain. The mem-comparable termination rules are made explicit:

- `remaining < GROUP_SIZE` (including 0): the group just written was the final padded group or the empty terminator — stop.
- `remaining == GROUP_SIZE`: a full data group was written (padding 0); one more iteration is needed for the empty terminator group. Advancing to exactly one-past-the-end is allowed.
- `remaining > GROUP_SIZE`: more full groups remain.

The encoded output is byte-for-byte unchanged, including the empty terminator group that follows a full final data group when the input length is a multiple of 8.

#### Review feedback from the previous PR (CodeRabbit on #19941) — addressed and empirically confirmed

CodeRabbit correctly flagged that the earlier version of this fix broke out of the loop with `remaining <= GROUP_SIZE`, which **dropped the empty terminator group** for inputs whose length is an exact multiple of 8, producing output one group shorter than the production encoder. I confirmed the finding by running that earlier version against this PR's test: it fails with `naive encoded length mismatch for len=8` (while being Miri-clean, which is why an equality check — not just a Miri run — is needed to catch it). This PR uses the `<`-semantics CodeRabbit suggested and asserts bitwise equality with production `encode_all` for every tested length.

#### Test

`miri_soundness_mem_comparable_encode_all_naive` runs the helper for lengths 0, 1, 7, 8, 9, 15, 16, 64, and 1000 and asserts the returned length and bitwise equality with production `encode_all`.

- Against the pre-fix code, Miri fails this test with the OOB pointer arithmetic error quoted above (already at the empty input).
- With the fix, Miri passes.
- The equality assertions also guard the helper's output, so the bench baseline stays honest.

```bash
cargo +nightly miri test -p codec -- miri_soundness_mem_comparable_encode_all_naive
```

Related PRs from the same Miri audit: #19939 (in-place decode) and #19945 (in-place encode) fix Stacked Borrows aliasing UB in production code paths.

Supersedes #19941 — that PR was closed and its head branch was force-pushed afterwards (to fix the DCO sign-off, add the regression test, and address the review feedback), which permanently blocks reopening on GitHub, hence this fresh PR.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`: not needed (bench-only change)
- Need to cherry-pick to the release branch: not needed (bench-only change)

### Check List

Tests

- [x] Unit test (`miri_soundness_mem_comparable_encode_all_naive`, also asserts output equality with production `encode_all`)
- [x] Manual test: `cargo +nightly miri test -p codec -- miri_soundness_mem_comparable_encode_all_naive` fails before the fix and passes after it; full `cargo test -p codec` passes (90/90)

Side effects

- None: `#[cfg(test)]` bench helper only; no production code, behavior, or performance change.

### Release note

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue that could cause memory access beyond the allocated encoding buffer for certain inputs.
  * Ensured empty, partial, full-group, and larger values are encoded with the correct length and bytes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->