### PR TITLE
coprocessor: add cache test for selection executor

### DIFF
--- a/tests/integrations/coprocessor/test_select.rs
+++ b/tests/integrations/coprocessor/test_select.rs
@@ -1848,6 +1848,94 @@ fn test_cache() {
     assert_eq!(resp.get_data(), resp4.get_data());
 }
 
+/// Verifies that the coprocessor cache works correctly when a selection
+/// executor (WHERE clause) is present in the executor chain.
+/// This test ensures that the `can_be_cached()` flag is properly propagated
+/// through the selection executor to the underlying scan executor.
+#[test_case(test_raftstore::new_server_cluster)]
+#[test_case(test_raftstore_v2::new_server_cluster)]
+fn test_cache_with_selection() {
+    use tidb_query_datatype::FieldTypeAccessor;
+
+    let mut cluster = new_cluster(0, 1);
+    let (raft_engine, ctx) = prepare_raft_engine!(cluster, "");
+
+    let data = vec![
+        (1, Some("name:0"), 2),
+        (2, Some("name:4"), 3),
+        (4, Some("name:3"), 1),
+        (5, Some("name:1"), 4),
+    ];
+    let product = ProductTable::new();
+    let (_, endpoint, _) =
+        init_data_with_engine_and_commit(ctx.clone(), raft_engine, &product, &data, true);
+
+    // Build a WHERE condition: count > 2
+    let cols = product.columns_info();
+    let cond = {
+        // Left: column ref for `count`
+        let mut col = Expr::default();
+        col.set_tp(ExprType::ColumnRef);
+        let count_offset = offset_for_column(&cols, product["count"].id);
+        col.mut_val().encode_i64(count_offset).unwrap();
+        col.mut_field_type()
+            .as_mut_accessor()
+            .set_tp(FieldTypeTp::LongLong);
+
+        // Right: constant integer 2
+        let mut value = Expr::default();
+        value.set_tp(ExprType::Int64);
+        value.mut_val().encode_i64(2).unwrap();
+        value
+            .mut_field_type()
+            .as_mut_accessor()
+            .set_tp(FieldTypeTp::LongLong);
+
+        // Condition: count > 2
+        let mut cond = Expr::default();
+        cond.set_tp(ExprType::ScalarFunc);
+        cond.set_sig(ScalarFuncSig::GtInt);
+        cond.mut_field_type()
+            .as_mut_accessor()
+            .set_tp(FieldTypeTp::LongLong);
+        cond.mut_children().push(col);
+        cond.mut_children().push(value);
+        cond
+    };
+
+    let req = DagSelect::from(&product)
+        .where_expr(cond)
+        .build_with(ctx, &[0]);
+
+    // First request: cache miss, should return filtered data.
+    let resp = handle_request(&endpoint, req.clone());
+    assert!(!resp.get_is_cache_hit());
+    let cache_version = resp.get_cache_last_version();
+    assert!(cache_version >= 5);
+
+    // Verify the response contains filtered data (only rows with count > 2).
+    let mut sel_resp = SelectResponse::default();
+    sel_resp.merge_from_bytes(resp.get_data()).unwrap();
+    // Should have 2 rows: (2, "name:4", 3) and (5, "name:1", 4)
+    assert_eq!(sel_resp.get_chunks().len(), 1);
+
+    // Second request with cache enabled and matching version: should be a cache hit.
+    let mut req2 = req.clone();
+    req2.set_is_cache_enabled(true);
+    req2.set_cache_if_match_version(cache_version);
+    let resp2 = handle_request(&endpoint, req2);
+    assert!(resp2.get_is_cache_hit());
+    assert!(resp2.get_data().is_empty());
+
+    // Third request with cache enabled but non-matching version: should be a cache miss.
+    let mut req3 = req;
+    req3.set_is_cache_enabled(true);
+    req3.set_cache_if_match_version(cache_version + 1);
+    let resp3 = handle_request(&endpoint, req3);
+    assert!(!resp3.get_is_cache_hit());
+    assert_eq!(resp.get_data(), resp3.get_data());
+}
+
 #[test]
 fn test_copr_bypass_or_access_locks() {
     let data = vec![


### PR DESCRIPTION
Add integration test to verify that the coprocessor cache works correctly when a selection executor (WHERE clause) is present in the executor chain.

The test ensures that the `can_be_cached()` flag is properly propagated through the selection executor to the underlying scan executor, allowing TiDB to cache query results for filtered SELECT queries.

Closes #2718

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?

Issue Number: Close #2718

This PR adds an integration test (`test_cache_with_selection`) to verify that the coprocessor cache works correctly when a selection executor (WHERE clause) is present in the executor chain.

#### Background

Issue #2718 requested support for caching in the select executor. The cache mechanism is already implemented in the codebase:

1. **`can_be_cached()` propagation**: The `can_be_cached()` method is properly implemented and propagated through all executor types:
   - `BatchTableScanExecutor` → `ScanExecutor` → `RangesScanner` → `Storage::met_uncacheable_data()`
   - `BatchSelectionExecutor` → delegates to source executor via `self.src.can_be_cached()`
   - `BatchTopNExecutor` → delegates to source executor
   - All aggregation executors → delegate to source executor

2. **Cache version tracking**: The `TikvStorage` wrapper tracks newer timestamp data via `NewerTsCheckState`, which determines whether cached results are still valid.

3. **Cache hit/miss handling**: The endpoint (`handle_unary_request_impl`) checks `cache_match_version` against `snapshot.ext().get_data_version()` and returns a `CachedRequestHandler` on match.

#### Test details

The `test_cache_with_selection` test:
- Builds a `DagSelect` with a WHERE clause (`count > 2`) using `ScalarFuncSig::GtInt`
- First request (cache disabled): verifies cache miss, checks `cache_last_version >= 5`, verifies filtered response contains expected chunks
- Second request (`is_cache_enabled=true`, matching version): verifies cache hit with empty data
- Third request (`is_cache_enabled=true`, non-matching version): verifies cache miss with correct data returned

```commit-message
coprocessor: add cache test for selection executor

Add integration test to verify that the coprocessor cache works correctly
when a selection executor (WHERE clause) is present in the executor chain.

The test ensures that the can_be_cached() flag is properly propagated
through the selection executor to the underlying scan executor, allowing
TiDB to cache query results for filtered SELECT queries.

Closes #2718
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```
