### PR TITLE
read_pool: submit FuturePools tasks on first poll

### DIFF
--- a/src/read_pool.rs
+++ b/src/read_pool.rs
@@ -1093,6 +1093,88 @@ mod tests {
     }
 
     #[test]
+    fn test_future_pools_spawn_submission_contract() {
+        use std::sync::mpsc;
+
+        use tracker::{
+            GLOBAL_TRACKERS, RequestInfo, RequestType, Tracker, TrackerToken,
+            get_tls_tracker_token, set_tls_tracker_token,
+        };
+
+        fn new_tracker() -> TrackerToken {
+            GLOBAL_TRACKERS.insert(Tracker::new(RequestInfo::new(
+                &kvproto::kvrpcpb::Context::default(),
+                RequestType::Unknown,
+                0,
+            )))
+        }
+
+        // Use one underlying pool for all priorities so the test observes
+        // submission timing and tracker propagation, not priority routing.
+        let pool = YatpPoolBuilder::new(yatp_pool::DefaultTicker::default())
+            .name_prefix("test-future-pools-spawn-contract")
+            .build_future_pool();
+        let handle = ReadPoolHandle::FuturePools {
+            read_pool_high: pool.clone(),
+            read_pool_normal: pool.clone(),
+            read_pool_low: pool.clone(),
+        };
+
+        // Preserve the test thread's ambient tracker, then create distinct
+        // tokens for the submitted task and for the context that polls its
+        // submission, so the two can be told apart below.
+        let previous_tracker = get_tls_tracker_token();
+        let task_tracker = new_tracker();
+        let caller_tracker = new_tracker();
+        set_tls_tracker_token(task_tracker);
+
+        // `started` reports the token seen by the task, `release` keeps the
+        // task pending so the running-task gauge is stable while it is read,
+        // and `finished` makes teardown wait until the task reaches its end.
+        let (started_tx, started_rx) = mpsc::channel();
+        let (release_tx, release_rx) = oneshot::channel();
+        let (finished_tx, finished_rx) = mpsc::channel();
+
+        let spawn_fut = handle.spawn(
+            async move {
+                started_tx.send(get_tls_tracker_token()).unwrap();
+                release_rx.await.unwrap();
+                finished_tx.send(()).unwrap();
+            },
+            CommandPri::Normal,
+            1,
+            TaskMetadata::default(),
+            None,
+        );
+        // Switch tracker before polling so the poller's context is
+        // distinguishable from the task's.
+        set_tls_tracker_token(caller_tracker);
+
+        // Current behavior on this backend: `spawn` enqueued the task before
+        // returning, so the task is already running and the gauge already
+        // counts it, without the submission future having been polled.
+        let observed_task_tracker = started_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+        let running_tasks = pool.get_running_task_count();
+        block_on(spawn_fut).unwrap();
+        let observed_caller_tracker = get_tls_tracker_token();
+
+        // The task reads its token while it runs, so let it reach the end
+        // before removing the trackers it and the poller point at.
+        release_tx.send(()).unwrap();
+        finished_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+        set_tls_tracker_token(previous_tracker);
+        GLOBAL_TRACKERS.remove(task_tracker);
+        GLOBAL_TRACKERS.remove(caller_tracker);
+
+        assert_eq!(running_tasks, 1);
+        // The task inherits its call-time tracker, and polling the submission
+        // leaves the poller's tracker intact. Both have to survive any change
+        // to when submission happens.
+        assert_eq!(observed_task_tracker, task_tracker);
+        assert_eq!(observed_caller_tracker, caller_tracker);
+    }
+
+    #[test]
     fn test_yatp_full() {
         let config = UnifiedReadPoolConfig {
             min_thread_count: 1,

--- a/src/read_pool.rs
+++ b/src/read_pool.rs
@@ -32,7 +32,7 @@ use tikv_util::{
     worker::{Runnable, RunnableWithTimer, Scheduler, Worker},
     yatp_pool::{self, CleanupMethod, FuturePool, PoolTicker, YatpPoolBuilder},
 };
-use tracker::TlsTrackedFuture;
+use tracker::{TlsTrackedFuture, get_tls_tracker_token, set_tls_tracker_token};
 use yatp::{
     metrics::MULTILEVEL_LEVEL_ELAPSED,
     pool::Remote,
@@ -189,6 +189,17 @@ async fn admission_and_enqueue(
 }
 
 impl ReadPoolHandle {
+    /// Spawns `f` in the pool selected by `priority`.
+    ///
+    /// On both backends the task is admitted and enqueued only when the
+    /// returned future is first polled, while the TLS tracker token the task
+    /// observes is captured here, at call time.
+    ///
+    /// Two consequences bind callers. A returned future that is never polled
+    /// never runs `f`. And the pool-full errors, `FuturePoolFull` and
+    /// `UnifiedReadPoolFull`, surface at that first poll rather than at this
+    /// call, so a caller that needs backpressure has to await the future
+    /// instead of inspecting the call.
     pub fn spawn<F>(
         &self,
         f: F,
@@ -210,9 +221,32 @@ impl ReadPoolHandle {
                     CommandPri::High => read_pool_high,
                     CommandPri::Normal => read_pool_normal,
                     CommandPri::Low => read_pool_low,
-                };
-                let res = pool.spawn(f).map_err(ReadPoolError::from);
-                futures::future::ready(res).boxed()
+                }
+                .clone();
+                // `FuturePool::spawn` wraps `f` in `TlsTrackedFuture`, which
+                // captures whichever token is set at the moment of that call.
+                // The token is therefore read here, at spawn time, and
+                // reinstalled around that call below, so the task observes its
+                // caller's tracker rather than the tracker of whoever polls
+                // the submission. This is load bearing: if `FuturePool::spawn`
+                // stopped wrapping the future, the task would silently lose
+                // its tracker instead of failing to compile.
+                //
+                // Wrapping the submission itself in `TlsTrackedFuture` would
+                // not work, because its `poll` resets the token to
+                // `INVALID_TRACKER_TOKEN` rather than restoring the previous
+                // value, clearing the poller's tracker. Wrapping `f` would
+                // repeat, on every poll of the task, the switching that
+                // `FuturePool::spawn` already does.
+                let task_tracker = get_tls_tracker_token();
+                async move {
+                    let caller_tracker = get_tls_tracker_token();
+                    set_tls_tracker_token(task_tracker);
+                    // Restore the caller's token on unwinding as well as return.
+                    tikv_util::defer!(set_tls_tracker_token(caller_tracker));
+                    pool.spawn(f).map_err(ReadPoolError::from)
+                }
+                .boxed()
             }
             ReadPoolHandle::Yatp {
                 remote,
@@ -1096,10 +1130,7 @@ mod tests {
     fn test_future_pools_spawn_submission_contract() {
         use std::sync::mpsc;
 
-        use tracker::{
-            GLOBAL_TRACKERS, RequestInfo, RequestType, Tracker, TrackerToken,
-            get_tls_tracker_token, set_tls_tracker_token,
-        };
+        use tracker::{GLOBAL_TRACKERS, RequestInfo, RequestType, Tracker, TrackerToken};
 
         fn new_tracker() -> TrackerToken {
             GLOBAL_TRACKERS.insert(Tracker::new(RequestInfo::new(
@@ -1109,8 +1140,8 @@ mod tests {
             )))
         }
 
-        // Use one underlying pool for all priorities so the test observes
-        // submission timing and tracker propagation, not priority routing.
+        // Use one underlying pool for all priorities so the test focuses on lazy
+        // submission and tracker propagation, not priority routing.
         let pool = YatpPoolBuilder::new(yatp_pool::DefaultTicker::default())
             .name_prefix("test-future-pools-spawn-contract")
             .build_future_pool();
@@ -1120,21 +1151,22 @@ mod tests {
             read_pool_low: pool.clone(),
         };
 
-        // Preserve the test thread's ambient tracker, then create distinct
-        // tokens for the submitted task and for the context that polls its
-        // submission, so the two can be told apart below.
+        // Preserve the test thread's ambient tracker, then create distinct tokens
+        // for the submitted task and the context that will poll its submission.
         let previous_tracker = get_tls_tracker_token();
         let task_tracker = new_tracker();
         let caller_tracker = new_tracker();
         set_tls_tracker_token(task_tracker);
 
-        // `started` reports the token seen by the task, `release` keeps the
-        // task pending so the running-task gauge is stable while it is read,
-        // and `finished` makes teardown wait until the task reaches its end.
+        // `started` reports the token seen by the task, `release` keeps the task
+        // pending so the running-task gauge is stable, and `finished` makes
+        // teardown wait until the task reaches its end.
         let (started_tx, started_rx) = mpsc::channel();
         let (release_tx, release_rx) = oneshot::channel();
         let (finished_tx, finished_rx) = mpsc::channel();
 
+        // Calling `spawn` must capture `task_tracker`, but must not enqueue the
+        // task until the returned submission future is polled.
         let spawn_fut = handle.spawn(
             async move {
                 started_tx.send(get_tls_tracker_token()).unwrap();
@@ -1146,17 +1178,18 @@ mod tests {
             TaskMetadata::default(),
             None,
         );
-        // Switch tracker before polling so the poller's context is
-        // distinguishable from the task's.
+
+        // Poll the submission under a different tracker to ensure polling does
+        // not overwrite the caller's TLS context.
         set_tls_tracker_token(caller_tracker);
 
-        // Current behavior on this backend: `spawn` enqueued the task before
-        // returning, so the task is already running and the gauge already
-        // counts it, without the submission future having been polled.
-        let observed_task_tracker = started_rx.recv_timeout(Duration::from_secs(5)).unwrap();
-        let running_tasks = pool.get_running_task_count();
+        let running_tasks_before_poll = pool.get_running_task_count();
+        // The first poll only admits and enqueues the task; it does not await the
+        // task's completion.
         block_on(spawn_fut).unwrap();
         let observed_caller_tracker = get_tls_tracker_token();
+        let running_tasks_after_poll = pool.get_running_task_count();
+        let observed_task_tracker = started_rx.recv_timeout(Duration::from_secs(5)).unwrap();
 
         // The task reads its token while it runs, so let it reach the end
         // before removing the trackers it and the poller point at.
@@ -1166,10 +1199,10 @@ mod tests {
         GLOBAL_TRACKERS.remove(task_tracker);
         GLOBAL_TRACKERS.remove(caller_tracker);
 
-        assert_eq!(running_tasks, 1);
-        // The task inherits its call-time tracker, and polling the submission
-        // leaves the poller's tracker intact. Both have to survive any change
-        // to when submission happens.
+        assert_eq!(running_tasks_before_poll, 0);
+        assert_eq!(running_tasks_after_poll, 1);
+        // The task inherits its call-time tracker, while the poller's tracker is
+        // preserved across submission.
         assert_eq!(observed_task_tracker, task_tracker);
         assert_eq!(observed_caller_tracker, caller_tracker);
     }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #20003

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
FuturePools admitted and enqueued at the call, returning a resolved
future; Yatp defers both to the first poll. Callers that control
submission by polling saw backend-dependent behavior.

Defer FuturePools submission to the first poll. The task's tracker is
still captured at the call and reinstalled around `FuturePool::spawn`,
with a `defer!` guard restoring the poller's token.

Pool-full errors now surface at the first poll, and an unpolled
submission never runs its task.
```

Two commits: the first pins the current behavior, the second changes it.

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved asynchronous task scheduling so work is submitted when it begins execution, rather than immediately when created.
  * Preserved execution tracking context across task submission and polling, including when errors occur.

* **Tests**
  * Added regression coverage for deferred scheduling and tracking-context propagation.

* **Documentation**
  * Clarified the scheduling and execution-context behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

