### PR TITLE
storage: report scheduler read flow to PD

### DIFF
--- a/doc/maintenance-guides/components/raftstore.md
+++ b/doc/maintenance-guides/components/raftstore.md
@@ -178,6 +178,9 @@ High-risk contracts:
 
 - metrics under `store/metrics.rs`, `store/local_metrics.rs`, and worker metrics
 - PD heartbeat and region/store statistics
+- `store/worker/pd.rs` merges `ReadStats` from both read pools and the
+  transaction scheduler, so region heartbeat read-byte deltas include storage
+  reads caused by foreground write commands.
 - logs around snapshot, split/merge, peer lifecycle, disk-full, and unsafe
   recovery paths
 - memory accounting for raft entries/messages/apply state

--- a/doc/maintenance-guides/src/storage.md
+++ b/doc/maintenance-guides/src/storage.md
@@ -101,6 +101,10 @@ High-risk contracts:
 - `txn/sched_pool.rs` selects the priority queue only for customized resource
   groups. Background-only control stays on the vanilla queue and throttles
   matching long-running tasks inside the pool.
+- `txn/sched_pool.rs` accumulates MVCC read flow from non-readonly scheduler
+  commands, including reads performed by foreground writes, and reports
+  region-level `ReadStats` to the raftstore reporter during ticker and worker
+  shutdown flushes. Key ranges and bucket deltas are unavailable on this path.
 
 ### MVCC
 
@@ -150,6 +154,9 @@ High-risk contracts:
 - MVCC conflict, read, and GC-related metrics
 - flow-control and memory-quota behavior
 - lock-wait and deadlock diagnostics
+- PD read-flow reports include reads performed by foreground write commands;
+  inspect `txn/sched_pool.rs` when PD read bytes do not match the read-pool
+  workload.
 
 Start triage with:
 

--- a/src/storage/txn/commands/compare_and_swap.rs
+++ b/src/storage/txn/commands/compare_and_swap.rs
@@ -5,7 +5,6 @@ use api_version::{ApiV2, KvFormat, RawValue, match_template_api_version};
 use engine_traits::{CfName, raw_ttl::ttl_to_expire_ts};
 use kvproto::kvrpcpb::ApiVersion;
 use raw::RawStore;
-use tikv_kv::Statistics;
 use txn_types::{Key, Value};
 
 use crate::storage::{
@@ -83,7 +82,7 @@ impl<S: Snapshot, L: LockManager> WriteCommand<S, L> for RawCompareAndSwap {
         let old_value = RawStore::new(snapshot, self.api_version).raw_get_key_value(
             cf,
             &key,
-            &mut Statistics::default(),
+            wctx.statistics,
         )?;
 
         let (pr, lock_guards) = if old_value == previous_value {
@@ -447,6 +446,11 @@ mod tests {
         };
         let cmd: Command = cmd.into();
         let write_result = cmd.process_write(snap, context).unwrap();
+        assert_eq!(statistic.data.flow_stats.read_keys, 1);
+        assert_eq!(
+            statistic.data.flow_stats.read_bytes,
+            F::encode_raw_key(raw_key, None).as_encoded().len()
+        );
         let modifies_with_ts = vec![Modify::Put(
             CF_DEFAULT,
             F::encode_raw_key(raw_key, Some(101.into())),

--- a/src/storage/txn/sched_pool.rs
+++ b/src/storage/txn/sched_pool.rs
@@ -9,9 +9,9 @@ use std::{
 use collections::HashMap;
 use file_system::{IoType, set_io_type};
 use kvproto::{kvrpcpb::CommandPri, pdpb::QueryKind};
-use pd_client::{Feature, FeatureGate};
+use pd_client::{Feature, FeatureGate, RegionWriteCfCopDetail};
 use prometheus::local::*;
-use raftstore::store::WriteStats;
+use raftstore::store::{ReadStats, WriteStats};
 use resource_control::{
     ControlledFuture, ResourceController, ResourceGroupManager, TaskMetadata, with_resource_limiter,
 };
@@ -34,6 +34,7 @@ use crate::storage::{
 pub struct SchedLocalMetrics {
     local_scan_details: HashMap<&'static str, Statistics>,
     command_keyread_histogram_vec: LocalHistogramVec,
+    local_read_stats: ReadStats,
     local_write_stats: WriteStats,
 }
 
@@ -42,6 +43,7 @@ thread_local! {
         SchedLocalMetrics {
             local_scan_details: HashMap::default(),
             command_keyread_histogram_vec: KV_COMMAND_KEYREAD_HISTOGRAM_VEC.local(),
+            local_read_stats: ReadStats::default(),
             local_write_stats:WriteStats::default(),
         }
     );
@@ -380,11 +382,55 @@ pub fn tls_flush<R: FlowStatsReporter>(reporter: &R) {
         m.command_keyread_histogram_vec.flush();
 
         // Report PD metrics
+        if !m.local_read_stats.is_empty() {
+            let mut read_stats = ReadStats::default();
+            mem::swap(&mut read_stats, &mut m.local_read_stats);
+            reporter.report_read_stats(read_stats);
+        }
         if !m.local_write_stats.is_empty() {
             let mut write_stats = WriteStats::default();
             mem::swap(&mut write_stats, &mut m.local_write_stats);
             reporter.report_write_stats(write_stats);
         }
+    });
+}
+
+/// Collect storage reads performed while handling a transaction command.
+///
+/// The scheduler does not have a key range or bucket snapshot, so these flow
+/// statistics are reported at region granularity. Empty statistics are
+/// ignored so write commands without storage reads do not create zero-load
+/// region entries.
+pub fn tls_collect_read_flow(region_id: u64, statistics: &Statistics) {
+    let write_flow = &statistics.write.flow_stats;
+    let data_flow = &statistics.data.flow_stats;
+    let has_write_cf_cop_detail = statistics.write.next > 0
+        || statistics.write.prev > 0
+        || statistics.write.processed_keys > 0;
+    if write_flow.read_bytes == 0
+        && write_flow.read_keys == 0
+        && data_flow.read_bytes == 0
+        && data_flow.read_keys == 0
+        && !has_write_cf_cop_detail
+    {
+        return;
+    }
+
+    TLS_SCHED_METRICS.with(|m| {
+        let mut m = m.borrow_mut();
+        m.local_read_stats.add_flow(
+            region_id,
+            None,
+            None,
+            None,
+            &statistics.write.flow_stats,
+            &statistics.data.flow_stats,
+            &RegionWriteCfCopDetail::new(
+                statistics.write.next,
+                statistics.write.prev,
+                statistics.write.processed_keys,
+            ),
+        );
     });
 }
 
@@ -406,6 +452,76 @@ pub fn tls_collect_keyread_histogram_vec(cmd: &str, count: f64) {
 
 pub fn tls_can_enable(feature: Feature) -> bool {
     TLS_FEATURE_GATE.with(|feature_gate| feature_gate.borrow().can_enable(feature))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use raftstore::store::ReadStats;
+
+    use super::*;
+
+    #[derive(Clone, Default)]
+    struct RecordingReporter {
+        read_stats: Arc<Mutex<Vec<ReadStats>>>,
+    }
+
+    impl FlowStatsReporter for RecordingReporter {
+        fn report_read_stats(&self, read_stats: ReadStats) {
+            self.read_stats.lock().unwrap().push(read_stats);
+        }
+
+        fn report_write_stats(&self, _write_stats: WriteStats) {}
+    }
+
+    #[test]
+    fn test_collect_read_flow_and_flush() {
+        let reporter = RecordingReporter::default();
+        tls_flush(&reporter);
+        let stats_before = reporter.read_stats.lock().unwrap().len();
+
+        let mut statistics = Statistics::default();
+        statistics.data.flow_stats.read_bytes = 11;
+        statistics.data.flow_stats.read_keys = 2;
+        statistics.write.flow_stats.read_bytes = 7;
+        statistics.write.flow_stats.read_keys = 3;
+        statistics.lock.flow_stats.read_bytes = 100;
+        statistics.lock.flow_stats.read_keys = 100;
+        statistics.write.next = 4;
+        statistics.write.prev = 5;
+        statistics.write.processed_keys = 6;
+
+        tls_collect_read_flow(42, &statistics);
+        tls_collect_read_flow(42, &statistics);
+        tls_flush(&reporter);
+
+        let read_stats = reporter.read_stats.lock().unwrap();
+        assert_eq!(read_stats.len(), stats_before + 1);
+        let region_info = read_stats.last().unwrap().region_infos.get(&42).unwrap();
+        assert_eq!(region_info.flow.read_bytes, 36);
+        assert_eq!(region_info.flow.read_keys, 10);
+        assert_eq!(region_info.cop_detail.next, 8);
+        assert_eq!(region_info.cop_detail.prev, 10);
+        assert_eq!(region_info.cop_detail.processed_keys, 12);
+        drop(read_stats);
+
+        tls_collect_read_flow(43, &Statistics::default());
+        let mut cop_only_statistics = Statistics::default();
+        cop_only_statistics.write.next = 1;
+        tls_collect_read_flow(43, &cop_only_statistics);
+        tls_flush(&reporter);
+        let read_stats = reporter.read_stats.lock().unwrap();
+        assert_eq!(read_stats.len(), stats_before + 2);
+        assert_eq!(
+            read_stats.last().unwrap().region_infos[&43].cop_detail.next,
+            1
+        );
+        drop(read_stats);
+
+        tls_flush(&reporter);
+        assert_eq!(reporter.read_stats.lock().unwrap().len(), stats_before + 2);
+    }
 }
 
 #[cfg(test)]

--- a/src/storage/txn/sched_pool.rs
+++ b/src/storage/txn/sched_pool.rs
@@ -455,6 +455,11 @@ pub fn tls_can_enable(feature: Feature) -> bool {
 }
 
 #[cfg(test)]
+pub fn set_tls_feature_gate(feature_gate: FeatureGate) {
+    TLS_FEATURE_GATE.with(|f| *f.borrow_mut() = feature_gate);
+}
+
+#[cfg(test)]
 mod tests {
     use std::sync::{Arc, Mutex};
 
@@ -522,9 +527,4 @@ mod tests {
         tls_flush(&reporter);
         assert_eq!(reporter.read_stats.lock().unwrap().len(), stats_before + 2);
     }
-}
-
-#[cfg(test)]
-pub fn set_tls_feature_gate(feature_gate: FeatureGate) {
-    TLS_FEATURE_GATE.with(|f| *f.borrow_mut() = feature_gate);
 }

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -87,7 +87,9 @@ use crate::{
             },
             flow_controller::FlowController,
             latch::{Latches, Lock},
-            sched_pool::{SchedPool, tls_collect_query, tls_collect_scan_details},
+            sched_pool::{
+                SchedPool, tls_collect_query, tls_collect_read_flow, tls_collect_scan_details,
+            },
             tracker::TlsFutureTracker,
             txn_status_cache::TxnStatusCache,
         },
@@ -1380,6 +1382,7 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
             } else {
                 record_logical_write_bytes(task.cmd().write_bytes() as u64);
                 self.process_write(snapshot, task, &mut sched_details).await;
+                tls_collect_read_flow(region_id, &sched_details.stat);
             };
             tls_collect_scan_details(tag.get_str(), &sched_details.stat);
             let elapsed = sched_details.start_instant.saturating_elapsed();


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: close #18870

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Collect MVCC read flow and write-CF coprocessor details from non-readonly
transaction scheduler commands and report region-level ReadStats to PD.

Foreground write commands can perform substantial reads while updating MVCC
state. Include their default-CF and write-CF read bytes and keys in the
existing FlowStatsReporter path so load-based read hotspot scheduling sees the
traffic. Flush the thread-local scheduler statistics on the normal ticker and
worker shutdown paths. The scheduler reports at region granularity because it
does not have key-range or bucket metadata.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Manual test:

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check -p tikv --lib`
- `cargo test -p tikv --lib storage::txn::sched_pool::tests::test_collect_read_flow_and_flush -- --nocapture`
- `cargo test -p tikv --lib storage::txn::scheduler::tests -- --nocapture`

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Report storage reads performed by foreground write commands to PD so load-based read hotspot scheduling can account for the resulting read traffic.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Region read-flow reporting now includes reads generated by foreground write operations.
  * Read statistics include read bytes, read keys, and write-CF coprocessor activity.
  * Statistics are aggregated by region and reported during regular and shutdown flushes.

* **Documentation**
  * Added guidance for interpreting region read-flow discrepancies.
  * Documented limitations, including unavailable key-range and bucket-delta details.

* **Tests**
  * Added coverage for aggregation, filtering, coprocessor-only statistics, and flushing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->