### PR TITLE
[cherry-pick] [test only] raftstore: add unsafe-no-raft-log-fsync (#19925)

### DIFF
--- a/components/raftstore/src/store/async_io/write.rs
+++ b/components/raftstore/src/store/async_io/write.rs
@@ -207,6 +207,10 @@ where
     pub trackers: Vec<TimeTracker>,
     pub has_snapshot: bool,
     pub flushed_epoch: Option<RegionEpoch>,
+    /// Whether the raft log write must be fsynced. Defaults to true so a task
+    /// from a path that never calls `set_must_sync`, as raftstore-v2 does,
+    /// keeps the old always-fsync behavior.
+    pub must_sync: bool,
 }
 
 impl<EK, ER> WriteTask<EK, ER>
@@ -230,7 +234,23 @@ where
             persisted_cbs: Vec::new(),
             has_snapshot: false,
             flushed_epoch: None,
+            must_sync: true,
         }
+    }
+
+    /// Raft requires term and vote to be durable before responding to RPCs, and
+    /// a snapshot rewrites metadata that cannot be replayed. Entry appends
+    /// are left out so `unsafe_no_raft_log_fsync` can drop their fsync.
+    pub fn set_must_sync(
+        &mut self,
+        prev_state: &RaftLocalState,
+        cur_state: &RaftLocalState,
+        has_snapshot: bool,
+    ) {
+        let prev = prev_state.get_hard_state();
+        let cur = cur_state.get_hard_state();
+        self.must_sync =
+            cur.get_term() != prev.get_term() || cur.get_vote() != prev.get_vote() || has_snapshot;
     }
 
     pub fn has_data(&self) -> bool {
@@ -496,6 +516,8 @@ where
     // region_id -> (peer_id, ready_number)
     pub readies: HashMap<u64, (u64, u64)>,
     pub(crate) raft_wb_split_size: usize,
+    /// True when any task in this batch requires an fsync.
+    pub must_sync: bool,
     recorder: WriteTaskBatchRecorder,
 }
 
@@ -518,6 +540,7 @@ where
             persisted_cbs: vec![],
             readies: HashMap::default(),
             raft_wb_split_size: RAFT_WB_SPLIT_SIZE,
+            must_sync: false,
             recorder: WriteTaskBatchRecorder::new(write_batch_size_hint, write_wait_duration),
         }
     }
@@ -598,6 +621,7 @@ where
         for v in task.persisted_cbs.drain(..) {
             self.persisted_cbs.push(v);
         }
+        self.must_sync |= task.must_sync;
         self.tasks.push(task);
         // Record the size of the batch.
         self.recorder.record(self.get_raft_size());
@@ -611,6 +635,7 @@ where
         self.state_size = 0;
         self.tasks.clear();
         self.readies.clear();
+        self.must_sync = false;
         self.recorder.reset_wait_count();
     }
 
@@ -707,6 +732,9 @@ where
     batch: WriteTaskBatch<EK, ER>,
     cfg_tracker: Tracker<Config>,
     raft_write_size_limit: usize,
+    /// See `Config::unsafe_no_raft_log_fsync`. Refreshed from `cfg_tracker`
+    /// after each batch.
+    unsafe_no_raft_log_fsync: bool,
     metrics: StoreWriteMetrics,
     message_metrics: RaftSendMessageMetrics,
     perf_context: ER::PerfContext,
@@ -749,6 +777,7 @@ where
             batch,
             cfg_tracker,
             raft_write_size_limit: cfg.value().raft_write_size_limit.0 as usize,
+            unsafe_no_raft_log_fsync: cfg.value().unsafe_no_raft_log_fsync,
             metrics: StoreWriteMetrics::new(cfg.value().waterfall_metrics),
             message_metrics: RaftSendMessageMetrics::default(),
             perf_context,
@@ -849,6 +878,12 @@ where
         self.batch.add_write_task(&self.raft_engine, task);
     }
 
+    /// Entry appends drop the fsync when the unsafe switch is on. Term/vote
+    /// changes and snapshots set `must_sync` and are still fsynced.
+    fn need_raft_log_fsync(&self) -> bool {
+        !self.unsafe_no_raft_log_fsync || self.batch.must_sync
+    }
+
     pub fn write_to_db(&mut self, notify: bool) {
         if self.batch.is_empty() {
             return;
@@ -901,11 +936,15 @@ where
 
             let now = Instant::now();
             self.perf_context.start_observe();
+            let need_sync = self.need_raft_log_fsync();
+            STORE_WRITE_RAFT_LOG_FSYNC_COUNTER_VEC
+                .with_label_values(&[if need_sync { "sync" } else { "skip" }])
+                .inc();
             for i in 0..self.batch.raft_wbs.len() {
                 self.raft_engine
                     .consume_and_shrink(
                         &mut self.batch.raft_wbs[i],
-                        true,
+                        need_sync,
                         RAFT_WB_SHRINK_SIZE,
                         RAFT_WB_DEFAULT_SIZE,
                     )
@@ -1023,6 +1062,9 @@ where
         if let Some(incoming) = self.cfg_tracker.any_new() {
             self.raft_write_size_limit = incoming.raft_write_size_limit.0 as usize;
             self.metrics.waterfall_metrics = incoming.waterfall_metrics;
+            // Turning this off takes effect on the next batch: that batch fsyncs the
+            // whole append queue, which covers the entries skipped while it was on.
+            self.unsafe_no_raft_log_fsync = incoming.unsafe_no_raft_log_fsync;
             self.batch.update_config(
                 incoming.raft_write_batch_size_hint.0 as usize,
                 incoming.raft_write_wait_duration.0,

--- a/components/raftstore/src/store/async_io/write_tests.rs
+++ b/components/raftstore/src/store/async_io/write_tests.rs
@@ -197,6 +197,7 @@ fn test_raft_kv(engine: &RaftTestEngine, key: u64) -> bool {
 
 struct TestWorker {
     worker: Worker<KvTestEngine, RaftTestEngine, TestNotifier, TestTransport>,
+    cfg: Arc<VersionTrack<Config>>,
     msg_rx: Receiver<RaftMessage>,
     notify_rx: Receiver<(u64, (u64, u64))>,
 }
@@ -208,6 +209,7 @@ impl TestWorker {
         let trans = TestTransport { tx: msg_tx };
         let (notify_tx, notify_rx) = unbounded();
         let notifier = TestNotifier { tx: notify_tx };
+        let cfg = Arc::new(VersionTrack::new(cfg.clone()));
         Self {
             worker: Worker::new(
                 1,
@@ -217,11 +219,22 @@ impl TestWorker {
                 task_rx,
                 notifier,
                 trans,
-                &Arc::new(VersionTrack::new(cfg.clone())),
+                &cfg,
             ),
+            cfg,
             msg_rx,
             notify_rx,
         }
+    }
+
+    /// Changes the tracked config the way `RaftstoreConfigManager` does.
+    fn update_cfg(&self, f: impl FnOnce(&mut Config)) {
+        self.cfg
+            .update(|cfg| {
+                f(cfg);
+                Ok::<(), ()>(())
+            })
+            .unwrap();
     }
 }
 
@@ -795,4 +808,236 @@ fn test_resource_group() {
 
     tx.send(()).unwrap();
     must_wait_same_notifies(vec![(region_1, (1, 10)), (region_2, (2, 20))], &t.notify_rx);
+}
+
+#[test]
+fn test_unsafe_no_raft_log_fsync_skips_only_entry_appends() {
+    let path = Builder::new().prefix("async-io-fsync").tempdir().unwrap();
+    let engines = new_temp_engine(&path);
+
+    let add_task = |t: &mut TestWorker, index: u64, must_sync: bool| {
+        let mut task = WriteTask::<KvTestEngine, RaftTestEngine>::new(1, 1, index);
+        init_write_batch(&engines, &mut task);
+        task.entries.push(new_entry(index, 5));
+        task.raft_state = Some(new_raft_state(5, 123, 6, index));
+        task.must_sync = must_sync;
+        t.worker.batch.add_write_task(&engines.raft, task);
+    };
+
+    // With the switch off, every batch is fsynced regardless of `must_sync`.
+    let mut t = TestWorker::new(&Config::default(), &engines);
+    add_task(&mut t, 10, false);
+    assert!(t.worker.need_raft_log_fsync());
+    t.worker.write_to_db(true);
+
+    let cfg = Config {
+        unsafe_no_raft_log_fsync: true,
+        ..Config::default()
+    };
+    let mut t = TestWorker::new(&cfg, &engines);
+
+    // A batch of plain entry appends skips the fsync.
+    add_task(&mut t, 11, false);
+    assert!(!t.worker.need_raft_log_fsync());
+
+    // A single task that requires durability makes the whole batch fsync.
+    add_task(&mut t, 12, true);
+    assert!(t.worker.need_raft_log_fsync());
+
+    // Writing the batch out resets the flag for the next batch.
+    t.worker.write_to_db(true);
+    assert!(!t.worker.batch.must_sync);
+    add_task(&mut t, 13, false);
+    assert!(!t.worker.need_raft_log_fsync());
+}
+
+#[test]
+fn test_worker_picks_up_switch_change_online() {
+    let path = Builder::new()
+        .prefix("async-io-fsync-online")
+        .tempdir()
+        .unwrap();
+    let engines = new_temp_engine(&path);
+
+    let add_append = |t: &mut TestWorker, index: u64| {
+        let mut task = WriteTask::<KvTestEngine, RaftTestEngine>::new(1, 1, index);
+        init_write_batch(&engines, &mut task);
+        task.entries.push(new_entry(index, 5));
+        task.raft_state = Some(new_raft_state(5, 123, 6, index));
+        task.must_sync = false;
+        t.worker.batch.add_write_task(&engines.raft, task);
+    };
+
+    let mut t = TestWorker::new(&Config::default(), &engines);
+    add_append(&mut t, 10);
+    assert!(t.worker.need_raft_log_fsync());
+
+    t.update_cfg(|cfg| cfg.unsafe_no_raft_log_fsync = true);
+
+    // The worker refreshes its config at the end of `write_to_db`, so the batch
+    // in flight still fsyncs and the change lands on the next one.
+    assert!(t.worker.need_raft_log_fsync());
+    t.worker.write_to_db(true);
+
+    add_append(&mut t, 11);
+    assert!(!t.worker.need_raft_log_fsync());
+}
+
+#[test]
+fn test_set_must_sync_covers_term_vote_and_snapshot() {
+    let mut task = WriteTask::<KvTestEngine, RaftTestEngine>::new(1, 1, 10);
+    let prev = new_raft_state(5, 123, 6, 8);
+
+    // A task that never calls `set_must_sync` keeps the old always-fsync path.
+    assert!(task.must_sync);
+
+    // A plain entry append only moves last_index and commit.
+    task.set_must_sync(&prev, &new_raft_state(5, 123, 7, 9), false);
+    assert!(!task.must_sync);
+
+    task.set_must_sync(&prev, &new_raft_state(6, 123, 6, 8), false);
+    assert!(task.must_sync);
+
+    task.set_must_sync(&prev, &new_raft_state(5, 124, 6, 8), false);
+    assert!(task.must_sync);
+
+    task.set_must_sync(&prev, &new_raft_state(5, 123, 6, 8), true);
+    assert!(task.must_sync);
+}
+
+/// Returns what one fsync costs on `dir`. Reported next to the speedup, because
+/// the speedup only means something in proportion to it: on storage where an
+/// fsync is nearly free, such as tmpfs, both settings take the same time and
+/// the ratio says nothing about the switch.
+fn measure_fsync_cost(dir: &str) -> Duration {
+    use std::io::Write;
+
+    const PROBES: u32 = 20;
+
+    std::fs::create_dir_all(dir).unwrap();
+    let probe_path = std::path::Path::new(dir).join("fsync_probe");
+    let mut file = std::fs::File::create(&probe_path).unwrap();
+    file.write_all(b"probe").unwrap();
+
+    let timer = Instant::now();
+    for _ in 0..PROBES {
+        file.sync_data().unwrap();
+    }
+    let per_fsync = timer.saturating_elapsed() / PROBES;
+    std::fs::remove_file(&probe_path).unwrap();
+    per_fsync
+}
+
+/// Compares raft log write throughput with `unsafe_no_raft_log_fsync` off and
+/// on. Ignored by default so it does not slow CI down. Run it explicitly with
+/// `--ignored --nocapture` to see the numbers.
+#[test]
+#[ignore = "benchmark, run explicitly with --ignored"]
+fn bench_unsafe_no_raft_log_fsync() {
+    const BATCHES: u64 = 500;
+    const ENTRIES_PER_BATCH: u64 = 8;
+    const ENTRY_SIZE: usize = 1024;
+    const ROUNDS: usize = 9;
+
+    let skipped_batches = || {
+        STORE_WRITE_RAFT_LOG_FSYNC_COUNTER_VEC
+            .with_label_values(&["skip"])
+            .get()
+    };
+
+    // The system temp dir is often tmpfs, so default to the workspace target
+    // dir, which sits on the same real storage as the repository.
+    let base_dir = std::env::var("TIKV_BENCH_DIR")
+        .unwrap_or_else(|_| format!("{}/../../target", env!("CARGO_MANIFEST_DIR")));
+    let fsync_cost = measure_fsync_cost(&base_dir);
+
+    let run = |unsafe_no_raft_log_fsync: bool| -> (Duration, u64) {
+        let path = Builder::new()
+            .prefix("bench-fsync")
+            .tempdir_in(&base_dir)
+            .unwrap();
+        let engines = new_temp_engine(&path);
+        let cfg = Config {
+            unsafe_no_raft_log_fsync,
+            ..Config::default()
+        };
+        let mut t = TestWorker::new(&cfg, &engines);
+
+        let skipped_before = skipped_batches();
+        let timer = Instant::now();
+        let mut index = 1;
+        for batch in 0..BATCHES {
+            let mut task = WriteTask::<KvTestEngine, RaftTestEngine>::new(1, 1, batch + 1);
+            init_write_batch(&engines, &mut task);
+            for _ in 0..ENTRIES_PER_BATCH {
+                let mut entry = new_entry(index, 5);
+                entry.set_data(vec![0u8; ENTRY_SIZE].into());
+                task.entries.push(entry);
+                index += 1;
+            }
+            let last_index = index - 1;
+            task.raft_state = Some(new_raft_state(5, 123, last_index, last_index));
+            // These batches stand for plain entry appends, the only case the
+            // switch is allowed to skip.
+            task.must_sync = false;
+            t.worker.batch.add_write_task(&engines.raft, task);
+            t.worker.write_to_db(false);
+        }
+        (
+            timer.saturating_elapsed(),
+            skipped_batches() - skipped_before,
+        )
+    };
+
+    let mut with_fsync = Vec::with_capacity(ROUNDS);
+    let mut without_fsync = Vec::with_capacity(ROUNDS);
+    let mut skipped = 0;
+
+    // Alternate the settings and drop the first round. A fixed order lets
+    // warm-up effects favour whichever setting runs second.
+    for round in 0..=ROUNDS {
+        let on = run(false).0;
+        let (off, round_skipped) = run(true);
+        if round == 0 {
+            continue;
+        }
+        with_fsync.push(on);
+        without_fsync.push(off);
+        skipped += round_skipped;
+    }
+
+    // Without this the two settings would be measuring the same thing and the
+    // comparison below would be meaningless. The counter is global, so a
+    // concurrent test can only push it higher.
+    assert!(skipped >= BATCHES * ROUNDS as u64);
+
+    let median = |mut samples: Vec<Duration>| {
+        samples.sort();
+        samples[samples.len() / 2]
+    };
+    let with_fsync = median(with_fsync);
+    let without_fsync = median(without_fsync);
+    let per_batch_us = |total: Duration| total.as_secs_f64() * 1e6 / BATCHES as f64;
+
+    println!(
+        "raft log fsync benchmark: {} batches x {} entries x {} B, median of {} rounds",
+        BATCHES, ENTRIES_PER_BATCH, ENTRY_SIZE, ROUNDS
+    );
+    println!(
+        "  fsync on  (default): {:?} total, {:.1} us per batch",
+        with_fsync,
+        per_batch_us(with_fsync)
+    );
+    println!(
+        "  fsync off (unsafe):  {:?} total, {:.1} us per batch",
+        without_fsync,
+        per_batch_us(without_fsync)
+    );
+    println!(
+        "  speedup: {:.2}x",
+        with_fsync.as_secs_f64() / without_fsync.as_secs_f64()
+    );
+    // A speedup near 1.00x against a near-zero fsync cost means the storage is
+    // too fast to measure on, not that the switch does nothing.
+    println!("  storage: {} ({:?} per fsync)", base_dir, fsync_cost);
 }

--- a/components/raftstore/src/store/config.rs
+++ b/components/raftstore/src/store/config.rs
@@ -90,6 +90,11 @@ pub struct Config {
     /// The maximum raft log numbers that applied_index can be ahead of
     /// persisted_index.
     pub max_apply_unpersisted_log_limit: u64,
+    /// Skips the fsync after appending raft log entries. Term/vote changes and
+    /// snapshots are still fsynced, so election safety holds. Testing only:
+    /// after a power loss the peer may fail to start, because the applied
+    /// state can survive in the kv engine while the raft log tail does not.
+    pub unsafe_no_raft_log_fsync: bool,
     /// Number of Raft ticks between follower read index request retries.
     pub raft_read_index_retry_interval_ticks: usize,
     // follower will reject this follower request to avoid falling behind leader too far,
@@ -528,6 +533,7 @@ impl Default for Config {
             raft_log_gc_count_limit: None,
             raft_log_gc_size_limit: None,
             max_apply_unpersisted_log_limit: 1024,
+            unsafe_no_raft_log_fsync: false,
             raft_read_index_retry_interval_ticks: 4,
             follower_read_max_log_gap: 100,
             raft_log_reserve_max_ticks: 6,
@@ -1050,6 +1056,14 @@ impl Config {
             ));
         }
 
+        if self.unsafe_no_raft_log_fsync {
+            warn!(
+                "raftstore.unsafe-no-raft-log-fsync is on: raft log appends are not fsynced, \
+                 a power loss can lose committed writes and leave peers unable to start. \
+                 Testing only, must not be used in production."
+            );
+        }
+
         Ok(())
     }
 
@@ -1344,6 +1358,12 @@ impl ConfigManager for RaftstoreConfigManager {
                 }
                 cfg.update(change)
             })?;
+        }
+        if let Some(ConfigValue::Bool(true)) = change.get("unsafe_no_raft_log_fsync") {
+            warn!(
+                "raftstore.unsafe-no-raft-log-fsync turned on at runtime: raft log appends \
+                 are not fsynced, a power loss can lose committed writes. Testing only."
+            );
         }
         if let Some(ConfigValue::Module(raft_batch_system_change)) =
             change.get("store_batch_system")
@@ -1690,5 +1710,18 @@ mod tests {
         cfg.inspect_kvdb_interval = ReadableDuration::millis(1);
         cfg.optimize_inspector(true);
         assert_eq!(cfg.inspect_kvdb_interval, ReadableDuration::millis(1));
+    }
+
+    #[test]
+    fn test_unsafe_no_raft_log_fsync_is_off_by_default_and_accepted_when_on() {
+        let split_size = coprocessor::config::SPLIT_SIZE;
+        let mut cfg = Config::new();
+        assert!(!cfg.unsafe_no_raft_log_fsync);
+
+        // Turning it on only warns, it must not be rejected.
+        cfg.unsafe_no_raft_log_fsync = true;
+        cfg.validate(split_size, false, ReadableSize(0), false)
+            .unwrap();
+        assert!(cfg.unsafe_no_raft_log_fsync);
     }
 }

--- a/components/raftstore/src/store/metrics.rs
+++ b/components/raftstore/src/store/metrics.rs
@@ -397,6 +397,13 @@ lazy_static! {
             "Bucketed histogram of store write raft db duration.",
             exponential_buckets(0.00001, 2.0, 26).unwrap()
         ).unwrap();
+    pub static ref STORE_WRITE_RAFT_LOG_FSYNC_COUNTER_VEC: IntCounterVec =
+        register_int_counter_vec!(
+            "tikv_raftstore_raft_log_fsync_total",
+            "Total number of raft log writes, by whether the write was fsynced. \
+             Writes are only skipped when raftstore.unsafe-no-raft-log-fsync is on.",
+            &["type"]
+        ).unwrap();
     pub static ref STORE_WRITE_SEND_DURATION_HISTOGRAM: Histogram =
         register_histogram!(
             "tikv_raftstore_store_write_send_duration_seconds",

--- a/components/raftstore/src/store/peer_storage.rs
+++ b/components/raftstore/src/store/peer_storage.rs
@@ -1020,6 +1020,12 @@ where
             }
         }
 
+        write_task.set_must_sync(
+            &prev_raft_state,
+            self.raft_state(),
+            !ready.snapshot().is_empty(),
+        );
+
         // Save raft state if it has changed or there is a snapshot.
         if prev_raft_state != *self.raft_state() || !ready.snapshot().is_empty() {
             write_task.raft_state = Some(self.raft_state().clone());

--- a/tests/integrations/config/dynamic/raftstore.rs
+++ b/tests/integrations/config/dynamic/raftstore.rs
@@ -169,6 +169,7 @@ fn test_update_raftstore_config() {
         ("raftstore.raft-entry-max-size", "32MiB"),
         ("raftstore.apply-yield-write-size", "10KiB"),
         ("raftstore.snap-wait-split-duration", "10s"),
+        ("raftstore.unsafe-no-raft-log-fsync", "true"),
     ]);
 
     cfg_controller.update(change).unwrap();
@@ -183,6 +184,7 @@ fn test_update_raftstore_config() {
     raft_store.raft_max_size_per_msg = ReadableSize::mb(128);
     raft_store.raft_entry_max_size = ReadableSize::mb(32);
     raft_store.snap_wait_split_duration = ReadableDuration::secs(10);
+    raft_store.unsafe_no_raft_log_fsync = true;
     let validate_store_cfg = |raft_cfg: &Config| {
         let raftstore_cfg = raft_cfg.clone();
         validate_store(&router, move |cfg: &Config| {


### PR DESCRIPTION
### What is changed and how it works?

Cherry-pick of #19925 to `release-8.5-20260811-v8.5.4`. The target branch sits on
the same parent commit, so the pick is clean and the tree is identical to the
merged one.

Issue Number: ref #7748

What's Changed:

```commit-message
raftstore: add unsafe-no-raft-log-fsync for testing

Raft log appends are always fsynced before a peer reports persisted.
The `sync-log` option that used to control this was removed in #8631,
partly because it never helped: raft-rs sets `must_sync` whenever a
ready carries entries, so on a write-heavy workload the flag was
always overridden. That leaves no way to measure how much of the write
latency the fsync itself accounts for.

Add `raftstore.unsafe-no-raft-log-fsync`, default false, online
changeable. When it is on, batches that only append entries skip the
fsync. Term and vote changes still fsync, because raft requires them
to be durable before responding to RPCs, and so do snapshots, whose
metadata cannot be replayed.
```

The decision is computed by `WriteTask::set_must_sync` and consumed by
`Worker::need_raft_log_fsync` in the write worker. Only entry appends lose
their fsync; everything raft needs for election safety keeps it:

| | switch off (default) | switch on |
|---|---|---|
| entry append | fsync | **skipped** |
| term / vote change | fsync | fsync |
| snapshot | fsync | fsync |

`WriteTask::must_sync` defaults to true, so a write task from a path that never
calls `set_must_sync`, as raftstore-v2 does, keeps the old always-fsync
behavior. Opting a path into the new behavior is explicit.

A skipped append is not left behind by the next fsync. Both engines flush
everything written so far when they sync: `raft_log_engine` forwards to
`raft_engine::Engine::write`, whose sync covers the whole active file, and
rotation closes the old file with a `truncate` plus `sync` before opening a new
one; the RocksDB raft engine syncs the WAL, which likewise covers earlier
unsynced writes to it.

A new metric `tikv_raftstore_raft_log_fsync_total{type="sync\|skip"}` reports
how many batches were fsynced and how many were skipped, so the effect of the
switch is observable.

This option gives up durability and is for measurement only. A power loss can
lose committed writes. Because a follower can acknowledge entries it has not
persisted, the loss is not confined to that peer: the leader may have counted it
toward the quorum and committed. It can also leave a peer unable to start, since
the kv engine may flush an apply state whose commit index the raft log tail no
longer covers, which `validate_states` rejects on load. Keeping the fsync for
term and vote does not make the option safe; it keeps the failure to lost writes
instead of also admitting two leaders in one term. The config comment, a startup
warning and a runtime warning on enabling it all say the option must not be used
in production. This is why the PR title is prefixed with `[test only]`.

How long that exposure lasts is set by the guest kernel, not by the storage. On
a Linux instance on AWS or Alibaba Cloud, a skipped append still reaches the
disk through ordinary page cache writeback: `vm.dirty_expire_centisecs` defaults
to 3000, so a page is written out once it has been dirty for 30 seconds, and
`vm.dirty_writeback_centisecs` defaults to 500, so the writeback thread checks
every 5 seconds. Under a write-heavy raft log the 10 percent
`vm.dirty_background_ratio` threshold is usually crossed well before that and
writeback starts earlier. So the window in which a power loss can take
acknowledged writes with it is seconds, up to about half a minute, rather than
unbounded. A TiKV process crash loses nothing, because the page cache belongs to
the kernel and outlives the process.

The switch has no effect while it is off, which is the default: the first term
of `need_raft_log_fsync` short-circuits and every batch is fsynced exactly as
before.

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Unit tests cover the four `set_must_sync` branches (plain append, term change,
vote change, snapshot), that a task which never calls it keeps `must_sync`, and
the write worker decision with the switch on and off, including batch-level
aggregation and its reset after a write. A case in `test_update_raftstore_config`
covers the online config path.

#### Raft log write path

`bench_unsafe_no_raft_log_fsync` measures what the switch is for. It drives the
write worker directly, so it sees the raft log write path with no network,
apply or client in the way. It is ignored by default:

```
cargo test --release -p raftstore --lib \
  bench_unsafe_no_raft_log_fsync -- --ignored --nocapture
```

500 batches x 8 entries x 1024 B, median of nine rounds with the order swapped
every round:

| | total | per batch |
|---|---|---|
| fsync on (default) | 18.884 ms | 37.8 us |
| fsync off (unsafe) | 4.017 ms | 8.0 us |

That is 4.70x on the raft log write path in isolation. The run also reports what
one fsync cost on the storage it used, 1.23 ms here, because the ratio only
means something in proportion to that: this laptop reported anywhere from 0.1 ms
to 8 ms per fsync across runs, and the ratio moved by tens of percent with it.
Read the two together rather than taking the ratio as a portable number.

That ratio is not an end-to-end target. The benchmark batches carry an empty kv
write batch, so only the raft engine is exercised. A real batch usually carries
kv data as well, and that write is still issued with `sync` set, which this
switch does not change.

#### Insert throughput on a cluster

1 PD, 3 TiKV built from this branch, 1 TiDB on one host, driven by
`sysbench oltp_insert` at 8 threads. The switch is online changeable, so both
settings ran against the same cluster and the same data, flipped with:

```
set config tikv `raftstore.unsafe-no-raft-log-fsync` = true;
```

The order was swapped every round so table growth could not favour one setting.
Median of three 30 s rounds:

| | insert throughput |
|---|---|
| fsync on (default) | 5213 tps |
| fsync off (unsafe) | 5729 tps |

That is 9.9%, and the two groups do not overlap: the slowest round with the
fsync skipped still beat the fastest round with it on.
`tikv_raftstore_raft_log_fsync_total` confirms which path each round took, 0
skipped and ~380k synced with the switch off against ~400k skipped and 0 synced
with it on.

#### Why the benchmark is not at cluster level

`test_raftstore` cannot show this. Every put there pays an unconditional 10 ms
sleep in the mock PD region lookup (`TestPdClient::get_region`), which leaves the
raft round trip at under 1 ms out of a ~13 ms put. The same comparison run there
moves the total by about one percent no matter what the switch does.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note

```release-note
None
```

