### PR TITLE
backup-stream: fix use-after-free of last_flush_time

### DIFF
--- a/components/backup-stream/src/router.rs
+++ b/components/backup-stream/src/router.rs
@@ -8,7 +8,7 @@ use std::{
     result,
     sync::{
         Arc, RwLock as SyncRwLock,
-        atomic::{AtomicBool, AtomicPtr, AtomicU64, AtomicUsize, Ordering},
+        atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
     },
     time::Duration,
 };
@@ -972,8 +972,8 @@ pub struct StreamTaskHandler {
     flushing_files: RwLock<Vec<(TempFileKey, DataFile, DataFileInfo)>>,
     /// flushing_meta_files contains meta files pending flush.
     flushing_meta_files: RwLock<Vec<(TempFileKey, DataFile, DataFileInfo)>>,
-    /// last_flush_ts represents last time this task flushed to storage.
-    last_flush_time: AtomicPtr<Instant>,
+    /// last_flush_time represents last time this task flushed to storage.
+    last_flush_time: SyncRwLock<Instant>,
     /// The min resolved TS of all regions involved.
     min_resolved_ts: TimeStamp,
     /// Total size of all temporary files in byte.
@@ -1053,7 +1053,7 @@ impl StreamTaskHandler {
             files: SlotMap::default(),
             flushing_files: RwLock::default(),
             flushing_meta_files: RwLock::default(),
-            last_flush_time: AtomicPtr::new(Box::into_raw(Box::new(Instant::now()))),
+            last_flush_time: SyncRwLock::new(Instant::now()),
             total_size: AtomicUsize::new(0),
             flushing: AtomicBool::new(false),
             flush_fail_count: AtomicUsize::new(0),
@@ -1085,7 +1085,7 @@ impl StreamTaskHandler {
             files: SlotMap::default(),
             flushing_files: RwLock::default(),
             flushing_meta_files: RwLock::default(),
-            last_flush_time: AtomicPtr::new(Box::into_raw(Box::new(Instant::now()))),
+            last_flush_time: SyncRwLock::new(Instant::now()),
             total_size: AtomicUsize::new(0),
             flushing: AtomicBool::new(false),
             flush_fail_count: AtomicUsize::new(0),
@@ -1149,7 +1149,10 @@ impl StreamTaskHandler {
     }
 
     pub fn get_last_flush_time(&self) -> Instant {
-        unsafe { *(self.last_flush_time.load(Ordering::SeqCst) as *const Instant) }
+        *self
+            .last_flush_time
+            .read()
+            .expect("last_flush_time lock poisoned")
     }
 
     pub fn total_size(&self) -> u64 {
@@ -1217,13 +1220,10 @@ impl StreamTaskHandler {
     }
 
     pub fn update_flush_time(&self) {
-        let ptr = self
+        *self
             .last_flush_time
-            .swap(Box::into_raw(Box::new(Instant::now())), Ordering::SeqCst);
-        // manual gc last instant
-        unsafe {
-            let _ = Box::from_raw(ptr);
-        };
+            .write()
+            .expect("last_flush_time lock poisoned") = Instant::now();
     }
 
     pub fn should_flush(&self, flush_interval: &Duration) -> bool {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #19968

`StreamTaskHandler::get_last_flush_time` loads a raw pointer from an
`AtomicPtr<Instant>` and dereferences it, while
`update_flush_time` can concurrently swap in a new pointer and free the
old one. A reader that loaded the pointer before the swap dereferences
freed memory.

```
reader (tokio worker):  let p = last_flush_time.load(SeqCst);  // = P
writer (flush pool):    swap(new box) -> P;  Box::from_raw(P);   // frees P
reader:                 *p                                          // UAF
```

The `flushing` CAS at router.rs gates only scheduling of new flushes; it
does not protect this read. `SeqCst` ordering guarantees pointer-value
visibility, not pointee lifetime.

### What is changed and how it works?

Replace `AtomicPtr<Instant>` with a `std::sync::RwLock<Instant>`
(`SyncRwLock`). The read side holds a short shared lock, the write side a
short exclusive lock, each held for a single `Instant` read/write. At the
per-flush-interval cadence (seconds), lock contention is negligible.

This also fixes a minor leak: the previous code never freed the final
`Instant` allocation when the handler was dropped.

### Related changes

- Removed the now-unused `AtomicPtr` import.

### Check List

Tests:
- [x] `cargo check -p backup-stream` builds (locally; vendored OpenSSL)
- [ ] Unit tests (awaiting local toolchain for full backup-stream test run)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timestamp handling for more reliable backup stream flushing.
  * Removed unsafe memory access involved in tracking flush times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Release note

```release-note
Fix a use-after-free of `last_flush_time` in backup-stream.
```

