### PR TITLE
server: retry raft address resolution when store is not found

### DIFF
--- a/components/file_system/src/io_stats/proc.rs
+++ b/components/file_system/src/io_stats/proc.rs
@@ -202,35 +202,64 @@ mod tests {
     use super::*;
     use crate::{OpenOptions, WithIoType, io_stats::A512};
 
+    #[repr(align(4096))]
+    struct A4096<const SZ: usize>([u8; SZ]);
+
     #[test]
     fn test_read_bytes() {
-        let tmp = tempdir_in("/var/tmp").unwrap_or_else(|_| tempdir().unwrap());
-        let file_path = tmp.path().join("test_read_bytes.txt");
-        let mut id = ThreadId::current();
-        let _type = WithIoType::new(IoType::Compaction);
-        {
+        fn test_read_bytes_with_block_size<const BLOCK_SIZE: usize>() -> Result<(), String> {
+            let tmp = tempdir_in("/var/tmp").unwrap_or_else(|_| tempdir().unwrap());
+            let file_path = tmp.path().join("test_read_bytes.txt");
+            let mut id = ThreadId::current();
+            let _type = WithIoType::new(IoType::Compaction);
+
+            {
+                let mut f = OpenOptions::new()
+                    .write(true)
+                    .create(true)
+                    .custom_flags(O_DIRECT)
+                    .open(&file_path)
+                    .map_err(|e| format!("open for write: {e}"))?;
+                let w = Box::new(A4096([0u8; 4096 * 10]));
+                f.write_all(&w.0).map_err(|e| format!("write file: {e}"))?;
+                f.sync_all().map_err(|e| format!("sync file: {e}"))?;
+            }
+
             let mut f = OpenOptions::new()
-                .write(true)
-                .create(true)
+                .read(true)
                 .custom_flags(O_DIRECT)
                 .open(&file_path)
-                .unwrap();
-            let w = Box::new(A512([0u8; 512 * 10]));
-            f.write_all(&w.0).unwrap();
-            f.sync_all().unwrap();
-        }
-        let mut f = OpenOptions::new()
-            .read(true)
-            .custom_flags(O_DIRECT)
-            .open(&file_path)
-            .unwrap();
-        let mut w = A512([0u8; 512]);
-        let base_local_bytes = id.fetch_io_bytes().unwrap();
-        for i in 1..=10 {
-            f.read_exact(&mut w.0).unwrap();
+                .map_err(|e| format!("open for read: {e}"))?;
+            let mut w = A4096([0u8; BLOCK_SIZE]);
+            let base_local_bytes = id.fetch_io_bytes()?;
+            for i in 1..=10 {
+                f.read_exact(&mut w.0)
+                    .map_err(|e| format!("read {BLOCK_SIZE} bytes: {e}"))?;
 
-            let local_bytes = id.fetch_io_bytes().unwrap();
-            assert_eq!(i * 512 + base_local_bytes.read, local_bytes.read);
+                let local_bytes = id.fetch_io_bytes()?;
+                let expected = i * BLOCK_SIZE + base_local_bytes.read;
+                if expected != local_bytes.read {
+                    return Err(format!(
+                        "after read {i}, expected read_bytes {expected}, got {}",
+                        local_bytes.read
+                    ));
+                }
+            }
+
+            Ok(())
+        }
+        // O_DIRECT alignment requirements vary by kernel and filesystem. Try
+        // both common request sizes with a 4 KiB-aligned buffer so this test
+        // checks proc accounting without assuming the CI filesystem layout.
+        let error_512 = match test_read_bytes_with_block_size::<512>() {
+            Ok(()) => return,
+            Err(e) => e,
+        };
+        if let Err(error_4096) = test_read_bytes_with_block_size::<4096>() {
+            panic!(
+                "direct reads were not accounted correctly with either request size; \
+                 512-byte error: {error_512}; 4 KiB error: {error_4096}"
+            );
         }
     }
 

--- a/components/file_system/src/io_stats/proc.rs
+++ b/components/file_system/src/io_stats/proc.rs
@@ -237,7 +237,7 @@ mod tests {
                     .map_err(|e| format!("read {BLOCK_SIZE} bytes: {e}"))?;
 
                 let local_bytes = id.fetch_io_bytes()?;
-                let expected = i * BLOCK_SIZE + base_local_bytes.read;
+                let expected = i * BLOCK_SIZE as u64 + base_local_bytes.read;
                 if expected != local_bytes.read {
                     return Err(format!(
                         "after read {i}, expected read_bytes {expected}, got {}",

--- a/doc/maintenance-guides/components/raftstore-v2.md
+++ b/doc/maintenance-guides/components/raftstore-v2.md
@@ -117,6 +117,9 @@ High-risk contracts:
   apply guarantees.
 - Tablet-backed state transitions must remain aligned with region/raft
   metadata.
+- A maybe-tombstone store hint may come from an ambiguous PD not-found response.
+  It may only confirm peers already present in removal records; connection
+  retry and tombstone blocking remain owned by the raft client.
 - Pending pre-transfer-leader messages and cache warm-up state belong to the
   leader ID and term that accepted them. They must be discarded when either
   changes, including term changes that do not yield a new Raft `SoftState`.

--- a/doc/maintenance-guides/src/server.md
+++ b/doc/maintenance-guides/src/server.md
@@ -116,8 +116,10 @@ High-risk service contracts:
 - Raft address resolution distinguishes a definitive PD tombstone from an
   ambiguous not-found response. A definitive tombstone is reported to the
   raftstore extension and permanently blocks new connections. Not-found is
-  retryable because the store may not have registered yet; it uses
-  `raft_client_max_backoff` and must not be reported as maybe tombstone.
+  retryable because the store may not have registered yet and uses
+  `raft_client_max_backoff`. It is also reported as a maybe-tombstone hint so
+  raftstore-v2 can clean up existing peer-removal records; this hint does not
+  add the store to the connection tombstone block list.
 
 ### Status and diagnostics
 

--- a/doc/maintenance-guides/src/server.md
+++ b/doc/maintenance-guides/src/server.md
@@ -113,6 +113,11 @@ High-risk service contracts:
 - `raftkv/mod.rs` is the bridge between storage and raftstore.
 - `raftkv2/mod.rs` is the bridge between storage and `raftstore-v2`.
 - `debug2.rs` is the matching debugger surface for the `RaftKv2` path.
+- Raft address resolution distinguishes a definitive PD tombstone from an
+  ambiguous not-found response. A definitive tombstone is reported to the
+  raftstore extension and permanently blocks new connections. Not-found is
+  retryable because the store may not have registered yet; it uses
+  `raft_client_max_backoff` and must not be reported as maybe tombstone.
 
 ### Status and diagnostics
 
@@ -141,6 +146,9 @@ High-risk service contracts:
 
 - gRPC service metrics and request-duration tracking
 - raft transport rejection and memory-pressure signals
+- raft address-resolution success, failure, tombstone, and not-found counters;
+  retryable not-found warnings are emitted immediately and then rate limited
+  per store while the counters continue to record every attempt
 - status-server endpoints for config, metrics, health, and profiles
 - GC and diagnostics metrics and logs
 

--- a/src/server/raft_client.rs
+++ b/src/server/raft_client.rs
@@ -55,6 +55,10 @@ use crate::server::{
     snap::Task as SnapTask,
 };
 
+// This interval only throttles repeated warnings. Resolve attempts still use
+// `raft_client_max_backoff`, and their metrics are recorded on every attempt.
+const STORE_NOT_FOUND_LOG_INTERVAL: Duration = Duration::from_secs(60);
+
 // Implement health_controller::HealthChecker for HealthChecker to bridge with
 // health_controller
 impl health_controller::HealthChecker for HealthChecker {
@@ -853,21 +857,50 @@ async fn start<S, R>(
         let addr = match f.await {
             Ok(addr) => {
                 RESOLVE_STORE_COUNTER.with_label_values(&["success"]).inc();
+                // End the current not-found episode so a later recurrence is
+                // reported immediately instead of inheriting the old throttle.
+                pool.lock()
+                    .unwrap()
+                    .store_not_found_last_log
+                    .remove(&back_end.store_id);
                 info!("resolve store address ok"; "store_id" => back_end.store_id, "addr" => %addr);
                 addr
             }
             Err(e) => {
                 RESOLVE_STORE_COUNTER.with_label_values(&["failed"]).inc();
                 back_end.clear_pending_message("resolve");
-                error_unknown!(?e; "resolve store address failed"; "store_id" => back_end.store_id,);
-                if let ResolveError::StoreTombstone(_) = e {
-                    let mut pool = pool.lock().unwrap();
-                    if let Some(conn_info) = pool.connections.remove(&(back_end.store_id, conn_id))
-                    {
-                        conn_info.queue.set_conn_state(ConnState::Disconnected);
+                match e {
+                    ResolveError::StoreTombstone(_) => {
+                        error_unknown!(?e; "resolve store address failed"; "store_id" => back_end.store_id,);
+                        let mut pool = pool.lock().unwrap();
+                        if let Some(conn_info) =
+                            pool.connections.remove(&(back_end.store_id, conn_id))
+                        {
+                            conn_info.queue.set_conn_state(ConnState::Disconnected);
+                        }
+                        // Tombstone is terminal for this connection, so its
+                        // transient not-found logging state is no longer useful.
+                        pool.store_not_found_last_log.remove(&back_end.store_id);
+                        pool.tombstone_stores.insert(back_end.store_id);
+                        return;
                     }
-                    pool.tombstone_stores.insert(back_end.store_id);
-                    return;
+                    ResolveError::StoreNotFound(_) => {
+                        // PD not-found is ambiguous: the store may register
+                        // later. Keep retrying while suppressing log floods.
+                        let should_log = pool
+                            .lock()
+                            .unwrap()
+                            .should_log_store_not_found(back_end.store_id, Instant::now());
+                        if should_log {
+                            warn!("store is not found in PD, retrying resolve";
+                                "store_id" => back_end.store_id,
+                                "retry_interval" => ?backoff_duration,
+                            );
+                        }
+                    }
+                    _ => {
+                        error_unknown!(?e; "resolve store address failed"; "store_id" => back_end.store_id,);
+                    }
                 }
                 continue;
             }
@@ -996,10 +1029,30 @@ struct ConnectionInfo {
 struct ConnectionPool {
     connections: HashMap<(u64, usize), ConnectionInfo>,
     tombstone_stores: HashSet<u64>,
+    // Last not-found warning time per store. Stores are independent so one
+    // missing store cannot suppress the first warning for another.
+    store_not_found_last_log: HashMap<u64, Instant>,
     store_allowlist: Vec<u64>,
 }
 
 impl ConnectionPool {
+    /// Returns whether this not-found attempt should emit a warning and records
+    /// `now` when it does. The caller still retries and updates metrics either
+    /// way.
+    fn should_log_store_not_found(&mut self, store_id: u64, now: Instant) -> bool {
+        if self
+            .store_not_found_last_log
+            .get(&store_id)
+            .is_some_and(|last_log| {
+                now.saturating_duration_since(*last_log) < STORE_NOT_FOUND_LOG_INTERVAL
+            })
+        {
+            return false;
+        }
+        self.store_not_found_last_log.insert(store_id, now);
+        true
+    }
+
     fn set_store_allowlist(&mut self, stores: Vec<u64>) {
         self.store_allowlist = stores;
         let need_pause_check = !self.store_allowlist.is_empty();
@@ -1640,6 +1693,23 @@ mod tests {
 
     use super::*;
     use crate::server::load_statistics::ThreadLoadPool;
+
+    #[test]
+    fn test_store_not_found_log_throttle() {
+        let mut pool = ConnectionPool::default();
+        let now = Instant::now();
+
+        assert!(pool.should_log_store_not_found(1, now));
+        assert!(!pool.should_log_store_not_found(
+            1,
+            now + STORE_NOT_FOUND_LOG_INTERVAL - Duration::from_millis(1)
+        ));
+        assert!(pool.should_log_store_not_found(1, now + STORE_NOT_FOUND_LOG_INTERVAL));
+        assert!(pool.should_log_store_not_found(2, now));
+
+        pool.store_not_found_last_log.remove(&1);
+        assert!(pool.should_log_store_not_found(1, now));
+    }
 
     #[test]
     fn test_push_raft_message_with_context() {

--- a/src/server/raft_client.rs
+++ b/src/server/raft_client.rs
@@ -861,7 +861,7 @@ async fn start<S, R>(
                 // reported immediately instead of inheriting the old throttle.
                 pool.lock()
                     .unwrap()
-                    .store_not_found_last_log
+                    .not_found_stores
                     .remove(&back_end.store_id);
                 info!("resolve store address ok"; "store_id" => back_end.store_id, "addr" => %addr);
                 addr
@@ -880,7 +880,7 @@ async fn start<S, R>(
                         }
                         // Tombstone is terminal for this connection, so its
                         // transient not-found logging state is no longer useful.
-                        pool.store_not_found_last_log.remove(&back_end.store_id);
+                        pool.not_found_stores.remove(&back_end.store_id);
                         pool.tombstone_stores.insert(back_end.store_id);
                         return;
                     }
@@ -1029,9 +1029,9 @@ struct ConnectionInfo {
 struct ConnectionPool {
     connections: HashMap<(u64, usize), ConnectionInfo>,
     tombstone_stores: HashSet<u64>,
-    // Last not-found warning time per store. Stores are independent so one
-    // missing store cannot suppress the first warning for another.
-    store_not_found_last_log: HashMap<u64, Instant>,
+    // Stores in the current not-found episode, mapped to their last warning
+    // time. Unlike `tombstone_stores`, entries are removed after resolution.
+    not_found_stores: HashMap<u64, Instant>,
     store_allowlist: Vec<u64>,
 }
 
@@ -1041,7 +1041,7 @@ impl ConnectionPool {
     /// way.
     fn should_log_store_not_found(&mut self, store_id: u64, now: Instant) -> bool {
         if self
-            .store_not_found_last_log
+            .not_found_stores
             .get(&store_id)
             .is_some_and(|last_log| {
                 now.saturating_duration_since(*last_log) < STORE_NOT_FOUND_LOG_INTERVAL
@@ -1049,7 +1049,7 @@ impl ConnectionPool {
         {
             return false;
         }
-        self.store_not_found_last_log.insert(store_id, now);
+        self.not_found_stores.insert(store_id, now);
         true
     }
 
@@ -1707,7 +1707,7 @@ mod tests {
         assert!(pool.should_log_store_not_found(1, now + STORE_NOT_FOUND_LOG_INTERVAL));
         assert!(pool.should_log_store_not_found(2, now));
 
-        pool.store_not_found_last_log.remove(&1);
+        pool.not_found_stores.remove(&1);
         assert!(pool.should_log_store_not_found(1, now));
     }
 

--- a/src/server/resolve.rs
+++ b/src/server/resolve.rs
@@ -119,6 +119,9 @@ where
                 // be distinguished from this response.
                 if format!("{:?}", e).contains("not found") {
                     RESOLVE_STORE_COUNTER_STATIC.not_found.inc();
+                    // Keep address resolution retryable, but let raftstore-v2
+                    // clean up existing peer-removal records for this store.
+                    self.router.report_store_maybe_tombstone(store_id);
                     return Err(Error::StoreNotFound(store_id));
                 }
                 return Err(box_err!(e));
@@ -227,13 +230,23 @@ impl Default for MockStoreAddrResolver {
 
 #[cfg(test)]
 mod tests {
-    use std::{net::SocketAddr, ops::Sub, str::FromStr, sync::Arc, thread, time::Duration};
+    use std::{
+        net::SocketAddr,
+        ops::Sub,
+        str::FromStr,
+        sync::{
+            Arc,
+            atomic::{AtomicU64, Ordering},
+        },
+        thread,
+        time::Duration,
+    };
 
     use collections::HashMap;
     use grpcio::{Error as GrpcError, RpcStatus, RpcStatusCode};
     use kvproto::metapb;
     use pd_client::{PdClient, Result};
-    use tikv_kv::FakeExtension;
+    use tikv_kv::RaftExtension;
 
     use super::*;
 
@@ -242,6 +255,18 @@ mod tests {
     struct MockPdClient {
         start: Instant,
         store: metapb::Store,
+    }
+
+    #[derive(Clone, Default)]
+    struct MockExtension {
+        maybe_tombstone_store_id: Arc<AtomicU64>,
+    }
+
+    impl RaftExtension for MockExtension {
+        fn report_store_maybe_tombstone(&self, store_id: u64) {
+            self.maybe_tombstone_store_id
+                .store(store_id, Ordering::SeqCst);
+        }
     }
 
     impl PdClient for MockPdClient {
@@ -278,7 +303,7 @@ mod tests {
         store
     }
 
-    fn new_runner(store: metapb::Store) -> Runner<MockPdClient, FakeExtension> {
+    fn new_runner(store: metapb::Store) -> Runner<MockPdClient, MockExtension> {
         let client = MockPdClient {
             start: Instant::now(),
             store,
@@ -287,7 +312,7 @@ mod tests {
             pd_client: Arc::new(client),
             store_addrs: HashMap::default(),
             state: Default::default(),
-            router: FakeExtension,
+            router: MockExtension::default(),
         }
     }
 
@@ -316,6 +341,13 @@ mod tests {
             runner.get_address(store_id),
             Err(Error::StoreTombstone(id)) if id == store_id
         ));
+        assert_eq!(
+            runner
+                .router
+                .maybe_tombstone_store_id
+                .load(Ordering::SeqCst),
+            store_id
+        );
     }
 
     #[test]
@@ -328,6 +360,13 @@ mod tests {
             runner.get_address(store_id),
             Err(Error::StoreNotFound(id)) if id == store_id
         ));
+        assert_eq!(
+            runner
+                .router
+                .maybe_tombstone_store_id
+                .load(Ordering::SeqCst),
+            store_id
+        );
     }
 
     #[test]

--- a/src/server/resolve.rs
+++ b/src/server/resolve.rs
@@ -13,7 +13,6 @@ use raftstore::store::GlobalReplicationState;
 use thiserror::Error;
 use tikv_kv::RaftExtension;
 use tikv_util::{
-    info,
     time::Instant,
     worker::{Runnable, Scheduler, Worker},
 };
@@ -26,6 +25,8 @@ const STORE_ADDRESS_REFRESH_SECONDS: u64 = 60;
 pub enum Error {
     #[error("{0:?}")]
     Other(#[from] Box<dyn StdError + Sync + Send>),
+    #[error("store {0} is not found in PD")]
+    StoreNotFound(u64),
     #[error("store {0} has been removed")]
     StoreTombstone(u64),
 }
@@ -112,17 +113,13 @@ where
                 return Err(Error::StoreTombstone(store_id));
             }
             Err(e) => {
-                // Tombstone store may be removed manually or automatically
-                // after 30 days of deletion. PD returns
-                // "invalid store ID %d, not found" for such store id.
-                // See https://github.com/tikv/pd/blob/v7.3.0/server/grpc_service.go#L777-L780
-                // And to avoid repeatedly logging the same errors, it
-                // can directly return the `StoreTombstone` err.
+                // PD returns the same not-found error when a store has not
+                // registered yet and when its tombstone record has been
+                // removed. Treat it as retryable because the two cases can't
+                // be distinguished from this response.
                 if format!("{:?}", e).contains("not found") {
                     RESOLVE_STORE_COUNTER_STATIC.not_found.inc();
-                    info!("resolve store not found"; "store_id" => store_id);
-                    self.router.report_store_maybe_tombstone(store_id);
-                    return Err(Error::StoreTombstone(store_id));
+                    return Err(Error::StoreNotFound(store_id));
                 }
                 return Err(box_err!(e));
             }
@@ -313,8 +310,12 @@ mod tests {
     #[test]
     fn test_resolve_store_state_tombstone() {
         let store = new_store(STORE_ADDR, metapb::StoreState::Tombstone);
+        let store_id = store.get_id();
         let runner = new_runner(store);
-        runner.get_address(0).unwrap_err();
+        assert!(matches!(
+            runner.get_address(store_id),
+            Err(Error::StoreTombstone(id)) if id == store_id
+        ));
     }
 
     #[test]
@@ -323,10 +324,10 @@ mod tests {
         store.set_id(u64::MAX);
         let store_id = store.get_id();
         let runner = new_runner(store);
-        let result = runner.get_address(store_id).unwrap_err();
-        if let Error::StoreTombstone(id) = result {
-            assert_eq!(store_id, id);
-        }
+        assert!(matches!(
+            runner.get_address(store_id),
+            Err(Error::StoreNotFound(id)) if id == store_id
+        ));
     }
 
     #[test]

--- a/tests/integrations/server/raft_client.rs
+++ b/tests/integrations/server/raft_client.rs
@@ -3,7 +3,7 @@
 use std::{
     sync::{
         Arc,
-        atomic::{AtomicUsize, Ordering},
+        atomic::{AtomicBool, AtomicUsize, Ordering},
         mpsc,
     },
     thread, time,
@@ -379,6 +379,59 @@ fn test_tombstone_block_list() {
         DiscardReason::Disconnected,
         raft_client.send(message).unwrap_err()
     );
+}
+
+/// A store missing from PD may still register later and must not be added to
+/// the tombstone block list.
+#[test]
+fn test_store_not_found_is_retryable() {
+    let msg_count = Arc::new(AtomicUsize::new(0));
+    let batch_msg_count = Arc::new(AtomicUsize::new(0));
+    let service = MockKvForRaft::new(Arc::clone(&msg_count), batch_msg_count, true);
+    let (_mock_server, port) = create_mock_server(service, 60300, 60400).unwrap();
+
+    let store_registered = Arc::new(AtomicBool::new(false));
+    let not_found_count = Arc::new(AtomicUsize::new(0));
+    let resolver = resolve::MockStoreAddrResolver {
+        resolve_fn: Arc::new({
+            let store_registered = Arc::clone(&store_registered);
+            let not_found_count = Arc::clone(&not_found_count);
+            move |store_id, cb| {
+                if store_registered.load(Ordering::SeqCst) {
+                    cb(Ok(format!("127.0.0.1:{}", port)));
+                } else {
+                    not_found_count.fetch_add(1, Ordering::SeqCst);
+                    cb(Err(resolve::Error::StoreNotFound(store_id)));
+                }
+                Ok(())
+            }
+        }),
+    };
+    let mut raft_client = get_raft_client(FakeExtension, resolver);
+
+    const STORE_ID: u64 = 2;
+    let mut message = RaftMessage::default();
+    message.mut_to_peer().set_store_id(STORE_ID);
+    raft_client.send(message.clone()).unwrap();
+    raft_client.flush();
+
+    for _ in 0..50 {
+        if not_found_count.load(Ordering::SeqCst) > 0 {
+            break;
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+    assert!(not_found_count.load(Ordering::SeqCst) > 0);
+    store_registered.store(true, Ordering::SeqCst);
+
+    // The connection task keeps resolving with backoff and should recover
+    // after the store registers.
+    for _ in 0..20 {
+        raft_client.send(message.clone()).unwrap();
+        raft_client.flush();
+        thread::sleep(Duration::from_millis(20));
+    }
+    check_msg_count(1000, &msg_count, 1);
 }
 
 #[test]


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #19980

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

- Introduce `StoreNotFound` to distinguish an ambiguous PD not-found response from a definitive store tombstone.
- Keep retrying address resolution for `StoreNotFound` using `raft_client_max_backoff`, allowing Raft connections to recover after the store registers with PD.
- Continue reporting definitive tombstones to raftstore and permanently block their connections.
- Emit the first not-found warning immediately and rate-limit subsequent warnings per store, while continuing to accumulate metrics for every resolution attempt.
- Add unit and integration coverage for warning throttling and recovery after delayed store registration.
- Document the address-resolution error handling and observability contract in the server maintenance guide.

```commit-message
PD may return the same not-found error when a store has not registered yet
and when a removed store's tombstone record is no longer available. Treating
both cases as tombstones permanently blocks Raft connections to stores that
register later.

Introduce a retryable StoreNotFound error and let the Raft client retry resolution
using raft_client_max_backoff. Preserve the existing terminal behavior for explicit
tombstones and rate-limit repeated not-found warnings per store without
suppressing metrics.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!--
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Fix an issue where TiKV could permanently block Raft connections when PD temporarily
returned a store-not-found error before the store completed registration.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved raft connection handling when a store is temporarily unavailable.
  * Retryable store lookup failures now reconnect using configured backoff instead of being treated as permanent removals.
  * Permanently removed stores now terminate connections correctly.
  * Reduced repeated warnings through rate limiting, with state reset after successful recovery or terminal removal.
  * Improved reliability of direct I/O read accounting across supported request sizes.

* **Documentation**
  * Documented store address-resolution behavior, cleanup safeguards, and observability expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->