### PR TITLE
coprocessor: remove request trackers on drop

### DIFF
--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -34,6 +34,7 @@ use tidb_query_common::{
 use tikv_alloc::trace::MemoryTraceGuard;
 use tikv_kv::{ExtraRegionOverride, SnapshotExt};
 use tikv_util::{
+    DeferContext,
     deadline::set_deadline_exceeded_busy_error,
     future::async_timeout,
     memory::{MemoryQuota, OwnedAllocated},
@@ -717,6 +718,11 @@ impl<E: Engine> Endpoint<E> {
             RequestType::Unknown,
             req.start_ts,
         )));
+        // Registered before the server-busy early return below, which is one of
+        // the paths that never reaches the future holding the removal.
+        let tracker_guard = DeferContext::new(move || {
+            GLOBAL_TRACKERS.remove(tracker);
+        });
         // Check the load of the read pool. If it's too busy, generate and return
         // error in the gRPC thread to avoid waiting in the queue of the read pool.
         if let Err(busy_err) = self.read_pool.check_busy_threshold(Duration::from_millis(
@@ -741,6 +747,9 @@ impl<E: Engine> Endpoint<E> {
                 tracker.req_info.begin.saturating_elapsed().as_nanos() as u64;
         });
         let fut = async move {
+            // Moving the guard into the future ties removal to the future's
+            // lifetime, so cancellation cleans up as well as completion.
+            let _tracker_guard = tracker_guard;
             let res = match result_of_future {
                 Err(e) => {
                     let mut res = make_error_response(e);
@@ -760,7 +769,6 @@ impl<E: Engine> Endpoint<E> {
                     res
                 }
             };
-            GLOBAL_TRACKERS.remove(tracker);
             res
         };
         Either::Right(fut)
@@ -803,9 +811,13 @@ impl<E: Engine> Endpoint<E> {
             match self.parse_request_and_check_memory_locks(cur_req, peer.clone(), false) {
                 Ok(r) => {
                     let cur_tracker = GLOBAL_TRACKERS.insert(::tracker::Tracker::new(request_info));
+                    let tracker_guard = DeferContext::new(move || {
+                        GLOBAL_TRACKERS.remove(cur_tracker);
+                    });
                     set_tls_tracker_token(cur_tracker);
                     let fut = self.handle_unary_request(r);
                     let fut = async move {
+                        let _tracker_guard = tracker_guard;
                         let res = fut.await;
                         match res {
                             Ok(mut resp) => {
@@ -829,7 +841,6 @@ impl<E: Engine> Endpoint<E> {
                                 make_error_batch_response(&mut response, e);
                             }
                         }
-                        GLOBAL_TRACKERS.remove(cur_tracker);
                         response
                     };
 
@@ -2083,11 +2094,7 @@ mod tests {
                 remaining += 1;
             }
         });
-        // Every removal sits inside the dropped future, so the top tracker and
-        // both batched task trackers stay registered. `TrackerToken` is a
-        // `Copy` wrapper around a `u64` with no `Drop`, so nothing reclaims
-        // them.
-        assert_eq!(remaining, 3);
+        assert_eq!(remaining, 0);
     }
 
     #[test]

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -2032,6 +2032,65 @@ mod tests {
     }
 
     #[test]
+    fn test_dropped_batch_request_trackers() {
+        let engine = TestEngineBuilder::new().build().unwrap();
+        let read_pool = ReadPool::from(build_read_pool_for_test(
+            &CoprReadPoolConfig::default_for_test(),
+            engine,
+        ));
+        let cm = ConcurrencyManager::new_for_test(1.into());
+        let copr = Endpoint::<RocksEngine>::new(
+            &Config::default(),
+            read_pool.handle(),
+            cm,
+            ResourceTagFactory::new_for_test(),
+            Arc::new(QuotaLimiter::default()),
+            None,
+        );
+
+        // `GLOBAL_TRACKERS` is a process-wide slab shared by every test in this
+        // binary, so this test counts only the trackers carrying its own
+        // `start_ts`. The value is arbitrary: `u64::MAX` minus the date this
+        // test was written, chosen so no realistic timestamp collides with it.
+        const DROPPED_START_TS: u64 = u64::MAX - 20260819;
+        let mut analyze = AnalyzeReq::default();
+        analyze.set_tp(AnalyzeType::TypeColumn);
+        let mut req = coppb::Request::default();
+        req.set_tp(REQ_TYPE_ANALYZE);
+        req.set_data(analyze.write_to_bytes().unwrap());
+        req.set_start_ts(DROPPED_START_TS);
+        for task_id in 1..=2 {
+            let mut task = coppb::StoreBatchTask::default();
+            task.set_task_id(task_id);
+            req.tasks.push(task);
+        }
+
+        // `parse_and_handle_unary_request` is not an `async fn`: it registers
+        // the top tracker, and `process_batch_tasks` registers one tracker per
+        // batched task, all while building the future rather than while
+        // polling it. Dropping the future therefore exercises the window in
+        // which the trackers are registered but nothing has run.
+        let previous_tracker = ::tracker::get_tls_tracker_token();
+        let future = copr.parse_and_handle_unary_request(req, None);
+        drop(future);
+        // Building the request also overwrote this thread's tracker token.
+        // Restore it so the count below is the only state this test observes.
+        set_tls_tracker_token(previous_tracker);
+
+        let mut remaining = 0;
+        GLOBAL_TRACKERS.for_each(|tracker| {
+            if tracker.req_info.start_ts == DROPPED_START_TS {
+                remaining += 1;
+            }
+        });
+        // Every removal sits inside the dropped future, so the top tracker and
+        // both batched task trackers stay registered. `TrackerToken` is a
+        // `Copy` wrapper around a `u64` with no `Drop`, so nothing reclaims
+        // them.
+        assert_eq!(remaining, 3);
+    }
+
+    #[test]
     fn test_unary_response_bytes_in_ru_v2() {
         let engine = TestEngineBuilder::new().build().unwrap();
         let read_pool = ReadPool::from(build_read_pool_for_test(


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: close #20009

What's Changed:

```commit-message
A request that never polls its future to completion leaks every tracker
it registered: the server-busy early return skips the top tracker's
removal, and dropping the future leaks it plus one per batched task.

Nothing reclaims them. Once a `GLOBAL_TRACKERS` shard fills, `insert`
returns `INVALID_TRACKER_TOKEN`, and scan details, execution details
and RU accounting stop being recorded until restart.

Move both removals into `DeferContext` guards owned by the futures,
created before the server-busy check.
```

Two commits: the first pins the leak (three trackers), the second fixes it.

The server-busy path has no test — `check_busy_threshold` always returns `Ok` on the `FuturePools` backend the endpoint tests use. The same guard covers it.

Split out of #19854, which will rebase once this merges.

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [x] Need to cherry-pick to the release branch

### Check List

Tests

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note

```release-note
Fix a coprocessor request tracker leak that could stop scan details, execution details and RU accounting from being recorded.
```
