### PR TITLE
cargo-deny: ignore RUSTSEC-2026-0253 for `lru`.

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -86,11 +86,12 @@ ignore = [
     # TODO: Remove after both dependency chains can move to quick-xml >= 0.41.
     "RUSTSEC-2026-0194",
     "RUSTSEC-2026-0195",
-    # Ignore RUSTSEC-2026-0253, as the version of "lru" crate has been limited
-    # by "aws-sdk-s3" for the requirement lru = "^0.16.3". Meanwhile, it only take
-    # affects only if unwinding panics are enabled and `std::panic::catch_unwind`
-    # is used with key types that have potentially-panicking Drop implementations,
-    # which `aws-sdk-s3` does not do.
+    # Ignore RUSTSEC-2026-0253 for now: Cargo.lock shows `lru` 0.16.3 is pulled
+    # in only via `aws-sdk-s3`. The advisory is only relevant when unwinding
+    # panics are enabled and `std::panic::catch_unwind` is used with key types
+    # that may panic in `Drop`.
+    # 
+    # See: https://rustsec.org/advisories/RUSTSEC-2026-0253
     "RUSTSEC-2026-0253",
 ]
 

--- a/deny.toml
+++ b/deny.toml
@@ -86,6 +86,12 @@ ignore = [
     # TODO: Remove after both dependency chains can move to quick-xml >= 0.41.
     "RUSTSEC-2026-0194",
     "RUSTSEC-2026-0195",
+    # Ignore RUSTSEC-2026-0253, as the version of "lru" crate has been limited
+    # by "aws-sdk-s3" for the requirement lru = "^0.16.3". Meanwhile, it only take
+    # affects only if unwinding panics are enabled and `std::panic::catch_unwind`
+    # is used with key types that have potentially-panicking Drop implementations,
+    # which `aws-sdk-s3` does not do.
+    "RUSTSEC-2026-0253",
 ]
 
 # TiKV is licensed under Apache 2.0, according to ASF 3RD PARTY LICENSE POLICY,


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: ref https://github.com/tikv/tikv/issues/15990

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Ignore RUSTSEC-2026-0253 for `lru`.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Chores

- Added an advisory exception for a reported security issue.
- Documented the limited conditions under which the issue applies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->