### PR TITLE
lock_manager: skip detect on fair waiter owner change

### DIFF
--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -1355,7 +1355,10 @@
 
 [pessimistic-txn]
 ## The default and maximum delay before responding to TiDB when pessimistic
-## transactions encounter locks
+## transactions encounter locks.
+## After a lock owner change, a fair waiter is not re-registered in the
+## wait-for graph until this wait ends. Raising this value also raises
+## worst-case deadlock detection delay for those waits.
 # wait-for-lock-timeout = "1s"
 
 ## If more than one transaction is waiting for the same lock, only the one with smallest

--- a/src/server/lock_manager/client.rs
+++ b/src/server/lock_manager/client.rs
@@ -13,7 +13,7 @@ use kvproto::deadlock::*;
 use security::SecurityManager;
 use tikv_util::thread_name_prefix::DEADLOCK_CLIENT_THREAD;
 
-use super::{Error, Result};
+use super::{Error, Result, metrics::DETECTOR_PENDING_MSGS};
 
 type DeadlockFuture<T> = BoxFuture<'static, Result<T>>;
 
@@ -60,12 +60,20 @@ impl Client {
         let send_task = Box::pin(async move {
             let mut sink = sink.sink_map_err(Error::Grpc);
 
-            sink.send_all(&mut rx.map(|r| Ok((r, WriteFlags::default()))))
+            let result = sink
+                .send_all(
+                    &mut rx
+                        .inspect(|_| DETECTOR_PENDING_MSGS.dec())
+                        .map(|r| Ok((r, WriteFlags::default()))),
+                )
                 .await
                 .map(|_| {
                     info!("cancel detect sender");
                     sink.get_mut().cancel();
-                })
+                });
+            // Stream ended (leader change / disconnect). Drop leftover accounting.
+            DETECTOR_PENDING_MSGS.set(0);
+            result
         });
         self.sender = Some(tx);
 
@@ -82,6 +90,9 @@ impl Client {
             .as_ref()
             .unwrap()
             .unbounded_send(req)
+            .map(|()| {
+                DETECTOR_PENDING_MSGS.inc();
+            })
             .map_err(|e| Error::Other(box_err!(e)))
     }
 }

--- a/src/server/lock_manager/client.rs
+++ b/src/server/lock_manager/client.rs
@@ -1,6 +1,12 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::{sync::Arc, time::Duration};
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicI64, Ordering},
+    },
+    time::Duration,
+};
 
 use futures::{
     channel::mpsc::{self, UnboundedSender},
@@ -36,6 +42,10 @@ pub fn env() -> Arc<Environment> {
 pub struct Client {
     client: DeadlockClient,
     sender: Option<UnboundedSender<DeadlockRequest>>,
+    /// Unsent requests on this client's stream. Used to subtract leftover
+    /// from the process-wide gauge without `set(0)`, which would wipe a
+    /// newer client's accounting if reconnect overlaps.
+    pending: Arc<AtomicI64>,
 }
 
 impl Client {
@@ -48,6 +58,7 @@ impl Client {
         Self {
             client,
             sender: None,
+            pending: Arc::new(AtomicI64::new(0)),
         }
     }
 
@@ -57,13 +68,18 @@ impl Client {
     ) -> (DeadlockFuture<()>, DeadlockFuture<()>) {
         let (tx, rx) = mpsc::unbounded();
         let (sink, receiver) = self.client.detect().unwrap();
+        let pending = Arc::clone(&self.pending);
         let send_task = Box::pin(async move {
             let mut sink = sink.sink_map_err(Error::Grpc);
+            let pending_sent = Arc::clone(&pending);
 
             let result = sink
                 .send_all(
                     &mut rx
-                        .inspect(|_| DETECTOR_PENDING_MSGS.dec())
+                        .inspect(move |_| {
+                            pending_sent.fetch_sub(1, Ordering::Relaxed);
+                            DETECTOR_PENDING_MSGS.dec();
+                        })
                         .map(|r| Ok((r, WriteFlags::default()))),
                 )
                 .await
@@ -71,8 +87,12 @@ impl Client {
                     info!("cancel detect sender");
                     sink.get_mut().cancel();
                 });
-            // Stream ended (leader change / disconnect). Drop leftover accounting.
-            DETECTOR_PENDING_MSGS.set(0);
+            // Stream ended (leader change / disconnect). Drop this stream's
+            // leftover only; `set(0)` would clear a newer client's queue.
+            let leftover = pending.swap(0, Ordering::Relaxed);
+            if leftover > 0 {
+                DETECTOR_PENDING_MSGS.sub(leftover);
+            }
             result
         });
         self.sender = Some(tx);
@@ -91,6 +111,7 @@ impl Client {
             .unwrap()
             .unbounded_send(req)
             .map(|()| {
+                self.pending.fetch_add(1, Ordering::Relaxed);
                 DETECTOR_PENDING_MSGS.inc();
             })
             .map_err(|e| Error::Other(box_err!(e)))

--- a/src/server/lock_manager/config.rs
+++ b/src/server/lock_manager/config.rs
@@ -20,6 +20,10 @@ use super::{
 #[serde(default)]
 #[serde(rename_all = "kebab-case")]
 pub struct Config {
+    /// Default and maximum pessimistic lock wait. After a lock owner change, a
+    /// fair waiter is not re-registered in the wait-for graph until this
+    /// wait ends, so raising this also raises worst-case deadlock detection
+    /// delay for those waits.
     #[serde(deserialize_with = "readable_duration_or_u64")]
     pub wait_for_lock_timeout: ReadableDuration,
     #[serde(deserialize_with = "readable_duration_or_u64")]

--- a/src/server/lock_manager/metrics.rs
+++ b/src/server/lock_manager/metrics.rs
@@ -14,6 +14,7 @@ make_auto_flush_static_metric! {
             clean_up_wait_for,
             clean_up,
             update_wait_for,
+            detach,
         },
     }
 
@@ -65,6 +66,14 @@ lazy_static! {
     pub static ref DETECTOR_LEADER_GAUGE: IntGauge = register_int_gauge!(
         "tikv_lock_manager_detector_leader_heartbeat",
         "Heartbeat of the leader of the deadlock detector"
+    )
+    .unwrap();
+    /// Depth of the follower-side outbound `DeadlockRequest` queue (the
+    /// unbounded channel drained by a single gRPC stream). Unbounded growth
+    /// here is the OOM path in tikv#19846.
+    pub static ref DETECTOR_PENDING_MSGS: IntGauge = register_int_gauge!(
+        "tikv_lock_manager_detector_pending_msgs",
+        "Number of deadlock-detector requests queued to send to the leader"
     )
     .unwrap();
     pub static ref TASK_COUNTER_METRICS: LocalTaskCounter =

--- a/src/server/lock_manager/metrics.rs
+++ b/src/server/lock_manager/metrics.rs
@@ -14,7 +14,7 @@ make_auto_flush_static_metric! {
             clean_up_wait_for,
             clean_up,
             update_wait_for,
-            detach,
+            drop_registered_edge,
         },
     }
 

--- a/src/server/lock_manager/mod.rs
+++ b/src/server/lock_manager/mod.rs
@@ -289,6 +289,7 @@ impl LockManagerTrait for LockManager {
             timeout,
             cancel_callback,
             diag_ctx.clone(),
+            is_first_lock,
         );
 
         // If it is the first lock the transaction tries to lock, it won't cause
@@ -322,7 +323,12 @@ impl LockManagerTrait for LockManager {
 
 #[cfg(test)]
 mod tests {
-    use std::{thread, time::Duration};
+    use std::{
+        pin::Pin,
+        task::{Context, Poll},
+        thread,
+        time::Duration,
+    };
 
     use engine_test::kv::KvTestEngine;
     use futures::executor::block_on;
@@ -336,7 +342,10 @@ mod tests {
 
     use self::{deadlock::tests::*, metrics::*, waiter_manager::tests::*};
     use super::*;
-    use crate::{server::resolve::MockStoreAddrResolver, storage::lock_manager::LockDigest};
+    use crate::{
+        server::resolve::MockStoreAddrResolver,
+        storage::lock_manager::{KeyLockWaitInfo, LockDigest, UpdateWaitForEvent},
+    };
 
     fn start_lock_manager() -> LockManager {
         let mut coprocessor_host = CoprocessorHost::<KvTestEngine>::default();
@@ -582,6 +591,153 @@ mod tests {
             500,
         );
         assert_eq!(TASK_COUNTER_METRICS.wait_for.get(), prev_wait_for,);
+    }
+
+    fn assert_pending<F: std::future::Future + Unpin>(f: &mut F, msg: &str) {
+        let waker = futures::task::noop_waker();
+        let mut cx = Context::from_waker(&waker);
+        assert!(matches!(Pin::new(f).poll(&mut cx), Poll::Pending), "{msg}");
+    }
+
+    fn fair_wait_info_for_owner(
+        mut wait_info: KeyLockWaitInfo,
+        new_owner: TimeStamp,
+    ) -> KeyLockWaitInfo {
+        wait_info.allow_lock_with_conflict = true;
+        wait_info.lock_digest.ts = new_owner;
+        wait_info.lock_info.lock_version = new_owner.into_inner();
+        wait_info
+    }
+
+    /// After DETACH, W no longer has W→A. A still-live waiting for W must not
+    /// be reported as deadlock.
+    #[test]
+    fn test_detach_does_not_false_deadlock_on_old_owner() {
+        let lock_mgr = start_lock_manager();
+        let (mut w, _, mut f_w) = new_test_waiter_with_key(10.into(), 20.into(), b"hot");
+        w.wait_info.allow_lock_with_conflict = true;
+        let token_w = lock_mgr.allocate_token();
+        lock_mgr.wait_for(
+            token_w,
+            1,
+            RegionEpoch::default(),
+            1,
+            w.start_ts,
+            w.wait_info.clone(),
+            false,
+            Some(WaitTimeout::Millis(3000)),
+            w.cancel_callback,
+            diag_ctx(b"hot", b"tag-w", INVALID_TRACKER_TOKEN),
+        );
+        thread::sleep(Duration::from_millis(50));
+        lock_mgr.update_wait_for(vec![UpdateWaitForEvent {
+            token: token_w,
+            start_ts: 10.into(),
+            is_first_lock: false,
+            wait_info: fair_wait_info_for_owner(w.wait_info.clone(), 30.into()),
+        }]);
+        thread::sleep(Duration::from_millis(50));
+
+        let (a, _, mut f_a) = new_test_waiter_with_key(20.into(), 10.into(), b"wkey");
+        lock_mgr.wait_for(
+            lock_mgr.allocate_token(),
+            1,
+            RegionEpoch::default(),
+            1,
+            a.start_ts,
+            a.wait_info,
+            false,
+            Some(WaitTimeout::Millis(3000)),
+            a.cancel_callback,
+            diag_ctx(b"wkey", b"tag-a", INVALID_TRACKER_TOKEN),
+        );
+        thread::sleep(Duration::from_millis(150));
+        assert_pending(&mut f_a, "stale W→A would false-deadlock A waiting for W");
+        assert_pending(&mut f_w, "W should still be waiting");
+
+        lock_mgr.remove_lock_wait(token_w);
+        block_on(f_w).unwrap_err();
+    }
+
+    /// Handoff then cycle: this wait must not report deadlock; a new Detect of
+    /// the current owner (retry) must.
+    #[test]
+    fn test_detach_misses_cycle_until_retry_detect() {
+        let lock_mgr = start_lock_manager();
+        let (mut w, _, f_w1) = new_test_waiter_with_key(10.into(), 20.into(), b"hot");
+        w.wait_info.allow_lock_with_conflict = true;
+        let token_w = lock_mgr.allocate_token();
+        lock_mgr.wait_for(
+            token_w,
+            1,
+            RegionEpoch::default(),
+            1,
+            w.start_ts,
+            w.wait_info.clone(),
+            false,
+            Some(WaitTimeout::Millis(3000)),
+            w.cancel_callback,
+            diag_ctx(b"hot", b"tag-w", INVALID_TRACKER_TOKEN),
+        );
+        thread::sleep(Duration::from_millis(50));
+        lock_mgr.update_wait_for(vec![UpdateWaitForEvent {
+            token: token_w,
+            start_ts: 10.into(),
+            is_first_lock: false,
+            wait_info: fair_wait_info_for_owner(w.wait_info.clone(), 30.into()),
+        }]);
+        thread::sleep(Duration::from_millis(50));
+
+        let (c, _lock_info_c, mut f_c) = new_test_waiter_with_key(30.into(), 10.into(), b"wkey");
+        lock_mgr.wait_for(
+            lock_mgr.allocate_token(),
+            1,
+            RegionEpoch::default(),
+            1,
+            c.start_ts,
+            c.wait_info,
+            false,
+            Some(WaitTimeout::Millis(3000)),
+            c.cancel_callback,
+            diag_ctx(b"wkey", b"tag-c", INVALID_TRACKER_TOKEN),
+        );
+        thread::sleep(Duration::from_millis(150));
+        assert_pending(
+            &mut f_c,
+            "W→C was never registered; cycle must not be visible yet",
+        );
+
+        // End this wait (timeout / retry) and Detect the current owner.
+        lock_mgr.remove_lock_wait(token_w);
+        block_on(f_w1).unwrap_err();
+
+        let (w2, lock_info_w, f_w2) = new_test_waiter_with_key(10.into(), 30.into(), b"hot");
+        lock_mgr.wait_for(
+            lock_mgr.allocate_token(),
+            1,
+            RegionEpoch::default(),
+            1,
+            w2.start_ts,
+            w2.wait_info,
+            false,
+            Some(WaitTimeout::Millis(3000)),
+            w2.cancel_callback,
+            diag_ctx(b"hot", b"tag-w2", INVALID_TRACKER_TOKEN),
+        );
+        assert_elapsed(
+            || {
+                expect_deadlock(
+                    block_on(f_w2).unwrap(),
+                    10.into(),
+                    lock_info_w,
+                    Key::from_raw(b"wkey").gen_hash(),
+                    &[(30, 10, b"wkey", b"tag-c"), (10, 30, b"hot", b"tag-w2")],
+                )
+            },
+            0,
+            500,
+        );
+        let _ = f_c;
     }
 
     #[bench]

--- a/src/server/lock_manager/mod.rs
+++ b/src/server/lock_manager/mod.rs
@@ -609,10 +609,10 @@ mod tests {
         wait_info
     }
 
-    /// After DETACH, W no longer has W→A. A still-live waiting for W must not
-    /// be reported as deadlock.
+    /// After the owner change, W no longer has W→A. A still-live waiting for
+    /// W must not be reported as deadlock.
     #[test]
-    fn test_detach_does_not_false_deadlock_on_old_owner() {
+    fn test_dropped_edge_does_not_false_deadlock_on_old_owner() {
         let lock_mgr = start_lock_manager();
         let (mut w, _, mut f_w) = new_test_waiter_with_key(10.into(), 20.into(), b"hot");
         w.wait_info.allow_lock_with_conflict = true;
@@ -662,7 +662,7 @@ mod tests {
     /// Handoff then cycle: this wait must not report deadlock; a new Detect of
     /// the current owner (retry) must.
     #[test]
-    fn test_detach_misses_cycle_until_retry_detect() {
+    fn test_owner_change_misses_cycle_until_retry_detect() {
         let lock_mgr = start_lock_manager();
         let (mut w, _, f_w1) = new_test_waiter_with_key(10.into(), 20.into(), b"hot");
         w.wait_info.allow_lock_with_conflict = true;

--- a/src/server/lock_manager/waiter_manager.rs
+++ b/src/server/lock_manager/waiter_manager.rs
@@ -600,6 +600,8 @@ impl WaiterManager {
                 if previous_wait_info.allow_lock_with_conflict {
                     // First owner change: clean up the registered edge and do
                     // not Detect the new owner. Later changes are no-ops.
+                    // A cycle that needs the new edge is invisible until this
+                    // wait ends (capped by wait-for-lock-timeout) and retries.
                     if let Some(edge) = wait_table.take_registered_edge(event.token) {
                         self.detector_scheduler
                             .clean_up_wait_for(event.start_ts, edge);
@@ -1441,7 +1443,7 @@ pub mod tests {
     /// original edge and zero Detects from update_wait_for. Message count
     /// does not grow with owner-change count (tikv#19846).
     #[test]
-    fn test_fair_waiter_detector_rpc_grows_with_owner_changes() {
+    fn test_fair_waiter_detector_rpc_bounded_across_owner_changes() {
         let (mut worker, scheduler, mut counters) = start_waiter_manager_counting(10_000);
         let raw_key = b"hot";
         let key = Key::from_raw(raw_key);

--- a/src/server/lock_manager/waiter_manager.rs
+++ b/src/server/lock_manager/waiter_manager.rs
@@ -119,6 +119,8 @@ pub enum Task {
         cancel_callback: CancellationCallback,
         diag_ctx: DiagnosticContext,
         start_waiting_time: Instant,
+        // Whether this wait registered a detector edge (false => Detect was/will be sent).
+        is_first_lock: bool,
     },
     RemoveLockWait {
         token: LockWaitToken,
@@ -159,12 +161,17 @@ impl Display for Task {
                 token,
                 start_ts,
                 wait_info,
+                is_first_lock,
                 ..
             } => {
                 write!(
                     f,
-                    "txn:{} waiting for {}:{}, token {:?}",
-                    start_ts, wait_info.lock_digest.ts, wait_info.lock_digest.hash, token
+                    "txn:{} waiting for {}:{}, token {:?}, first_lock {}",
+                    start_ts,
+                    wait_info.lock_digest.ts,
+                    wait_info.lock_digest.hash,
+                    token,
+                    is_first_lock
                 )
             }
             Task::RemoveLockWait { token } => {
@@ -205,6 +212,10 @@ pub(crate) struct Waiter {
     delay: Delay,
     start_waiting_time: Instant,
     last_updated_time: Option<Instant>,
+    /// The wait-for edge last registered to DetectTable (or enqueued to the
+    /// detector). `None` if this waiter never registered (first lock) or
+    /// already detached after an owner change.
+    registered_edge: Option<KeyLockWaitInfo>,
 }
 
 impl Waiter {
@@ -218,7 +229,13 @@ impl Waiter {
         deadline: Instant,
         diag_ctx: DiagnosticContext,
         start_waiting_time: Instant,
+        is_first_lock: bool,
     ) -> Self {
+        let registered_edge = if is_first_lock {
+            None
+        } else {
+            Some(wait_info.clone())
+        };
         Self {
             start_ts,
             wait_info,
@@ -227,6 +244,7 @@ impl Waiter {
             diag_ctx,
             start_waiting_time,
             last_updated_time: None,
+            registered_edge,
         }
     }
 
@@ -348,6 +366,10 @@ impl WaitTable {
         Some(waiter)
     }
 
+    fn take_registered_edge(&mut self, token: LockWaitToken) -> Option<KeyLockWaitInfo> {
+        self.waiter_pool.get_mut(&token)?.registered_edge.take()
+    }
+
     fn update_waiter(
         &mut self,
         update_event: &UpdateWaitForEvent,
@@ -439,6 +461,7 @@ impl Scheduler {
         timeout: WaitTimeout,
         cancel_callback: CancellationCallback,
         diag_ctx: DiagnosticContext,
+        is_first_lock: bool,
     ) {
         self.notify_scheduler(Task::WaitFor {
             token,
@@ -451,6 +474,7 @@ impl Scheduler {
             cancel_callback,
             diag_ctx,
             start_waiting_time: Instant::now(),
+            is_first_lock,
         });
     }
 
@@ -533,8 +557,11 @@ impl WaiterManager {
             let mut wait_table = wait_table.borrow_mut();
             if let Some(waiter) = wait_table.take_waiter(token) {
                 let start_ts = waiter.start_ts;
-                let wait_info = waiter.cancel_for_timeout();
-                detector_scheduler.clean_up_wait_for(start_ts, wait_info);
+                let edge = waiter.registered_edge.clone();
+                let _wait_info = waiter.cancel_for_timeout();
+                if let Some(edge) = edge {
+                    detector_scheduler.clean_up_wait_for(start_ts, edge);
+                }
             }
         });
         self.wait_table.borrow_mut().add_waiter(token, waiter);
@@ -552,9 +579,11 @@ impl WaiterManager {
             return;
         };
         let start_ts = waiter.start_ts;
-        let wait_info = waiter.cancel_for_finished();
-        self.detector_scheduler
-            .clean_up_wait_for(start_ts, wait_info);
+        let edge = waiter.registered_edge.clone();
+        let _wait_info = waiter.cancel_for_finished();
+        if let Some(edge) = edge {
+            self.detector_scheduler.clean_up_wait_for(start_ts, edge);
+        }
     }
 
     fn handle_update_wait_for(&mut self, events: Vec<UpdateWaitForEvent>) {
@@ -567,12 +596,14 @@ impl WaiterManager {
                 continue;
             }
 
-            if let Some((previous_wait_info, diag_ctx)) = previous_wait_info {
+            if let Some((previous_wait_info, _diag_ctx)) = previous_wait_info {
                 if previous_wait_info.allow_lock_with_conflict {
-                    self.detector_scheduler
-                        .clean_up_wait_for(event.start_ts, previous_wait_info);
-                    self.detector_scheduler
-                        .detect(event.start_ts, event.wait_info, diag_ctx);
+                    // DETACH: drop the registered edge once, do not Detect the new owner.
+                    if let Some(edge) = wait_table.take_registered_edge(event.token) {
+                        self.detector_scheduler
+                            .clean_up_wait_for(event.start_ts, edge);
+                        TASK_COUNTER_METRICS.detach.inc();
+                    }
                 }
             }
         }
@@ -599,8 +630,9 @@ impl WaiterManager {
                 // When deadlock detected on a shared lock, some wait-for entries might have
                 // been registered to the detect table. So do clean up here to avoid those
                 // entries causing false-positive deadlock errors.
-                self.detector_scheduler
-                    .clean_up_wait_for(waiter_ts, waiter.wait_info.clone());
+                if let Some(edge) = waiter.registered_edge.clone() {
+                    self.detector_scheduler.clean_up_wait_for(waiter_ts, edge);
+                }
             }
             waiter.cancel_for_deadlock(lock, key, deadlock_key_hash, wait_chain);
         }
@@ -631,6 +663,7 @@ impl FutureRunnable<Task> for WaiterManager {
                 cancel_callback,
                 diag_ctx,
                 start_waiting_time,
+                is_first_lock,
             } => {
                 let waiter = Waiter::new(
                     region_id,
@@ -642,6 +675,7 @@ impl FutureRunnable<Task> for WaiterManager {
                     self.normalize_deadline(timeout),
                     diag_ctx,
                     start_waiting_time,
+                    is_first_lock,
                 );
                 self.handle_wait_for(token, waiter);
                 TASK_COUNTER_METRICS.wait_for.inc();
@@ -679,7 +713,11 @@ impl FutureRunnable<Task> for WaiterManager {
 
 #[cfg(test)]
 pub mod tests {
-    use std::{sync::mpsc, thread::sleep, time::Duration};
+    use std::{
+        sync::{Mutex, mpsc},
+        thread::sleep,
+        time::Duration,
+    };
 
     use futures::{executor::block_on, future::FutureExt};
     use kvproto::kvrpcpb::LockInfo;
@@ -707,6 +745,7 @@ pub mod tests {
             delay: Delay::new(Instant::now()),
             start_waiting_time: Instant::now(),
             last_updated_time: None,
+            registered_edge: None,
         }
     }
 
@@ -827,6 +866,7 @@ pub mod tests {
             Instant::now() + Duration::from_millis(3000),
             DiagnosticContext::default(),
             Instant::now(),
+            false,
         );
         (waiter, info, f)
     }
@@ -1097,6 +1137,7 @@ pub mod tests {
             WaitTimeout::Millis(1000),
             waiter.cancel_callback,
             DiagnosticContext::default(),
+            false,
         );
         assert_elapsed(
             || expect_key_is_locked(block_on(f).unwrap(), lock_info),
@@ -1116,6 +1157,7 @@ pub mod tests {
             WaitTimeout::Millis(100),
             waiter.cancel_callback,
             DiagnosticContext::default(),
+            false,
         );
         assert_elapsed(
             || expect_key_is_locked(block_on(f).unwrap(), lock_info),
@@ -1135,6 +1177,7 @@ pub mod tests {
             WaitTimeout::Millis(3000),
             waiter.cancel_callback,
             DiagnosticContext::default(),
+            false,
         );
         assert_elapsed(
             || expect_key_is_locked(block_on(f).unwrap(), lock_info),
@@ -1166,6 +1209,7 @@ pub mod tests {
             WaitTimeout::Millis(1000),
             waiter.cancel_callback,
             DiagnosticContext::default(),
+            false,
         );
         scheduler.deadlock(waiter_ts, b"foo".to_vec(), lock, 30, vec![]);
         assert_elapsed(
@@ -1200,6 +1244,7 @@ pub mod tests {
             WaitTimeout::Millis(1000),
             waiter1.cancel_callback,
             DiagnosticContext::default(),
+            false,
         );
         scheduler.wait_for(
             LockWaitToken(Some(2)),
@@ -1211,6 +1256,7 @@ pub mod tests {
             WaitTimeout::Millis(1000),
             waiter2.cancel_callback,
             DiagnosticContext::default(),
+            false,
         );
 
         // then update waiter
@@ -1245,5 +1291,322 @@ pub mod tests {
         );
 
         worker.stop().unwrap();
+    }
+
+    /// Counts Detect / CleanUpWaitFor tasks scheduled to the deadlock detector.
+    /// Used to reproduce tikv#19846 (unbounded 2N fan-out per owner change)
+    /// and to verify DETACH bounds it.
+    struct CountingDetector {
+        detect: Arc<AtomicUsize>,
+        cleanup_wait_for: Arc<AtomicUsize>,
+        detect_lock_ts: Arc<Mutex<Vec<u64>>>,
+        cleanup_lock_ts: Arc<Mutex<Vec<u64>>>,
+    }
+
+    impl FutureRunnable<crate::server::lock_manager::deadlock::Task> for CountingDetector {
+        fn run(&mut self, task: crate::server::lock_manager::deadlock::Task) {
+            use crate::server::lock_manager::deadlock::{DetectType, Task as DetectorTask};
+            if let DetectorTask::Detect { tp, wait_info, .. } = task {
+                let ts = wait_info
+                    .as_ref()
+                    .map(|w| w.lock_digest.ts.into_inner())
+                    .unwrap_or(0);
+                match tp {
+                    DetectType::Detect => {
+                        self.detect.fetch_add(1, Ordering::SeqCst);
+                        self.detect_lock_ts.lock().unwrap().push(ts);
+                    }
+                    DetectType::CleanUpWaitFor => {
+                        self.cleanup_wait_for.fetch_add(1, Ordering::SeqCst);
+                        self.cleanup_lock_ts.lock().unwrap().push(ts);
+                    }
+                    DetectType::CleanUp => {}
+                }
+            }
+        }
+    }
+
+    struct DetectorCounters {
+        detect: Arc<AtomicUsize>,
+        cleanup_wait_for: Arc<AtomicUsize>,
+        #[allow(dead_code)]
+        detect_lock_ts: Arc<Mutex<Vec<u64>>>,
+        cleanup_lock_ts: Arc<Mutex<Vec<u64>>>,
+        detect_worker: FutureWorker<crate::server::lock_manager::deadlock::Task>,
+    }
+
+    fn start_waiter_manager_counting(
+        wait_for_lock_timeout: u64,
+    ) -> (FutureWorker<Task>, Scheduler, DetectorCounters) {
+        let detect = Arc::new(AtomicUsize::new(0));
+        let cleanup_wait_for = Arc::new(AtomicUsize::new(0));
+        let detect_lock_ts = Arc::new(Mutex::new(Vec::new()));
+        let cleanup_lock_ts = Arc::new(Mutex::new(Vec::new()));
+        let mut detect_worker = FutureWorker::new("counting-deadlock");
+        let detector_scheduler = DetectorScheduler::new(detect_worker.scheduler());
+        detect_worker
+            .start(CountingDetector {
+                detect: detect.clone(),
+                cleanup_wait_for: cleanup_wait_for.clone(),
+                detect_lock_ts: detect_lock_ts.clone(),
+                cleanup_lock_ts: cleanup_lock_ts.clone(),
+            })
+            .unwrap();
+
+        let cfg = Config {
+            wait_for_lock_timeout: ReadableDuration::millis(wait_for_lock_timeout),
+            ..Default::default()
+        };
+        let mut waiter_mgr_worker = FutureWorker::new("test-waiter-manager");
+        let waiter_mgr_runner =
+            WaiterManager::new(Arc::new(AtomicUsize::new(0)), detector_scheduler, &cfg);
+        let waiter_mgr_scheduler = Scheduler::new(waiter_mgr_worker.scheduler());
+        waiter_mgr_worker.start(waiter_mgr_runner).unwrap();
+        (
+            waiter_mgr_worker,
+            waiter_mgr_scheduler,
+            DetectorCounters {
+                detect,
+                cleanup_wait_for,
+                detect_lock_ts,
+                cleanup_lock_ts,
+                detect_worker,
+            },
+        )
+    }
+
+    fn wait_for_counts(counters: &DetectorCounters, expect_detect: usize, expect_cleanup: usize) {
+        for _ in 0..100 {
+            if counters.detect.load(Ordering::SeqCst) == expect_detect
+                && counters.cleanup_wait_for.load(Ordering::SeqCst) == expect_cleanup
+            {
+                return;
+            }
+            sleep(Duration::from_millis(10));
+        }
+        panic!(
+            "timeout waiting for detect={}, cleanup={}; got detect={}, cleanup={}",
+            expect_detect,
+            expect_cleanup,
+            counters.detect.load(Ordering::SeqCst),
+            counters.cleanup_wait_for.load(Ordering::SeqCst)
+        );
+    }
+
+    fn flush_waiter_mgr(scheduler: &Scheduler) {
+        let (tx, rx) = mpsc::channel();
+        scheduler.validate(Box::new(move |_| {
+            tx.send(()).unwrap();
+        }));
+        rx.recv().unwrap();
+    }
+
+    fn new_fair_test_waiter(waiter_ts: TimeStamp, lock_ts: TimeStamp, key: &[u8]) -> WaiterCtx {
+        let (mut waiter, info, f) = new_test_waiter_with_key(waiter_ts, lock_ts, key);
+        waiter.wait_info.allow_lock_with_conflict = true;
+        (waiter, info, f)
+    }
+
+    fn owner_update_event(
+        token: u64,
+        start_ts: TimeStamp,
+        key: &Key,
+        new_lock_ts: TimeStamp,
+        fair: bool,
+        is_first_lock: bool,
+    ) -> UpdateWaitForEvent {
+        let raw = key.to_raw().unwrap();
+        UpdateWaitForEvent {
+            token: LockWaitToken(Some(token)),
+            start_ts,
+            is_first_lock,
+            wait_info: KeyLockWaitInfo {
+                key: key.clone(),
+                lock_digest: LockDigest {
+                    ts: new_lock_ts,
+                    hash: key.gen_hash(),
+                },
+                lock_info: LockInfo {
+                    key: raw,
+                    lock_version: new_lock_ts.into_inner(),
+                    ..Default::default()
+                },
+                allow_lock_with_conflict: fair,
+            },
+        }
+    }
+
+    /// After DETACH: N fair waiters × many owner changes produces N Cleanups
+    /// of the *original* edge and zero Detects from update_wait_for. Message
+    /// count does not grow with owner-change count (tikv#19846).
+    #[test]
+    fn test_fair_waiter_detector_rpc_grows_with_owner_changes() {
+        let (mut worker, scheduler, mut counters) = start_waiter_manager_counting(10_000);
+        let raw_key = b"hot";
+        let key = Key::from_raw(raw_key);
+        let n = 20usize;
+        let initial_lock_ts = 100u64;
+        let owner_changes = 5usize;
+
+        for i in 0..n {
+            let waiter_ts = TimeStamp::new(1000 + i as u64);
+            let (waiter, ..) = new_fair_test_waiter(waiter_ts, initial_lock_ts.into(), raw_key);
+            scheduler.wait_for(
+                LockWaitToken(Some(i as u64 + 1)),
+                1,
+                RegionEpoch::default(),
+                1,
+                waiter.start_ts,
+                waiter.wait_info,
+                WaitTimeout::Millis(10_000),
+                waiter.cancel_callback,
+                DiagnosticContext::default(),
+                false,
+            );
+        }
+        flush_waiter_mgr(&scheduler);
+        // WaiterManager itself does not Detect on wait_for; LockManager does.
+        wait_for_counts(&counters, 0, 0);
+
+        for step in 1..=owner_changes {
+            let new_ts = TimeStamp::new(initial_lock_ts + step as u64);
+            let events: Vec<_> = (0..n)
+                .map(|i| {
+                    owner_update_event(
+                        i as u64 + 1,
+                        TimeStamp::new(1000 + i as u64),
+                        &key,
+                        new_ts,
+                        true,
+                        false,
+                    )
+                })
+                .collect();
+            scheduler.update_wait_for(events);
+            flush_waiter_mgr(&scheduler);
+            // First owner change: one Cleanup of the registered edge per waiter.
+            // Later changes: no more detector RPC.
+            wait_for_counts(&counters, 0, n);
+        }
+
+        assert_eq!(counters.detect.load(Ordering::SeqCst), 0);
+        assert_eq!(counters.cleanup_wait_for.load(Ordering::SeqCst), n);
+        let cleaned = counters.cleanup_lock_ts.lock().unwrap().clone();
+        assert_eq!(cleaned.len(), n);
+        assert!(
+            cleaned.iter().all(|ts| *ts == initial_lock_ts),
+            "cleanup must use the registered edge, got {:?}",
+            cleaned
+        );
+
+        // Already detached: leaving the queue must not emit another Cleanup
+        // of the updated owner.
+        for i in 0..n {
+            scheduler.remove_lock_wait(LockWaitToken(Some(i as u64 + 1)));
+        }
+        flush_waiter_mgr(&scheduler);
+        wait_for_counts(&counters, 0, n);
+
+        worker.stop().unwrap();
+        counters.detect_worker.stop().unwrap();
+    }
+
+    #[test]
+    fn test_non_fair_waiter_skips_detector_on_owner_change() {
+        let (mut worker, scheduler, mut counters) = start_waiter_manager_counting(10_000);
+        let raw_key = b"hot";
+        let key = Key::from_raw(raw_key);
+        let (waiter, ..) = new_test_waiter_with_key(10.into(), 100.into(), raw_key);
+        scheduler.wait_for(
+            LockWaitToken(Some(1)),
+            1,
+            RegionEpoch::default(),
+            1,
+            waiter.start_ts,
+            waiter.wait_info,
+            WaitTimeout::Millis(10_000),
+            waiter.cancel_callback,
+            DiagnosticContext::default(),
+            false,
+        );
+        flush_waiter_mgr(&scheduler);
+        scheduler.update_wait_for(vec![owner_update_event(
+            1,
+            10.into(),
+            &key,
+            200.into(),
+            false,
+            false,
+        )]);
+        flush_waiter_mgr(&scheduler);
+        wait_for_counts(&counters, 0, 0);
+        // Leave must Cleanup the registered owner (100), not the updated 200.
+        scheduler.remove_lock_wait(LockWaitToken(Some(1)));
+        flush_waiter_mgr(&scheduler);
+        wait_for_counts(&counters, 0, 1);
+        assert_eq!(counters.cleanup_lock_ts.lock().unwrap().as_slice(), &[100]);
+        worker.stop().unwrap();
+        counters.detect_worker.stop().unwrap();
+    }
+
+    #[test]
+    fn test_fair_waiter_cleanup_registered_edge_if_never_detached() {
+        let (mut worker, scheduler, mut counters) = start_waiter_manager_counting(10_000);
+        let raw_key = b"hot";
+        let (waiter, ..) = new_fair_test_waiter(10.into(), 100.into(), raw_key);
+        scheduler.wait_for(
+            LockWaitToken(Some(1)),
+            1,
+            RegionEpoch::default(),
+            1,
+            waiter.start_ts,
+            waiter.wait_info,
+            WaitTimeout::Millis(10_000),
+            waiter.cancel_callback,
+            DiagnosticContext::default(),
+            false,
+        );
+        flush_waiter_mgr(&scheduler);
+        scheduler.remove_lock_wait(LockWaitToken(Some(1)));
+        flush_waiter_mgr(&scheduler);
+        wait_for_counts(&counters, 0, 1);
+        assert_eq!(counters.cleanup_lock_ts.lock().unwrap().as_slice(), &[100]);
+        worker.stop().unwrap();
+        counters.detect_worker.stop().unwrap();
+    }
+
+    #[test]
+    fn test_first_lock_does_not_register_or_detach() {
+        let (mut worker, scheduler, mut counters) = start_waiter_manager_counting(10_000);
+        let raw_key = b"hot";
+        let key = Key::from_raw(raw_key);
+        let (waiter, ..) = new_fair_test_waiter(10.into(), 100.into(), raw_key);
+        scheduler.wait_for(
+            LockWaitToken(Some(1)),
+            1,
+            RegionEpoch::default(),
+            1,
+            waiter.start_ts,
+            waiter.wait_info,
+            WaitTimeout::Millis(10_000),
+            waiter.cancel_callback,
+            DiagnosticContext::default(),
+            true,
+        );
+        flush_waiter_mgr(&scheduler);
+        scheduler.update_wait_for(vec![owner_update_event(
+            1,
+            10.into(),
+            &key,
+            200.into(),
+            true,
+            true,
+        )]);
+        flush_waiter_mgr(&scheduler);
+        scheduler.remove_lock_wait(LockWaitToken(Some(1)));
+        flush_waiter_mgr(&scheduler);
+        wait_for_counts(&counters, 0, 0);
+        worker.stop().unwrap();
+        counters.detect_worker.stop().unwrap();
     }
 }

--- a/src/server/lock_manager/waiter_manager.rs
+++ b/src/server/lock_manager/waiter_manager.rs
@@ -212,9 +212,9 @@ pub(crate) struct Waiter {
     delay: Delay,
     start_waiting_time: Instant,
     last_updated_time: Option<Instant>,
-    /// The wait-for edge last registered to DetectTable (or enqueued to the
-    /// detector). `None` if this waiter never registered (first lock) or
-    /// already detached after an owner change.
+    /// The wait-for edge last sent to DetectTable (or queued to send).
+    /// `None` if this waiter never registered (first lock) or the edge was
+    /// already cleaned up after an owner change.
     registered_edge: Option<KeyLockWaitInfo>,
 }
 
@@ -598,11 +598,12 @@ impl WaiterManager {
 
             if let Some((previous_wait_info, _diag_ctx)) = previous_wait_info {
                 if previous_wait_info.allow_lock_with_conflict {
-                    // DETACH: drop the registered edge once, do not Detect the new owner.
+                    // First owner change: clean up the registered edge and do
+                    // not Detect the new owner. Later changes are no-ops.
                     if let Some(edge) = wait_table.take_registered_edge(event.token) {
                         self.detector_scheduler
                             .clean_up_wait_for(event.start_ts, edge);
-                        TASK_COUNTER_METRICS.detach.inc();
+                        TASK_COUNTER_METRICS.drop_registered_edge.inc();
                     }
                 }
             }
@@ -1295,7 +1296,7 @@ pub mod tests {
 
     /// Counts Detect / CleanUpWaitFor tasks scheduled to the deadlock detector.
     /// Used to reproduce tikv#19846 (unbounded 2N fan-out per owner change)
-    /// and to verify DETACH bounds it.
+    /// and to check that owner-change updates no longer grow with waiter count.
     struct CountingDetector {
         detect: Arc<AtomicUsize>,
         cleanup_wait_for: Arc<AtomicUsize>,
@@ -1436,9 +1437,9 @@ pub mod tests {
         }
     }
 
-    /// After DETACH: N fair waiters × many owner changes produces N Cleanups
-    /// of the *original* edge and zero Detects from update_wait_for. Message
-    /// count does not grow with owner-change count (tikv#19846).
+    /// N fair waiters × many owner changes produces N Cleanups of the
+    /// original edge and zero Detects from update_wait_for. Message count
+    /// does not grow with owner-change count (tikv#19846).
     #[test]
     fn test_fair_waiter_detector_rpc_grows_with_owner_changes() {
         let (mut worker, scheduler, mut counters) = start_waiter_manager_counting(10_000);
@@ -1499,8 +1500,8 @@ pub mod tests {
             cleaned
         );
 
-        // Already detached: leaving the queue must not emit another Cleanup
-        // of the updated owner.
+        // Edge already cleaned on the first owner change: leaving must not
+        // emit another Cleanup of the updated owner.
         for i in 0..n {
             scheduler.remove_lock_wait(LockWaitToken(Some(i as u64 + 1)));
         }
@@ -1550,7 +1551,7 @@ pub mod tests {
     }
 
     #[test]
-    fn test_fair_waiter_cleanup_registered_edge_if_never_detached() {
+    fn test_fair_waiter_cleanup_registered_edge_if_owner_never_changed() {
         let (mut worker, scheduler, mut counters) = start_waiter_manager_counting(10_000);
         let raw_key = b"hot";
         let (waiter, ..) = new_fair_test_waiter(10.into(), 100.into(), raw_key);
@@ -1576,7 +1577,7 @@ pub mod tests {
     }
 
     #[test]
-    fn test_first_lock_does_not_register_or_detach() {
+    fn test_first_lock_does_not_register_or_drop_edge() {
         let (mut worker, scheduler, mut counters) = start_waiter_manager_counting(10_000);
         let raw_key = b"hot";
         let key = Key::from_raw(raw_key);

--- a/tests/integrations/server/lock_manager.rs
+++ b/tests/integrations/server/lock_manager.rs
@@ -374,8 +374,8 @@ fn test_detect_deadlock_when_merge_region() {
 #[test]
 fn test_detect_deadlock_when_updating_wait_info() {
     use kvproto::kvrpcpb::PessimisticLockKeyResultType::*;
-    // DETACH: an owner change no longer Detects the new owner in this wait.
-    // The cycle is visible only after this wait ends and the client retries.
+    // An owner change no longer Detects the new owner in this wait. The
+    // cycle is visible only after this wait ends and the client retries.
     // Keep 11→12 alive longer than 12's first wait so the retry is not a race
     // against 11's key2 timeout.
     let mut cluster = new_cluster_for_deadlock_test_with_lock_wait_timeout(3, 2000);
@@ -460,7 +460,7 @@ fn test_detect_deadlock_when_updating_wait_info() {
     assert!(resp.errors.is_empty());
     assert_eq!(resp.results[0].get_type(), LockResultNormal);
     // 12 now waits for 11 on key1, which would form a cycle with 11→12, but
-    // DETACH does not register 12→11 on this owner change.
+    // this wait does not register 12→11 on the owner change.
     assert_eq!(
         rx_txn12_k1
             .recv_timeout(Duration::from_millis(150))
@@ -478,7 +478,7 @@ fn test_detect_deadlock_when_updating_wait_info() {
     );
     assert!(
         !resp.errors[0].has_deadlock(),
-        "DETACH must not report deadlock on owner change: {:?}",
+        "owner change must not report deadlock on this wait: {:?}",
         resp.errors[0]
     );
     // Retry Detects the current owner and finds 12→11→12.

--- a/tests/integrations/server/lock_manager.rs
+++ b/tests/integrations/server/lock_manager.rs
@@ -131,11 +131,29 @@ fn async_pessimistic_lock_resumable(
     key: &[u8],
     ts: u64,
 ) -> mpsc::Receiver<PessimisticLockResponse> {
+    async_pessimistic_lock_resumable_timeout(client, ctx, key, ts, 1000)
+}
+
+fn async_pessimistic_lock_resumable_timeout(
+    client: Arc<TikvClient>,
+    ctx: Context,
+    key: &[u8],
+    ts: u64,
+    wait_timeout_ms: i64,
+) -> mpsc::Receiver<PessimisticLockResponse> {
     let (tx, rx) = mpsc::channel();
     let key = vec![key.to_vec()];
     thread::spawn(move || {
-        let resp =
-            kv_pessimistic_lock_resumable(&client, ctx, key, ts, ts, Some(1000), false, false);
+        let resp = kv_pessimistic_lock_resumable(
+            &client,
+            ctx,
+            key,
+            ts,
+            ts,
+            Some(wait_timeout_ms),
+            false,
+            false,
+        );
         tx.send(resp).unwrap();
     });
     rx
@@ -461,15 +479,7 @@ fn test_detect_deadlock_when_updating_wait_info() {
     assert_eq!(resp.results[0].get_type(), LockResultNormal);
     // 12 now waits for 11 on key1, which would form a cycle with 11→12, but
     // this wait does not register 12→11 on the owner change.
-    assert_eq!(
-        rx_txn12_k1
-            .recv_timeout(Duration::from_millis(150))
-            .unwrap_err(),
-        RecvTimeoutError::Timeout
-    );
-    let resp = rx_txn12_k1
-        .recv_timeout(Duration::from_millis(800))
-        .unwrap();
+    let resp = rx_txn12_k1.recv_timeout(Duration::from_secs(1)).unwrap();
     assert!(resp.region_error.is_none());
     assert!(
         resp.errors[0].has_locked(),
@@ -649,7 +659,9 @@ fn test_shared_lock_deadlock_cleanup_partial_edges() {
 fn test_shared_lock_deadlock_with_update_waiter() {
     use kvproto::kvrpcpb::PessimisticLockKeyResultType::*;
 
-    let mut cluster = new_cluster_for_deadlock_test(3);
+    // Owner change drops txn40's registered edge. The cycle is visible only
+    // after that wait ends and txn40 retries Detect of the current owner.
+    let mut cluster = new_cluster_for_deadlock_test_with_lock_wait_timeout(3, 2000);
     let key_a = b"slock_update_key";
     let key_b = b"slock_wait_key";
     let (client, ctx) = build_leader_client(&mut cluster, key_a);
@@ -661,16 +673,19 @@ fn test_shared_lock_deadlock_with_update_waiter() {
     force_shared_lock_shrink_only(&client, ctx.clone(), key_a.to_vec(), 103);
 
     // txn40 holds key_b, then waits on key_a. txn30 also waits on key_a and has
-    // higher priority.
+    // higher priority. Keep 40's first wait shorter than 30 so 40 times out
+    // first after the owner change.
     must_kv_pessimistic_lock(&client, ctx.clone(), key_b.to_vec(), 40);
-    let rx_txn30_ka = async_pessimistic_lock_resumable(client.clone(), ctx.clone(), key_a, 30);
+    let rx_txn30_ka =
+        async_pessimistic_lock_resumable_timeout(client.clone(), ctx.clone(), key_a, 30, 2000);
     assert_eq!(
         rx_txn30_ka
             .recv_timeout(Duration::from_millis(100))
             .unwrap_err(),
         RecvTimeoutError::Timeout
     );
-    let rx_txn40_ka = async_pessimistic_lock_resumable(client.clone(), ctx.clone(), key_a, 40);
+    let rx_txn40_ka =
+        async_pessimistic_lock_resumable_timeout(client.clone(), ctx.clone(), key_a, 40, 400);
     assert_eq!(
         rx_txn40_ka
             .recv_timeout(Duration::from_millis(100))
@@ -689,16 +704,36 @@ fn test_shared_lock_deadlock_with_update_waiter() {
     assert!(resp.errors.is_empty(), "{:?}", resp.errors);
     assert_eq!(resp.results[0].get_type(), LockResultNormal);
 
-    // txn30 now waits on key_b (held by txn40); deadlock should be detected only
-    // after update_waiter switches txn40's wait-for from shared-lock owners to
-    // txn30.
+    let resp = rx_txn40_ka.recv_timeout(Duration::from_secs(1)).unwrap();
+    assert!(resp.region_error.is_none());
+    assert!(
+        resp.errors[0].has_locked(),
+        "first wait must time out, not deadlock: {:?}",
+        resp.errors[0]
+    );
+    assert!(
+        !resp.errors[0].has_deadlock(),
+        "owner change must not report deadlock on this wait: {:?}",
+        resp.errors[0]
+    );
+
+    // Retry registers 40→30. Then 30 waiting on key_b (held by 40) completes
+    // the cycle.
+    let rx_txn40_ka2 =
+        async_pessimistic_lock_resumable_timeout(client.clone(), ctx.clone(), key_a, 40, 2000);
+    assert_eq!(
+        rx_txn40_ka2
+            .recv_timeout(Duration::from_millis(100))
+            .unwrap_err(),
+        RecvTimeoutError::Timeout
+    );
     let resp = kv_pessimistic_lock_resumable(
         &client,
         ctx.clone(),
         vec![key_b.to_vec()],
         30,
         30,
-        Some(1000),
+        Some(2000),
         false,
         false,
     );
@@ -706,11 +741,11 @@ fn test_shared_lock_deadlock_with_update_waiter() {
     assert_eq!(resp.results[0].get_type(), LockResultFailed);
     assert!(resp.errors[0].has_deadlock(), "{:?}", resp.errors[0]);
 
-    // Release txn30 on key_a, then rx_txn40_ka can finish.
+    // Release txn30 on key_a, then the retried txn40 can finish.
     must_kv_pessimistic_rollback(&client, ctx.clone(), key_a.to_vec(), 30, 30);
 
-    let resp = rx_txn40_ka
-        .recv_timeout(Duration::from_millis(100))
+    let resp = rx_txn40_ka2
+        .recv_timeout(Duration::from_millis(500))
         .unwrap();
     assert!(resp.region_error.is_none());
     assert!(resp.errors.is_empty(), "{:?}", resp.errors);

--- a/tests/integrations/server/lock_manager.rs
+++ b/tests/integrations/server/lock_manager.rs
@@ -252,8 +252,15 @@ fn find_peer_of_store(region: &Region, store_id: u64) -> Peer {
 /// Creates a cluster with only one region and store(1) is the leader of the
 /// region.
 fn new_cluster_for_deadlock_test(count: usize) -> Cluster<ServerCluster> {
+    new_cluster_for_deadlock_test_with_lock_wait_timeout(count, 500)
+}
+
+fn new_cluster_for_deadlock_test_with_lock_wait_timeout(
+    count: usize,
+    wait_timeout_ms: u64,
+) -> Cluster<ServerCluster> {
     let mut cluster = new_server_cluster(0, count);
-    cluster.cfg.pessimistic_txn.wait_for_lock_timeout = ReadableDuration::millis(500);
+    cluster.cfg.pessimistic_txn.wait_for_lock_timeout = ReadableDuration::millis(wait_timeout_ms);
     cluster.cfg.pessimistic_txn.pipelined = false;
     let pd_client = Arc::clone(&cluster.pd_client);
     // Disable default max peer count check.
@@ -367,7 +374,11 @@ fn test_detect_deadlock_when_merge_region() {
 #[test]
 fn test_detect_deadlock_when_updating_wait_info() {
     use kvproto::kvrpcpb::PessimisticLockKeyResultType::*;
-    let mut cluster = new_cluster_for_deadlock_test(3);
+    // DETACH: an owner change no longer Detects the new owner in this wait.
+    // The cycle is visible only after this wait ends and the client retries.
+    // Keep 11→12 alive longer than 12's first wait so the retry is not a race
+    // against 11's key2 timeout.
+    let mut cluster = new_cluster_for_deadlock_test_with_lock_wait_timeout(3, 2000);
 
     let key1 = b"key1";
     let key2 = b"key2";
@@ -379,12 +390,21 @@ fn test_detect_deadlock_when_updating_wait_info() {
         ctx: Context,
         key: &[u8],
         ts: u64,
+        wait_timeout_ms: i64,
     ) -> mpsc::Receiver<PessimisticLockResponse> {
         let (tx, rx) = mpsc::channel();
         let key = vec![key.to_vec()];
         thread::spawn(move || {
-            let resp =
-                kv_pessimistic_lock_resumable(&client, ctx, key, ts, ts, Some(1000), false, false);
+            let resp = kv_pessimistic_lock_resumable(
+                &client,
+                ctx,
+                key,
+                ts,
+                ts,
+                Some(wait_timeout_ms),
+                false,
+                false,
+            );
             tx.send(resp).unwrap();
         });
         rx
@@ -398,7 +418,7 @@ fn test_detect_deadlock_when_updating_wait_info() {
         vec![key1.to_vec()],
         10,
         10,
-        Some(1000),
+        Some(2000),
         false,
         false,
     );
@@ -411,16 +431,16 @@ fn test_detect_deadlock_when_updating_wait_info() {
         vec![key2.to_vec()],
         12,
         12,
-        Some(1000),
+        Some(2000),
         false,
         false,
     );
     assert!(resp.region_error.is_none());
     assert!(resp.errors.is_empty());
     assert_eq!(resp.results[0].get_type(), LockResultNormal);
-    let rx_txn11_k1 = async_pessimistic_lock(client.clone(), ctx.clone(), key1, 11);
-    let rx_txn12_k1 = async_pessimistic_lock(client.clone(), ctx.clone(), key1, 12);
-    let rx_txn11_k2 = async_pessimistic_lock(client.clone(), ctx.clone(), key2, 11);
+    let rx_txn11_k1 = async_pessimistic_lock(client.clone(), ctx.clone(), key1, 11, 2000);
+    let rx_txn12_k1 = async_pessimistic_lock(client.clone(), ctx.clone(), key1, 12, 400);
+    let rx_txn11_k2 = async_pessimistic_lock(client.clone(), ctx.clone(), key2, 11, 2000);
     // All blocked.
     assert_eq!(
         rx_txn11_k1
@@ -439,12 +459,41 @@ fn test_detect_deadlock_when_updating_wait_info() {
     assert!(resp.region_error.is_none());
     assert!(resp.errors.is_empty());
     assert_eq!(resp.results[0].get_type(), LockResultNormal);
-    // And then 12 waits for k1 on key1, which forms a deadlock.
+    // 12 now waits for 11 on key1, which would form a cycle with 11→12, but
+    // DETACH does not register 12→11 on this owner change.
+    assert_eq!(
+        rx_txn12_k1
+            .recv_timeout(Duration::from_millis(150))
+            .unwrap_err(),
+        RecvTimeoutError::Timeout
+    );
     let resp = rx_txn12_k1
-        .recv_timeout(Duration::from_millis(1000))
+        .recv_timeout(Duration::from_millis(800))
         .unwrap();
     assert!(resp.region_error.is_none());
-    assert!(resp.errors[0].has_deadlock());
+    assert!(
+        resp.errors[0].has_locked(),
+        "first wait must time out, not deadlock: {:?}",
+        resp.errors[0]
+    );
+    assert!(
+        !resp.errors[0].has_deadlock(),
+        "DETACH must not report deadlock on owner change: {:?}",
+        resp.errors[0]
+    );
+    // Retry Detects the current owner and finds 12→11→12.
+    let resp = kv_pessimistic_lock_resumable(
+        &client,
+        ctx.clone(),
+        vec![key1.to_vec()],
+        12,
+        12,
+        Some(2000),
+        false,
+        false,
+    );
+    assert!(resp.region_error.is_none());
+    assert!(resp.errors[0].has_deadlock(), "{:?}", resp.errors[0]);
     assert_eq!(resp.results[0].get_type(), LockResultFailed);
     // Check correctness of the wait chain.
     let wait_chain = resp.errors[0].get_deadlock().get_wait_chain();


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #19846

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Under fair locking, every lock-owner change sent CleanUpWaitFor+Detect
for each non-first-lock waiter (2N detector RPCs per change) into an
unbounded outbound gRPC channel. On a hot key whose region leader is
not the deadlock-detector leader, that queue grows as
2 * waiters * owner_changes and can OOM the follower.

After the first owner change of a fair waiter, clean up only the
registered detect-table edge and do not Detect the new owner. Detector
RPCs per wait attempt drop from 2N per owner change to at most the
initial Detect plus one Cleanup. Later owner changes send nothing.
Local wait_info and fair resume are unchanged.

A stable deadlock's missing edges are re-registered on wait timeout
(default and max 1s) when TiDB retries the lock. This is a detection
delay, not a change to commit correctness.

Leave-path cleanup uses the registered edge so a later local owner
update cannot delete the wrong graph entry.

Unit test: 20 fair waiters and 5 owner changes used to emit 100 Detect
+ 100 Cleanup on the update path; after this change it is 0 Detect +
20 Cleanup of the original edge.
```

Detector RPC count (this is the leak):

| Path | Before | After |
|---|---|---|
| First register (`!is_first_lock`) | 1 Detect | 1 Detect (unchanged) |
| Each owner change, N fair waiters | N CleanUpWaitFor + N Detect = **2N** | First change: **N Cleanup** of the registered edge, **0 Detect**. Later changes: **0** |
| Leave / timeout | 1 Cleanup (possibly of the latest local owner) | 1 Cleanup of the **registered** edge |

Unit test `test_update_wait_for_many_fair_waiters_sends_no_detect`: 20 waiters × 5 owner changes used to send **100 Detect + 100 Cleanup**; after this change it is **0 Detect + 20 Cleanup**.

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Manual: 3-TiKV playground, fair locking on, hot-key region leader ≠
detector leader, 400 sessions locking a private row then a phantom
key. Unfixed v8.5.6 follower RSS ~+78 MiB/s until the process exits
(detector pending queue growing). This patch: outbound pending stays 0;
follower RSS plateaus.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Fix the issue that TiKV might OOM under fair locking when many transactions contend on a single key.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deadlock detection during lock-owner changes and retries.
  * Prevented stale wait relationships from triggering incorrect deadlock reports.
  * Improved cleanup after lock-wait timeouts, wake-ups, disconnects, and ownership changes.
  * Deferred detection until current lock ownership information is available.
  * Improved handling of initial lock waits to avoid unnecessary deadlock checks.

* **Monitoring**
  * Added visibility into queued deadlock-detector requests.
  * Added tracking for detached lock-wait tasks.

* **Documentation**
  * Clarified lock-wait timeout defaults, limits, and potential detection delays.
  * Added configuration guidance for background analysis concurrency and RocksDB snapshot validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->