### PR TITLE
tidb_query: handle JSON uint overflow in signed casts

### DIFF
--- a/components/tidb_query_datatype/src/codec/convert.rs
+++ b/components/tidb_query_datatype/src/codec/convert.rs
@@ -526,7 +526,7 @@ impl ToInt for JsonRef<'_> {
         let val = match self.get_type() {
             JsonType::Literal => Ok(self.get_literal().map_or(0, |x| x as i64)),
             JsonType::I64 => Ok(self.get_i64()),
-            JsonType::U64 => Ok(self.get_u64() as i64),
+            JsonType::U64 => self.get_u64().to_int(ctx, tp),
             JsonType::Double => self.get_double().to_int(ctx, tp),
             JsonType::String => self.get_str_bytes()?.to_int(ctx, tp),
             _ => Ok(ctx
@@ -1552,6 +1552,23 @@ mod tests {
             let json: Json = jstr.parse().unwrap();
             let get = json.to_int(&mut ctx, FieldTypeTp::LongLong).unwrap();
             assert_eq!(get, exp, "json.as_i64 get: {}, exp: {}", get, exp);
+        }
+    }
+
+    #[test]
+    fn test_json_u64_to_int_overflow() {
+        for value in ["9223372036854775808", "18446744073709551615"] {
+            let json: Json = value.parse().unwrap();
+
+            let mut ctx = EvalContext::new(Arc::new(EvalConfig::new()));
+            let err = json.to_int(&mut ctx, FieldTypeTp::LongLong).unwrap_err();
+            assert_eq!(err.code(), ERR_DATA_OUT_OF_RANGE);
+
+            let mut ctx =
+                EvalContext::new(Arc::new(EvalConfig::from_flag(Flag::OVERFLOW_AS_WARNING)));
+            let val = json.to_int(&mut ctx, FieldTypeTp::LongLong).unwrap();
+            assert_eq!(val, i64::MAX);
+            assert_eq!(ctx.warnings.warning_cnt, 1);
         }
     }
 

--- a/components/tidb_query_executors/src/selection_executor.rs
+++ b/components/tidb_query_executors/src/selection_executor.rs
@@ -270,6 +270,8 @@ mod tests {
     use futures::executor::block_on;
     use tidb_query_codegen::rpn_fn;
     use tidb_query_datatype::{FieldTypeTp, codec::batch::LazyBatchColumnVec, expr::EvalWarnings};
+    use tipb::ScalarFuncSig;
+    use tipb_helper::ExprDefBuilder;
 
     use super::*;
     use crate::util::mock_executor::MockExecutor;
@@ -709,6 +711,41 @@ mod tests {
         let r = block_on(exec.next_batch(1));
         assert!(r.logical_rows.is_empty());
         r.is_drained.unwrap_err();
+    }
+
+    #[test]
+    fn test_json_u64_overflow_in_selection() {
+        let src_exec = MockExecutor::new(
+            vec![FieldTypeTp::Json.into()],
+            vec![BatchExecuteResult {
+                physical_columns: LazyBatchColumnVec::from(vec![VectorValue::Json(
+                    vec![Some(Json::from_u64(i64::MAX as u64 + 1).unwrap())].into(),
+                )]),
+                logical_rows: vec![0],
+                warnings: EvalWarnings::default(),
+                is_drained: Ok(BatchExecIsDrain::Drain),
+            }],
+        );
+
+        let mut cast =
+            ExprDefBuilder::scalar_func(ScalarFuncSig::CastJsonAsInt, FieldTypeTp::LongLong)
+                .build();
+        cast.mut_children()
+            .push(ExprDefBuilder::column_ref(0, FieldTypeTp::Json).build());
+
+        let mut predicate =
+            ExprDefBuilder::scalar_func(ScalarFuncSig::LtInt, FieldTypeTp::LongLong).build();
+        predicate.mut_children().push(cast);
+        predicate
+            .mut_children()
+            .push(ExprDefBuilder::constant_int(0).build());
+
+        let mut exec =
+            BatchSelectionExecutor::new(Arc::new(EvalConfig::new()), src_exec, vec![predicate])
+                .unwrap();
+
+        let result = block_on(exec.next_batch(1));
+        assert!(result.is_drained.is_err());
     }
 
     #[test]


### PR DESCRIPTION
What is changed and how it works?

Issue Number: close #19887

Unsigned JSON integers above the signed range were cast with `as i64`, allowing them to wrap into negative values before overflow handling.

What changed

- Route `JsonType::U64` through the existing checked `u64::to_int` conversion instead of an unchecked cast.
- Add regression coverage for `9223372036854775808` and `18446744073709551615`.
- Verify strict overflow handling and `OVERFLOW_AS_WARNING` behavior.
- Add pushed Selection regression coverage for `CastJsonAsInt < 0`, ensuring overflow is returned instead of treating the wrapped value as negative.

Validation

- `cargo test -p tidb_query_datatype --lib test_json_u64_to_int_overflow -- --nocapture` — 1 passed, 0 failed.
- `cargo test -p tidb_query_datatype --lib` — 301 passed, 0 failed.
- `cargo test -p tidb_query_executors --lib test_json_u64_overflow_in_selection -- --nocapture` — 1 passed, 0 failed.
- `cargo test -p tidb_query_executors --lib` — 121 passed, 0 failed.
- `cargo fmt --all` passes.
- `git diff --check` passes.

Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`
- [ ] Need to cherry-pick to the release branch

Check List

Tests

- [x] Unit test
- [ ] Integration test
- [ ] Manual test

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

 Release note


```release-note
Fix JSON unsigned integer values above the signed range wrapping to negative values when cast to signed integers in TiKV.
```
