### PR TITLE
tidb_query: reject invalid bool niche in decimal chunk decode

### DIFF
--- a/components/tidb_query_datatype/src/codec/mysql/decimal.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/decimal.rs
@@ -2290,8 +2290,26 @@ pub trait DecimalDecoder: NumberDecoder {
 
     /// `read_decimal_from_chunk` decode Decimal encoded by
     /// `write_decimal_to_chunk`.
+    ///
+    /// The on-wire layout is a raw `#[repr(C)] Decimal` (40 bytes:
+    /// `int_cnt`, `frac_cnt`, `result_frac_cnt`, `negative: bool`,
+    /// `word_buf: [u32; 9]`). Offset 3 is a Rust `bool`, which must be `0` or
+    /// `1` — any other bit pattern is undefined behavior if materialised via
+    /// `MaybeUninit::assume_init`. Chunk bytes can come from untrusted input
+    /// (e.g. `Column::get_decimal`), so the niche is checked before
+    /// `assume_init`. For a `u8`, `buf[3] > 1` rejects every invalid pattern.
     fn read_decimal_from_chunk(&mut self) -> Result<Decimal> {
         let buf = self.read_bytes(DECIMAL_STRUCT_SIZE)?;
+        // Offset 3 is `negative: bool` — only 0/1 are valid niches.
+        if buf[3] > 1 {
+            return Err(box_err!(
+                "invalid decimal negative flag in chunk: {}",
+                buf[3]
+            ));
+        }
+        // SAFETY: after the bool niche check, every field of Decimal has a
+        // valid bit pattern for its type (u8/bool/[u32; 9]); size is
+        // const-asserted equal to DECIMAL_STRUCT_SIZE.
         let d = unsafe {
             let mut d = mem::MaybeUninit::<Decimal>::uninit();
             let p = d.as_mut_ptr() as *mut u8;
@@ -3185,6 +3203,76 @@ mod tests {
         ];
         let decoded = src.as_slice().read_decimal_from_chunk().unwrap();
         assert_eq!(Decimal::from_f64(123.456).unwrap(), decoded);
+    }
+
+    /// Miri soundness regression for invalid `bool` niche in chunk decode.
+    ///
+    /// # Unsoundness (pre-fix)
+    ///
+    /// `read_decimal_from_chunk` copied 40 untrusted bytes into
+    /// `MaybeUninit::<Decimal>` and called `assume_init` with no check that
+    /// offset 3 (`negative: bool`) was `0` or `1`. Safe callers such as
+    /// `Column::get_decimal` can feed arbitrary chunk bytes (library
+    /// unsoundness).
+    ///
+    /// # How this test proves it
+    ///
+    /// Builds a 40-byte buffer with `buf[3] = 0xff` and calls
+    /// `read_decimal_from_chunk`.
+    ///
+    /// Under Miri with the pre-fix code this fails with:
+    /// ```text
+    /// error: Undefined Behavior: constructing invalid value of type
+    ///        codec::mysql::decimal::Decimal: at .negative, encountered
+    ///        0xff, but expected a boolean
+    ///   --> ... d.assume_init()
+    /// ```
+    ///
+    /// With the fix, the call returns
+    /// `Err(... invalid decimal negative flag in chunk: 255 ...)` and Miri
+    /// accepts the test. It is also a plain unit test for regular CI.
+    ///
+    /// Run:
+    /// ```text
+    /// cargo +nightly miri test -p tidb_query_datatype --lib \
+    ///   miri_soundness_decimal_chunk_invalid_bool -- --exact
+    /// ```
+    #[test]
+    fn miri_soundness_decimal_chunk_invalid_bool() {
+        let mut bad = vec![0u8; DECIMAL_STRUCT_SIZE];
+        bad[0] = 1; // int_cnt
+        bad[3] = 0xff; // invalid bool for `negative`
+        let err = bad
+            .as_slice()
+            .read_decimal_from_chunk()
+            .expect_err("invalid negative flag must error, not UB");
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("invalid decimal negative flag"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    /// Miri / unit: valid `bool` niches (`0` and `1`) still decode.
+    ///
+    /// Complements `miri_soundness_decimal_chunk_invalid_bool` so the fix
+    /// does not reject legal encodings. Also covered by `test_chunk_codec`
+    /// (round-trip via `write_decimal_to_chunk`).
+    ///
+    /// Run:
+    /// ```text
+    /// cargo +nightly miri test -p tidb_query_datatype --lib \
+    ///   miri_soundness_decimal_chunk_valid_bools -- --exact
+    /// ```
+    #[test]
+    fn miri_soundness_decimal_chunk_valid_bools() {
+        for neg in [0u8, 1u8] {
+            let mut buf = vec![0u8; DECIMAL_STRUCT_SIZE];
+            buf[0] = 1;
+            buf[3] = neg;
+            let d = buf.as_slice().read_decimal_from_chunk().unwrap();
+            assert_eq!(d.is_negative(), neg == 1);
+        }
     }
 
     #[test]


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: close #19960

What's Changed:

```commit-message
Validate that the raw Decimal chunk's negative flag byte is 0 or 1 before
MaybeUninit::assume_init, so safe chunk decode cannot materialise an
invalid bool niche.
```

#### The problem

`DecimalDecoder::read_decimal_from_chunk` (used by the safe
`Column::get_decimal`) decoded a fixed 40-byte on-wire layout by copying
bytes into `MaybeUninit::<Decimal>` and calling `assume_init`:

```rust
// components/tidb_query_datatype/src/codec/mysql/decimal.rs (pre-fix)
fn read_decimal_from_chunk(&mut self) -> Result<Decimal> {
    let buf = self.read_bytes(DECIMAL_STRUCT_SIZE)?;
    let d = unsafe {
        let mut d = mem::MaybeUninit::<Decimal>::uninit();
        let p = d.as_mut_ptr() as *mut u8;
        copy_nonoverlapping(buf.as_ptr(), p, DECIMAL_STRUCT_SIZE);
        d.assume_init()
    };
    Ok(d)
}
```

`Decimal` is `#[repr(C)]`:

```text
offset 0: int_cnt: u8
offset 1: frac_cnt: u8
offset 2: result_frac_cnt: u8
offset 3: negative: bool   // only 0 or 1 are valid
offset 4..: word_buf: [u32; 9]
```

A Rust `bool` may only be the bit patterns `0` or `1`. Feeding untrusted
chunk bytes with e.g. `buf[3] = 0xff` and then `assume_init` is undefined
behavior. Miri reports:

```text
error: Undefined Behavior: constructing invalid value of type
       codec::mysql::decimal::Decimal: at .negative, encountered 0xff,
       but expected a boolean
  --> ... d.assume_init()
```

Because the entry points are safe (`read_decimal_from_chunk` on a public
trait, `Column::get_decimal`), any safe caller with malformed chunk data
can trigger this — library unsoundness rather than misuse of an `unsafe`
API. No miscompilation is known on current toolchains; the risk is that
rustc/LLVM may exploit `bool` niches more aggressively in future releases.
See #19960 for the full report.

#### The fix

Reject an invalid niche before constructing the value. For a `u8`,
`buf[3] > 1` is exactly "not 0 and not 1":

```rust
if buf[3] > 1 {
    return Err(box_err!(
        "invalid decimal negative flag in chunk: {}",
        buf[3]
    ));
}
// then the same copy + assume_init as before
```

Valid encodings (`0` / `1`, including all paths that go through
`write_decimal_to_chunk`) are unchanged. Existing round-trip coverage
(`test_chunk_codec`, `test_decode_chunk_from_tidb`) still passes.

#### Test

In-tree on this PR:

- `codec::mysql::decimal::tests::miri_soundness_decimal_chunk_invalid_bool`
  — buffer with `buf[3] = 0xff` must return
  `Err(... invalid decimal negative flag ...)` and not reach UB.
- `codec::mysql::decimal::tests::miri_soundness_decimal_chunk_valid_bools`
  — `buf[3] ∈ {0,1}` still decodes.

Each test documents the Miri pre-fix error and how to run it (same style
as `miri_soundness_try_decode_first_in_place` in `codec`, #19939).

```bash
# native (also runs in regular CI)
cargo test -p tidb_query_datatype --lib \
  miri_soundness_decimal_chunk -- --nocapture

# Miri: fails with pre-fix assume_init; passes with this PR
cargo +nightly miri test -p tidb_query_datatype --lib \
  miri_soundness_decimal_chunk_invalid_bool -- --exact

cargo +nightly miri test -p tidb_query_datatype --lib \
  miri_soundness_decimal_chunk_valid_bools -- --exact
```

- Against the pre-fix code (current master), Miri fails
  `..._invalid_bool` with the invalid-bool error quoted above.
- With the fix, Miri passes both tests; native also passes
  `test_chunk_codec` and `test_decode_chunk_from_tidb`.

### Related changes

- PR to update `pingcap/docs` / `pingcap/docs-cn`: not needed
- Cherry-pick to release branch: at maintainers' discretion — UB is real
  with malformed chunk bytes; no miscompilation observed on current
  toolchains

### Check List

Tests

- [x] Unit test (`miri_soundness_decimal_chunk_invalid_bool`,
      `miri_soundness_decimal_chunk_valid_bools`)
- [x] Manual: native tests pass; Miri commands above pass after the fix
      (pre-fix reproduces the quoted UB on the bare `assume_init` path)

Side effects

- None expected for well-formed data. Malformed chunks that previously
  were UB now return a clear `Err`.

### Release note

```release-note
tidb_query: reject invalid bool niche when decoding Decimal from chunk bytes (undefined behavior under Miri)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved decimal data decoding by rejecting invalid boolean encodings.
  * Added validation to prevent malformed values from being interpreted incorrectly.

* **Tests**
  * Added regression coverage for valid and invalid boolean representations.
  * Documented memory-safety verification for the affected decoding scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->