### PR TITLE
codec: fix OOB pointer arithmetic on truncated mem-comparable decode

### DIFF
--- a/components/codec/src/byte.rs
+++ b/components/codec/src/byte.rs
@@ -367,10 +367,14 @@ impl MemComparableByteCodec {
             let src_ptr_end = src_ptr.add(src_len);
 
             loop {
-                let src_ptr_next = src_ptr.add(MEMCMP_GROUP_SIZE + 1);
-                if std::intrinsics::unlikely(src_ptr_next > src_ptr_end) {
+                // Check the remaining length before forming src_ptr + (GROUP_SIZE + 1):
+                // for a truncated final group that pointer would be out of bounds of
+                // the source allocation, which is UB even without a dereference.
+                let remaining = src_ptr_end.offset_from(src_ptr) as usize;
+                if std::intrinsics::unlikely(remaining < MEMCMP_GROUP_SIZE + 1) {
                     return Err(ErrorInner::eof().into());
                 }
+                let src_ptr_next = src_ptr.add(MEMCMP_GROUP_SIZE + 1);
 
                 // Copy `MEMCMP_GROUP_SIZE` bytes any way. However we will truncate the returned
                 // length according to padding size if it is the last block.
@@ -1327,6 +1331,98 @@ mod tests {
                 assert_eq!(read, encoded.len());
                 assert_eq!(written, payload.len());
                 assert_eq!(&buf[..written], payload);
+            }
+        }
+    }
+
+    /// Miri soundness regression for OOB pointer arithmetic on truncated input.
+    ///
+    /// # Unsoundness (pre-fix)
+    ///
+    /// `try_decode_first_internal` formed `src_ptr + (MEMCMP_GROUP_SIZE + 1)`
+    /// *before* checking whether that many bytes remain:
+    ///
+    /// ```ignore
+    /// let src_ptr_next = src_ptr.add(MEMCMP_GROUP_SIZE + 1);
+    /// if unlikely(src_ptr_next > src_ptr_end) {
+    ///     return Err(ErrorInner::eof().into());
+    /// }
+    /// ```
+    ///
+    /// For a truncated / malformed input (fewer than `MEMCMP_GROUP_SIZE + 1`
+    /// bytes remaining), `ptr::add` produces a pointer beyond one-past-the-end
+    /// of the source allocation — and for the empty input it offsets a
+    /// dangling pointer. Both are UB under Rust's in-bounds pointer arithmetic
+    /// rules even though the pointer is only compared, never dereferenced. All
+    /// safe decode entry points (`try_decode_first`,
+    /// `try_decode_first_in_place` and the `_desc` variants) funnel into
+    /// this loop, so any safe caller handing over a truncated buffer
+    /// triggers it (library unsoundness).
+    ///
+    /// # How this test proves it
+    ///
+    /// Under Miri with the pre-fix code this test fails at
+    /// `src_ptr.add(MEMCMP_GROUP_SIZE + 1)` with
+    /// `Undefined Behavior: in-bounds pointer arithmetic failed`.
+    /// With the fix (remaining length checked before forming the pointer),
+    /// Miri accepts the test and every truncation returns `Err` as documented.
+    ///
+    /// Run: `cargo +nightly miri test -p codec --
+    /// miri_soundness_try_decode_first_truncated`
+    #[test]
+    fn miri_soundness_try_decode_first_truncated() {
+        for payload_len in [0usize, 1, 7, 8, 9, 16] {
+            let payload = vec![0xA5u8; payload_len];
+            let enc_len = MemComparableByteCodec::encoded_len(payload_len);
+
+            // ascending
+            {
+                let mut encoded = vec![0; enc_len];
+                MemComparableByteCodec::encode_all(&payload, &mut encoded);
+                for cut in 1..=enc_len {
+                    // The truncated buffer must be its own allocation: `ptr::add`
+                    // bounds are allocation-level, so a short slice of a larger
+                    // buffer would keep src_ptr + 9 in-bounds and hide the UB.
+                    let truncated = encoded[..enc_len - cut].to_vec();
+                    let truncated = truncated.as_slice();
+                    let mut dest = vec![0; truncated.len()];
+                    assert!(
+                        MemComparableByteCodec::try_decode_first(truncated, &mut dest).is_err(),
+                        "asc truncated decode must fail (payload_len={}, cut={})",
+                        payload_len,
+                        cut
+                    );
+                }
+                let mut dest = vec![0; enc_len];
+                let (read, written) =
+                    MemComparableByteCodec::try_decode_first(&encoded, &mut dest).unwrap();
+                assert_eq!(read, enc_len);
+                assert_eq!(&dest[..written], payload.as_slice());
+            }
+            // descending
+            {
+                let mut encoded = vec![0; enc_len];
+                MemComparableByteCodec::encode_all_desc(&payload, &mut encoded);
+                for cut in 1..=enc_len {
+                    // The truncated buffer must be its own allocation: `ptr::add`
+                    // bounds are allocation-level, so a short slice of a larger
+                    // buffer would keep src_ptr + 9 in-bounds and hide the UB.
+                    let truncated = encoded[..enc_len - cut].to_vec();
+                    let truncated = truncated.as_slice();
+                    let mut dest = vec![0; truncated.len()];
+                    assert!(
+                        MemComparableByteCodec::try_decode_first_desc(truncated, &mut dest)
+                            .is_err(),
+                        "desc truncated decode must fail (payload_len={}, cut={})",
+                        payload_len,
+                        cut
+                    );
+                }
+                let mut dest = vec![0; enc_len];
+                let (read, written) =
+                    MemComparableByteCodec::try_decode_first_desc(&encoded, &mut dest).unwrap();
+                assert_eq!(read, enc_len);
+                assert_eq!(&dest[..written], payload.as_slice());
             }
         }
     }


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: close #19948

What's Changed:

```commit-message
Check the remaining length in try_decode_first_internal before forming
src_ptr + (MEMCMP_GROUP_SIZE + 1). For a truncated input whose buffer is
its own allocation, forming that pointer goes beyond one-past-the-end of
the allocation, which is UB under Rust's in-bounds pointer arithmetic
rules even though the pointer is only compared, never dereferenced. All
safe decode entry points funnel into this loop.
```

#### The problem

The decode loop in `try_decode_first_internal` formed the next-group pointer **before** checking whether that many bytes remain:

```rust
let src_ptr_next = src_ptr.add(MEMCMP_GROUP_SIZE + 1);
if unlikely(src_ptr_next > src_ptr_end) {
    return Err(ErrorInner::eof().into());
}
```

When fewer than `MEMCMP_GROUP_SIZE + 1` bytes remain — a truncated or malformed input — `ptr::add` produces a pointer beyond one-past-the-end of the source allocation, and for an empty input it offsets a dangling pointer. Both are undefined behavior under Rust's in-bounds pointer arithmetic rules even though the pointer is only compared, never dereferenced. Miri reports:

```
error: Undefined Behavior: in-bounds pointer arithmetic failed: attempting
       to offset pointer by 9 bytes, but got alloc which is only 8 bytes
       from the end of the allocation
  --> src_ptr.add(MEMCMP_GROUP_SIZE + 1) in try_decode_first_internal
```

All safe decode entry points (`try_decode_first`, `try_decode_first_in_place`, and the `_desc` variants) funnel into this loop, and the input to decoding is externally supplied data, so safe callers reach this with malformed/truncated input — library unsoundness.

Scoping, to be precise: `ptr::add` bounds are allocation-level, not slice-level, so the UB manifests when the truncated buffer sits within 9 bytes of the end of its allocation (e.g. a short or cut-off key held in its own `Vec`). A truncated *slice* into a larger buffer stays in-bounds of the allocation and does not trigger it. No miscompilation is known on current toolchains; the risk is future compilers exploiting these rules more aggressively.

#### The fix

Check the remaining length first, then form the pointer:

```rust
let remaining = src_ptr_end.offset_from(src_ptr) as usize;
if unlikely(remaining < MEMCMP_GROUP_SIZE + 1) {
    return Err(ErrorInner::eof().into());
}
let src_ptr_next = src_ptr.add(MEMCMP_GROUP_SIZE + 1);
```

Error behavior is unchanged: exactly the inputs that previously took the EOF path still take it.

Codegen impact: verified by diffing the emitted assembly (pinned nightly, `--release`, `-C codegen-units=1`, aarch64) — the change is confined to the two `try_decode_first_internal` monomorphizations and is **neutral-to-positive**: LLVM now compiles the loop head to a fused `subs` + `b.lo` (compare folded into the subtraction, counting remaining down) instead of `add`/`add`/`cmp`/branch, two fewer instructions per group iteration; the 8-byte group load/store is unchanged. No other function in the crate changes.

#### Test

`miri_soundness_try_decode_first_truncated` encodes payloads of several sizes (ascending and descending), then asserts that **every** truncation of the encoding returns `Err` — with each truncated buffer allocated exactly (see scoping note above) — and that the untruncated input still round-trips.

- Against the pre-fix code, Miri fails this test with the OOB pointer arithmetic error quoted above.
- With the fix, Miri passes.
- The test also runs as a plain unit test in CI.

The test exercises the non-in-place entry points; the in-place ones funnel into the same fixed loop but additionally hit the separate `as_ptr`/`as_mut_ptr` aliasing unsoundness #19943, which is fixed independently by #19939.

```bash
cargo +nightly miri test -p codec -- miri_soundness_try_decode_first_truncated
```

Related PRs from the same Miri audit: #19939 (in-place decode aliasing), #19945 (in-place encode aliasing), #19947 (bench-helper OOB).

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`: not needed (no user-facing change)
- Need to cherry-pick to the release branch: at the maintainers' discretion — the UB is reachable with malformed input, but no miscompilation has been observed on current toolchains

### Check List

Tests

- [x] Unit test (`miri_soundness_try_decode_first_truncated`)
- [x] Manual test: the Miri command above fails before the fix and passes after it; full `cargo test -p codec` passes (90/90); emitted assembly diffed before/after

Side effects

- None expected: no API or behavior change; the fixed loop compiles two instructions shorter per group on aarch64.

### Release note

```release-note
codec: fix undefined behavior (out-of-bounds pointer arithmetic) when decoding truncated mem-comparable input
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved in-place encoding and decoding reliability across varied payload sizes.
  * Truncated encoded input now returns a clear end-of-file result instead of risking invalid memory access.
  * Prevented encoding from reading or advancing beyond available source data.
  * Added validation for incomplete ascending and descending inputs.
  * Confirmed complete inputs continue to decode successfully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->