### PR TITLE
resource_control: add background egress limit

### DIFF
--- a/components/resource_control/src/config.rs
+++ b/components/resource_control/src/config.rs
@@ -29,6 +29,12 @@ pub struct Config {
     /// Minimum write IO rate that background tasks are always allowed,
     /// even under maximum compaction pressure.
     pub bg_write_io_floor: ReadableSize,
+    /// Maximum network egress rate (response bytes sent out) allowed for
+    /// background tasks on this node, aggregated over all background requests.
+    /// This bounds the outbound bandwidth a large background scan takes from
+    /// foreground reads, no matter how many clients scan the node at the same
+    /// time. Set to 0 (the default) to disable egress throttling.
+    pub bg_egress_limit: ReadableSize,
     /// When true, enables fair two-phase scheduling for reads: groups whose
     /// current-minute RU rate exceeds their historical baseline are placed in
     /// phase 1 (deprioritised in the yatp priority queue) relative to groups
@@ -73,6 +79,7 @@ impl Default for Config {
             bg_compaction_pressure_threshold: 70.0,
             bg_write_io_ceiling: ReadableSize::gb(100),
             bg_write_io_floor: ReadableSize::mb(10),
+            bg_egress_limit: ReadableSize(0),
             enable_fair_scheduling: false,
             enable_read_admission_control: false,
             enable_write_admission_control: false,

--- a/components/resource_control/src/resource_group.rs
+++ b/components/resource_control/src/resource_group.rs
@@ -464,6 +464,9 @@ impl ResourceGroupManager {
             self.bg_limiter
                 .get_write_io_limiter()
                 .set_rate_limit(f64::INFINITY);
+            self.bg_limiter
+                .get_egress_limiter()
+                .set_rate_limit(f64::INFINITY);
         }
     }
 

--- a/components/resource_control/src/resource_limiter.rs
+++ b/components/resource_control/src/resource_limiter.rs
@@ -44,6 +44,13 @@ pub struct ResourceLimiter {
     // Independent from the combined IO limiter; rate is set by do_adjust
     // based on compaction pressure. Defaults to f64::INFINITY (no throttle).
     write_io_limiter: QuotaLimiter,
+    // Dedicated network egress (bytes sent out) limiter for background tasks.
+    // Bytes are charged where the response is built, via `consume_egress`,
+    // which never sleeps in flight; the resulting debt is paid by the next
+    // background request at the admission gate. The rate is set by
+    // `resource-control.bg-egress-limit` and defaults to f64::INFINITY
+    // (no throttle).
+    egress_limiter: QuotaLimiter,
     // whether the resource limiter is a background limiter or priority limiter.
     is_background: bool,
     // the wait duration histogram for prioitry limiter.
@@ -82,6 +89,7 @@ impl ResourceLimiter {
             version,
             limiters: [cpu_limiter, io_limiter],
             write_io_limiter: QuotaLimiter::new(f64::INFINITY),
+            egress_limiter: QuotaLimiter::new(f64::INFINITY),
             is_background,
             wait_histogram,
         }
@@ -110,13 +118,26 @@ impl ResourceLimiter {
         } else {
             self.write_io_limiter.consume(io_bytes.write, wait)
         };
-        let wait_dur = cpu_dur.max(io_dur).max(write_io_dur);
+        // Surface the egress debt that `consume_egress` has already built up.
+        // The value 0 adds no new consumption, it only reads back the debt so
+        // that egress flows into the admission delay just like CPU and IO debt.
+        let egress_dur = self.egress_limiter.consume(0, wait);
+        let wait_dur = cpu_dur.max(io_dur).max(write_io_dur).max(egress_dur);
         if !wait_dur.is_zero()
             && let Some(h) = &self.wait_histogram
         {
             h.observe(wait_dur.as_secs_f64());
         }
         wait_dur
+    }
+
+    /// Charges network egress (response bytes sent out) to the egress token
+    /// bucket. This only builds debt, it never sleeps in flight, so the caller
+    /// keeps neither a read-pool slot nor the response buffer while the bucket
+    /// is over budget. The debt is paid by the next background request at the
+    /// admission gate, see `admission_delay`.
+    pub fn consume_egress(&self, bytes: u64) {
+        let _ = self.egress_limiter.consume(bytes, false);
     }
 
     /// Returns the current token-bucket debt the caller should wait before
@@ -127,10 +148,11 @@ impl ResourceLimiter {
     /// For write requests (`is_read = false`), the write-specific IO limiter
     /// debt is also considered alongside CPU and combined IO debt.
     ///
-    /// Note: `write_io_limiter` and the combined IO limiter are only rate-set
-    /// for background limiters (via `do_adjust`); for foreground per-group
-    /// limiters their rates remain at `f64::INFINITY`, so their debt is
-    /// always zero and only CPU debt drives the delay in practice.
+    /// Note: `write_io_limiter`, `egress_limiter` and the combined IO limiter
+    /// are only rate-set for background limiters (via `do_adjust`); for
+    /// foreground per-group limiters their rates remain at `f64::INFINITY`, so
+    /// their debt is always zero and only CPU debt drives the delay in
+    /// practice.
     pub fn admission_delay(&self, is_read: bool) -> Duration {
         self.consume(
             Duration::ZERO,
@@ -164,6 +186,11 @@ impl ResourceLimiter {
     #[inline]
     pub(crate) fn get_write_io_limiter(&self) -> &QuotaLimiter {
         &self.write_io_limiter
+    }
+
+    #[inline]
+    pub(crate) fn get_egress_limiter(&self) -> &QuotaLimiter {
+        &self.egress_limiter
     }
 
     pub(crate) fn get_limit_statistics(&self, ty: ResourceType) -> GroupStatistics {
@@ -300,5 +327,51 @@ impl std::ops::Div<f64> for GroupStatistics {
             write_consumed: (self.write_consumed as f64 / rhs) as u64,
             request_count: (self.request_count as f64 / rhs) as u64,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // A background limiter with a finite egress rate turns a burst of egress
+    // bytes into token-bucket debt, which the next request pays at the
+    // admission gate. This is how the throttle rides the existing gate instead
+    // of adding a new sleep on the response path.
+    #[test]
+    fn test_background_egress_builds_admission_debt() {
+        let rate = 50.0 * 1024.0 * 1024.0;
+        let bg = ResourceLimiter::new("test-bg".to_owned(), f64::INFINITY, f64::INFINITY, 0, true);
+        bg.get_egress_limiter().set_rate_limit(rate);
+
+        // Nothing is consumed yet, so there is no egress debt.
+        assert_eq!(bg.admission_delay(true), Duration::ZERO);
+
+        // Charge several seconds of egress in one shot, well over the capacity
+        // of the bucket, which refills over 1s.
+        bg.consume_egress(rate as u64 * 4);
+        assert!(
+            bg.admission_delay(true) > Duration::ZERO,
+            "expected a non-zero admission delay after a background egress burst",
+        );
+    }
+
+    // With the throttle disabled (rate INFINITY, the default) `consume_egress`
+    // never builds debt, so requests are not delayed.
+    #[test]
+    fn test_egress_throttle_disabled_by_default() {
+        let bg = ResourceLimiter::new("test-bg".to_owned(), f64::INFINITY, f64::INFINITY, 0, true);
+        bg.consume_egress(u64::MAX / 2);
+        assert_eq!(bg.admission_delay(true), Duration::ZERO);
+    }
+
+    // Egress debt never mixes into the foreground path: priority limiters keep
+    // an infinite egress rate.
+    #[test]
+    fn test_foreground_egress_is_unlimited() {
+        let fg = ResourceLimiter::new("test-fg".to_owned(), f64::INFINITY, f64::INFINITY, 0, false);
+        assert!(fg.get_egress_limiter().get_rate_limit().is_infinite());
+        fg.consume_egress(500 * 1024 * 1024);
+        assert_eq!(fg.admission_delay(true), Duration::ZERO);
     }
 }

--- a/components/resource_control/src/worker.rs
+++ b/components/resource_control/src/worker.rs
@@ -240,6 +240,7 @@ impl<R: ResourceStatsProvider> GroupQuotaAdjustWorker<R> {
             None,
         );
         self.adjust_write_io_by_compaction_pressure();
+        self.adjust_egress_limit();
     }
 
     fn background_adjust_resource_quota(
@@ -373,6 +374,27 @@ impl<R: ResourceStatsProvider> GroupQuotaAdjustWorker<R> {
         self.bg_limiter
             .get_write_io_limiter()
             .set_rate_limit(new_limit);
+    }
+
+    /// Apply `resource-control.bg-egress-limit` to the background egress
+    /// limiter. Unlike the write IO limit this rate is absolute: it does not
+    /// scale with utilization, because the resource it protects is the node's
+    /// outbound network allowance, which is fixed. A value of 0 disables the
+    /// throttle.
+    fn adjust_egress_limit(&self) {
+        let limit = self.resource_ctl.get_config().value().bg_egress_limit.0;
+        let new_limit = if limit == 0 {
+            f64::INFINITY
+        } else {
+            limit as f64
+        };
+        self.bg_limiter
+            .get_egress_limiter()
+            .set_rate_limit(new_limit);
+        // 0 on the gauge means the throttle is disabled.
+        BACKGROUND_QUOTA_LIMIT_VEC
+            .with_label_values(&["egress"])
+            .set(limit as i64);
     }
 }
 
@@ -622,7 +644,7 @@ impl PriorityLimiterStatsTracker {
 mod tests {
     use std::time::Duration;
 
-    use tikv_util::thread_name_prefix::BACKGROUND_WORKER_THREAD;
+    use tikv_util::{config::ReadableSize, thread_name_prefix::BACKGROUND_WORKER_THREAD};
 
     use super::*;
     use crate::resource_group::tests::*;
@@ -1323,6 +1345,68 @@ mod tests {
         reset_quota(&mut worker, 0.0, 0.0, Duration::from_secs(1));
         worker.adjust_quota();
         check(limiter.get_write_io_limiter().get_rate_limit(), ceiling);
+    }
+
+    // The background egress limit is an absolute rate taken straight from the
+    // config: it does not scale with utilization, and 0 disables it.
+    #[test]
+    fn test_bg_egress_limit_from_config() {
+        let resource_ctl = Arc::new(ResourceGroupManager::new(crate::config::Config {
+            bg_egress_limit: ReadableSize::mb(50),
+            ..Default::default()
+        }));
+        let test_provider = TestResourceStatsProvider::new(8.0, 10000.0);
+        let mut worker = GroupQuotaAdjustWorker::with_quota_getter(
+            resource_ctl.clone(),
+            test_provider,
+            Arc::new(AtomicU32::new(0)),
+        );
+        resource_ctl.add_resource_group(new_background_resource_group_ru(
+            "default".into(),
+            2000,
+            8,
+            vec!["br".into()],
+        ));
+        let limiter = resource_ctl
+            .get_background_resource_limiter("default", "br")
+            .unwrap();
+
+        // Before the first tick the limiter is unthrottled.
+        assert!(limiter.get_egress_limiter().get_rate_limit().is_infinite());
+
+        worker.last_adjust_time = Instant::now_coarse() - Duration::from_secs(1);
+        worker.adjust_quota();
+        assert_eq!(
+            limiter.get_egress_limiter().get_rate_limit(),
+            ReadableSize::mb(50).0 as f64
+        );
+
+        // A new value is picked up on the next tick.
+        resource_ctl
+            .get_config()
+            .update(|c| {
+                c.bg_egress_limit = ReadableSize::mb(10);
+                Ok::<(), String>(())
+            })
+            .unwrap();
+        worker.last_adjust_time = Instant::now_coarse() - Duration::from_secs(1);
+        worker.adjust_quota();
+        assert_eq!(
+            limiter.get_egress_limiter().get_rate_limit(),
+            ReadableSize::mb(10).0 as f64
+        );
+
+        // 0 disables the throttle again.
+        resource_ctl
+            .get_config()
+            .update(|c| {
+                c.bg_egress_limit = ReadableSize(0);
+                Ok::<(), String>(())
+            })
+            .unwrap();
+        worker.last_adjust_time = Instant::now_coarse() - Duration::from_secs(1);
+        worker.adjust_quota();
+        assert!(limiter.get_egress_limiter().get_rate_limit().is_infinite());
     }
 
     // Verify that with multiple background groups the budget is set globally on

--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -177,6 +177,12 @@
 ##                   impacted when the overall load is high.
 # priority-ctl-strategy = "moderate"
 
+## Maximum network egress rate (response bytes sent out) for background tasks on this node,
+## aggregated over all background requests. Use it to stop a large background scan, such as the
+## scan phase of a distributed ADD INDEX, from taking the whole outbound network allowance of
+## the node from foreground reads. Set to 0 to disable egress throttling.
+# bg-egress-limit = "0B"
+
 [server]
 ## Listening address.
 # addr = "127.0.0.1:20160"

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -528,6 +528,7 @@ impl<E: Engine> Endpoint<E> {
         semaphore_group: SemaphoreGroup,
         mut tracker: Box<Tracker<E>>,
         handler_builder: RequestHandlerBuilder<E::IMSnap>,
+        resource_limiter: Option<Arc<ResourceLimiter>>,
     ) -> Result<MemoryTraceGuard<coppb::Response>> {
         with_tls_tracker(|tracker1| {
             record_network_in_bytes(tracker1.metrics.grpc_req_size);
@@ -607,6 +608,7 @@ impl<E: Engine> Endpoint<E> {
                 let resp_size = resp.data.len() as u64;
                 COPR_RESP_SIZE.inc_by(resp_size);
                 record_network_out_bytes(resp_size);
+                charge_background_egress(&resource_limiter, resp_size);
                 with_tls_tracker(|tracker| {
                     tracker.metrics.coprocessor_response_bytes = tracker
                         .metrics
@@ -684,6 +686,7 @@ impl<E: Engine> Endpoint<E> {
             semaphore_group,
             tracker,
             handler_builder,
+            resource_limiter.clone(),
         )
         .in_resource_metering_tag(resource_tag)
         .map(move |res| {
@@ -854,6 +857,7 @@ impl<E: Engine> Endpoint<E> {
         semaphore: Option<Arc<Semaphore>>,
         mut tracker: Box<Tracker<E>>,
         handler_builder: RequestHandlerBuilder<E::IMSnap>,
+        resource_limiter: Option<Arc<ResourceLimiter>>,
     ) -> impl futures::stream::Stream<Item = Result<coppb::Response>> {
         try_stream! {
             let _permit = if let Some(semaphore) = semaphore.as_ref() {
@@ -913,6 +917,7 @@ impl<E: Engine> Endpoint<E> {
                         let resp_size = resp.data.len() as u64;
                         COPR_RESP_SIZE.inc_by(resp_size);
                         record_network_out_bytes(resp_size);
+                        charge_background_egress(&resource_limiter, resp_size);
                         with_tls_tracker(|tracker| {
                             tracker.metrics.coprocessor_response_bytes = tracker
                                 .metrics
@@ -982,6 +987,7 @@ impl<E: Engine> Endpoint<E> {
             self.request_semaphore(semaphore_group),
             tracker,
             handler_builder,
+            resource_limiter.clone(),
         )
         .in_resource_metering_tag(resource_tag)
         .then(futures::future::ok::<_, mpsc::SendError>)
@@ -1162,6 +1168,22 @@ macro_rules! make_error_response_common {
         };
         COPR_REQ_ERROR.with_label_values(&[$tag]).inc();
     }};
+}
+
+/// Charges the response size of a background request to the background egress
+/// token bucket, so that a large background scan cannot take the whole outbound
+/// network allowance of the node from foreground reads.
+///
+/// This only builds debt, it never sleeps here: the response buffer and the
+/// read-pool slot are released as usual, and the next background request pays
+/// the debt at the admission gate. Foreground requests are not charged, and the
+/// call is a no-op unless `resource-control.bg-egress-limit` is set.
+fn charge_background_egress(resource_limiter: &Option<Arc<ResourceLimiter>>, resp_size: u64) {
+    if let Some(limiter) = resource_limiter {
+        if limiter.is_background() {
+            limiter.consume_egress(resp_size);
+        }
+    }
 }
 
 fn make_error_batch_response(batch_resp: &mut coppb::StoreBatchTaskResponse, e: Error) {
@@ -1985,6 +2007,7 @@ mod tests {
                     slow_log_threshold,
                 )),
                 background_handler,
+                None,
             );
             background_tx.send(block_on(background_future)).unwrap();
         });
@@ -2011,6 +2034,7 @@ mod tests {
                     slow_log_threshold,
                 )),
                 shared_handler,
+                None,
             );
             shared_tx.send(block_on(shared_future)).unwrap();
         });

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -926,6 +926,7 @@ fn test_serde_custom_tikv_config() {
         bg_compaction_pressure_threshold: 70.0,
         bg_write_io_ceiling: ReadableSize::gb(100),
         bg_write_io_floor: ReadableSize::mb(10),
+        bg_egress_limit: ReadableSize::mb(50),
         enable_fair_scheduling: false,
         enable_read_admission_control: false,
         enable_write_admission_control: false,

--- a/tests/integrations/config/test-custom.toml
+++ b/tests/integrations/config/test-custom.toml
@@ -700,6 +700,7 @@ fg-cpu-throttle-threshold = 70.0
 bg-compaction-pressure-threshold = 70.0
 bg-write-io-ceiling = "100GB"
 bg-write-io-floor = "10MB"
+bg-egress-limit = "50MB"
 enable-fair-scheduling = false
 enable-read-admission-control = false
 enable-write-admission-control = false


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: close #19988

The scan phase of an `ADD INDEX` (DXF + global sort) makes TiKV outbound network
traffic reach the egress bandwidth allowance of the instance, and foreground
transaction latency degrades ~7x. The background resource limiter bounds
background CPU and write IO, but not network bytes out. The TiDB-side knobs (`tidb_ddl_reorg_worker_cnt`,
`tidb_ddl_reorg_batch_size`) are per executor pod, so the egress that one TiKV
node serves is the sum over all pods that read from it. Full measurements and
the evidence that the allowance is what binds are in #19988.

This adds the missing per-node layer: `resource-control.bg-egress-limit`, an
absolute bytes/s cap on background egress, **off by default (0)**.

How it works:

- `ResourceLimiter` gets a dedicated `egress_limiter` token bucket, next to the
  CPU, IO and write-IO limiters it already has. Its rate stays `INFINITY` for
  foreground per-group limiters, so foreground requests are never charged.
- Each background coprocessor response charges its size to that bucket, where
  the response is built. The charge is measure-only: it never
  sleeps in flight.
- The debt is paid at the existing admission gate: `consume` folds egress debt
  into the delay that `admission_delay` returns, so the next background request
  waits before it takes a pool slot, exactly as CPU and IO debt do today. 
- `GroupQuotaAdjustWorker` applies the config on every adjust tick, so the value
  is dynamically adjustable, and reports the applied rate on
  `tikv_resource_control_background_quota_limiter{type="egress"}`.

Unlike the write IO limit, the rate does not scale with utilization: the
resource it protects is the fixed outbound allowance of the instance, not a
share of a budget that grows and shrinks.

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests

- [x] Unit test
- [x] Manual test (add detailed scripts or steps below)

Unit tests:

- `resource_limiter`: a finite background egress rate turns a burst of egress
  bytes into a non-zero admission delay; the disabled default (`INFINITY`)
  builds no debt; foreground limiters keep an infinite rate and are never
  delayed.
- `worker`: the config value is applied on the adjust tick, a new value is
  picked up on the next tick, and 0 disables the throttle.
- `tests/integrations/config`: TOML round-trip coverage for the new key.

Manual test: sysbench `oltp_read_only` (16 workers) against a 2B-row table,
concurrent with `ADD INDEX` on a ~400 GiB index via DXF + global sort, on a
3-store cluster of `r6i.4xlarge`. With a 50 MiB/s per-node cap, foreground
throughput holds at the ~700 tps baseline (against ~600 tps uncapped), p95
latency matches baseline, and p99 tracks baseline for the large majority of the
scan with occasional short spikes. Scan time goes from ~6 minutes to
~30 minutes. Full method and measurements in #19988.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

None. The feature is off by default (`bg-egress-limit = 0`)

### Release note

```release-note
Add the `resource-control.bg-egress-limit` configuration item to limit the
network egress rate of background tasks on each TiKV node, which prevents large
background scans, such as the scan phase of `ADD INDEX`, from exhausting the
outbound network bandwidth needed by foreground reads. This is disabled by
default.
```
