### PR TITLE
raftstore: pass RaftCmdExtraOpts through local read path to enable deadline cancellation

### DIFF
--- a/components/raftstore/src/router.rs
+++ b/components/raftstore/src/router.rs
@@ -138,6 +138,7 @@ where
         ctx: ReadContext,
         req: RaftCmdRequest,
         cb: Callback<EK::Snapshot>,
+        extra_opts: RaftCmdExtraOpts,
     ) -> RaftStoreResult<()>;
 
     fn release_snapshot_cache(&mut self);
@@ -272,8 +273,9 @@ impl<EK: KvEngine, ER: RaftEngine> LocalReadRouter<EK> for ServerRaftStoreRouter
         ctx: ReadContext,
         req: RaftCmdRequest,
         cb: Callback<EK::Snapshot>,
+        extra_opts: RaftCmdExtraOpts,
     ) -> RaftStoreResult<()> {
-        self.local_reader.read(ctx, req, cb);
+        self.local_reader.read(ctx, req, cb, extra_opts);
         Ok(())
     }
 

--- a/components/raftstore/src/store/worker/read.rs
+++ b/components/raftstore/src/store/worker/read.rs
@@ -38,10 +38,9 @@ use crate::{
     errors::RAFTSTORE_IS_BUSY,
     router::ReadContext,
     store::{
-        Callback, CasualMessage, CasualRouter, Peer, ProposalRouter, RaftCommand, ReadCallback,
-        ReadResponse, RegionSnapshot, RequestInspector, RequestPolicy, TxnExt, cmd_resp,
-        fsm::store::StoreMeta,
-        util::{self, LeaseState, RegionReadProgress, RemoteLease},
+        Callback, CasualMessage, CasualRouter, Peer, ProposalRouter, RaftCommand, RaftCmdExtraOpts,
+        ReadCallback, ReadResponse, RegionSnapshot, RequestInspector, RequestPolicy, TxnExt,
+        cmd_resp, fsm::store::StoreMeta, util::{self, LeaseState, RegionReadProgress, RemoteLease},
     },
 };
 
@@ -1101,6 +1100,7 @@ where
         ctx: &ReadContext,
         mut req: RaftCmdRequest,
         cb: Callback<E::Snapshot>,
+        extra_opts: RaftCmdExtraOpts,
     ) {
         TLS_LOCAL_READ_METRICS.with(|m| m.borrow_mut().local_received_requests.inc());
         match self.pre_propose_raft_command(&req) {
@@ -1121,7 +1121,7 @@ where
                         } else {
                             fail_point!("localreader_before_redirect", |_| {});
                             // Forward to raftstore.
-                            self.redirect(RaftCommand::new(req, cb));
+                            self.redirect(RaftCommand::new_ext(req, cb, extra_opts.clone()));
                             return;
                         }
                     }
@@ -1194,7 +1194,7 @@ where
                         }
                     }
                     RequestPolicy::ReadIndex => {
-                        self.redirect(RaftCommand::new(req, cb));
+                        self.redirect(RaftCommand::new_ext(req, cb, extra_opts.clone()));
                         return;
                     }
                     RequestPolicy::ReadIndexReplicaRead => {
@@ -1213,7 +1213,7 @@ where
                             });
                             read_resp
                         } else {
-                            self.redirect(RaftCommand::new(req, cb));
+                            self.redirect(RaftCommand::new_ext(req, cb, extra_opts.clone()));
                             return;
                         }
                     }
@@ -1241,7 +1241,7 @@ where
                 cb.set_result(response);
             }
             // Forward to raftstore.
-            Ok(None) => self.redirect(RaftCommand::new(req, cb)),
+            Ok(None) => self.redirect(RaftCommand::new_ext(req, cb, extra_opts)),
             Err(e) => {
                 let mut response = cmd_resp::new_error(e);
                 if let Some(delegate) = self
@@ -1267,8 +1267,8 @@ where
     /// which left a snapshot cached in LocalReader. ThreadReadId is composed by
     /// thread_id and a thread_local incremental sequence.
     #[inline]
-    pub fn read(&mut self, ctx: ReadContext, req: RaftCmdRequest, cb: Callback<E::Snapshot>) {
-        self.propose_raft_command(&ctx, req, cb);
+    pub fn read(&mut self, ctx: ReadContext, req: RaftCmdRequest, cb: Callback<E::Snapshot>, extra_opts: RaftCmdExtraOpts) {
+        self.propose_raft_command(&ctx, req, cb, extra_opts);
         maybe_tls_local_read_metrics_flush();
     }
 
@@ -1437,6 +1437,15 @@ mod tests {
         rx: &Receiver<RaftCommand<KvTestSnapshot>>,
         cmd: RaftCmdRequest,
     ) {
+        must_redirect_with_extra_opts(reader, rx, cmd, RaftCmdExtraOpts::default());
+    }
+
+    fn must_redirect_with_extra_opts(
+        reader: &mut LocalReader<KvTestEngine, MockRouter>,
+        rx: &Receiver<RaftCommand<KvTestSnapshot>>,
+        cmd: RaftCmdRequest,
+        extra_opts: RaftCmdExtraOpts,
+    ) {
         let read_ctx = &ReadContext::new(None, None);
         reader.propose_raft_command(
             read_ctx,
@@ -1444,6 +1453,7 @@ mod tests {
             Callback::read(Box::new(|resp| {
                 panic!("unexpected invoke, {:?}", resp);
             })),
+            extra_opts,
         );
         assert_eq!(
             rx.recv_timeout(std::time::Duration::try_from(Duration::seconds(5)).unwrap())
@@ -1467,8 +1477,18 @@ mod tests {
         task: RaftCommand<KvTestSnapshot>,
         read_id: Option<ThreadReadId>,
     ) {
+        must_not_redirect_with_read_id_and_opts(reader, rx, task, read_id, RaftCmdExtraOpts::default());
+    }
+
+    fn must_not_redirect_with_read_id_and_opts(
+        reader: &mut LocalReader<KvTestEngine, MockRouter>,
+        rx: &Receiver<RaftCommand<KvTestSnapshot>>,
+        task: RaftCommand<KvTestSnapshot>,
+        read_id: Option<ThreadReadId>,
+        extra_opts: RaftCmdExtraOpts,
+    ) {
         let ctx = ReadContext::new(read_id, None);
-        reader.propose_raft_command(&ctx, task.request, task.callback);
+        reader.propose_raft_command(&ctx, task.request, task.callback, extra_opts);
         assert_eq!(rx.try_recv().unwrap_err(), TryRecvError::Empty);
     }
 
@@ -1609,6 +1629,7 @@ mod tests {
                 assert!(err.has_store_not_match());
                 assert!(resp.snapshot.is_none());
             })),
+            RaftCmdExtraOpts::default(),
         );
         assert_eq!(
             TLS_LOCAL_READ_METRICS.with(|m| m.borrow().reject_reason.store_id_mismatch.get()),
@@ -1636,6 +1657,7 @@ mod tests {
                 );
                 assert!(resp.snapshot.is_none());
             })),
+            RaftCmdExtraOpts::default(),
         );
         assert_eq!(
             TLS_LOCAL_READ_METRICS.with(|m| m.borrow().reject_reason.peer_id_mismatch.get()),
@@ -1658,6 +1680,7 @@ mod tests {
                 assert!(err.has_stale_command(), "{:?}", resp);
                 assert!(resp.snapshot.is_none());
             })),
+            RaftCmdExtraOpts::default(),
         );
         assert_eq!(
             TLS_LOCAL_READ_METRICS.with(|m| m.borrow().reject_reason.term_mismatch.get()),
@@ -1687,7 +1710,7 @@ mod tests {
         );
 
         // Channel full.
-        reader.propose_raft_command(read_ctx, cmd.clone(), Callback::None);
+        reader.propose_raft_command(read_ctx, cmd.clone(), Callback::None, RaftCmdExtraOpts::default());
         reader.propose_raft_command(
             read_ctx,
             cmd.clone(),
@@ -1696,6 +1719,7 @@ mod tests {
                 assert!(err.has_server_is_busy(), "{:?}", resp);
                 assert!(resp.snapshot.is_none());
             })),
+            RaftCmdExtraOpts::default(),
         );
         rx.try_recv().unwrap();
         assert_eq!(rx.try_recv().unwrap_err(), TryRecvError::Empty);
@@ -1726,6 +1750,7 @@ mod tests {
             Callback::read(Box::new(|resp| {
                 panic!("unexpected invoke, {:?}", resp);
             })),
+            RaftCmdExtraOpts::default(),
         );
         assert_eq!(
             rx.recv_timeout(std::time::Duration::try_from(Duration::seconds(5)).unwrap())

--- a/components/test_raftstore/src/node.rs
+++ b/components/test_raftstore/src/node.rs
@@ -531,7 +531,7 @@ impl Simulator for NodeCluster {
         let mut guard = self.trans.core.lock().unwrap();
         let router = guard.routers.get_mut(&node_id).unwrap();
         let read_ctx = ReadContext::new(batch_id, None);
-        router.read(read_ctx, request, cb).unwrap();
+        router.read(read_ctx, request, cb, raftstore::store::RaftCmdExtraOpts::default()).unwrap();
     }
 
     fn send_raft_msg(&mut self, msg: raft_serverpb::RaftMessage) -> Result<()> {

--- a/components/test_raftstore/src/server.rs
+++ b/components/test_raftstore/src/server.rs
@@ -873,7 +873,9 @@ impl Simulator for ServerCluster {
             }
             Some(meta) => {
                 let read_ctx = ReadContext::new(batch_id, None);
-                meta.sim_router.read(read_ctx, request, cb).unwrap();
+                meta.sim_router
+                    .read(read_ctx, request, cb, raftstore::store::RaftCmdExtraOpts::default())
+                    .unwrap();
             }
         };
     }

--- a/components/test_raftstore/src/transport_simulate.rs
+++ b/components/test_raftstore/src/transport_simulate.rs
@@ -20,7 +20,7 @@ use raftstore::{
     DiscardReason, Error, Result as RaftStoreResult, Result,
     router::{LocalReadRouter, RaftStoreRouter, ReadContext},
     store::{
-        Callback, CasualMessage, CasualRouter, PeerMsg, ProposalRouter, RaftCommand,
+        Callback, CasualMessage, CasualRouter, PeerMsg, ProposalRouter, RaftCommand, RaftCmdExtraOpts,
         SignificantMsg, SignificantRouter, StoreMsg, StoreRouter, Transport,
     },
 };
@@ -257,8 +257,9 @@ impl<C: LocalReadRouter<RocksEngine>> LocalReadRouter<RocksEngine> for SimulateT
         ctx: ReadContext,
         req: RaftCmdRequest,
         cb: Callback<RocksSnapshot>,
+        extra_opts: RaftCmdExtraOpts,
     ) -> RaftStoreResult<()> {
-        self.ch.read(ctx, req, cb)
+        self.ch.read(ctx, req, cb, extra_opts)
     }
 
     fn release_snapshot_cache(&mut self) {

--- a/src/server/raftkv/mod.rs
+++ b/src/server/raftkv/mod.rs
@@ -814,8 +814,12 @@ where
 
     let read_ctx = ReadContext::new(ctx.read_id, ctx.start_ts.map(|ts| ts.into_inner()));
     if res.is_ok() {
+        let extra_opts = RaftCmdExtraOpts {
+            deadline: ctx.deadline,
+            disk_full_opt: kvproto::kvrpcpb::DiskFullOpt::default(),
+        };
         res = router
-            .read(read_ctx, cmd, store_cb)
+            .read(read_ctx, cmd, store_cb, extra_opts)
             .map_err(kv::Error::from);
     }
     async move {

--- a/tests/benches/misc/raftkv/mod.rs
+++ b/tests/benches/misc/raftkv/mod.rs
@@ -124,8 +124,9 @@ impl LocalReadRouter<RocksEngine> for SyncBenchRouter {
         _: ReadContext,
         req: RaftCmdRequest,
         cb: Callback<RocksSnapshot>,
+        extra_opts: RaftCmdExtraOpts,
     ) -> Result<()> {
-        self.send_command(req, cb, RaftCmdExtraOpts::default())
+        self.send_command(req, cb, extra_opts)
     }
 
     fn release_snapshot_cache(&mut self) {}


### PR DESCRIPTION
Issue #19798 added a client-side timeout to kv::snapshot(), but the underlying read
 index request dispatched to raftstore via router.read() was never cancelled. The RaftCmdExtraOpts.deadline was
 always None for read requests, so the existing deadline check at peer.rs:779 was a no-op.

   This change threads deadline information from SnapContext through the LocalReadRouter::read() trait method to
 RaftCommand.extra_opts.deadline. When the client times out, the existing deadline check now triggers and rejects
 the request before any raft proposal occurs, preventing resource leaks.

   Changes:
   - LocalReadRouter::read() now accepts RaftCmdExtraOpts parameter
   - LocalReader::propose_raft_command() uses RaftCommand::new_ext() for all redirect paths, embedding extra_opts
 into the RaftCommand
   - raftkv::async_snapshot() constructs RaftCmdExtraOpts from ctx.deadline
   - Test/mock implementations updated to match new trait signature

   All raftstore unit tests pass (9/9 read-specific, 265/266 total with 1 pre-existing flaky test unrelated to this
 change).

Issue Number: close #19799

   ```release-note
   raftstore: Fix read index requests not being cancelled when client-side timeout occurs, preventing resource
 leaks.
   ```

```
      Issue Number: close #19799
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Read requests now preserve and forward additional execution options across local, remote, simulated, and snapshot read paths.
  * Snapshot reads retain their configured deadline and disk-full handling behavior.

* **Bug Fixes**
  * Prevented supplied read options from being replaced by defaults during request forwarding.

* **Tests**
  * Updated read-related test and benchmark utilities to support the enhanced options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->