### PR TITLE
*: update h2 for RUSTSEC-2026-0258

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -634,7 +634,7 @@ dependencies = [
  "aws-smithy-types",
  "bytes",
  "h2 0.3.26",
- "h2 0.4.13",
+ "h2 0.4.16",
  "http 0.2.12",
  "http 1.4.0",
  "http-body 0.4.6",
@@ -3559,9 +3559,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3871,7 +3871,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.13",
+ "h2 0.4.16",
  "http 1.4.0",
  "http-body 1.0.1",
  "httparse",

--- a/deny.toml
+++ b/deny.toml
@@ -41,6 +41,12 @@ deny = [
     { name = "digest", wrappers = ["sha2", "md-5", "sha1", "hmac", "crc-fast"] },
     { name = "password-hash" },
     { name = "signature" },
+    # Advisory exceptions apply by ID rather than package version. Restrict
+    # the unpatched h2 0.3 line to its known direct consumers, and reject all
+    # other versions affected by RUSTSEC-2026-0258.
+    { crate = "h2:<0.3", reason = "not part of the temporary h2 0.3 exception" },
+    { crate = "h2:>=0.3,<0.4", wrappers = ["aws-smithy-http-client", "hyper", "reqwest"], reason = "only the existing h2 0.3 dependency chains are temporarily accepted" },
+    { crate = "h2:>=0.4,<0.4.16", reason = "upgrade h2 0.4 to at least 0.4.16" },
 ]
 multiple-versions = "allow"
 
@@ -93,6 +99,14 @@ ignore = [
     # 
     # See: https://rustsec.org/advisories/RUSTSEC-2026-0253
     "RUSTSEC-2026-0253",
+    # Ignore RUSTSEC-2026-0258 for the legacy h2 0.3 dependency chains only.
+    # Cargo.lock upgrades h2 0.4 to the patched 0.4.16 release, but hyper 0.14,
+    # reqwest 0.11, and aws-smithy-http-client still require h2 0.3, for which
+    # upstream has not released a patch. Exploitation requires a malicious
+    # direct HTTP/2 peer and an incoming body that is not fully drained.
+    #
+    # TODO: Remove after the legacy clients move off h2 0.3.
+    "RUSTSEC-2026-0258",
 ]
 
 # TiKV is licensed under Apache 2.0, according to ASF 3RD PARTY LICENSE POLICY,


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #20006

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
RUSTSEC-2026-0258 flags both h2 versions in the current lockfile and blocks cargo-deny-dependent CI.

Upgrade h2 0.4.13 to the patched 0.4.16 release. h2 0.3.26 remains because upstream has no patched 0.3 release, while removing it would require broader HTTP, TLS, and cloud SDK migrations.

Temporarily exempt h2 0.3, restrict it to its existing hyper, reqwest, and aws-smithy-http-client consumers, and ban every other affected h2 version. Remove the exception after the legacy clients migrate away from h2 0.3.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
  - `cargo +1.92.0 deny check advisories`
  - `cargo +1.92.0 deny check bans advisories`
  - `cargo metadata --locked --format-version=1 --no-deps`
  - `cargo check --all`
  - `make format`
  - `make clippy`
- [x] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Strengthened safeguards against vulnerable networking components.
  * Restricted legacy compatibility exceptions to narrowly defined, documented scenarios.
  * Improved protection against affected dependency versions while preserving supported application functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


