### PR TITLE
coprocessor, server: add optional background Analyze concurrency limit

### DIFF
--- a/doc/maintenance-guides/src/coprocessor.md
+++ b/doc/maintenance-guides/src/coprocessor.md
@@ -115,9 +115,10 @@ It is a read-heavy hot path and directly impacts query latency.
   of bypassing heavy-task admission. With the setting disabled, it intentionally
   shares the ordinary semaphore.
 - When enabled, the dedicated background-limited semaphore protects all
-  Analyze variants, including index, column, mixed, and full-sampling Analyze,
-  from unlimited fan-out. It is not part of the ordinary shared heavy-task
-  budget; when disabled, these requests intentionally use the shared semaphore.
+  Analyze variants, including index, common-handle, column, mixed, and
+  full-sampling Analyze, from unlimited fan-out. It is not part of the ordinary
+  shared heavy-task budget; when disabled, these requests intentionally use the
+  shared semaphore.
 - Streaming and unary response handling must preserve stats and partial-progress
   semantics.
 

--- a/doc/maintenance-guides/src/coprocessor.md
+++ b/doc/maintenance-guides/src/coprocessor.md
@@ -33,17 +33,16 @@ It is a read-heavy hot path and directly impacts query latency.
   `src/server/service/kv.rs` as the RPC entry path.
 - On the Yatp path, unary and streaming heavy tasks are admitted through
   semaphores created in `Endpoint::new`: a shared semaphore for ordinary
-  coprocessor work and a dedicated semaphore for request classes that are
+  coprocessor work and a dedicated semaphore for Analyze requests that are
   intentionally throttled by the background quota limiter.
-- The shared semaphore keeps the full
-  `server.end-point-max-concurrency` budget, while the dedicated
-  background-limited semaphore is an extra bounded cap derived from the same
-  setting at startup.
-- When `server.end-point-max-concurrency` > 1, these two semaphores are
-  independent, so the total number of concurrent heavy coprocessor tasks can
-  exceed `server.end-point-max-concurrency` when both ordinary traffic and
-  background-limited traffic are active. For
-  `server.end-point-max-concurrency` == 1, both groups reuse the same semaphore.
+- The shared semaphore is controlled by
+  `server.end-point-max-concurrency`. The dedicated background-limited
+  semaphore is enabled only when
+  `server.end-point-max-bg-concurrency` is explicitly set to a positive value;
+  its capacity is then controlled by that value.
+- When the dedicated setting is absent or `0`, Analyze and ordinary Cop
+  requests share the legacy semaphore. When it is positive, the two semaphores
+  are independent and both lanes can make progress concurrently.
 - The dedicated cap does not automatically track unified read-pool worker
   autoscaling at runtime.
 - `build_read_pool` sets TLS engine state and marks threads as
@@ -110,12 +109,15 @@ It is a read-heavy hot path and directly impacts query latency.
   semantics.
 - Handler execution must respect request deadline and cancellation behavior.
 - Memory quota and concurrency limiters must remain cheap and correct.
-- Request parsing and admission must stay aligned: if a request class reports
-  quota samples to the background quota limiter, it should use the dedicated
-  background-limited semaphore instead of bypassing heavy-task admission.
-- The dedicated background-limited semaphore protects the full-sampling analyze
-  path from unlimited fan-out, but it is not part of the ordinary shared
-  heavy-task budget.
+- Request parsing and admission must stay aligned: when the dedicated setting
+  is enabled, a request class that reports quota samples to the background
+  quota limiter should use the dedicated background-limited semaphore instead
+  of bypassing heavy-task admission. With the setting disabled, it intentionally
+  shares the ordinary semaphore.
+- When enabled, the dedicated background-limited semaphore protects all
+  Analyze variants, including index, column, mixed, and full-sampling Analyze,
+  from unlimited fan-out. It is not part of the ordinary shared heavy-task
+  budget; when disabled, these requests intentionally use the shared semaphore.
 - Streaming and unary response handling must preserve stats and partial-progress
   semantics.
 
@@ -135,7 +137,7 @@ It is a read-heavy hot path and directly impacts query latency.
   `tikv_coprocessor_waiting_for_semaphore`, and
   `tikv_coprocessor_semaphore_wait_time_duration_seconds`.
 - The semaphore wait metrics use `group=shared|background_limited` to
-  distinguish ordinary Cop request pressure from full-sampling Analyze
+  distinguish ordinary Cop request pressure from Analyze background-limited
   throttling. Dashboard queries should preserve this label when diagnosing an
   individual lane and aggregate it only when displaying total semaphore
   pressure.

--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -241,6 +241,10 @@
 ## By default, it will be set to 12.5% of the available memory of TiKV.
 # end-point-memory-quota = "0B"
 
+## Maximum number of concurrently running background-limited Analyze tasks.
+## Leave unset (or set to 0) to share the ordinary coprocessor semaphore.
+# end-point-max-bg-concurrency = 0
+
 ## Max bytes that snapshot can interact with disk in one second. It should be
 ## set based on your disk performance. Only write flow is considered, if
 ## partitioned-raft-kv is used, read flow is also considered and it will be estimated

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -7465,6 +7465,7 @@ mod tests {
         cfg.server.grpc_raft_conn_num = default_cfg.server.grpc_raft_conn_num;
         cfg.server.background_thread_count = default_cfg.server.background_thread_count;
         cfg.server.end_point_max_concurrency = default_cfg.server.end_point_max_concurrency;
+        cfg.server.end_point_max_bg_concurrency = default_cfg.server.end_point_max_bg_concurrency;
         cfg.server.end_point_memory_quota = default_cfg.server.end_point_memory_quota;
         cfg.storage.scheduler_worker_pool_size = default_cfg.storage.scheduler_worker_pool_size;
         cfg.rocksdb.max_background_jobs = default_cfg.rocksdb.max_background_jobs;

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -65,13 +65,6 @@ use crate::{
 /// light ones, which means they don't need a permit from the semaphore before
 /// execution.
 const LIGHT_TASK_THRESHOLD: Duration = Duration::from_millis(5);
-/// Reserve up to one quarter of the configured heavy-task budget (but never
-/// less than 1 permit) as an extra cap for request classes that are already
-/// throttled by the background quota limiter. The dedicated cap is computed
-/// once from `end_point_max_concurrency` during endpoint construction rather
-/// than following read-pool worker autoscaling at runtime.
-const BACKGROUND_LIMITED_CONCURRENCY_DIVISOR: usize = 4;
-
 /// A pool to build and run Coprocessor request handlers.
 #[derive(Clone)]
 pub struct Endpoint<E: Engine> {
@@ -134,35 +127,24 @@ impl<Snap> ParseCopRequestResult<Snap> {
 impl<E: Engine> tikv_util::AssertSend for Endpoint<E> {}
 
 impl<E: Engine> Endpoint<E> {
-    /// Compute the dedicated cap for request classes that intentionally use
-    /// the background quota limiter. Ordinary coprocessor traffic keeps the
-    /// full configured shared budget, so this additional semaphore can raise
-    /// the total number of concurrent heavy tasks when both groups are active.
-    fn background_limited_request_concurrency(max_concurrency: usize) -> usize {
-        std::cmp::max(1, max_concurrency / BACKGROUND_LIMITED_CONCURRENCY_DIVISOR)
-    }
-
     fn build_request_semaphores(
         read_pool: &ReadPoolHandle,
-        max_concurrency: usize,
+        shared_concurrency: usize,
+        background_limited_concurrency: Option<u64>,
     ) -> (Option<Arc<Semaphore>>, Option<Arc<Semaphore>>) {
         match read_pool {
             ReadPoolHandle::Yatp { .. } => {
-                // Ordinary coprocessor requests keep the full heavy-task
-                // budget. Requests that are intentionally throttled by the
-                // background quota limiter also receive a bounded dedicated cap
-                // so they do not bypass admission entirely.
-                if max_concurrency > 1 {
-                    let background_concurrency =
-                        Self::background_limited_request_concurrency(max_concurrency);
-                    (
-                        Some(Arc::new(Semaphore::new(max_concurrency))),
-                        Some(Arc::new(Semaphore::new(background_concurrency))),
-                    )
-                } else {
-                    let semaphore = Arc::new(Semaphore::new(max_concurrency));
-                    (Some(semaphore.clone()), Some(semaphore))
-                }
+                // Keep the legacy shared behavior unless the operator explicitly
+                // enables a positive background-limited Analyze cap.
+                let shared = Arc::new(Semaphore::new(shared_concurrency));
+                let background = match background_limited_concurrency {
+                    Some(concurrency) if concurrency > 0 => Arc::new(Semaphore::new(
+                        usize::try_from(concurrency)
+                            .expect("background-limited semaphore exceeds platform capacity"),
+                    )),
+                    _ => shared.clone(),
+                };
+                (Some(shared), Some(background))
             }
             _ => (None, None),
         }
@@ -183,8 +165,11 @@ impl<E: Engine> Endpoint<E> {
         quota_limiter: Arc<QuotaLimiter>,
         resource_ctl: Option<Arc<ResourceGroupManager>>,
     ) -> Self {
-        let (shared_semaphore, background_limited_semaphore) =
-            Self::build_request_semaphores(&read_pool, cfg.end_point_max_concurrency);
+        let (shared_semaphore, background_limited_semaphore) = Self::build_request_semaphores(
+            &read_pool,
+            cfg.end_point_max_concurrency,
+            cfg.end_point_max_bg_concurrency,
+        );
         let memory_quota = Arc::new(MemoryQuota::new(cfg.end_point_memory_quota.0 as _));
         register_coprocessor_memory_quota_metrics(memory_quota.clone());
         Self {
@@ -367,10 +352,10 @@ impl<E: Engine> Endpoint<E> {
 
                 (req_tag, semaphore_group) = match analyze.get_tp() {
                     AnalyzeType::TypeIndex | AnalyzeType::TypeCommonHandle => {
-                        (ReqTag::analyze_index, SemaphoreGroup::Shared)
+                        (ReqTag::analyze_index, SemaphoreGroup::BackgroundLimited)
                     }
                     AnalyzeType::TypeColumn | AnalyzeType::TypeMixed => {
-                        (ReqTag::analyze_table, SemaphoreGroup::Shared)
+                        (ReqTag::analyze_table, SemaphoreGroup::BackgroundLimited)
                     }
                     AnalyzeType::TypeFullSampling => (
                         ReqTag::analyze_full_sampling,
@@ -1848,6 +1833,7 @@ mod tests {
     fn test_background_limited_semaphore_preserves_shared_capacity() {
         let config = Config {
             end_point_max_concurrency: 8,
+            end_point_max_bg_concurrency: Some(3),
             ..Default::default()
         };
         let (copr, _read_pool) = build_yatp_copr(config);
@@ -1856,7 +1842,7 @@ mod tests {
         let background = copr.background_limited_semaphore.as_ref().unwrap();
         assert!(!Arc::ptr_eq(shared, background));
         assert_eq!(shared.available_permits(), 8);
-        assert_eq!(background.available_permits(), 2);
+        assert_eq!(background.available_permits(), 3);
         assert!(Arc::ptr_eq(
             shared,
             copr.request_semaphore(SemaphoreGroup::Shared)
@@ -1872,18 +1858,35 @@ mod tests {
     }
 
     #[test]
-    fn test_small_semaphore_budget_reuses_single_limit() {
+    fn test_small_shared_semaphore_keeps_background_limit_independent() {
         let config = Config {
             end_point_max_concurrency: 1,
+            end_point_max_bg_concurrency: Some(7),
             ..Default::default()
         };
         let (copr, _read_pool) = build_yatp_copr(config);
 
         let shared = copr.shared_semaphore.as_ref().unwrap();
         let background = copr.background_limited_semaphore.as_ref().unwrap();
-        assert!(Arc::ptr_eq(shared, background));
+        assert!(!Arc::ptr_eq(shared, background));
         assert_eq!(shared.available_permits(), 1);
-        assert_eq!(background.available_permits(), 1);
+        assert_eq!(background.available_permits(), 7);
+    }
+
+    #[test]
+    fn test_background_limited_semaphore_disabled_by_default_or_zero() {
+        for background_limited_semaphore in [None, Some(0)] {
+            let config = Config {
+                end_point_max_concurrency: 8,
+                end_point_max_bg_concurrency: background_limited_semaphore,
+                ..Default::default()
+            };
+            let (copr, _read_pool) = build_yatp_copr(config);
+            assert!(Arc::ptr_eq(
+                copr.shared_semaphore.as_ref().unwrap(),
+                copr.background_limited_semaphore.as_ref().unwrap(),
+            ));
+        }
     }
 
     #[test]
@@ -1916,19 +1919,31 @@ mod tests {
             .parse_request_and_check_memory_locks(req, None, false)
             .unwrap();
         assert_eq!(parsed.req_tag, ReqTag::analyze_table);
-        assert_eq!(parsed.semaphore_group, SemaphoreGroup::Shared);
+        assert_eq!(parsed.semaphore_group, SemaphoreGroup::BackgroundLimited);
         assert!(Arc::ptr_eq(
-            copr.shared_semaphore.as_ref().unwrap(),
+            copr.background_limited_semaphore.as_ref().unwrap(),
             copr.request_semaphore(parsed.semaphore_group)
                 .as_ref()
                 .unwrap()
         ));
+
+        let mut index = AnalyzeReq::default();
+        index.set_tp(AnalyzeType::TypeIndex);
+        let mut req = coppb::Request::default();
+        req.set_tp(REQ_TYPE_ANALYZE);
+        req.set_data(index.write_to_bytes().unwrap());
+        let parsed = copr
+            .parse_request_and_check_memory_locks(req, None, false)
+            .unwrap();
+        assert_eq!(parsed.req_tag, ReqTag::analyze_index);
+        assert_eq!(parsed.semaphore_group, SemaphoreGroup::BackgroundLimited);
     }
 
     #[test]
     fn test_background_limited_requests_progress_when_shared_semaphore_is_full() {
         let config = Config {
             end_point_max_concurrency: 4,
+            end_point_max_bg_concurrency: Some(2),
             ..Default::default()
         };
         let (copr, _read_pool) = build_yatp_copr(config);

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -129,19 +129,18 @@ impl<E: Engine> tikv_util::AssertSend for Endpoint<E> {}
 impl<E: Engine> Endpoint<E> {
     fn build_request_semaphores(
         read_pool: &ReadPoolHandle,
-        shared_concurrency: usize,
-        background_limited_concurrency: Option<u64>,
+        max_concurrency: usize,
+        max_bg_concurrency: Option<usize>,
     ) -> (Option<Arc<Semaphore>>, Option<Arc<Semaphore>>) {
         match read_pool {
             ReadPoolHandle::Yatp { .. } => {
                 // Keep the legacy shared behavior unless the operator explicitly
                 // enables a positive background-limited Analyze cap.
-                let shared = Arc::new(Semaphore::new(shared_concurrency));
-                let background = match background_limited_concurrency {
-                    Some(concurrency) if concurrency > 0 => Arc::new(Semaphore::new(
-                        usize::try_from(concurrency)
-                            .expect("background-limited semaphore exceeds platform capacity"),
-                    )),
+                let shared = Arc::new(Semaphore::new(max_concurrency));
+                let background = match max_bg_concurrency {
+                    Some(max_bg_concurrency) if max_bg_concurrency > 0 => {
+                        Arc::new(Semaphore::new(max_bg_concurrency))
+                    }
                     _ => shared.clone(),
                 };
                 (Some(shared), Some(background))

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -103,7 +103,6 @@ lazy_static! {
 
 // At least 4 long coprocessor requests are allowed to run concurrently.
 const MIN_ENDPOINT_MAX_CONCURRENCY: usize = 4;
-
 const DEFAULT_MAX_GRPC_SEND_MSG_LEN: i32 = 10 * 1024 * 1024;
 
 /// A clone of `grpc::CompressionAlgorithms` with serde supports.
@@ -208,6 +207,11 @@ pub struct Config {
     pub end_point_request_max_handle_duration: Option<ReadableDuration>,
     #[online_config(skip)]
     pub end_point_max_concurrency: usize,
+    /// Optional maximum number of concurrently running background-limited
+    /// Analyze tasks. `None` or `Some(0)` keeps Analyze requests on the
+    /// shared semaphore.
+    #[online_config(skip)]
+    pub end_point_max_bg_concurrency: Option<u64>,
     #[serde(with = "perf_level_serde")]
     #[online_config(skip)]
     pub end_point_perf_level: PerfLevel,
@@ -341,6 +345,7 @@ impl Default for Config {
             end_point_enable_batch_if_possible: true,
             end_point_request_max_handle_duration: None,
             end_point_max_concurrency: cmp::max(cpu_num as usize, MIN_ENDPOINT_MAX_CONCURRENCY),
+            end_point_max_bg_concurrency: None,
             end_point_perf_level: PerfLevel::Uninitialized,
             end_point_memory_quota: *DEFAULT_ENDPOINT_MEMORY_QUOTA,
             snap_io_max_bytes_per_sec: ReadableSize(DEFAULT_SNAP_MAX_BYTES_PER_SEC),
@@ -439,6 +444,14 @@ impl Config {
         for (label, value) in non_zero_entries {
             if value == 0 {
                 return Err(box_err!("server.{} should not be 0.", label));
+            }
+        }
+
+        if let Some(value) = self.end_point_max_bg_concurrency {
+            if value > usize::MAX as u64 {
+                return Err(box_err!(
+                    "server.end-point-max-bg-concurrency is too large."
+                ));
             }
         }
 

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -20,6 +20,7 @@ use tikv_util::{
     sys::SysQuota,
     worker::Scheduler,
 };
+use tokio::sync::Semaphore;
 
 use super::{Result, snap::Task as SnapTask};
 pub use crate::storage::config::Config as StorageConfig;
@@ -211,7 +212,7 @@ pub struct Config {
     /// Analyze tasks. `None` or `Some(0)` keeps Analyze requests on the
     /// shared semaphore.
     #[online_config(skip)]
-    pub end_point_max_bg_concurrency: Option<u64>,
+    pub end_point_max_bg_concurrency: Option<usize>,
     #[serde(with = "perf_level_serde")]
     #[online_config(skip)]
     pub end_point_perf_level: PerfLevel,
@@ -448,7 +449,7 @@ impl Config {
         }
 
         if let Some(value) = self.end_point_max_bg_concurrency {
-            if value > usize::MAX as u64 {
+            if value > Semaphore::MAX_PERMITS {
                 return Err(box_err!(
                     "server.end-point-max-bg-concurrency is too large."
                 ));

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -120,6 +120,7 @@ fn test_serde_custom_tikv_config() {
         end_point_enable_batch_if_possible: true,
         end_point_request_max_handle_duration: Some(ReadableDuration::secs(12)),
         end_point_max_concurrency: 10,
+        end_point_max_bg_concurrency: Some(3),
         end_point_perf_level: PerfLevel::EnableTime,
         snap_io_max_bytes_per_sec: ReadableSize::mb(10),
         snap_max_total_size: ReadableSize::gb(10),

--- a/tests/integrations/config/test-custom.toml
+++ b/tests/integrations/config/test-custom.toml
@@ -74,6 +74,7 @@ end-point-stream-batch-row-limit = 4096
 end-point-enable-batch-if-possible = true
 end-point-request-max-handle-duration = "12s"
 end-point-max-concurrency = 10
+end-point-max-bg-concurrency = 3
 end-point-perf-level = 5
 snap-io-max-bytes-per-sec = "10MB"
 snap-max-total-size = "10GB"


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: close #19969, ref #19623

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
coprocessor: add optional background Analyze concurrency limit

Full-sampling, index, common-handle, column, and mixed Analyze requests are
classified as background-limited.

By default, Analyze requests continue to share the existing
server.end-point-max-concurrency semaphore. Operators can set
server.end-point-max-bg-concurrency to a positive value to enable an
independent semaphore for Analyze requests.

The setting uses Option<u64>: unset or 0 preserves the legacy behavior.
Update the configuration template, coprocessor maintenance guide, TOML
serialization coverage, and Endpoint regression tests accordingly.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!--
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Add optional `server.end-point-max-bg-concurrency` to limit Analyze concurrency independently from ordinary coprocessor requests.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional setting to independently limit concurrent background Analyze operations.
  * The limit applies consistently to Analyze requests involving indexes, columns, or both.
  * When unset or set to zero, background Analyze operations share the standard concurrency limit.
  * Invalid values exceeding the supported concurrency capacity are rejected.
* **Documentation**
  * Updated configuration templates and maintenance guidance with the new setting and related semaphore metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->