### PR TITLE
backup-stream: bind published checkpoint to flushed payload on retry

### DIFF
--- a/components/backup-stream/src/endpoint.rs
+++ b/components/backup-stream/src/endpoint.rs
@@ -922,6 +922,12 @@ where
         let store_id = self.store_id;
         let mut flush_ob = self.flush_observer();
         async move {
+            // On retry, reuse the generation's bound proof so we never publish
+            // progress past the uploaded payload. See #19897.
+            let resolved = match router.get_task_handler(&task) {
+                Ok(handler) => handler.effective_flushing_resolved(resolved).await,
+                Err(_) => resolved,
+            };
             let mut new_rts = resolved.global_checkpoint();
             fail::fail_point!("delay_on_flush");
             flush_ob.before(resolved.resolve_results().to_vec()).await;
@@ -1061,7 +1067,15 @@ where
     }
 
     fn on_exec_flush(&mut self, task: String, resolved: ResolvedRegions, flush_ts: TimeStamp) {
-        self.checkpoint_mgr.freeze();
+        // Freeze only on a new generation; a retry keeps the generation it was
+        // frozen for, else it would publish progress past the payload. See #19897.
+        let is_new_generation = match self.range_router.get_task_handler(&task) {
+            Ok(handler) => self.pool.block_on(handler.is_new_flush_generation()),
+            Err(_) => true, // task gone; nothing will be published
+        };
+        if is_new_generation {
+            self.checkpoint_mgr.freeze();
+        }
         let fut = self.do_flush(task.clone(), resolved, flush_ts);
         let sched = self.scheduler.clone();
         self.pool.spawn(root!("flush"; async move {

--- a/components/backup-stream/src/router.rs
+++ b/components/backup-stream/src/router.rs
@@ -972,6 +972,10 @@ pub struct StreamTaskHandler {
     flushing_files: RwLock<Vec<(TempFileKey, DataFile, DataFileInfo)>>,
     /// flushing_meta_files contains meta files pending flush.
     flushing_meta_files: RwLock<Vec<(TempFileKey, DataFile, DataFileInfo)>>,
+    /// Checkpoint proof bound to the current flushing generation: set on the
+    /// first flush, reused on retry, cleared with the files on success. Keeps
+    /// the published checkpoint tied to the uploaded payload. See #19897.
+    flushing_resolved: RwLock<Option<ResolvedRegions>>,
     /// last_flush_ts represents last time this task flushed to storage.
     last_flush_time: AtomicPtr<Instant>,
     /// The min resolved TS of all regions involved.
@@ -1053,6 +1057,7 @@ impl StreamTaskHandler {
             files: SlotMap::default(),
             flushing_files: RwLock::default(),
             flushing_meta_files: RwLock::default(),
+            flushing_resolved: RwLock::default(),
             last_flush_time: AtomicPtr::new(Box::into_raw(Box::new(Instant::now()))),
             total_size: AtomicUsize::new(0),
             flushing: AtomicBool::new(false),
@@ -1085,6 +1090,7 @@ impl StreamTaskHandler {
             files: SlotMap::default(),
             flushing_files: RwLock::default(),
             flushing_meta_files: RwLock::default(),
+            flushing_resolved: RwLock::default(),
             last_flush_time: AtomicPtr::new(Box::into_raw(Box::new(Instant::now()))),
             total_size: AtomicUsize::new(0),
             flushing: AtomicBool::new(false),
@@ -1237,6 +1243,22 @@ impl StreamTaskHandler {
         self.flushing.load(Ordering::SeqCst)
     }
 
+    /// True when no proof is bound yet, i.e. this flush is not a retry.
+    pub async fn is_new_flush_generation(&self) -> bool {
+        self.flushing_resolved.read().await.is_none()
+    }
+
+    /// The proof to flush with: the bound one on retry, or `fresh` (stored) on
+    /// a new generation. Keeps the published checkpoint bound to the
+    /// uploaded payload. See #19897.
+    pub async fn effective_flushing_resolved(&self, fresh: ResolvedRegions) -> ResolvedRegions {
+        self.flushing_resolved
+            .write()
+            .await
+            .get_or_insert(fresh)
+            .clone()
+    }
+
     /// move need-flushing files to flushing_files.
     #[instrument(skip_all)]
     pub async fn move_to_flushing_files(&self) -> Result<&Self> {
@@ -1269,6 +1291,9 @@ impl StreamTaskHandler {
 
     #[instrument(skip_all)]
     pub async fn clear_flushing_files(&self) {
+        // Drop the generation's proof with its files so the next flush resolves
+        // fresh. See #19897.
+        *self.flushing_resolved.write().await = None;
         for (_, data_file, _) in self.flushing_files.write().await.drain(..) {
             debug!("removing data file"; "size" => %data_file.file_size, "name" => %data_file.inner.path().display());
             self.total_size
@@ -1342,6 +1367,10 @@ impl StreamTaskHandler {
             .await?;
 
         let filepath = &merged_file_info.path;
+
+        fail::fail_point!("log_backup_flush_log_upload", |_| {
+            Err(Error::Other(box_err!("injected upload failure")))
+        });
 
         // flush to external storage
         let ret = self

--- a/components/backup-stream/src/subscription_manager.rs
+++ b/components/backup-stream/src/subscription_manager.rs
@@ -75,6 +75,7 @@ struct ScanCmd {
 }
 
 /// The response of requesting resolve the new checkpoint of regions.
+#[derive(Clone)]
 pub struct ResolvedRegions {
     items: Vec<ResolveResult>,
     checkpoint: TimeStamp,

--- a/components/backup-stream/tests/failpoints/mod.rs
+++ b/components/backup-stream/tests/failpoints/mod.rs
@@ -445,6 +445,77 @@ mod all {
         )
     }
 
+    // Regression test for #19897: a flush retry re-uploads the retained old
+    // payload but must NOT publish a checkpoint that covers writes which only
+    // arrived after the first (failed) attempt froze its generation.
+    #[test]
+    fn flush_retry_does_not_cross_uncommitted() {
+        let mut suite = SuiteBuilder::new_named("flush_retry_does_not_cross_uncommitted")
+            .cfg(|cfg| {
+                cfg.min_ts_interval = ReadableDuration::days(1);
+                cfg.initial_scan_concurrency = 1;
+            })
+            .nodes(1)
+            .build();
+        suite.must_register_task(1, "flush_retry_does_not_cross_uncommitted");
+
+        // A belongs to generation G's payload.
+        let key_a = make_record_key(1, 1);
+        let a_start = suite.tso();
+        suite.must_kv_prewrite(
+            1,
+            vec![mutation(
+                key_a.clone(),
+                Suite::PROMISED_SHORT_VALUE.to_owned(),
+            )],
+            key_a.clone(),
+            a_start,
+        );
+        let a_commit = suite.tso();
+        suite.just_commit_a_key(key_a.clone(), a_start, a_commit);
+
+        // Attempt 1: fail the upload. Payload G is retained; nothing is
+        // published (the failure path skips the observer). The flushing flag
+        // clears on failure too, so wait_for_flush returns.
+        fail::cfg("log_backup_flush_log_upload", "1*return").unwrap();
+        suite.force_flush_files("flush_retry_does_not_cross_uncommitted");
+        suite.wait_for_flush();
+        fail::remove("log_backup_flush_log_upload");
+
+        // Now B arrives and commits AFTER generation G was frozen, and the
+        // resolved ts advances past B.
+        let key_b = make_record_key(1, 2);
+        let b_start = suite.tso();
+        suite.must_kv_prewrite(
+            1,
+            vec![mutation(
+                key_b.clone(),
+                Suite::PROMISED_SHORT_VALUE.to_owned(),
+            )],
+            key_b.clone(),
+            b_start,
+        );
+        let b_commit = suite.tso();
+        suite.just_commit_a_key(key_b.clone(), b_start, b_commit);
+        suite.run(|| Task::RegionCheckpointsOp(RegionCheckpointOperation::PrepareMinTsForResolve));
+        std::thread::sleep(Duration::from_secs(2));
+
+        // Attempt 2 (retry): re-uploads the retained A-only payload and succeeds.
+        suite.force_flush_files("flush_retry_does_not_cross_uncommitted");
+        suite.wait_for_flush();
+        // Let the async FlushWith / checkpoint publish settle.
+        suite.sync();
+
+        // The published checkpoint must not cross B, because B is not in any
+        // durable payload yet.
+        assert!(
+            suite.global_checkpoint() < b_commit.into_inner(),
+            "published checkpoint {} crossed uncommitted B at {}",
+            suite.global_checkpoint(),
+            b_commit,
+        );
+    }
+
     #[test]
     fn encryption() {
         let key_folder = TempDir::new().unwrap();


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: Close #19897

What's Changed:

on a flush retry, backup-stream re-uploads the retained old payload but was recomputing the checkpoint fresh every attempt. so a retry could upload the old payload while publishing region and scalar progress covering a write that only arrived after the payload was frozen. `br log status` could then report a global checkpoint past the log data that actually reached storage and a point restore to that ts could finish successfully while dropping committed rows

this binds one resolved-regions proof to the flushing generation. it is captured on the first flush, reused unchanged on retry (so the re freeze is skipped) and cleared with the files on success. the published checkpoint now stays tied to the payload that was actually uploaded. the proof lives next to `flushing_files` in the task handler so it has the same lifetime and the same clear point

```commit-message
backup-stream: bind published checkpoint to flushed payload on retry
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [x] Need to cherry-pick to the release branch

### Check List

Tests

- [x] Integration test

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note

```release-note
Fix a log backup issue where a flush retry after a storage write failure could publish a checkpoint beyond the durable log data, which could cause a point-in-time restore to silently omit committed rows.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed flush retries so they publish only the data included in the original uploaded payload.
  * Prevented checkpoints from advancing beyond writes that were not included in a durable payload.
  * Ensured missing tasks are skipped safely during publication.

* **Tests**
  * Added regression coverage for retries after new writes arrive during a failed flush.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->