### PR TITLE
tracker: attribute poll time by tracker token

### DIFF
--- a/components/tracker/src/future.rs
+++ b/components/tracker/src/future.rs
@@ -38,13 +38,13 @@ pub fn track<F: Future, T: FutureTrack>(fut: F, fut_tracker: T) -> impl Future<O
 /// first poll has no poll callback and therefore cannot flush that initial
 /// wait.
 #[derive(Debug)]
-pub struct TokenFutureTracker {
+pub struct PollTimeTracker {
     token: TrackerToken,
     poll_began: Instant,
     last_finished: Instant,
 }
 
-impl TokenFutureTracker {
+impl PollTimeTracker {
     /// Creates a poll-time tracker for the slab tracker addressed by `token`.
     pub fn new(token: TrackerToken) -> Self {
         let now = Instant::now();
@@ -56,7 +56,7 @@ impl TokenFutureTracker {
     }
 }
 
-impl FutureTrack for TokenFutureTracker {
+impl FutureTrack for PollTimeTracker {
     fn on_poll_begin(&mut self) {
         self.poll_began = Instant::now();
     }

--- a/components/tracker/src/future.rs
+++ b/components/tracker/src/future.rs
@@ -4,9 +4,12 @@ use std::{
     future::Future,
     pin::Pin,
     task::{Context, Poll},
+    time::Instant,
 };
 
 use pin_project::pin_project;
+
+use crate::slab::{GLOBAL_TRACKERS, TrackerToken};
 
 /// A trait for tracking the polling of a future.
 /// It is used to do some work before and after polling the inner future.
@@ -21,6 +24,56 @@ pub trait FutureTrack {
 /// A future that tracks the polling of the inner future.
 pub fn track<F: Future, T: FutureTrack>(fut: F, fut_tracker: T) -> impl Future<Output = F::Output> {
     Tracker::new(fut, fut_tracker)
+}
+
+/// Attributes a tracked future's poll time to the slab tracker addressed by
+/// a token: busy poll time accumulates into
+/// [`crate::RequestMetrics::future_process_nanos`] and the gaps between polls,
+/// plus the wait before the first poll when that poll begins, accumulate into
+/// [`crate::RequestMetrics::future_suspend_nanos`], which
+/// [`crate::Tracker::merge_time_detail`] folds into the request's
+/// `TimeDetailV2`. Unlike `TlsFutureTracker` in the storage layer it keeps no
+/// thread local state, so it can track a future handed to a foreign executor;
+/// an invalid or removed token makes it a no-op. An instance dropped before its
+/// first poll has no poll callback and therefore cannot flush that initial
+/// wait.
+#[derive(Debug)]
+pub struct TokenFutureTracker {
+    token: TrackerToken,
+    poll_began: Instant,
+    last_finished: Instant,
+}
+
+impl TokenFutureTracker {
+    /// Creates a poll-time tracker for the slab tracker addressed by `token`.
+    pub fn new(token: TrackerToken) -> Self {
+        let now = Instant::now();
+        Self {
+            token,
+            poll_began: now,
+            last_finished: now,
+        }
+    }
+}
+
+impl FutureTrack for TokenFutureTracker {
+    fn on_poll_begin(&mut self) {
+        self.poll_began = Instant::now();
+    }
+
+    fn on_poll_finish(&mut self) {
+        let now = Instant::now();
+        let process_nanos = now.saturating_duration_since(self.poll_began).as_nanos() as u64;
+        let suspend_nanos = self
+            .poll_began
+            .saturating_duration_since(self.last_finished)
+            .as_nanos() as u64;
+        GLOBAL_TRACKERS.with_tracker(self.token, |tracker| {
+            tracker.metrics.future_process_nanos += process_nanos;
+            tracker.metrics.future_suspend_nanos += suspend_nanos;
+        });
+        self.last_finished = now;
+    }
 }
 
 #[pin_project]

--- a/components/tracker/src/lib.rs
+++ b/components/tracker/src/lib.rs
@@ -10,7 +10,7 @@ use std::time::Instant;
 use kvproto::kvrpcpb as pb;
 
 pub use self::{
-    future::{FutureTrack, TokenFutureTracker, track},
+    future::{FutureTrack, PollTimeTracker, track},
     slab::{GLOBAL_TRACKERS, INVALID_TRACKER_TOKEN, TrackerToken, TrackerTokenArray},
     tls::*,
 };
@@ -352,7 +352,7 @@ mod tests {
                     Poll::Pending
                 }
             }),
-            TokenFutureTracker::new(token),
+            PollTimeTracker::new(token),
         );
         let mut fut = pin!(fut);
         let mut cx = Context::from_waker(Waker::noop());

--- a/components/tracker/src/lib.rs
+++ b/components/tracker/src/lib.rs
@@ -325,7 +325,7 @@ mod tests {
     }
 
     #[test]
-    fn test_token_future_tracker_attributes_poll_time() {
+    fn test_poll_time_tracker_attributes_process_and_suspend_time() {
         use std::{
             future::{Future, poll_fn},
             pin::pin,

--- a/components/tracker/src/lib.rs
+++ b/components/tracker/src/lib.rs
@@ -10,7 +10,7 @@ use std::time::Instant;
 use kvproto::kvrpcpb as pb;
 
 pub use self::{
-    future::{FutureTrack, track},
+    future::{FutureTrack, TokenFutureTracker, track},
     slab::{GLOBAL_TRACKERS, INVALID_TRACKER_TOKEN, TrackerToken, TrackerTokenArray},
     tls::*,
 };
@@ -322,5 +322,53 @@ mod tests {
         assert_eq!(detail_v2.get_processed_versions(), 11);
         assert_eq!(detail_v2.get_total_versions(), 13);
         assert_eq!(detail_v2.get_processed_versions_size(), 17);
+    }
+
+    #[test]
+    fn test_token_future_tracker_attributes_poll_time() {
+        use std::{
+            future::{Future, poll_fn},
+            pin::pin,
+            task::{Context, Poll, Waker},
+            time::Duration,
+        };
+
+        // Spinning self-measures, so assertions hold under arbitrary
+        // scheduling load, unlike sleeps.
+        fn spin(d: Duration) {
+            let begin = Instant::now();
+            while begin.elapsed() < d {}
+        }
+
+        let token = GLOBAL_TRACKERS.insert(Tracker::new(new_req_info()));
+        let mut polled = false;
+        let fut = track(
+            poll_fn(move |_cx| {
+                spin(Duration::from_millis(2));
+                if polled {
+                    Poll::Ready(())
+                } else {
+                    polled = true;
+                    Poll::Pending
+                }
+            }),
+            TokenFutureTracker::new(token),
+        );
+        let mut fut = pin!(fut);
+        let mut cx = Context::from_waker(Waker::noop());
+
+        spin(Duration::from_millis(2));
+        assert!(fut.as_mut().poll(&mut cx).is_pending());
+        spin(Duration::from_millis(2));
+        assert!(fut.as_mut().poll(&mut cx).is_ready());
+
+        let mut detail = pb::TimeDetailV2::default();
+        GLOBAL_TRACKERS.with_tracker(token, |tracker| tracker.merge_time_detail(&mut detail));
+        GLOBAL_TRACKERS.remove(token);
+
+        // Two polls spun >= 2ms each; a >= 2ms gap preceded each poll.
+        let expected = Duration::from_millis(4).as_nanos() as u64;
+        assert!(detail.get_process_wall_time_ns() >= expected);
+        assert!(detail.get_process_suspend_wall_time_ns() >= expected);
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Split from #19854

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Add `PollTimeTracker` to attribute future poll and suspend time to
the request tracker identified by a token. This avoids relying on
thread-local state when work moves to another executor.
```

PR #19854 uses `PollTimeTracker` when work moves to another executor.

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added public poll-time tracking for futures.
  * Future processing and suspension durations are now recorded in tracker metrics.
  * Updated the tracker’s public API to expose the new poll-time tracker.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->