### PR TITLE
raftstore: don't advance ready_cnt past unresolved replica reads

### DIFF
--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -4277,7 +4277,9 @@ where
 
     /// `ReadIndex` requests could be lost in network, so on followers commands
     /// could queue in `pending_reads` forever. Sending a new `ReadIndex`
-    /// periodically can resolve this.
+    /// periodically can resolve this. Re-propose every unresolved read,
+    /// not just the tail: a mid-queue loss would otherwise block the
+    /// FIFO drain permanently.
     pub fn retry_pending_reads(&mut self, cfg: &Config) {
         if self.is_leader()
             || !self.pending_reads.check_needs_retry(cfg)
@@ -4286,21 +4288,28 @@ where
             return;
         }
 
-        let read = self.pending_reads.back_mut().unwrap();
-        debug_assert!(read.read_index.is_none());
-        self.raft_group
-            .read_index(ReadIndexContext::fields_to_bytes(
-                read.id,
-                read.addition_request.as_deref(),
-                None,
-                None,
-            ));
-        debug!(
-            "request to get a read index";
-            "request_id" => ?read.id,
-            "region_id" => self.region_id,
-            "peer_id" => self.peer.get_id(),
-        );
+        // Materialize before calling `read_index` to avoid holding a
+        // borrow of `self.pending_reads` across the mutation.
+        let unresolved: Vec<(Uuid, Option<Box<raft_cmdpb::ReadIndexRequest>>)> = self
+            .pending_reads
+            .unresolved_iter()
+            .map(|r| (r.id, r.addition_request.clone()))
+            .collect();
+        for (id, addition_request) in unresolved {
+            self.raft_group
+                .read_index(ReadIndexContext::fields_to_bytes(
+                    id,
+                    addition_request.as_deref(),
+                    None,
+                    None,
+                ));
+            debug!(
+                "request to get a read index";
+                "request_id" => ?id,
+                "region_id" => self.region_id,
+                "peer_id" => self.peer.get_id(),
+            );
+        }
     }
 
     pub fn push_pending_read(

--- a/components/raftstore/src/store/read_queue.rs
+++ b/components/raftstore/src/store/read_queue.rs
@@ -1,7 +1,7 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
 // #[PerformanceCriticalPath]
-use std::{cmp, collections::VecDeque, mem};
+use std::{collections::VecDeque, mem};
 
 use collections::HashMap;
 use kvproto::{
@@ -203,6 +203,13 @@ impl<C: ErrorCallback> ReadIndexQueue<C> {
         self.reads.back()
     }
 
+    /// Iterate reads whose `read_index` has not yet been resolved.
+    /// Used by `retry_pending_reads` to re-fetch every stuck read;
+    /// retrying only the tail leaves mid-queue losses permanent.
+    pub fn unresolved_iter(&self) -> impl Iterator<Item = &ReadIndexRequest<C>> {
+        self.reads.iter().filter(|r| r.read_index.is_none())
+    }
+
     pub fn last_ready(&self) -> Option<&ReadIndexRequest<C>> {
         if self.ready_cnt > 0 {
             return Some(&self.reads[self.ready_cnt - 1]);
@@ -251,7 +258,7 @@ impl<C: ErrorCallback> ReadIndexQueue<C> {
     where
         T: IntoIterator<Item = (Uuid, Option<LockInfo>, u64)>,
     {
-        let (mut min_changed_offset, mut max_changed_offset) = (usize::MAX, 0);
+        let mut any_changed = false;
         for (uuid, locked, index) in states {
             if let Some(raw_offset) = self.contexts.remove(&uuid) {
                 let offset = match raw_offset.checked_sub(self.handled_cnt) {
@@ -276,8 +283,7 @@ impl<C: ErrorCallback> ReadIndexQueue<C> {
                     }
                 }
                 self.reads[offset].read_index = Some(index);
-                min_changed_offset = cmp::min(min_changed_offset, offset);
-                max_changed_offset = cmp::max(max_changed_offset, offset);
+                any_changed = true;
                 continue;
             }
             debug!(
@@ -286,13 +292,22 @@ impl<C: ErrorCallback> ReadIndexQueue<C> {
             );
         }
 
-        if min_changed_offset != usize::MAX {
-            self.ready_cnt = cmp::max(self.ready_cnt, max_changed_offset + 1);
+        // Advance `ready_cnt` only over entries with a resolved
+        // `read_index`. Advancing past a `None` entry (from a lost or
+        // reordered `MsgReadIndexResp`) would break the invariant that
+        // `post_pending_read_index_on_replica` asserts on the popped
+        // entry. The stuck entry is re-fetched by `retry_pending_reads`.
+        //
+        // NOTE: we still must not fold indices forward — an earlier
+        // request can rely on a higher committed index under 1pc /
+        // async-commit. See https://github.com/tikv/tikv/issues/17018.
+        if any_changed {
+            while self.ready_cnt < self.reads.len()
+                && self.reads[self.ready_cnt].read_index.is_some()
+            {
+                self.ready_cnt += 1;
+            }
         }
-        // NOTE: We should not try to fold these read index requests anymore,
-        // an earlier request can rely a higher committed index due to txn
-        // lock when 1pc/async-commit is used.
-        // See https://github.com/tikv/tikv/issues/17018 for more details.
     }
 
     pub fn gc(&mut self) {
@@ -621,12 +636,75 @@ mod tests {
             queue.push_back(req, false);
         }
 
+        // Later response arrives first. `ready_cnt` must stay at 0
+        // because the head's `read_index` is still `None`; advancing
+        // past it would violate the invariant asserted by
+        // `post_pending_read_index_on_replica`.
         queue.advance_replica_reads(vec![(ids[1], None, 100)]);
+        assert_eq!(queue.ready_cnt, 0);
+        assert!(queue.pop_front().is_none());
+
+        // Head response arrives; both entries become drainable.
+        queue.advance_replica_reads(vec![(ids[0], None, 100)]);
         assert_eq!(queue.ready_cnt, 2);
         while let Some(mut read) = queue.pop_front() {
             read.cmds.clear();
         }
+    }
 
+    /// Regression: when the response for the head of the queue is
+    /// lost and a later response arrives, `advance_replica_reads` must
+    /// not bump `ready_cnt` past the still-unresolved head. Otherwise
+    /// `post_pending_read_index_on_replica` would `pop_front` an entry
+    /// with `read_index == None` and hit its
+    /// `assert!(read.read_index.is_some())`. Also verifies the drain
+    /// completes once the missing response arrives.
+    #[test]
+    fn test_post_pending_read_index_on_replica_lost_response() {
+        let mut queue = ReadIndexQueue::<Callback<KvTestSnapshot>> {
+            handled_cnt: 0,
+            ..Default::default()
+        };
+
+        // Two in-flight follower reads queued as `pending_reads`.
+        let ids: [Uuid; 2] = [Uuid::new_v4(), Uuid::new_v4()];
+        for id in &ids {
+            let req = ReadIndexRequest::with_command(
+                *id,
+                RaftCmdRequest::default(),
+                Callback::None,
+                Timespec::new(0, 0),
+            );
+            queue.push_back(req, false);
+        }
+
+        // The response for `ids[0]` is lost; only `ids[1]`'s response
+        // arrives in this raft ready batch.
+        queue.advance_replica_reads(vec![(ids[1], None, 100)]);
+
+        // Drain the queue exactly as `post_pending_read_index_on_replica`
+        // does, executing the same assertion. Without the fix,
+        // `ready_cnt` was bumped to 2 despite `reads[0].read_index` being
+        // `None`, so `pop_front` returns the head with `read_index ==
+        // None` and this assertion aborts the process.
+        while let Some(mut read) = queue.pop_front() {
+            assert!(read.read_index.is_some(), "read.read_index.is_some()");
+            read.cmds.clear();
+        }
+        // Nothing should have drained yet: `advance_replica_reads`
+        // must not have bumped `ready_cnt` past the unresolved head.
+        assert_eq!(queue.reads.len(), 2);
+        assert_eq!(queue.ready_cnt, 0);
+
+        // The missing response finally arrives (via
+        // `retry_pending_reads` in production).
         queue.advance_replica_reads(vec![(ids[0], None, 100)]);
+        let mut drained = 0;
+        while let Some(mut read) = queue.pop_front() {
+            assert!(read.read_index.is_some());
+            read.cmds.clear();
+            drained += 1;
+        }
+        assert_eq!(drained, 2);
     }
 }


### PR DESCRIPTION
`ReadIndexQueue::advance_replica_reads` unconditionally set `ready_cnt = max(ready_cnt, max_changed_offset + 1)` after resolving one or more offsets. When a `MsgReadIndexResp` for an earlier read was lost or reordered, this bumped `ready_cnt` past an entry whose `read_index` was still `None`. On the next raft ready, `Peer::post_pending_read_index_on_replica` would `pop_front` that entry and abort the process at

    assert!(read.read_index.is_some())

(peer.rs). The follower would then crashloop as it replayed the same raft state on restart; whichever peer held leadership for the affected region survived because the assertion is on the `!is_leader` branch of `apply_reads`.

The fold-forward logic that previously masked this by back-filling `read_index` on earlier entries was removed in `apply_reads` were not updated to match the new invariants.

Fix in two parts:

1. `advance_replica_reads` extends `ready_cnt` forward only over consecutive entries whose `read_index` is `Some`. This preserves the drain invariant without reintroducing the forward-fold. Out-of-order responses still resolve their own offsets; `ready_cnt` catches up once the head resolves.

2. `Peer::retry_pending_reads` re-proposes every unresolved read, not just `back_mut()`. A mid-queue lost response would otherwise never be re-fetched — the FIFO drain would stall forever behind it. Adds `ReadIndexQueue::unresolved_iter` for this.

Regression test `test_post_pending_read_index_on_replica_lost_response` mirrors the drain loop and its assertion inline. On master it panics with `assertion failed: read.read_index.is_some()`; with the fix it passes and verifies the queue drains cleanly once the missing response finally arrives.

`test_advance_replica_reads_out_of_order` is updated: with the fix, receiving only the tail's response no longer bumps `ready_cnt` past the unresolved head, so the head is not drained until its own response arrives.

Refs: #17950, #17018

Issue Number: Close #20000

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [X] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Fix a rare bug in tikv that could cause a crash after a dropped gRPC message
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved follower read retry handling so all unresolved read requests are retried, preserving their request details.
  * Fixed replica-read processing to prevent unresolved requests from being removed prematurely.
  * Improved recovery when read responses are lost or arrive out of order.
  * Ensured queued reads drain correctly once missing responses are received.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->