### PR TITLE
engine_rocks: re-enable allow_write for external SST ingestion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4493,7 +4493,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git#63eeecd90ee7d3b84810f9d643ae1f54bd961258"
+source = "git+https://github.com/tikv/rust-rocksdb.git#64a092fd3b4b1639b42fdc3c5f31edbd05528177"
 dependencies = [
  "bindgen 0.65.1",
  "bzip2-sys",
@@ -4512,7 +4512,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/tikv/rust-rocksdb.git#63eeecd90ee7d3b84810f9d643ae1f54bd961258"
+source = "git+https://github.com/tikv/rust-rocksdb.git#64a092fd3b4b1639b42fdc3c5f31edbd05528177"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -6709,7 +6709,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git#63eeecd90ee7d3b84810f9d643ae1f54bd961258"
+source = "git+https://github.com/tikv/rust-rocksdb.git#64a092fd3b4b1639b42fdc3c5f31edbd05528177"
 dependencies = [
  "libc 0.2.176",
  "librocksdb_sys",

--- a/components/engine_rocks/src/import.rs
+++ b/components/engine_rocks/src/import.rs
@@ -13,9 +13,6 @@ use crate::{
     r2e, util,
 };
 
-// Temporarily disabled due to https://github.com/tikv/tikv/issues/19891.
-const ENABLE_INGEST_ALLOW_WRITE: bool = false;
-
 impl ImportExt for RocksEngine {
     type IngestExternalFileOptions = RocksIngestExternalFileOptions;
 
@@ -37,7 +34,7 @@ impl ImportExt for RocksEngine {
         let cf = util::get_cf_handle(self.as_inner(), cf_name)?;
         let mut opts = RocksIngestExternalFileOptions::new();
         opts.move_files(true);
-        let allow_write = ENABLE_INGEST_ALLOW_WRITE && (range.is_some() || force_allow_write);
+        let allow_write = range.is_some() || force_allow_write;
         opts.allow_write(allow_write);
         if allow_write {
             INGEST_EXTERNAL_FILE_ALLOW_WRITE_COUNTER


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close https://github.com/tikv/tikv/issues/19954

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
- Update `rust-rocksdb` to include [tikv/rocksdb#435](https://github.com/tikv/rocksdb/pull/435), which fixes the sequence-number publication race during allow-write ingestion.
- Remove the temporary switch introduced by #19906 and re-enable `allow_write` for external SST ingestion.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [x] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enabled write access when a valid range is provided or write access is explicitly forced.
  * Removed the previous restriction that could prevent eligible write operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->