### PR TITLE
resource_control: penalize only the noisiest groups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10033,7 +10033,7 @@ checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 [[package]]
 name = "yatp"
 version = "0.0.1"
-source = "git+https://github.com/tikv/yatp.git?branch=master#9fcf102bfcc3acaa0d992b018ada7593deb04d97"
+source = "git+https://github.com/tikv/yatp.git?branch=master#1a2f56b52ca57cce4bb7825f706b073977a72098"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-skiplist 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/resource_control/Cargo.toml
+++ b/components/resource_control/Cargo.toml
@@ -30,7 +30,7 @@ slog-global = { workspace = true }
 strum = { version = "0.20", features = ["derive"] }
 tikv_util = { workspace = true }
 tokio-timer = { workspace = true }
-yatp = { git = "https://github.com/tikv/yatp.git", branch = "master" }
+yatp = { workspace = true }
 
 [dev-dependencies]
 file_system = { workspace = true, features = ["testexport"] }

--- a/components/resource_control/src/config.rs
+++ b/components/resource_control/src/config.rs
@@ -12,6 +12,8 @@ pub struct Config {
     #[online_config(skip)]
     pub enabled: bool,
     pub priority_ctl_strategy: PriorityCtlStrategy,
+    /// How `select_noisy_groups` decides which groups caused an overload.
+    pub noisy_detection: NoisyDetection,
     /// CPU utilization percentage at which background task throttling begins.
     /// Background budget scales linearly from full down to zero between this
     /// value and fg_cpu_throttle_threshold.
@@ -70,6 +72,25 @@ pub struct Config {
     /// (SchedTooBusy) rather than delayed. Set to 0 to disable the limit
     /// (unlimited delayed requests). Default: 10_000.
     pub admission_max_delayed_count: u64,
+    /// RU charged to a group for every request that arrives, on top of the CPU
+    /// that request's execution consumes.
+    ///
+    /// Charged at gRPC handler entry, before admission control, so a rejected
+    /// request pays it too. That is the point: a rejection consumes no read
+    /// pool CPU, so without this it is free, and throttling a group drops its
+    /// measured RU, which relaxes the throttle while the group keeps loading
+    /// the node. No request is free in reality -- each costs the gRPC
+    /// transport a message in and a message out, which resource control
+    /// cannot otherwise see. Foreground RU is CPU microseconds, so this is in
+    /// microseconds. Set to 0 to disable.
+    ///
+    /// The default is taken from published gRPC performance benchmarks: a
+    /// tuned server costs on the order of 45-65us of CPU for a small unary
+    /// call on one allocated core (grpc_bench). That is a floor, not this
+    /// cluster's real cost -- measured client-attributable gRPC CPU is nearer
+    /// 140us per request -- chosen so this term stays small beside the ~180us
+    /// a read already consumes in the read pool.
+    pub request_base_cost_micros: u64,
 }
 
 impl Default for Config {
@@ -77,6 +98,7 @@ impl Default for Config {
         Self {
             enabled: true,
             priority_ctl_strategy: PriorityCtlStrategy::Moderate,
+            noisy_detection: NoisyDetection::Baseline,
             bg_cpu_throttle_threshold: 60.0,
             fg_cpu_throttle_threshold: 70.0,
             bg_compaction_pressure_threshold: 70.0,
@@ -88,6 +110,7 @@ impl Default for Config {
             historical_usage_window_mins: 15,
             baseline_burst_pct: 20.0,
             admission_max_delayed_count: 10_000,
+            request_base_cost_micros: 40,
         }
     }
 }
@@ -96,6 +119,7 @@ const MIN_CPU_PCT: f64 = 1.0;
 const MAX_CPU_PCT: f64 = 99.0;
 const MIN_HISTORICAL_WINDOW_MINS: u64 = 2;
 const MAX_HISTORICAL_WINDOW_MINS: u64 = 60;
+const MAX_REQUEST_BASE_COST_MICROS: u64 = 10_000;
 
 fn validate_cpu_pct(name: &str, value: f64) -> Result<(), Box<dyn Error>> {
     // `!is_finite()` also rejects NaN, which would otherwise compare false
@@ -157,7 +181,63 @@ impl Config {
             .into());
         }
 
+        // Arrival is a fraction of a request's cost, never a multiple of one.
+        // The cap keeps a fat-fingered value from swamping measured execution
+        // CPU, which would throttle every group by request rate alone.
+        if self.request_base_cost_micros > MAX_REQUEST_BASE_COST_MICROS {
+            return Err(format!(
+                "resource-control.request-base-cost-micros must not exceed {}, but got {}",
+                MAX_REQUEST_BASE_COST_MICROS, self.request_base_cost_micros
+            )
+            .into());
+        }
+
         Ok(())
+    }
+}
+
+/// Which signal identifies the groups responsible for an overload.
+#[derive(Clone, Copy, Default, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum NoisyDetection {
+    /// Blame the groups furthest above their own quiet-window baseline. Picks
+    /// out the group that *changed*, so a tenant that is simply large is not
+    /// blamed for an overload someone else caused.
+    #[default]
+    Baseline,
+    /// Blame the groups consuming most right now, ignoring history. No
+    /// baseline to go stale or to be measured wrong, but a tenant that is
+    /// legitimately the largest is the one blamed every time.
+    CurrentUsage,
+}
+
+impl fmt::Display for NoisyDetection {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match *self {
+            Self::Baseline => "baseline",
+            Self::CurrentUsage => "current-usage",
+        })
+    }
+}
+
+impl From<NoisyDetection> for ConfigValue {
+    fn from(v: NoisyDetection) -> Self {
+        ConfigValue::String(format!("{}", v))
+    }
+}
+
+impl TryFrom<ConfigValue> for NoisyDetection {
+    type Error = String;
+    fn try_from(v: ConfigValue) -> Result<Self, Self::Error> {
+        if let ConfigValue::String(s) = v {
+            match s.as_str() {
+                "baseline" => Ok(Self::Baseline),
+                "current-usage" => Ok(Self::CurrentUsage),
+                s => Err(format!("invalid config value: {}", s)),
+            }
+        } else {
+            panic!("expect ConfigValue::String, got: {:?}", v);
+        }
     }
 }
 

--- a/components/resource_control/src/config.rs
+++ b/components/resource_control/src/config.rs
@@ -3,7 +3,9 @@ use std::{error::Error, fmt, sync::Arc};
 
 use online_config::{ConfigManager, ConfigValue, OnlineConfig};
 use serde::{Deserialize, Serialize};
-use tikv_util::config::{ReadableSize, VersionTrack};
+use tikv_util::config::ReadableSize;
+
+use crate::ResourceGroupManager;
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug, OnlineConfig)]
 #[serde(default)]
@@ -302,12 +304,12 @@ impl TryFrom<ConfigValue> for PriorityCtlStrategy {
 }
 
 pub struct ResourceContrlCfgMgr {
-    config: Arc<VersionTrack<Config>>,
+    resource_ctl: Arc<ResourceGroupManager>,
 }
 
 impl ResourceContrlCfgMgr {
-    pub fn new(config: Arc<VersionTrack<Config>>) -> Self {
-        Self { config }
+    pub fn new(resource_ctl: Arc<ResourceGroupManager>) -> Self {
+        Self { resource_ctl }
     }
 }
 
@@ -316,8 +318,11 @@ impl ConfigManager for ResourceContrlCfgMgr {
         let cfg_str = format!("{:?}", change);
         // `ConfigController::update` already validated the whole TikvConfig,
         // including this submodule, before dispatching.
-        let res = self.config.update(|c| c.update(change));
+        let res = self.resource_ctl.get_config().update(|c| c.update(change));
         if res.is_ok() {
+            // The per-request path reads some of these from a cache outside
+            // the config lock.
+            self.resource_ctl.refresh_cached_config();
             tikv_util::info!("update resource control config"; "change" => cfg_str);
         }
         res
@@ -419,8 +424,8 @@ mod tests {
 
     #[test]
     fn test_config_manager_applies_valid_update() {
-        let tracker = Arc::new(VersionTrack::new(Config::default()));
-        let mut mgr = ResourceContrlCfgMgr::new(tracker.clone());
+        let resource_ctl = Arc::new(ResourceGroupManager::new(Config::default()));
+        let mut mgr = ResourceContrlCfgMgr::new(resource_ctl.clone());
 
         let mut change = ConfigChange::new();
         change.insert(
@@ -429,6 +434,28 @@ mod tests {
         );
         mgr.dispatch(change).unwrap();
 
-        assert_eq!(tracker.value().fg_cpu_throttle_threshold, 90.0);
+        assert_eq!(
+            resource_ctl.get_config().value().fg_cpu_throttle_threshold,
+            90.0
+        );
+    }
+
+    /// The per-request path reads the arrival cost from a cache outside the
+    /// config lock, so dispatching a change has to refresh it -- otherwise the
+    /// knob would not take effect until the next 10s control tick.
+    #[test]
+    fn test_config_manager_refreshes_cached_request_base_cost() {
+        let resource_ctl = Arc::new(ResourceGroupManager::new(Config::default()));
+        let mut mgr = ResourceContrlCfgMgr::new(resource_ctl.clone());
+
+        let mut change = ConfigChange::new();
+        change.insert("request_base_cost_micros".to_owned(), ConfigValue::U64(0));
+        mgr.dispatch(change).unwrap();
+
+        assert_eq!(
+            resource_ctl.get_config().value().request_base_cost_micros,
+            0
+        );
+        assert_eq!(resource_ctl.cached_request_base_cost_micros(), 0);
     }
 }

--- a/components/resource_control/src/lib.rs
+++ b/components/resource_control/src/lib.rs
@@ -7,8 +7,8 @@ use pd_client::RpcClient;
 
 mod resource_group;
 pub use resource_group::{
-    AdmissionDecision, DelaySlotGuard, MIN_PRIORITY_UPDATE_INTERVAL, ResourceConsumeType,
-    ResourceController, ResourceGroupManager,
+    AdmissionDecision, CONTROL_TICK, DelaySlotGuard, LEEWAY_FRACTION, LEEWAY_PCT,
+    MIN_PRIORITY_UPDATE_INTERVAL, ResourceConsumeType, ResourceController, ResourceGroupManager,
 };
 pub use tikv_util::resource_control::*;
 
@@ -29,7 +29,7 @@ pub mod config;
 mod resource_limiter;
 pub use resource_limiter::ResourceLimiter;
 use tikv_util::worker::Worker;
-use worker::{GroupQuotaAdjustWorker, QUOTA_ADJUST_DURATION};
+use worker::GroupQuotaAdjustWorker;
 
 mod metrics;
 pub use metrics::READ_POOL_CPU_VEC;
@@ -72,7 +72,7 @@ pub fn start_periodic_tasks(
     // We disable the priority worker by default because the current adjust
     // algorithm is buggy. We may reenable it only we find a better algorithm.
     // let mut priority_worker = PriorityLimiterAdjustWorker::new(mgr.clone());
-    bg_worker.spawn_interval_task(QUOTA_ADJUST_DURATION, move || {
+    bg_worker.spawn_interval_task(CONTROL_TICK, move || {
         worker.adjust_quota();
         // priority_worker.adjust();
     });

--- a/components/resource_control/src/lib.rs
+++ b/components/resource_control/src/lib.rs
@@ -7,7 +7,7 @@ use pd_client::RpcClient;
 
 mod resource_group;
 pub use resource_group::{
-    AdmissionDecision, CONTROL_TICK, DelaySlotGuard, LEEWAY_FRACTION, LEEWAY_PCT,
+    AdmissionDecision, CONTROL_TICK, DelaySlotGuard, LEEWAY_FACTOR, LEEWAY_FRACTION,
     MIN_PRIORITY_UPDATE_INTERVAL, ResourceConsumeType, ResourceController, ResourceGroupManager,
 };
 pub use tikv_util::resource_control::*;

--- a/components/resource_control/src/metrics.rs
+++ b/components/resource_control/src/metrics.rs
@@ -64,6 +64,13 @@ lazy_static! {
     )
     .unwrap();
 
+    pub static ref GROUP_RU_BASELINE: GaugeVec = register_gauge_vec!(
+        "tikv_resource_control_group_ru_baseline",
+        "Quiet-window baseline per resource group, as CPU utilization %. 0 means no quiet window has elapsed yet, which is also what the eligibility gate compares against, so any traffic is over it",
+        &["resource_group"]
+    )
+    .unwrap();
+
     pub static ref GROUP_QUOTA_LIMIT_VEC: GaugeVec = register_gauge_vec!(
         "tikv_resource_control_group_quota_limit",
         "Current rate limit per resource group per resource type (CPU as utilization %, 0 means unlimited)",
@@ -99,7 +106,7 @@ lazy_static! {
 
     pub static ref READ_POOL_CPU_VEC: GaugeVec = register_gauge_vec!(
         "tikv_resource_control_read_pool_cpu_percent",
-        "Unified read pool CPU usage as a percentage of one core (100 = 1 core): historical (floor), current (measured), and target (foreground-pressure-driven ceiling)",
+        "Unified read pool CPU usage as a percentage of one core (100 = 1 core): historical (live sliding average), baseline (floor frozen at overload onset, 0 when not frozen), current (measured), and target (foreground-pressure-driven ceiling)",
         &["type"]
     )
     .unwrap();
@@ -112,11 +119,21 @@ lazy_static! {
     .unwrap();
 }
 
+/// Drops the per-tick gauges for an evicted tracker; without this they keep
+/// reporting its last value. Gauges only, so a returning group is not a reset.
+pub fn deregister_tracker_gauges(name: &str) {
+    _ = GROUP_RU_HISTORICAL_RATE.remove_label_values(&[name]);
+    _ = GROUP_RU_CURRENT_RATE.remove_label_values(&[name]);
+    _ = GROUP_RU_BASELINE.remove_label_values(&[name]);
+    _ = GROUP_QUOTA_LIMIT_VEC.remove_label_values(&[name, "cpu"]);
+}
+
 pub fn deregister_metrics(name: &str) {
     _ = TWO_PHASE_THROTTLED_REQUESTS.remove_label_values(&[name]);
     _ = GROUP_QUOTA_LIMIT_VEC.remove_label_values(&[name, "cpu"]);
     _ = GROUP_RU_HISTORICAL_RATE.remove_label_values(&[name]);
     _ = GROUP_RU_CURRENT_RATE.remove_label_values(&[name]);
+    _ = GROUP_RU_BASELINE.remove_label_values(&[name]);
     _ = ADMISSION_DELAYED_REQUESTS.remove_label_values(&[name]);
     _ = ADMISSION_REJECTED_REQUESTS.remove_label_values(&[name]);
     _ = ADMISSION_DELAY_DURATION.remove_label_values(&[name]);

--- a/components/resource_control/src/resource_group.rs
+++ b/components/resource_control/src/resource_group.rs
@@ -32,6 +32,7 @@ use crate::{
     metrics,
     metrics::{TWO_PHASE_THROTTLED_REQUESTS, deregister_metrics},
     resource_limiter::{ResourceLimiter, ResourceType},
+    score::PEAK_CPU_PCT,
 };
 
 // a read task cost at least 50us.
@@ -690,8 +691,52 @@ impl ResourceGroupManager {
         self.adjust_group_scheduling(cpu_score);
     }
 
-    /// Per-group CPU rate-limit throttling. Only groups whose current rate
-    /// exceeds their historical rate are limited.
+    /// Picks the groups responsible for the current overload.
+    ///
+    /// Every group whose current rate sits above its own burst target is a
+    /// candidate, but only the biggest movers are selected: candidates are
+    /// sorted by absolute excess over their own baseline and taken from the
+    /// top until that excess covers `PEAK_CPU_PCT -
+    /// fg_cpu_throttle_threshold` percent of total usage across all groups.
+    /// A tenant that grew 2× is therefore left alone while one that grew 10×
+    /// is penalized. The top candidate is always selected, so an overloaded
+    /// node never ends a tick having spared every group.
+    fn select_noisy_groups(&self, now: u64) -> HashSet<String> {
+        let cfg = self.config.value();
+        let burst_factor = 1.0 + cfg.baseline_burst_pct / 100.0;
+        let overshoot_pct = (PEAK_CPU_PCT - cfg.fg_cpu_throttle_threshold).max(0.0);
+
+        let mut total_usage = 0.0;
+        // (group, excess over its own baseline)
+        let mut candidates: Vec<(String, f64)> = Vec::new();
+        for entry in &self.ru_trackers {
+            let guard = entry.lock().unwrap();
+            let hist = guard.0.cached_historical_rate;
+            let current = guard.0.current_rate(now);
+            drop(guard);
+            total_usage += current;
+            if hist > 0.0 && current > hist * burst_factor {
+                candidates.push((entry.key().clone(), current - hist));
+            }
+        }
+        candidates.sort_unstable_by(|a, b| b.1.total_cmp(&a.1));
+
+        let target = total_usage * overshoot_pct / 100.0;
+        let mut selected = HashSet::with_capacity(candidates.len());
+        let mut excess_sum = 0.0;
+        for (name, excess) in candidates {
+            if !selected.is_empty() && excess_sum >= target {
+                break;
+            }
+            excess_sum += excess;
+            selected.insert(name);
+        }
+        selected
+    }
+
+    /// Per-group CPU rate-limit throttling. Only the noisy groups picked by
+    /// [`Self::select_noisy_groups`] are limited; a group over its own
+    /// baseline that is not among the biggest movers is left alone.
     ///
     /// Ramp-up: when CPU drops below threshold, recover ×1.1/tick until
     /// NO_LIMIT is restored.
@@ -722,7 +767,11 @@ impl ResourceGroupManager {
 
         let engaged = cpu_score > throttle_threshold && self.is_bg_cpu_at_floor();
         if engaged {
+            let noisy = self.select_noisy_groups(now);
             for entry in &self.ru_trackers {
+                if !noisy.contains(entry.key()) {
+                    continue;
+                }
                 let mut guard = entry.lock().unwrap();
                 let hist = guard.0.cached_historical_rate;
                 let burst_target = hist * burst_factor;
@@ -816,10 +865,10 @@ impl ResourceGroupManager {
             .store(cpu_score < leeway_threshold, Ordering::Relaxed);
     }
 
-    /// Marks resource groups that have exceeded their own quota (current
-    /// rate over their historical baseline by more than `baseline_burst_pct`)
-    /// as over-quota (phase 1), deprioritizing them. A group within its
-    /// baseline is left untouched.
+    /// Marks the noisy resource groups picked by
+    /// [`Self::select_noisy_groups`] as over-quota (phase 1), deprioritizing
+    /// them. A group within its baseline — or over it but not among the
+    /// biggest movers — is left untouched.
     ///
     /// This function only ever sets the over-quota flag, never clears it —
     /// clearing is the caller's responsibility, once the unified read pool
@@ -833,18 +882,9 @@ impl ResourceGroupManager {
             return;
         }
         let now = RuTracker::now_secs();
-        let burst_factor = 1.0 + self.config.value().baseline_burst_pct / 100.0;
-        for entry in &self.ru_trackers {
-            let group_bytes = entry.key().as_bytes();
-            let guard = entry.value().lock().unwrap();
-            let hist = guard.0.cached_historical_rate;
-            let current = guard.0.current_rate(now);
-            let over_quota = hist > 0.0 && current > hist * burst_factor;
-            drop(guard);
-            if over_quota {
-                for controller in self.registry.read().iter() {
-                    controller.set_group_phase(group_bytes, true);
-                }
+        for name in self.select_noisy_groups(now) {
+            for controller in self.registry.read().iter() {
+                controller.set_group_phase(name.as_bytes(), true);
             }
         }
     }
@@ -1567,10 +1607,7 @@ pub(crate) mod tests {
     use yatp::queue::Extras;
 
     use super::*;
-    use crate::{
-        resource_limiter::ResourceType::{Cpu, Io},
-        score::TARGET_CPU,
-    };
+    use crate::resource_limiter::ResourceType::{Cpu, Io};
 
     pub fn new_resource_group_ru(name: String, ru: u64, group_priority: u32) -> PbResourceGroup {
         new_resource_group(name, true, ru, ru, group_priority)
@@ -2096,6 +2133,67 @@ pub(crate) mod tests {
         assert!(high_phase1 < low_phase0);
     }
 
+    // Inserts a tracker whose current rate is `current` and whose cached
+    // baseline is `hist`, both in RU/s.
+    fn seed_tracker(mgr: &ResourceGroupManager, name: &str, hist: f64, current: f64, t0: u64) {
+        let e = mgr.ru_trackers.entry(name.to_owned()).or_insert_with(|| {
+            Mutex::new((
+                RuTracker::new(t0, 30),
+                Arc::new(ResourceLimiter::new(
+                    name.into(),
+                    f64::INFINITY,
+                    f64::INFINITY,
+                    0,
+                    false,
+                )),
+            ))
+        });
+        let mut tr = e.lock().unwrap();
+        tr.0.record_at((current * RU_BUCKET_SECS as f64) as u64, t0);
+        tr.0.cached_historical_rate = hist;
+        assert!((tr.0.current_rate(t0) - current).abs() < 1.0);
+    }
+
+    #[test]
+    fn test_select_noisy_groups_prefers_biggest_movers() {
+        // Default threshold 70 → target reduction is 20% of total usage.
+        // "noisy" alone covers that, so "mild" is spared even though it is
+        // over its own burst target.
+        let mgr = ResourceGroupManager::new(Config::default());
+        let t0 = RuTracker::now_secs();
+        seed_tracker(&mgr, "noisy", 100.0, 3000.0, t0);
+        seed_tracker(&mgr, "mild", 500.0, 1000.0, t0);
+        seed_tracker(&mgr, "steady", 1000.0, 1000.0, t0);
+
+        let selected = mgr.select_noisy_groups(t0);
+        assert!(selected.contains("noisy"), "biggest mover must be selected");
+        assert!(
+            !selected.contains("mild"),
+            "2x mover must be spared once the 10x mover covers the target"
+        );
+        assert!(
+            !selected.contains("steady"),
+            "within burst target → never a candidate"
+        );
+    }
+
+    #[test]
+    fn test_select_noisy_groups_always_takes_top_candidate() {
+        // No single group can cover the target, so selection walks down the
+        // sorted list; the group within its burst target stays out.
+        let mgr = ResourceGroupManager::new(Config::default());
+        let t0 = RuTracker::now_secs();
+        seed_tracker(&mgr, "mild", 500.0, 1000.0, t0);
+        seed_tracker(&mgr, "steady", 1000.0, 1000.0, t0);
+
+        let selected = mgr.select_noisy_groups(t0);
+        assert!(
+            selected.contains("mild"),
+            "the only candidate must still be penalized"
+        );
+        assert!(!selected.contains("steady"));
+    }
+
     #[test]
     fn test_deprioritize_over_quota_groups_ru_based() {
         // Two-phase scheduling driven by real RU (CPU µs) from
@@ -2430,7 +2528,7 @@ pub(crate) mod tests {
 
         // Pressure is still tracked (adjust_group_scheduling is not gated)...
         mgr.set_bg_cpu_at_floor(true);
-        mgr.online_adjust_resource_quota(TARGET_CPU);
+        mgr.online_adjust_resource_quota(PEAK_CPU_PCT);
         assert_eq!(mgr.read_pool_cpu_pressure(), 1.0);
 
         // ...but it must not turn into a ceiling, or hold back scale-out.
@@ -2492,9 +2590,9 @@ pub(crate) mod tests {
         cfg.enable_fair_scheduling = true;
         let mgr = ResourceGroupManager::new(cfg);
         // Seed a historical floor of 0 cores (cold tracker), then engage
-        // pressure (cpu_score == TARGET_CPU).
+        // pressure (cpu_score == PEAK_CPU_PCT).
         mgr.set_bg_cpu_at_floor(true);
-        mgr.online_adjust_resource_quota(TARGET_CPU);
+        mgr.online_adjust_resource_quota(PEAK_CPU_PCT);
         assert_eq!(mgr.read_pool_cpu_pressure(), 1.0);
 
         // Once engaged, the ceiling is 10% below the currently measured

--- a/components/resource_control/src/resource_group.rs
+++ b/components/resource_control/src/resource_group.rs
@@ -5,7 +5,7 @@ use std::{
     cmp::{max, min},
     collections::HashSet,
     sync::{
-        Arc, Mutex,
+        Arc, LockResult, Mutex, MutexGuard,
         atomic::{AtomicBool, AtomicI64, AtomicU64, Ordering},
     },
     time::{Duration, SystemTime, UNIX_EPOCH},
@@ -128,8 +128,9 @@ pub struct RuTracker {
     /// Ring buffer of completed 30-second bucket totals (oldest at `head`).
     buckets: Vec<u64>,
     /// RU accumulated in the currently-open (incomplete) bucket.
-    /// Atomic so that `record_ru_consumption` can add without taking the Mutex.
-    current_bucket: AtomicU64,
+    /// Atomic, and shared with the enclosing [`RuTrackerSlot`], so that
+    /// `record_ru_consumption` can add without taking the Mutex.
+    current_bucket: Arc<AtomicU64>,
     /// RU/s over the trailing 30-60 seconds, refreshed once per tick. See
     /// [`Self::current_rate`].
     cached_current_rate: f64,
@@ -166,7 +167,7 @@ impl RuTracker {
         let num_buckets = num_buckets.max(2); // need at least 2 to warm up
         Self {
             buckets: vec![0u64; num_buckets],
-            current_bucket: AtomicU64::new(0),
+            current_bucket: Arc::new(AtomicU64::new(0)),
             cached_current_rate: 0.0,
             bucket_start_secs: now_secs,
             head: 0,
@@ -190,6 +191,12 @@ impl RuTracker {
     #[inline]
     fn num_buckets(&self) -> usize {
         self.buckets.len()
+    }
+
+    /// The open-bucket counter, so a holder can add to it without reaching
+    /// through the Mutex. Only [`RuTrackerSlot::new`] needs this.
+    fn open_bucket_counter(&self) -> Arc<AtomicU64> {
+        self.current_bucket.clone()
     }
 
     /// Record `ru` in the current bucket (lock-free atomic add).
@@ -478,6 +485,42 @@ impl Drop for DelaySlotGuard {
 }
 
 /// ResourceGroupManager manages the metadata of each resource group.
+/// A group's sliding-window tracker together with its foreground limiter.
+///
+/// `open_bucket` is the tracker's own open-bucket counter, held out here so
+/// `record_ru_consumption` can add to it with a single atomic and no lock --
+/// which is what making that counter atomic was always for. The Mutex is
+/// still what the tick takes to advance buckets and read the derived rates.
+pub(crate) struct RuTrackerSlot {
+    open_bucket: Arc<AtomicU64>,
+    inner: Mutex<(RuTracker, Arc<ResourceLimiter>)>,
+}
+
+impl RuTrackerSlot {
+    fn new(tracker: RuTracker, limiter: Arc<ResourceLimiter>) -> Self {
+        Self {
+            open_bucket: tracker.open_bucket_counter(),
+            inner: Mutex::new((tracker, limiter)),
+        }
+    }
+
+    /// Add to the open bucket without taking the lock.
+    fn record(&self, ru: u64) {
+        self.open_bucket.fetch_add(ru, Ordering::Relaxed);
+    }
+
+    /// Deliberately the same shape as locking the Mutex directly, so every
+    /// caller that needs the tracker itself reads as it did before the
+    /// counter was lifted out.
+    fn lock(&self) -> LockResult<MutexGuard<'_, (RuTracker, Arc<ResourceLimiter>)>> {
+        self.inner.lock()
+    }
+
+    fn get_mut(&mut self) -> LockResult<&mut (RuTracker, Arc<ResourceLimiter>)> {
+        self.inner.get_mut()
+    }
+}
+
 pub struct ResourceGroupManager {
     pub(crate) resource_groups: DashMap<String, ResourceGroup>,
     // the count of all groups, a fast path because call `DashMap::len` is a little slower.
@@ -493,7 +536,7 @@ pub struct ResourceGroupManager {
     // Per-group sliding-window tracker and token-bucket limiter. The Arc
     // allows handing out limiter references to LimitedFuture wrappers in the
     // read/write pools without copying the limiter state.
-    ru_trackers: DashMap<String, Mutex<(RuTracker, Arc<ResourceLimiter>)>>,
+    ru_trackers: DashMap<String, RuTrackerSlot>,
     // Number of requests currently held in the admission-control delay phase.
     delayed_req_count: AtomicI64,
     // Unix seconds when this manager was created. Used to determine whether
@@ -862,20 +905,19 @@ impl ResourceGroupManager {
     /// Record `ru` units consumed by `group` into the sliding-window tracker
     /// and consume tokens from the group's rate limiter.
     pub fn record_ru_consumption(&self, group: &str, ru: u64) {
-        // Fast path: a shared shard read, no allocation, no config lock.
-        // `entry()` below takes the shard exclusively even when the key is
-        // already there, and needs an owned key to do it, so on the hot
-        // default group -- one key, every gRPC thread -- it would serialize
-        // what is otherwise a single atomic add.
+        // Fast path: a shared shard read and a single atomic add. `entry()`
+        // below takes the shard exclusively even when the key is already
+        // there, and needs an owned key to do it, so on the hot default group
+        // -- one key, every gRPC thread -- it would serialize this.
         if let Some(entry) = self.ru_trackers.get(group) {
-            entry.lock().unwrap().0.record(ru);
+            entry.record(ru);
             return;
         }
         let entry = self.ru_trackers.entry(group.to_owned()).or_insert_with(|| {
             // 2 buckets per minute (30s each) to match RU_BUCKET_SECS.
             let num_buckets =
                 (self.config.value().historical_usage_window_mins.max(2) as usize) * 2;
-            Mutex::new((
+            RuTrackerSlot::new(
                 RuTracker::new(RuTracker::now_secs(), num_buckets),
                 Arc::new(ResourceLimiter::new(
                     group.to_owned(),
@@ -884,12 +926,11 @@ impl ResourceGroupManager {
                     0,
                     false,
                 )),
-            ))
+            )
         });
-        // Lock-free: only atomically adds to current_bucket.
-        // advance() is called separately by online_adjust_resource_quota under the
-        // lock.
-        entry.lock().unwrap().0.record(ru);
+        // advance() is called separately by online_adjust_resource_quota
+        // under the lock.
+        entry.record(ru);
     }
 
     /// Called by the background adjust worker after computing the new
@@ -1451,7 +1492,7 @@ impl ResourceGroupManager {
         self.ru_trackers
             .entry(group.to_owned())
             .or_insert_with(|| {
-                Mutex::new((
+                RuTrackerSlot::new(
                     RuTracker::new(now, num_buckets),
                     Arc::new(ResourceLimiter::new(
                         group.to_owned(),
@@ -1460,7 +1501,7 @@ impl ResourceGroupManager {
                         0,
                         false,
                     )),
-                ))
+                )
             })
             .lock()
             .unwrap()
@@ -2535,7 +2576,7 @@ pub(crate) mod tests {
     // baseline is `hist`, both in RU/s.
     fn seed_tracker(mgr: &ResourceGroupManager, name: &str, hist: f64, current: f64, t0: u64) {
         let e = mgr.ru_trackers.entry(name.to_owned()).or_insert_with(|| {
-            Mutex::new((
+            RuTrackerSlot::new(
                 RuTracker::new(t0 - RU_BUCKET_SECS, 30),
                 Arc::new(ResourceLimiter::new(
                     name.into(),
@@ -2544,7 +2585,7 @@ pub(crate) mod tests {
                     0,
                     false,
                 )),
-            ))
+            )
         });
         let mut tr = e.lock().unwrap();
         // Recorded so the tracker is not idle, and so `retain` keeps it. The
@@ -3095,7 +3136,7 @@ pub(crate) mod tests {
                 .ru_trackers
                 .entry("steady".to_owned())
                 .or_insert_with(|| {
-                    Mutex::new((
+                    RuTrackerSlot::new(
                         RuTracker::new(t0, 30),
                         Arc::new(ResourceLimiter::new(
                             "".into(),
@@ -3104,7 +3145,7 @@ pub(crate) mod tests {
                             0,
                             false,
                         )),
-                    ))
+                    )
                 });
             let mut tr = e.lock().unwrap();
             tr.0.record_at(6000, t0 + 15);
@@ -3118,7 +3159,7 @@ pub(crate) mod tests {
                 .ru_trackers
                 .entry("spike".to_owned())
                 .or_insert_with(|| {
-                    Mutex::new((
+                    RuTrackerSlot::new(
                         RuTracker::new(t0, 30),
                         Arc::new(ResourceLimiter::new(
                             "".into(),
@@ -3127,7 +3168,7 @@ pub(crate) mod tests {
                             0,
                             false,
                         )),
-                    ))
+                    )
                 });
             let mut tr = e.lock().unwrap();
             tr.0.record_at(3000, t0 + 30);
@@ -3229,7 +3270,7 @@ pub(crate) mod tests {
                 .ru_trackers
                 .entry("spike".to_owned())
                 .or_insert_with(|| {
-                    Mutex::new((
+                    RuTrackerSlot::new(
                         RuTracker::new(t0, 30),
                         Arc::new(ResourceLimiter::new(
                             "".into(),
@@ -3238,7 +3279,7 @@ pub(crate) mod tests {
                             0,
                             false,
                         )),
-                    ))
+                    )
                 });
             let mut tr = e.lock().unwrap();
             tr.0.record_at(3000, t0 + 30);
@@ -3300,7 +3341,7 @@ pub(crate) mod tests {
                 .ru_trackers
                 .entry("spike".to_owned())
                 .or_insert_with(|| {
-                    Mutex::new((
+                    RuTrackerSlot::new(
                         RuTracker::new(t0, 30),
                         Arc::new(ResourceLimiter::new(
                             "".into(),
@@ -3309,7 +3350,7 @@ pub(crate) mod tests {
                             0,
                             false,
                         )),
-                    ))
+                    )
                 });
             let mut tr = e.lock().unwrap();
             tr.0.record_at(3000, t0 + 30);
@@ -3437,7 +3478,7 @@ pub(crate) mod tests {
                 .ru_trackers
                 .entry("spike".to_owned())
                 .or_insert_with(|| {
-                    Mutex::new((
+                    RuTrackerSlot::new(
                         RuTracker::new(t0, 30),
                         Arc::new(ResourceLimiter::new(
                             "".into(),
@@ -3446,7 +3487,7 @@ pub(crate) mod tests {
                             0,
                             false,
                         )),
-                    ))
+                    )
                 });
             let mut tr = e.lock().unwrap();
             tr.0.record_at(3000, t0 + 30);
@@ -4768,6 +4809,38 @@ pub(crate) mod tests {
 
         assert!(mgr.ru_trackers.get("never-configured").is_none());
         assert_eq!(open_bucket(&mgr, DEFAULT_RESOURCE_GROUP_NAME), 40);
+    }
+
+    /// The slot's lock-free counter and the tracker inside its Mutex have to
+    /// be the same counter, or a tick would flush a bucket that never saw the
+    /// arrival charges.
+    #[test]
+    fn test_slot_counter_is_the_trackers_own() {
+        let mgr = ResourceGroupManager::default();
+        mgr.record_ru_consumption("g", 9);
+
+        let entry = mgr.ru_trackers.get("g").unwrap();
+        // Written without the lock, read through it.
+        assert_eq!(
+            entry
+                .lock()
+                .unwrap()
+                .0
+                .current_bucket
+                .load(Ordering::Relaxed),
+            9
+        );
+        // And the other way round.
+        entry.lock().unwrap().0.record(5);
+        assert_eq!(entry.open_bucket.load(Ordering::Relaxed), 14);
+
+        // A tick flushing the bucket must see both.
+        entry
+            .lock()
+            .unwrap()
+            .0
+            .advance(RuTracker::now_secs() + RU_BUCKET_SECS);
+        assert_eq!(entry.open_bucket.load(Ordering::Relaxed), 0);
     }
 
     /// `record_ru_consumption` takes a shared-read fast path when the group is

--- a/components/resource_control/src/resource_group.rs
+++ b/components/resource_control/src/resource_group.rs
@@ -83,6 +83,20 @@ const THROTTLE_DECREASE_FACTOR: f64 = 0.9;
 /// Duration of each bucket in the RuTracker ring buffer.
 const RU_BUCKET_SECS: u64 = 30;
 
+/// How much a selected group is expected to give back, used to size the noisy
+/// set in [`ResourceGroupManager::select_noisy_groups`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum NoisyRelief {
+    /// Throttling clamps a group toward its own baseline, so only what it uses
+    /// above that baseline is recovered.
+    Excess,
+    /// Deprioritizing does not cap a group at its baseline — it puts all of the
+    /// group's tasks behind phase-0 work, so under contention its whole share
+    /// yields. Sizing the set by excess would select far more groups than the
+    /// relief requires.
+    Total,
+}
+
 /// Sliding-window RU consumption tracker for both Tier-1 admission control
 /// and two-phase scheduling phase decisions.
 ///
@@ -695,20 +709,26 @@ impl ResourceGroupManager {
     ///
     /// Every group whose current rate sits above its own burst target is a
     /// candidate, but only the biggest movers are selected: candidates are
-    /// sorted by absolute excess over their own baseline and taken from the
-    /// top until that excess covers `PEAK_CPU_PCT -
-    /// fg_cpu_throttle_threshold` percent of total usage across all groups.
-    /// A tenant that grew 2× is therefore left alone while one that grew 10×
-    /// is penalized. The top candidate is always selected, so an overloaded
-    /// node never ends a tick having spared every group.
-    fn select_noisy_groups(&self, now: u64) -> HashSet<String> {
+    /// sorted by absolute excess over their own baseline — the biggest movers
+    /// first — and taken from the top until the relief they provide covers
+    /// `PEAK_CPU_PCT - fg_cpu_throttle_threshold` percent of total usage across
+    /// all groups. A tenant that grew 2× is therefore left alone while one that
+    /// grew 10× is penalized. The top candidate is always selected, so an
+    /// overloaded node never ends a tick having spared every group.
+    ///
+    /// Ranking is always by excess, since that is what identifies the group
+    /// responsible for the change. `relief` only decides how much each selected
+    /// group is credited with giving back, which differs between throttling and
+    /// scheduling — see [`NoisyRelief`].
+
+    fn select_noisy_groups(&self, now: u64, relief: NoisyRelief) -> HashSet<String> {
         let cfg = self.config.value();
         let burst_factor = 1.0 + cfg.baseline_burst_pct / 100.0;
         let overshoot_pct = (PEAK_CPU_PCT - cfg.fg_cpu_throttle_threshold).max(0.0);
 
         let mut total_usage = 0.0;
-        // (group, excess over its own baseline)
-        let mut candidates: Vec<(String, f64)> = Vec::new();
+        // (group, excess over its own baseline, current rate)
+        let mut candidates: Vec<(String, f64, f64)> = Vec::new();
         for entry in &self.ru_trackers {
             let guard = entry.lock().unwrap();
             let hist = guard.0.cached_historical_rate;
@@ -716,19 +736,22 @@ impl ResourceGroupManager {
             drop(guard);
             total_usage += current;
             if hist > 0.0 && current > hist * burst_factor {
-                candidates.push((entry.key().clone(), current - hist));
+                candidates.push((entry.key().clone(), current - hist, current));
             }
         }
         candidates.sort_unstable_by(|a, b| b.1.total_cmp(&a.1));
 
         let target = total_usage * overshoot_pct / 100.0;
         let mut selected = HashSet::with_capacity(candidates.len());
-        let mut excess_sum = 0.0;
-        for (name, excess) in candidates {
-            if !selected.is_empty() && excess_sum >= target {
+        let mut relieved = 0.0;
+        for (name, excess, current) in candidates {
+            if !selected.is_empty() && relieved >= target {
                 break;
             }
-            excess_sum += excess;
+            relieved += match relief {
+                NoisyRelief::Excess => excess,
+                NoisyRelief::Total => current,
+            };
             selected.insert(name);
         }
         selected
@@ -767,7 +790,7 @@ impl ResourceGroupManager {
 
         let engaged = cpu_score > throttle_threshold && self.is_bg_cpu_at_floor();
         if engaged {
-            let noisy = self.select_noisy_groups(now);
+            let noisy = self.select_noisy_groups(now, NoisyRelief::Excess);
             for entry in &self.ru_trackers {
                 if !noisy.contains(entry.key()) {
                     continue;
@@ -867,8 +890,9 @@ impl ResourceGroupManager {
 
     /// Marks the noisy resource groups picked by
     /// [`Self::select_noisy_groups`] as over-quota (phase 1), deprioritizing
-    /// them. A group within its baseline — or over it but not among the
-    /// biggest movers — is left untouched.
+    /// them. Sized with [`NoisyRelief::Total`]: phase 1 yields a group's whole
+    /// share, not just the part above its baseline. A group within its baseline
+    /// — or over it but not among the biggest movers — is left untouched.
     ///
     /// This function only ever sets the over-quota flag, never clears it —
     /// clearing is the caller's responsibility, once the unified read pool
@@ -882,7 +906,7 @@ impl ResourceGroupManager {
             return;
         }
         let now = RuTracker::now_secs();
-        for name in self.select_noisy_groups(now) {
+        for name in self.select_noisy_groups(now, NoisyRelief::Total) {
             for controller in self.registry.read().iter() {
                 controller.set_group_phase(name.as_bytes(), true);
             }
@@ -2155,6 +2179,30 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn test_select_noisy_groups_relief_mode_sizes_the_set() {
+        // Four groups each 1.25x their own baseline: excess 20 apiece, current
+        // 100 apiece, total usage 400. Default threshold 70 → target is 20% of
+        // 400 = 80. Crediting excess needs all four to reach it; crediting the
+        // whole share, which is what phase 1 actually yields, needs one.
+        let mgr = ResourceGroupManager::new(Config::default());
+        let t0 = RuTracker::now_secs();
+        for name in ["g1", "g2", "g3", "g4"] {
+            seed_tracker(&mgr, name, 80.0, 100.0, t0);
+        }
+
+        assert_eq!(
+            mgr.select_noisy_groups(t0, NoisyRelief::Excess).len(),
+            4,
+            "excess credit only reclaims 20 per group, so the target needs all four"
+        );
+        assert_eq!(
+            mgr.select_noisy_groups(t0, NoisyRelief::Total).len(),
+            1,
+            "deprioritizing yields the whole 100, so one group covers the target"
+        );
+    }
+
+    #[test]
     fn test_select_noisy_groups_prefers_biggest_movers() {
         // Default threshold 70 → target reduction is 20% of total usage.
         // "noisy" alone covers that, so "mild" is spared even though it is
@@ -2165,7 +2213,7 @@ pub(crate) mod tests {
         seed_tracker(&mgr, "mild", 500.0, 1000.0, t0);
         seed_tracker(&mgr, "steady", 1000.0, 1000.0, t0);
 
-        let selected = mgr.select_noisy_groups(t0);
+        let selected = mgr.select_noisy_groups(t0, NoisyRelief::Excess);
         assert!(selected.contains("noisy"), "biggest mover must be selected");
         assert!(
             !selected.contains("mild"),
@@ -2186,7 +2234,7 @@ pub(crate) mod tests {
         seed_tracker(&mgr, "mild", 500.0, 1000.0, t0);
         seed_tracker(&mgr, "steady", 1000.0, 1000.0, t0);
 
-        let selected = mgr.select_noisy_groups(t0);
+        let selected = mgr.select_noisy_groups(t0, NoisyRelief::Excess);
         assert!(
             selected.contains("mild"),
             "the only candidate must still be penalized"

--- a/components/resource_control/src/resource_group.rs
+++ b/components/resource_control/src/resource_group.rs
@@ -28,7 +28,7 @@ use tikv_util::{
 use yatp::queue::priority::TaskPriorityProvider;
 
 use crate::{
-    config::Config,
+    config::{Config, NoisyDetection},
     metrics,
     metrics::{TWO_PHASE_THROTTLED_REQUESTS, deregister_metrics},
     resource_limiter::{ResourceLimiter, ResourceType},
@@ -57,45 +57,59 @@ const HIGH_PRIORITY: u32 = 16;
 // virtual time overflow.
 const RESET_VT_THRESHOLD: u64 = (u64::MAX >> 4) / 2;
 
-/// Fraction of `fg_cpu_throttle_threshold` below which foreground CPU
-/// pressure counts as cleared — a dead zone so tighten/release don't flap
-/// when `cpu_score` hovers near the threshold. Shared by
-/// [`ResourceGroupManager::adjust_group_throttling`] and
-/// [`ResourceGroupManager::adjust_group_scheduling`].
-///
-/// Must stay strictly less than [`THROTTLE_DECREASE_FACTOR`]: the tighten
-/// step below shrinks whatever's currently enforced by
-/// `1 - THROTTLE_DECREASE_FACTOR` each tick, so the leeway gap
-/// (`1 - LEEWAY_THRESHOLD_RATIO`) must stay larger than that per-tick step —
-/// otherwise a single tick could swing straight through the dead zone and
-/// the engaged/disengaged state — and the throttle it drives — would just
-/// toggle every tick instead of settling.
-const LEEWAY_THRESHOLD_RATIO: f64 = 0.85;
+/// Period of both control loops: the quota worker and the unified read pool's
+/// thread ladder. Independent timers, so the same period but unsynchronised
+/// phase — the read pool acts on a verdict up to one tick stale. Every `*_PCT`
+/// below is per this tick.
+pub const CONTROL_TICK: Duration = Duration::from_secs(10);
 
-/// Per-tick multiplicative step used to tighten the per-group CPU rate limit
-/// ([`ResourceGroupManager::adjust_group_throttling`]) and to ratchet down
-/// the read pool's CPU ceiling
-/// ([`ResourceGroupManager::compute_read_pool_target_cpu`]) once foreground
-/// CPU pressure is engaged. See [`LEEWAY_THRESHOLD_RATIO`] for the invariant
-/// this must satisfy relative to the leeway threshold.
-const THROTTLE_DECREASE_FACTOR: f64 = 0.9;
+/// Margin below a setpoint before a controller trusts there is room to expand:
+/// `measured < (1 - LEEWAY_FRACTION) * setpoint`. Shared by the foreground
+/// throttle's release gate, the read pool's scale-up permission and scale-out
+/// band, and the background idle gate.
+pub const LEEWAY_PCT: f64 = 10.0;
+pub const LEEWAY_FRACTION: f64 = LEEWAY_PCT / 100.0;
+
+/// How far below `fg_cpu_throttle_threshold` the node must sit for a group's
+/// sliding average to be trusted as its baseline. Above that mark the baseline
+/// is left alone, so it holds the last quiet reading for the whole episode.
+/// Stricter than [`LEEWAY_PCT`]: that decides when to hand capacity back, this
+/// decides when a sample is representative.
+const BASELINE_QUIET_PCT: f64 = 15.0;
+const BASELINE_QUIET_FACTOR: f64 = 1.0 - BASELINE_QUIET_PCT / 100.0;
+
+/// Per-tick step that tightens an enforced rate while pressure is engaged: the
+/// per-group CPU limit and the read pool's CPU ceiling. Larger than the
+/// increase step on purpose — react fast, restore slowly — so one engaged tick
+/// undoes about 1.7 recovery ticks. The background budget has no equivalent;
+/// it interpolates on pressure instead of stepping.
+const THROTTLE_DECREASE_PCT: f64 = 15.0;
+
+/// Per-tick step that gives an enforced rate back once pressure clears. Held
+/// at 10% so the ramp can finish: ~5 ticks to reach the `2x` baseline that
+/// lifts the limit, and any engaged tick in between resets that progress.
+const THROTTLE_INCREASE_PCT: f64 = 10.0;
+
+const THROTTLE_DECREASE_FACTOR: f64 = 1.0 - THROTTLE_DECREASE_PCT / 100.0;
+pub(crate) const THROTTLE_INCREASE_FACTOR: f64 = 1.0 + THROTTLE_INCREASE_PCT / 100.0;
+
+/// Consecutive loaded ticks a group must be over its own burst target before
+/// `select_noisy_groups` will blame it. The read pool needs no equivalent: its
+/// ceiling moves `THROTTLE_DECREASE_PCT` per tick, which is already gradual.
+const MIN_ENGAGE_TICKS: u32 = 2;
+
+/// A candidate whose excess is under this share of the worst offender's is
+/// tail, not cause. A ratio, so it holds at any scale.
+const TAIL_EXCESS_RATIO: f64 = 0.1;
 
 /// Duration of each bucket in the RuTracker ring buffer.
 const RU_BUCKET_SECS: u64 = 30;
 
-/// How much a selected group is expected to give back, used to size the noisy
-/// set in [`ResourceGroupManager::select_noisy_groups`].
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum NoisyRelief {
-    /// Throttling clamps a group toward its own baseline, so only what it uses
-    /// above that baseline is recovered.
-    Excess,
-    /// Deprioritizing does not cap a group at its baseline — it puts all of the
-    /// group's tasks behind phase-0 work, so under contention its whole share
-    /// yields. Sizing the set by excess would select far more groups than the
-    /// relief requires.
-    Total,
-}
+/// Floor the read pool's CPU ceiling never ratchets below, in cores. The
+/// counterpart of the 1 RU/s floor a throttled group gets: without a sampled
+/// quiet floor the target is only `THROTTLE_DECREASE_PCT` below current, which
+/// compounds toward zero and would leave the pool unable to serve anything.
+const MIN_READ_POOL_TARGET_CORES: f64 = 1.0;
 
 /// Sliding-window RU consumption tracker for both Tier-1 admission control
 /// and two-phase scheduling phase decisions.
@@ -112,6 +126,9 @@ pub struct RuTracker {
     /// RU accumulated in the currently-open (incomplete) bucket.
     /// Atomic so that `record_ru_consumption` can add without taking the Mutex.
     current_bucket: AtomicU64,
+    /// RU/s over the trailing 30-60 seconds, refreshed once per tick. See
+    /// [`Self::current_rate`].
+    cached_current_rate: f64,
     /// Unix seconds at which the current bucket started.
     bucket_start_secs: u64,
     /// Index of the oldest completed bucket.
@@ -124,6 +141,22 @@ pub struct RuTracker {
     /// Consecutive ramp-up epochs where new_limit >= 2x hist. Must reach
     /// MIN_RAMP_UP_EPOCHS before the limit is fully lifted to INFINITY.
     ramp_up_epochs: u32,
+    /// `cached_historical_rate` as of the last quiet window, in RU/s. The
+    /// clamp-down paths use it; the paths that let go use the live value,
+    /// which has climbed with the load and so keeps release conservative.
+    /// `None` until the first quiet window.
+    quiet_baseline: Option<f64>,
+    /// True while `adjust_group_throttling` holds a CPU rate limit on this
+    /// group.
+    throttle_backpressure: bool,
+    /// True while this group is deprioritized in the read scheduler.
+    scheduler_backpressure: bool,
+    /// Consecutive ticks over this group's own burst target, saturating at
+    /// `MIN_ENGAGE_TICKS`. See [`Self::sustained_over_baseline`].
+    over_baseline_ticks: u32,
+    /// When the current run of quiet ticks began, or `u64::MAX` if the last
+    /// tick was not quiet. See [`Self::refresh_quiet_baseline`].
+    quiet_since_secs: u64,
 }
 
 impl RuTracker {
@@ -133,11 +166,17 @@ impl RuTracker {
         Self {
             buckets: vec![0u64; num_buckets],
             current_bucket: AtomicU64::new(0),
+            cached_current_rate: 0.0,
             bucket_start_secs: now_secs,
             head: 0,
             completed: 0,
             cached_historical_rate: 0.0,
             ramp_up_epochs: 0,
+            quiet_baseline: None,
+            throttle_backpressure: false,
+            scheduler_backpressure: false,
+            over_baseline_ticks: 0,
+            quiet_since_secs: u64::MAX,
         }
     }
 
@@ -168,7 +207,7 @@ impl RuTracker {
     #[cfg(test)]
     pub fn record_at(&mut self, ru: u64, now_secs: u64) {
         self.advance(now_secs);
-        self.current_bucket.fetch_add(ru, Ordering::Relaxed);
+        self.record(ru);
     }
 
     fn advance(&mut self, now_secs: u64) {
@@ -193,7 +232,6 @@ impl RuTracker {
             } else {
                 self.head = (self.head + 1) % n;
             }
-            // Zero out the remaining (buckets_to_advance - 1) slots.
             for _ in 1..buckets_to_advance {
                 let slot = (self.head + self.completed) % n;
                 self.buckets[slot] = 0;
@@ -207,32 +245,44 @@ impl RuTracker {
         self.bucket_start_secs += buckets_to_advance as u64 * RU_BUCKET_SECS;
     }
 
-    /// RU/s rate estimated from the current partial bucket and the most recent
-    /// completed bucket. Using both avoids stale readings — the last completed
-    /// bucket alone can be up to 60s old at the end of the current 30s window.
-    ///
-    /// rate = (current_bucket + last_completed) / (elapsed_in_current + 30s)
-    pub fn current_rate(&self, now_secs: u64) -> f64 {
-        let elapsed = now_secs
-            .saturating_sub(self.bucket_start_secs)
-            .min(RU_BUCKET_SECS) as f64;
-        let last_completed = if self.completed > 0 {
-            let newest_slot = (self.head + self.completed - 1) % self.num_buckets();
-            self.buckets[newest_slot]
-        } else {
-            0
-        };
-        let window = elapsed + RU_BUCKET_SECS as f64;
-        (self.current_bucket.load(Ordering::Relaxed) + last_completed) as f64 / window
+    /// RU/s over the trailing 30-60 seconds, sampled by
+    /// [`Self::refresh_cached_current_rate`]. A getter, so either clock that
+    /// reaches `select_noisy_groups` may call it freely; the read pool's sees
+    /// it one tick stale, as it already does the baseline.
+    #[inline]
+    pub fn current_rate(&self) -> f64 {
+        self.cached_current_rate
     }
 
-    /// Average RU/s rate over all completed buckets (long-term baseline).
-    /// Average RU/s baseline. If the system has been up longer than the full
-    /// historical window, always divide by the full window (not just completed
-    /// buckets). This means a tracker that just started (e.g. spike with no
-    /// prior traffic) has historical=0 and any traffic is immediately detected
-    /// as over baseline, rather than letting new traffic inflate its own
-    /// baseline.
+    /// The newest closed bucket plus the one still filling, over the time the
+    /// two actually cover. The window slides between 30 and 60 seconds and
+    /// always ends at `now`, so a single tick of traffic cannot swing the
+    /// verdict, and traffic that has not yet closed a bucket is still visible.
+    ///
+    /// Idempotent, unlike the per-tick delta this replaced: a second caller in
+    /// the same tick reads the same value rather than a consumed one.
+    pub fn refresh_cached_current_rate(&mut self, now_secs: u64) {
+        let open = self.current_bucket.load(Ordering::Relaxed);
+        // Clamped because a caller that has not advanced the ring would
+        // otherwise divide by a window the buckets do not cover.
+        let open_secs = now_secs
+            .saturating_sub(self.bucket_start_secs)
+            .min(RU_BUCKET_SECS);
+        self.cached_current_rate = if self.completed == 0 {
+            // No closed bucket yet: measure the open one alone rather than
+            // report zero, so a group's first traffic is not invisible.
+            open as f64 / open_secs.max(1) as f64
+        } else {
+            let n = self.num_buckets();
+            let closed = self.buckets[(self.head + self.completed - 1) % n];
+            (closed + open) as f64 / (RU_BUCKET_SECS + open_secs) as f64
+        };
+    }
+
+    /// Average RU/s baseline. Once the system has been up longer than the
+    /// window, always divides by the full window rather than by the completed
+    /// buckets, so a tracker that just started has historical = 0 and any
+    /// traffic reads as over baseline instead of inflating its own.
     pub fn historical_rate(&self, system_start_secs: u64, now_secs: u64) -> f64 {
         let window_secs = self.num_buckets() as u64 * RU_BUCKET_SECS;
         let system_uptime = now_secs.saturating_sub(system_start_secs);
@@ -262,6 +312,88 @@ impl RuTracker {
     /// entries.
     pub fn is_idle(&self) -> bool {
         self.current_bucket.load(Ordering::Relaxed) == 0 && self.buckets.iter().all(|&b| b == 0)
+    }
+
+    /// Takes the reference the clamp-down paths use, but only after a full
+    /// window of quiet ticks: above the gate the sliding average climbs with
+    /// the load it is used to judge, and for a window after an episode the
+    /// ring buffer still holds it, so a sample would come back inflated.
+    ///
+    /// A cold tracker is skipped: a zero here is indistinguishable from never
+    /// having had a quiet window, and the next quiet tick freezes a real value.
+    fn refresh_quiet_baseline(&mut self, quiet: bool, now: u64) {
+        if !quiet {
+            self.quiet_since_secs = u64::MAX;
+            return;
+        }
+        if self.quiet_since_secs == u64::MAX {
+            self.quiet_since_secs = now;
+        }
+        if now.saturating_sub(self.quiet_since_secs) >= self.window_secs()
+            && self.cached_historical_rate > 0.0
+        {
+            self.quiet_baseline = Some(self.cached_historical_rate);
+        }
+    }
+
+    /// Baseline the eligibility gate compares against: the last quiet reading,
+    /// or zero until there has been one. Zero, not the live sliding average --
+    /// that average climbs with the load it is being used to judge, so a group
+    /// ramping into an overload measures itself against its own spike and
+    /// stays inside the gate. Judged on raw usage instead, it ranks by what it
+    /// is actually consuming, which is what the biggest-mover ranking needs.
+    /// Also what `GROUP_RU_BASELINE` reports, so the panel cannot disagree
+    /// with the gate.
+    fn effective_baseline(&self) -> f64 {
+        self.quiet_baseline.unwrap_or(0.0)
+    }
+
+    /// Whether this group is over its own burst target right now.
+    fn is_over_burst_target(&self, burst_factor: f64) -> bool {
+        let current = self.current_rate();
+        current > 0.0 && current > self.effective_baseline() * burst_factor
+    }
+
+    /// Advances the candidacy counter, once per tick for every group. Load
+    /// matters as well as excess: on excess alone the counter sat saturated,
+    /// since a group above its trailing average stays there for minutes.
+    ///
+    /// `cleared`, not `!loaded`, is what wipes it — a score hovering on the
+    /// threshold would otherwise erase the evidence every other tick. A group
+    /// inside its own target still resets outright: that is evidence about the
+    /// group, not the node. Background reaching its floor is deliberately not a
+    /// condition; it gates whether an actuator may fire, not who is at fault.
+    fn update_over_baseline_ticks(&mut self, burst_factor: f64, loaded: bool, cleared: bool) {
+        if !self.is_over_burst_target(burst_factor) || cleared {
+            self.over_baseline_ticks = 0;
+        } else if loaded {
+            self.over_baseline_ticks = self
+                .over_baseline_ticks
+                .saturating_add(1)
+                .min(MIN_ENGAGE_TICKS);
+        }
+    }
+
+    /// Whether this group has been over its burst target long enough to be
+    /// blamed. One sample is not evidence.
+    fn sustained_over_baseline(&self) -> bool {
+        self.over_baseline_ticks >= MIN_ENGAGE_TICKS
+    }
+
+    /// Records whether a CPU rate limit is applied to this group.
+    fn set_throttle_backpressure(&mut self, on: bool) {
+        self.throttle_backpressure = on;
+    }
+
+    /// Records whether this group is deprioritized in the read scheduler.
+    fn set_scheduler_backpressure(&mut self, on: bool) {
+        self.scheduler_backpressure = on;
+    }
+
+    /// Span the ring buffer covers, in seconds: also how long an episode takes
+    /// to age out of it.
+    fn window_secs(&self) -> u64 {
+        self.num_buckets() as u64 * RU_BUCKET_SECS
     }
 
     /// Refresh the cached historical rate. Called periodically from
@@ -362,11 +494,9 @@ pub struct ResourceGroupManager {
     has_background: AtomicBool,
     // lastest config.
     config: Arc<VersionTrack<Config>>,
-    // Per-group RU consumption trackers for Tier-1 high-priority throttling.
-    // Per-group sliding-window tracker and token-bucket limiter.
-    // Rate on the limiter is set to `fraction × historical_rate` each tick.
-    // The Arc allows handing out limiter references to LimitedFuture wrappers
-    // in the read/write pools without copying the limiter state.
+    // Per-group sliding-window tracker and token-bucket limiter. The Arc
+    // allows handing out limiter references to LimitedFuture wrappers in the
+    // read/write pools without copying the limiter state.
     ru_trackers: DashMap<String, Mutex<(RuTracker, Arc<ResourceLimiter>)>>,
     // Number of requests currently held in the admission-control delay phase.
     delayed_req_count: AtomicI64,
@@ -379,24 +509,76 @@ pub struct ResourceGroupManager {
     // only engages when this flag is set, ensuring background is fully
     // squeezed before foreground traffic is touched.
     bg_cpu_at_floor: AtomicBool,
-    // Latest foreground CPU pressure (0.0-1.0), refreshed every tick by
-    // `online_adjust_resource_quota`. Consumed by the unified read pool to
-    // drive its thread-count scale-down decision. Encoded via `f64::to_bits`.
+    // Whether foreground CPU pressure is engaged, refreshed every tick by
+    // `online_adjust_resource_quota`. A plain 1.0/0.0 rather than a varying
+    // fraction, since the read pool only tests it against zero to drive its
+    // thread-count scale-down. Encoded via `f64::to_bits`.
     read_pool_cpu_pressure: AtomicU64,
-    // Sliding-window tracker of the unified read pool's actual CPU usage
-    // (in µs of CPU time per tick). Its `historical_rate()` is used as a
-    // floor: the read pool should never be scaled below the thread count
-    // needed to sustain its historical CPU consumption.
+    // Sliding-window tracker of the unified read pool's actual CPU usage (in
+    // µs of CPU time per tick). Its `quiet_baseline` is the floor: the pool
+    // should never be scaled below the thread count needed to sustain what it
+    // sustained while the node was quiet.
     read_pool_cpu_tracker: Mutex<RuTracker>,
     // True when the last `adjust_group_scheduling` tick saw cpu_score below
     // the leeway threshold, i.e. the system is comfortably idle and the
     // unified read pool may scale its thread count up toward its max.
     read_pool_scale_up_allowed: AtomicBool,
+    // The groups the last tick blamed. One writer, both actuators reading, so
+    // detection cannot run on two unsynchronised clocks.
+    noisy_groups: RwLock<HashSet<String>>,
 }
 
 impl Default for ResourceGroupManager {
     fn default() -> Self {
         Self::new(Config::default())
+    }
+}
+
+/// A group eligible to be blamed this tick.
+struct Candidate {
+    name: String,
+    /// Rate above its own baseline. What identifies the group that *changed*,
+    /// so it is what the ranking uses.
+    excess: f64,
+    /// Whole share, credited against the target when selected.
+    current: f64,
+}
+
+/// What one pass over the trackers found.
+#[derive(Default)]
+struct GroupSurvey {
+    /// Ranked, biggest mover first.
+    candidates: Vec<Candidate>,
+    /// Every group's rate, whether eligible or not: the target is a share of
+    /// what the node is actually doing.
+    total_usage: f64,
+    /// Load an actuator is already reclaiming, from every held group.
+    relieved: f64,
+    /// Groups the actuators are already holding. Still noisy — they are only
+    /// inside their gate because they are being held there.
+    held: HashSet<String>,
+}
+
+impl GroupSurvey {
+    /// Takes candidates from the top until the relief they provide covers
+    /// `target`, stopping early at the tail cut. Always takes the first unless
+    /// something is already held.
+    fn take_biggest_movers(&self, target: f64) -> Vec<&Candidate> {
+        let tail_floor = self.candidates.first().map_or(0.0, |c| c.excess) * TAIL_EXCESS_RATIO;
+        let mut relieved = self.relieved;
+        let mut noisy_tenants: Vec<&Candidate> = Vec::new();
+        for candidate in &self.candidates {
+            let covered = relieved >= target || candidate.excess < tail_floor;
+            if (!self.held.is_empty() || !noisy_tenants.is_empty()) && covered {
+                break;
+            }
+            // Already in `relieved`, credited when the survey saw it held.
+            if !self.held.contains(&candidate.name) {
+                relieved += candidate.current;
+            }
+            noisy_tenants.push(candidate);
+        }
+        noisy_tenants
     }
 }
 
@@ -437,6 +619,7 @@ impl ResourceGroupManager {
             read_pool_cpu_pressure: AtomicU64::new(0.0f64.to_bits()),
             read_pool_cpu_tracker: Mutex::new(RuTracker::new(start_secs, read_pool_num_buckets)),
             read_pool_scale_up_allowed: AtomicBool::new(false),
+            noisy_groups: RwLock::new(HashSet::new()),
         };
 
         // init the default resource group by default.
@@ -622,6 +805,29 @@ impl ResourceGroupManager {
         // RU tracking for foreground admission control is handled by
         // LimitedFuture (measure-only mode) which calls record_ru_consumption
         // with actual CPU measured per poll.
+        //
+        // The fixed arrival cost is charged here because this is the one place
+        // that runs exactly once per request, at gRPC handler entry -- before
+        // admission control, so a request that gets rejected still pays it.
+        self.charge_request_base_cost(&ctx.resource_group_name);
+    }
+
+    /// Charge `group` the fixed cost of a request arriving, whether or not it
+    /// goes on to run. See `Config::request_base_cost_micros`.
+    fn charge_request_base_cost(&self, group: &str) {
+        let micros = self.config.value().request_base_cost_micros;
+        if micros == 0 {
+            return;
+        }
+        // `group` comes straight off the wire, so normalize it the way
+        // `get_resource_limiter` does: an unknown or removed group must not
+        // leak a `ru_trackers` entry.
+        let name = if self.resource_groups.contains_key(group) {
+            group
+        } else {
+            DEFAULT_RESOURCE_GROUP_NAME
+        };
+        self.record_ru_consumption(name, micros);
     }
 
     /// Record `ru` units consumed by `group` into the sliding-window tracker
@@ -648,16 +854,10 @@ impl ResourceGroupManager {
         entry.lock().unwrap().0.record(ru);
     }
 
-    /// Called by `PriorityLimiterAdjustWorker` every ~1 second with the
-    /// latest process-level CPU utilisation percentage.
-    ///
-    /// Throttle-down: linearly reduces the allowed fraction of historical rate
-    /// for groups that are over their baseline. At `fg_cpu_throttle_threshold`
-    /// (70%) fraction = 1.0 (no throttle), at 90% CPU fraction = 0.8
-    /// (target). Called by the background adjust worker after computing the
-    /// new background CPU budget. `at_floor` should be true when the budget
-    /// has been clamped to the minimum floor AND background consumption
-    /// is within that floor.
+    /// Called by the background adjust worker after computing the new
+    /// background CPU budget. `at_floor` should be true when the budget has
+    /// been clamped to the minimum floor AND background consumption is within
+    /// that floor.
     pub fn set_bg_cpu_at_floor(&self, at_floor: bool) {
         self.bg_cpu_at_floor.store(at_floor, Ordering::Relaxed);
     }
@@ -673,14 +873,32 @@ impl ResourceGroupManager {
             .store(pressure.to_bits(), Ordering::Relaxed);
     }
 
-    /// Latest foreground CPU pressure (0.0-1.0), refreshed every tick by
-    /// `online_adjust_resource_quota`.
+    /// Whether foreground CPU pressure is engaged, as 1.0 or 0.0, refreshed
+    /// every tick by `online_adjust_resource_quota`.
     pub fn read_pool_cpu_pressure(&self) -> f64 {
         f64::from_bits(self.read_pool_cpu_pressure.load(Ordering::Relaxed))
     }
 
+    /// Quiet-window floor in cores, or `None` before there has been one. The
+    /// pool's floor is the same mechanism as a group's baseline, so it is the
+    /// same field on the pool's own tracker.
+    fn quiet_read_pool_floor(&self) -> Option<f64> {
+        self.read_pool_cpu_tracker
+            .lock()
+            .unwrap()
+            .quiet_baseline
+            .map(|ru| ru / 1_000_000.0)
+    }
+
+    fn refresh_quiet_read_pool_floor(&self, quiet: bool, now: u64) {
+        self.read_pool_cpu_tracker
+            .lock()
+            .unwrap()
+            .refresh_quiet_baseline(quiet, now);
+    }
+
     /// Records `read_pool_cpu` (in cores) into the historical tracker and
-    /// returns the floor CPU:
+    /// returns the resulting live average, in cores.
     pub fn read_pool_cpu_floor(&self, read_pool_cpu: f64, interval_secs: f64) -> f64 {
         self.read_pool_cpu_floor_at(read_pool_cpu, interval_secs, RuTracker::now_secs())
     }
@@ -700,84 +918,76 @@ impl ResourceGroupManager {
     /// [`crate::score::compute_resource_scores`]: the max of process and grpc
     /// normalized utilization.
     pub fn online_adjust_resource_quota(&self, cpu_score: f64) {
-        let now = RuTracker::now_secs();
-        self.adjust_group_throttling(cpu_score, now);
-        self.adjust_group_scheduling(cpu_score);
+        self.online_adjust_resource_quota_at(cpu_score, RuTracker::now_secs());
     }
 
-    /// Picks the groups responsible for the current overload.
-    ///
-    /// Every group whose current rate sits above its own burst target is a
-    /// candidate, but only the biggest movers are selected: candidates are
-    /// sorted by absolute excess over their own baseline — the biggest movers
-    /// first — and taken from the top until the relief they provide covers
-    /// `PEAK_CPU_PCT - fg_cpu_throttle_threshold` percent of total usage across
-    /// all groups. A tenant that grew 2× is therefore left alone while one that
-    /// grew 10× is penalized. The top candidate is always selected, so an
-    /// overloaded node never ends a tick having spared every group.
-    ///
-    /// Ranking is always by excess, since that is what identifies the group
-    /// responsible for the change. `relief` only decides how much each selected
-    /// group is credited with giving back, which differs between throttling and
-    /// scheduling — see [`NoisyRelief`].
+    /// One tick: measure, decide, then actuate. Detection lives here rather
+    /// than inside either actuator, so it runs exactly once per tick against
+    /// one set of measurements, and both actuators act on the same verdict.
+    fn online_adjust_resource_quota_at(&self, cpu_score: f64, now: u64) {
+        // Three bands of the same score. Above the threshold is evidence,
+        // below the leeway threshold clears it, and between them the candidacy
+        // counter holds.
+        let threshold = self.config.value().fg_cpu_throttle_threshold;
+        let loaded = cpu_score > threshold;
+        let cleared = cpu_score < threshold * (1.0 - LEEWAY_FRACTION);
+        let quiet = cpu_score < threshold * BASELINE_QUIET_FACTOR;
 
-    fn select_noisy_groups(&self, now: u64, relief: NoisyRelief) -> HashSet<String> {
+        // A group over its own average is no problem on an idle node, so both
+        // actuators need this, and neither debounces it further. Background
+        // yielding first gates the actuators only — see
+        // `update_over_baseline_ticks`.
+        let under_pressure = loaded && self.is_bg_cpu_at_floor();
+
+        self.refresh_trackers(now, loaded, cleared, quiet);
+        self.evict_idle_trackers();
+        // Written, never cleared here. The read pool reads this on its own
+        // clock, driven by `busy_cpu_scale_in`, which does not track
+        // `under_pressure` — wiping it on a quiet tick would leave that clock
+        // without a verdict mid-ratchet. `reset_group_priorities` clears it.
+        if under_pressure {
+            *self.noisy_groups.write() = self.select_noisy_groups();
+        }
+
+        self.adjust_group_throttling(cpu_score, under_pressure);
+        self.adjust_group_scheduling_at(cpu_score, under_pressure, now);
+    }
+
+    /// Brings every tracker up to `now` and samples it. Must precede
+    /// detection, which reads what this leaves behind.
+    fn refresh_trackers(&self, now: u64, loaded: bool, cleared: bool, quiet: bool) {
         let cfg = self.config.value();
         let burst_factor = 1.0 + cfg.baseline_burst_pct / 100.0;
-        let overshoot_pct = (PEAK_CPU_PCT - cfg.fg_cpu_throttle_threshold).max(0.0);
-
-        let mut total_usage = 0.0;
-        // (group, excess over its own baseline, current rate)
-        let mut candidates: Vec<(String, f64, f64)> = Vec::new();
-        for entry in &self.ru_trackers {
-            let guard = entry.lock().unwrap();
-            let hist = guard.0.cached_historical_rate;
-            let current = guard.0.current_rate(now);
-            drop(guard);
-            total_usage += current;
-            if hist > 0.0 && current > hist * burst_factor {
-                candidates.push((entry.key().clone(), current - hist, current));
-            }
-        }
-        candidates.sort_unstable_by(|a, b| b.1.total_cmp(&a.1));
-
-        let target = total_usage * overshoot_pct / 100.0;
-        let mut selected = HashSet::with_capacity(candidates.len());
-        let mut relieved = 0.0;
-        for (name, excess, current) in candidates {
-            if !selected.is_empty() && relieved >= target {
-                break;
-            }
-            relieved += match relief {
-                NoisyRelief::Excess => excess,
-                NoisyRelief::Total => current,
-            };
-            selected.insert(name);
-        }
-        selected
-    }
-
-    /// Per-group CPU rate-limit throttling. Only the noisy groups picked by
-    /// [`Self::select_noisy_groups`] are limited; a group over its own
-    /// baseline that is not among the biggest movers is left alone.
-    ///
-    /// Ramp-up: when CPU drops below threshold, recover ×1.1/tick until
-    /// NO_LIMIT is restored.
-    fn adjust_group_throttling(&self, cpu_score: f64, now: u64) {
-        const RAMP_FACTOR: f64 = 1.1;
-        const MIN_RAMP_UP_EPOCHS: u32 = 2;
-
-        let throttle_threshold = self.config.value().fg_cpu_throttle_threshold;
-        let leeway_threshold = throttle_threshold * LEEWAY_THRESHOLD_RATIO;
-        let burst_factor = 1.0 + self.config.value().baseline_burst_pct / 100.0;
-
-        // Advance all trackers to `now` and refresh cached historical rates
-        // up front so adjust_group_scheduling and the throttling logic below
-        // always see fresh baseline data.
+        let usage_based = matches!(cfg.noisy_detection, NoisyDetection::CurrentUsage);
         for entry in &self.ru_trackers {
             let mut guard = entry.lock().unwrap();
             guard.0.advance(now);
             guard.0.refresh_cached_historical_rate(self.start_secs, now);
+            // The one place these are sampled, so the read pool's clock can
+            // neither consume the rate delta nor double-count the ticks.
+            guard.0.refresh_cached_current_rate(now);
+            if usage_based {
+                // Judge every group on what it is consuming now. A zero
+                // baseline is all that takes: the eligibility gate reduces to
+                // "has traffic", the candidate ranking is by `excess`, which
+                // becomes the raw rate, and the candidacy counter's target
+                // becomes zero. Nothing else has to know about the mode.
+                guard.0.quiet_baseline = Some(0.0);
+            } else {
+                // Only the branch above ever writes a zero here —
+                // `refresh_quiet_baseline` requires a positive average — so a
+                // zero is a leftover from `current-usage` and has to be
+                // dropped. Left in place, a switch back to `baseline` would
+                // read as a sampled baseline of zero until a full quiet window
+                // has passed, which on a busy node may be never.
+                if guard.0.quiet_baseline == Some(0.0) {
+                    guard.0.quiet_baseline = None;
+                }
+                guard.0.refresh_quiet_baseline(quiet, now);
+            }
+            guard
+                .0
+                .update_over_baseline_ticks(burst_factor, loaded, cleared);
             let name = guard.1.name();
 
             metrics::GROUP_RU_HISTORICAL_RATE
@@ -785,23 +995,133 @@ impl ResourceGroupManager {
                 .set((guard.0.cached_historical_rate / 1_000_000.0) * 100.0);
             metrics::GROUP_RU_CURRENT_RATE
                 .with_label_values(&[name])
-                .set((guard.0.current_rate(now) / 1_000_000.0) * 100.0);
+                .set((guard.0.current_rate() / 1_000_000.0) * 100.0);
+            // Same `unwrap_or(0.0)` as `effective_baseline`, so the panel
+            // reports the number the gate actually used.
+            metrics::GROUP_RU_BASELINE
+                .with_label_values(&[name])
+                .set(guard.0.quiet_baseline.unwrap_or(0.0) / 1_000_000.0 * 100.0);
         }
+    }
 
-        let engaged = cpu_score > throttle_threshold && self.is_bg_cpu_at_floor();
-        if engaged {
-            let noisy = self.select_noisy_groups(now, NoisyRelief::Excess);
-            for entry in &self.ru_trackers {
-                if !noisy.contains(entry.key()) {
+    /// The groups this tick blamed. Read by the actuators; written only by
+    /// [`Self::online_adjust_resource_quota_at`].
+    fn noisy_groups(&self) -> HashSet<String> {
+        self.noisy_groups.read().clone()
+    }
+
+    /// Picks the groups responsible for the current overload: the biggest
+    /// movers, taken until the relief they provide covers the overshoot.
+    fn select_noisy_groups(&self) -> HashSet<String> {
+        let cfg = self.config.value();
+        let survey = self.survey_groups(1.0 + cfg.baseline_burst_pct / 100.0);
+        // Groups already being held stay named. They sit inside their gate
+        // only because an actuator is keeping them there, and the callers
+        // overwrite this wholesale, so dropping them would release them.
+        let mut noisy = survey.held.clone();
+
+        let overshoot_pct = (PEAK_CPU_PCT - cfg.fg_cpu_throttle_threshold).max(0.0);
+        let noisy_tenants = survey.take_biggest_movers(survey.total_usage * overshoot_pct / 100.0);
+
+        for tenant in &noisy_tenants {
+            noisy.insert(tenant.name.clone());
+        }
+        noisy
+    }
+
+    /// Drops trackers for groups that have gone quiet, so a removed or renamed
+    /// group cannot grow the map without bound. Relies on `refresh_trackers`
+    /// having just advanced them, which flushes partial buckets.
+    fn evict_idle_trackers(&self) {
+        self.ru_trackers.retain(|name, entry| {
+            let inner = entry.get_mut().unwrap();
+            if inner.0.is_idle() {
+                metrics::deregister_tracker_gauges(name);
+                return false;
+            }
+            true
+        });
+    }
+
+    /// One pass over the trackers, reading each group's standing once.
+    /// Candidates come back ranked, biggest mover first.
+    fn survey_groups(&self, burst_factor: f64) -> GroupSurvey {
+        let mut survey = GroupSurvey::default();
+        for entry in &self.ru_trackers {
+            let guard = entry.lock().unwrap();
+            let baseline = guard.0.effective_baseline();
+            let current = guard.0.current_rate();
+            let held = guard.0.throttle_backpressure || guard.0.scheduler_backpressure;
+            let sustained = guard.0.sustained_over_baseline();
+            drop(guard);
+
+            if held {
+                survey.held.insert(entry.key().clone());
+                // An actuator is already reclaiming this load, so it counts
+                // toward the target rather than inflating one the innocent
+                // tail would be taken to meet. Credited here rather than in
+                // the arm below, because whether the group is still above its
+                // gate says nothing about the relief already in flight, and
+                // the ranking would otherwise only credit it at its own
+                // position -- after anything with a larger excess had been
+                // taken. `take_biggest_movers` skips held candidates so this
+                // is not counted twice.
+                survey.relieved += current;
+            }
+            survey.total_usage += current;
+            // No history means any traffic is over baseline. Excluding those
+            // groups hid the culprit during its ramp.
+            let over_gate = current > 0.0 && current > baseline * burst_factor;
+            if over_gate && sustained {
+                survey.candidates.push(Candidate {
+                    name: entry.key().clone(),
+                    excess: current - baseline,
+                    current,
+                });
+            }
+        }
+        survey
+            .candidates
+            .sort_unstable_by(|a, b| b.excess.total_cmp(&a.excess));
+        survey
+    }
+
+    /// Per-group CPU rate-limit throttling. Only the noisy groups picked by
+    /// [`Self::select_noisy_groups`] are limited; a group over its own
+    /// baseline that is not among the biggest movers is left alone.
+    ///
+    /// Ramp-up: once CPU drops below the leeway threshold, recover one step
+    /// per tick until the limit is infinite again.
+    fn adjust_group_throttling(&self, cpu_score: f64, under_pressure: bool) {
+        const MIN_RAMP_UP_EPOCHS: u32 = 2;
+
+        let throttle_threshold = self.config.value().fg_cpu_throttle_threshold;
+        let leeway_threshold = throttle_threshold * (1.0 - LEEWAY_FRACTION);
+        let burst_factor = 1.0 + self.config.value().baseline_burst_pct / 100.0;
+
+        // Live pressure, not the cache being non-empty: the cache outlives the
+        // episode and says only *whom* to act on.
+        if under_pressure {
+            for name in self.noisy_groups() {
+                // Gone if its tracker was evicted between the tick that named
+                // it and now.
+                let Some(entry) = self.ru_trackers.get(&name) else {
                     continue;
-                }
+                };
                 let mut guard = entry.lock().unwrap();
-                let hist = guard.0.cached_historical_rate;
+                // The quiet-tick baseline, so the throttle floor cannot drift
+                // up with the load being shed.
+                let hist = guard.0.effective_baseline();
                 let burst_target = hist * burst_factor;
-                if hist > 0.0 {
+                // `>=`: a zero baseline is a target of zero, not a reason to
+                // skip. A group with no history of its own, and every group
+                // under `current-usage` detection, is throttled on the same
+                // path — the target simply stops clamping the decrease, so a
+                // named group keeps being cut while it stays named.
+                if hist >= 0.0 {
                     let current_limit = guard.1.get_limiter(ResourceType::Cpu).get_rate_limit();
                     let base = if current_limit.is_infinite() {
-                        guard.0.current_rate(now)
+                        guard.0.current_rate()
                     } else {
                         current_limit
                     };
@@ -815,40 +1135,50 @@ impl ResourceGroupManager {
                     }
                 }
             }
-        } else if cpu_score < leeway_threshold {
-            // CPU below start threshold — ramp up by RAMP_FACTOR each tick.
-            // Only lift to INFINITY after MIN_RAMP_UP_EPOCHS consecutive epochs
-            // where the limit has grown past 2x hist, to avoid premature release.
-            for entry in &self.ru_trackers {
-                let mut guard = entry.lock().unwrap();
-                let current_limit = guard.1.get_limiter(ResourceType::Cpu).get_rate_limit();
-                if current_limit.is_finite() {
-                    let hist = guard.0.cached_historical_rate;
-                    let new_limit = current_limit * RAMP_FACTOR;
-                    if hist <= 0.0 || new_limit >= 2.0 * hist {
-                        guard.0.ramp_up_epochs += 1;
-                        if guard.0.ramp_up_epochs >= MIN_RAMP_UP_EPOCHS {
-                            guard.0.ramp_up_epochs = 0;
-                            guard
-                                .1
-                                .get_limiter(ResourceType::Cpu)
-                                .set_rate_limit(f64::INFINITY);
-                        }
-                    } else {
+        }
+
+        // One pass over every group, not just the named ones: this both hands
+        // capacity back and clears `throttle_backpressure` once a limit is
+        // infinite again, and a group that has left the verdict still needs
+        // both. Skipping it would strand a finite limit and freeze its
+        // baseline for good.
+        let recovering = !under_pressure && cpu_score < leeway_threshold;
+        for entry in &self.ru_trackers {
+            let mut guard = entry.lock().unwrap();
+            // Ramp up one step per tick, lifting to INFINITY only after
+            // MIN_RAMP_UP_EPOCHS epochs past 2x hist so release is not
+            // premature. Against the live average, not the quiet baseline:
+            // recovery hands capacity back relative to what it consumes now,
+            // and the live one has climbed, which keeps release conservative.
+            let current_limit = guard.1.get_limiter(ResourceType::Cpu).get_rate_limit();
+            if recovering && current_limit.is_finite() {
+                let hist = guard.0.cached_historical_rate;
+                let new_limit = current_limit * THROTTLE_INCREASE_FACTOR;
+                // No zero special case: at `hist == 0` the comparison is
+                // already true, so a zero takes the same path as any other
+                // value.
+                if new_limit >= 2.0 * hist {
+                    guard.0.ramp_up_epochs += 1;
+                    if guard.0.ramp_up_epochs >= MIN_RAMP_UP_EPOCHS {
                         guard.0.ramp_up_epochs = 0;
                         guard
                             .1
                             .get_limiter(ResourceType::Cpu)
-                            .set_rate_limit(new_limit);
+                            .set_rate_limit(f64::INFINITY);
                     }
+                } else {
+                    guard.0.ramp_up_epochs = 0;
+                    guard
+                        .1
+                        .get_limiter(ResourceType::Cpu)
+                        .set_rate_limit(new_limit);
                 }
             }
-        }
 
-        // Emit current rate limit per resource group.
-        for entry in &self.ru_trackers {
-            let guard = entry.lock().unwrap();
+            // Derived from the limiter so no transition is missed: finite =
+            // throttled.
             let limit = guard.1.get_limiter(ResourceType::Cpu).get_rate_limit();
+            guard.0.set_throttle_backpressure(limit.is_finite());
             let val = if limit.is_finite() {
                 (limit / 1_000_000.0) * 100.0
             } else {
@@ -858,29 +1188,20 @@ impl ResourceGroupManager {
                 .with_label_values(&[guard.1.name(), "cpu"])
                 .set(val);
         }
-
-        // Evict idle ru_trackers entries to prevent unbounded growth from
-        // removed or renamed groups. Advance first so stale partial buckets
-        // are flushed before the idle check.
-        self.ru_trackers.retain(|_, entry| {
-            let inner = entry.get_mut().unwrap();
-            inner.0.advance(now);
-            !inner.0.is_idle()
-        });
     }
 
-    fn adjust_group_scheduling(&self, cpu_score: f64) {
+    fn adjust_group_scheduling_at(&self, cpu_score: f64, engaged: bool, now: u64) {
         let throttle_threshold = self.config.value().fg_cpu_throttle_threshold;
-        let leeway_threshold = throttle_threshold * LEEWAY_THRESHOLD_RATIO;
+        let leeway_threshold = throttle_threshold * (1.0 - LEEWAY_FRACTION);
 
-        // Engaged/not-engaged gate consumed by compute_read_pool_target_cpu,
-        // which only ever checks read_pool_cpu_pressure() > 0.0 — so this
-        // stores a plain 1.0/0.0 rather than a continuously-varying
-        // fraction. Reset to 0 whenever foreground is not under CPU
-        // pressure so a transient spike can't pin the read pool down
-        // indefinitely.
-        let engaged = cpu_score > throttle_threshold && self.is_bg_cpu_at_floor();
+        // Reset to 0 whenever foreground is not under CPU pressure, so a
+        // transient spike cannot pin the read pool down indefinitely.
         self.set_read_pool_cpu_pressure(if engaged { 1.0 } else { 0.0 });
+
+        self.refresh_quiet_read_pool_floor(
+            cpu_score < throttle_threshold * BASELINE_QUIET_FACTOR,
+            now,
+        );
 
         // Comfortably idle (below leeway) → allow the read pool to scale its
         // thread count back up toward its max on the next tick it checks in.
@@ -890,25 +1211,25 @@ impl ResourceGroupManager {
 
     /// Marks the noisy resource groups picked by
     /// [`Self::select_noisy_groups`] as over-quota (phase 1), deprioritizing
-    /// them. Sized with [`NoisyRelief::Total`]: phase 1 yields a group's whole
-    /// share, not just the part above its baseline. A group within its baseline
-    /// — or over it but not among the biggest movers — is left untouched.
+    /// them. A group within its baseline — or over it but not among the
+    /// biggest movers — is left untouched.
     ///
-    /// This function only ever sets the over-quota flag, never clears it —
-    /// clearing is the caller's responsibility, once the unified read pool
-    /// has scaled back up to `core_thread_count`, via
-    /// [`Self::reset_group_priorities`]. Otherwise a sustained noisy group's
-    /// own `cached_historical_rate` eventually drifts up to absorb its
-    /// elevated usage, and comparing against it again here would silently
-    /// (and wrongly) release the group early.
+    /// Only ever sets the flag, never clears it: the release signal is the
+    /// unified read pool recovering to `core_thread_count`, which this path
+    /// cannot see, so clearing is the caller's job via
+    /// [`Self::reset_group_priorities`].
     pub fn deprioritize_over_quota_groups(&self) {
         if !self.config.value().enable_fair_scheduling {
             return;
         }
-        let now = RuTracker::now_secs();
-        for name in self.select_noisy_groups(now, NoisyRelief::Total) {
+        // The quota-worker tick decided this; recomputing here would run
+        // detection on a second, unsynchronised clock.
+        for name in self.noisy_groups() {
             for controller in self.registry.read().iter() {
                 controller.set_group_phase(name.as_bytes(), true);
+            }
+            if let Some(entry) = self.ru_trackers.get(&name) {
+                entry.lock().unwrap().0.set_scheduler_backpressure(true);
             }
         }
     }
@@ -921,26 +1242,46 @@ impl ResourceGroupManager {
         for controller in self.registry.read().iter() {
             controller.reset_all_group_phases();
         }
+        self.noisy_groups.write().clear();
+        for entry in &self.ru_trackers {
+            entry.lock().unwrap().0.set_scheduler_backpressure(false);
+        }
     }
 
-    /// Decides the unified read pool's target CPU (in cores) under
-    /// foreground pressure: once pressure engages, returns
-    /// `THROTTLE_DECREASE_FACTOR` below the currently measured
-    /// `read_pool_cpu`, instead of jumping straight to a computed value. The
-    /// ceiling is clamped to the historical-CPU floor so
-    /// it never drops below what the pool has sustained historically, and
-    /// resets to `f64::INFINITY` (no ceiling) as soon as pressure clears —
-    /// callers that `min()` this into their own ceiling get back exactly
-    /// that ceiling, unaffected. Also records `read_pool_cpu` into the
-    /// historical tracker so the floor stays current.
-    /// [`Self::read_pool_scale_up_allowed`] to know whether it's safe to do
-    /// so.
+    /// The unified read pool's target CPU in cores, while foreground pressure
+    /// is engaged: one `THROTTLE_DECREASE_PCT` step below the measured
+    /// `read_pool_cpu`, floored at the quiet-window baseline so it never drops
+    /// below what the pool sustained while the node was quiet, and never below
+    /// `MIN_READ_POOL_TARGET_CORES` whether or not there is one. Returns
+    /// `f64::INFINITY` once pressure clears, so callers that `min()` it into
+    /// their own ceiling get that ceiling back unaffected. Also records
+    /// `read_pool_cpu`, keeping the floor current.
     pub fn compute_read_pool_target_cpu(&self, read_pool_cpu: f64, interval_secs: f64) -> f64 {
-        let floor_cpu = self.read_pool_cpu_floor(read_pool_cpu, interval_secs);
+        self.compute_read_pool_target_cpu_at(read_pool_cpu, interval_secs, RuTracker::now_secs())
+    }
+
+    fn compute_read_pool_target_cpu_at(
+        &self,
+        read_pool_cpu: f64,
+        interval_secs: f64,
+        now: u64,
+    ) -> f64 {
+        let historical_cpu = self.read_pool_cpu_floor_at(read_pool_cpu, interval_secs, now);
+        // The quiet-tick floor, or a fixed one core until there has been a
+        // quiet tick -- not the live average, which keeps recording the
+        // overload and so rises in step with the load being shed, floating the
+        // floor up under the ratchet. Same rule as a group's baseline, and
+        // `MIN_READ_POOL_TARGET_CORES` is what stops the unfloored ratchet
+        // compounding to zero.
+        let quiet_cpu = self.quiet_read_pool_floor();
+        let floor_cpu = quiet_cpu.unwrap_or(0.0).max(MIN_READ_POOL_TARGET_CORES);
 
         metrics::READ_POOL_CPU_VEC
             .with_label_values(&["historical"])
-            .set(floor_cpu * 100.0);
+            .set(historical_cpu * 100.0);
+        metrics::READ_POOL_CPU_VEC
+            .with_label_values(&["baseline"])
+            .set(quiet_cpu.unwrap_or(0.0) * 100.0);
         metrics::READ_POOL_CPU_VEC
             .with_label_values(&["current"])
             .set(read_pool_cpu * 100.0);
@@ -970,8 +1311,8 @@ impl ResourceGroupManager {
     /// Conditions for a non-zero delay (all must hold):
     ///   1. `enable_read_admission_control` / `enable_write_admission_control`
     ///      on
-    ///   2. Rate-limit is active (not NO_LIMIT sentinel)
-    ///   3. Tracker has warmed up (≥2 completed 1-min buckets)
+    ///   2. Rate-limit is active (finite)
+    ///   3. Tracker has warmed up (≥2 completed 30s buckets)
     ///   4. Token-bucket has accumulated debt (group exceeded its allowed rate)
     pub fn compute_admission_delay(
         &self,
@@ -2162,7 +2503,7 @@ pub(crate) mod tests {
     fn seed_tracker(mgr: &ResourceGroupManager, name: &str, hist: f64, current: f64, t0: u64) {
         let e = mgr.ru_trackers.entry(name.to_owned()).or_insert_with(|| {
             Mutex::new((
-                RuTracker::new(t0, 30),
+                RuTracker::new(t0 - RU_BUCKET_SECS, 30),
                 Arc::new(ResourceLimiter::new(
                     name.into(),
                     f64::INFINITY,
@@ -2173,33 +2514,495 @@ pub(crate) mod tests {
             ))
         });
         let mut tr = e.lock().unwrap();
-        tr.0.record_at((current * RU_BUCKET_SECS as f64) as u64, t0);
+        // Recorded so the tracker is not idle, and so `retain` keeps it. The
+        // two rates are then stated directly, as a tick would have sampled them.
+        tr.0.record_at(
+            (current * RU_BUCKET_SECS as f64) as u64,
+            t0 - RU_BUCKET_SECS,
+        );
+        tr.0.advance(t0);
         tr.0.cached_historical_rate = hist;
-        assert!((tr.0.current_rate(t0) - current).abs() < 1.0);
+        tr.0.cached_current_rate = current;
+        // A group that has been running has had quiet ticks to sample.
+        tr.0.quiet_baseline = Some(hist);
+        // The fixture states the group is already running at `current`, so it
+        // has been over its target for as long as it needs to be blamed.
+        tr.0.over_baseline_ticks = MIN_ENGAGE_TICKS;
+        assert!((tr.0.current_rate() - current).abs() < 1.0);
+    }
+
+    /// States the rate the quota-worker tick would have sampled for `name`.
+    /// Needed by tests that reach selection without a tick — as the read pool
+    /// does — since that path samples nothing.
+    fn set_sampled_rate(mgr: &ResourceGroupManager, name: &str, rate: f64) {
+        mgr.ru_trackers
+            .get(name)
+            .unwrap()
+            .lock()
+            .unwrap()
+            .0
+            .cached_current_rate = rate;
+    }
+
+    /// Records `ru` into the still-open bucket: traffic the ring has not
+    /// absorbed yet, so it raises the current rate while leaving the closed
+    /// buckets — and so the baseline — untouched.
+    fn stage_open_bucket(mgr: &ResourceGroupManager, name: &str, ru: u64) {
+        let entry = mgr.ru_trackers.get(name).unwrap();
+        let guard = entry.lock().unwrap();
+        guard.0.record(ru);
+    }
+
+    /// One tick with the sampled rates stated rather than measured, so a
+    /// scenario reads as the story it tests instead of ring-buffer
+    /// bookkeeping. Mirrors `online_adjust_resource_quota_at` without the part
+    /// of `refresh_trackers` that recomputes the rates, and without the quiet
+    /// baseline refresh: no time passes here for a quiet window to elapse.
+    fn tick(mgr: &ResourceGroupManager, cpu_score: f64) {
+        let cfg = mgr.get_config().value();
+        let loaded = cpu_score > cfg.fg_cpu_throttle_threshold;
+        let cleared = cpu_score < cfg.fg_cpu_throttle_threshold * (1.0 - LEEWAY_FRACTION);
+        let under_pressure = loaded && mgr.is_bg_cpu_at_floor();
+        let burst_factor = 1.0 + cfg.baseline_burst_pct / 100.0;
+        for entry in &mgr.ru_trackers {
+            let mut guard = entry.lock().unwrap();
+            guard
+                .0
+                .update_over_baseline_ticks(burst_factor, loaded, cleared);
+        }
+        if under_pressure {
+            *mgr.noisy_groups.write() = mgr.select_noisy_groups();
+        }
+        mgr.adjust_group_throttling(cpu_score, under_pressure);
+    }
+
+    /// States the pool's sampled quiet floor, in cores.
+    fn set_quiet_read_pool_floor(mgr: &ResourceGroupManager, cores: f64) {
+        mgr.read_pool_cpu_tracker.lock().unwrap().quiet_baseline = Some(cores * 1_000_000.0);
+    }
+
+    fn limit_of(mgr: &ResourceGroupManager, name: &str) -> f64 {
+        mgr.ru_trackers
+            .get(name)
+            .unwrap()
+            .lock()
+            .unwrap()
+            .1
+            .get_limiter(ResourceType::Cpu)
+            .get_rate_limit()
+    }
+
+    fn set_baseline(mgr: &ResourceGroupManager, name: &str, hist: f64) {
+        mgr.ru_trackers
+            .get(name)
+            .unwrap()
+            .lock()
+            .unwrap()
+            .0
+            .cached_historical_rate = hist;
+    }
+
+    /// Runs detection and stores its verdict as a tick would, but without the
+    /// tracker refresh, which would overwrite a staged rate.
+    fn stage_noisy(mgr: &ResourceGroupManager) {
+        *mgr.noisy_groups.write() = mgr.select_noisy_groups();
+    }
+
+    /// Marks `name` as having been over its target for long enough to be
+    /// blamed. The quota-worker tick counts this; a test that calls
+    /// `deprioritize_over_quota_groups` directly, as the read pool does, has
+    /// to state it.
+    fn mark_sustained(mgr: &ResourceGroupManager, name: &str) {
+        mgr.ru_trackers
+            .get(name)
+            .unwrap()
+            .lock()
+            .unwrap()
+            .0
+            .over_baseline_ticks = MIN_ENGAGE_TICKS;
+    }
+
+    /// Ticks the manager until the per-group counter has been satisfied.
+    fn tick_until_engaged(mgr: &ResourceGroupManager, cpu_score: f64) {
+        for _ in 0..MIN_ENGAGE_TICKS {
+            mgr.online_adjust_resource_quota(cpu_score);
+        }
+    }
+
+    fn baseline_of(mgr: &ResourceGroupManager, name: &str) -> Option<f64> {
+        mgr.ru_trackers
+            .get(name)
+            .unwrap()
+            .lock()
+            .unwrap()
+            .0
+            .quiet_baseline
+    }
+
+    fn set_backpressure(mgr: &ResourceGroupManager, name: &str, throttle: bool, scheduler: bool) {
+        let e = mgr.ru_trackers.get(name).unwrap();
+        let mut tr = e.lock().unwrap();
+        tr.0.set_throttle_backpressure(throttle);
+        tr.0.set_scheduler_backpressure(scheduler);
+    }
+
+    /// States the baseline a previous quiet tick would have taken for `name`.
+    fn set_quiet_baseline(mgr: &ResourceGroupManager, name: &str, hist: f64) {
+        mgr.ru_trackers
+            .get(name)
+            .unwrap()
+            .lock()
+            .unwrap()
+            .0
+            .quiet_baseline = Some(hist);
+    }
+
+    // seed_tracker builds a 30-bucket tracker, so one window is 15 minutes.
+    const TEST_WINDOW_SECS: u64 = 30 * RU_BUCKET_SECS;
+
+    #[test]
+    fn test_held_load_counts_toward_the_target_instead_of_inflating_it() {
+        // The tikv-50 case at 19:56:30. uds_006's baseline is 783 and it has been
+        // throttled down to 464, so 464 > 783 * 1.2 is false and it dropped out
+        // of the candidates -- while its 464 still set the target, and default
+        // (spiking 25.6 -> 50.8) plus two negligible groups were taken to meet
+        // a target none of them could reach.
+        let mgr = ResourceGroupManager::new(Config::default());
+        let t0 = RuTracker::now_secs();
+        seed_tracker(&mgr, "uds_006", 783.0, 464.0, t0);
+        seed_tracker(&mgr, "default", 25.6, 50.8, t0);
+        seed_tracker(&mgr, "uds_000", 0.1, 0.9, t0);
+        seed_tracker(&mgr, "uds_008", 0.0, 0.3, t0);
+        // uds_006 is the group already under backpressure.
+        set_backpressure(&mgr, "uds_006", true, true);
+
+        let selected = mgr.select_noisy_groups();
+        assert!(
+            selected.contains("uds_006") && selected.len() == 1,
+            "only the group already held is named: the load it is giving back \
+             covers the target, so nothing new is taken: {selected:?}"
+        );
     }
 
     #[test]
-    fn test_select_noisy_groups_relief_mode_sizes_the_set() {
+    fn test_held_group_still_over_its_gate_covers_the_target() {
+        // The tikv-24-1b case at 16:12. uds_006 is throttled to its burst
+        // target, which is the same 239.8 * 1.2 the gate uses, so it sits on
+        // the gate and a one-minute burst to 294 put it over. That took its
+        // 294 of already-reclaimed load out of `relieved` and made it a
+        // candidate instead -- ranked second, behind default spiking 25.4 ->
+        // 118.2 -- so the loop reached default before ever crediting it.
+        let mgr = ResourceGroupManager::new(Config::default());
+        let t0 = RuTracker::now_secs();
+        seed_tracker(&mgr, "uds_006", 239.8, 294.3, t0);
+        seed_tracker(&mgr, "default", 25.4, 118.2, t0);
+        set_backpressure(&mgr, "uds_006", true, true);
+
+        let selected = mgr.select_noisy_groups();
+        assert!(
+            selected.contains("uds_006") && selected.len() == 1,
+            "the held group covers the target whether or not it is still over \
+             its gate, so default is not taken with it: {selected:?}"
+        );
+    }
+
+    #[test]
+    fn test_tail_groups_below_the_head_ratio_are_spared() {
+        // Nothing is held and the head cannot reach the target on its own, so
+        // the loop used to walk the whole list. Groups an order of magnitude
+        // below the worst offender are tail, not cause.
+        let mgr = ResourceGroupManager::new(Config::default());
+        let t0 = RuTracker::now_secs();
+        seed_tracker(&mgr, "quiet", 900.0, 800.0, t0); // under its gate
+        seed_tracker(&mgr, "head", 25.6, 50.8, t0); // excess 25.2
+        seed_tracker(&mgr, "tail_a", 0.1, 0.9, t0); // excess 0.8
+        seed_tracker(&mgr, "tail_b", 0.0, 0.3, t0); // excess 0.3
+
+        let selected = mgr.select_noisy_groups();
+        assert_eq!(
+            selected.iter().map(String::as_str).collect::<Vec<_>>(),
+            vec!["head"],
+            "only the head is a plausible cause: {:?}",
+            selected
+        );
+    }
+
+    #[test]
+    fn test_ramping_group_with_no_history_is_selected_alone() {
+        // The tikv-48 case: the culprit ramped 0 -> 5428 with historical still
+        // 0, so it was excluded and every small jittering group was taken.
+        let mgr = ResourceGroupManager::new(Config::default());
+        let t0 = RuTracker::now_secs();
+        seed_tracker(&mgr, "ramping", 0.0, 5428.0, t0);
+        seed_tracker(&mgr, "default", 7.40, 9.31, t0);
+        seed_tracker(&mgr, "small_a", 0.235, 0.288, t0);
+        seed_tracker(&mgr, "small_b", 0.187, 0.225, t0);
+
+        let selected = mgr.select_noisy_groups();
+        assert!(selected.contains("ramping"), "{:?}", selected);
+        assert_eq!(
+            selected.len(),
+            1,
+            "the ramping group covers the target alone, sparing the rest: {:?}",
+            selected
+        );
+        assert_eq!(baseline_of(&mgr, "ramping"), Some(0.0));
+    }
+
+    #[test]
+    fn test_zero_baseline_is_frozen_and_keeps_the_group_selected() {
+        let mgr = ResourceGroupManager::new(Config::default());
+        let t0 = RuTracker::now_secs();
+        seed_tracker(&mgr, "fresh", 0.0, 500.0, t0);
+        assert!(mgr.select_noisy_groups().contains("fresh"));
+        assert_eq!(baseline_of(&mgr, "fresh"), Some(0.0));
+
+        // First selection wins; a later historical does not displace it.
+        mgr.ru_trackers
+            .get("fresh")
+            .unwrap()
+            .lock()
+            .unwrap()
+            .0
+            .cached_historical_rate = 100.0;
+        assert!(mgr.select_noisy_groups().contains("fresh"));
+        assert_eq!(baseline_of(&mgr, "fresh"), Some(0.0));
+    }
+
+    #[test]
+    fn test_idle_eviction_clears_the_group_gauges() {
+        // An evicted tracker's gauges keep reporting their last value -- a
+        // stale baseline then reads as still noisy.
+        //
+        // The gauge registry is global to the test binary, so this group name
+        // must not be shared with a test that could run alongside it.
+        let mgr = ResourceGroupManager::new(Config::default());
+        let t0 = RuTracker::now_secs();
+        seed_tracker(&mgr, "evicted", 100.0, 1000.0, t0);
+        mgr.select_noisy_groups();
+        assert_eq!(baseline_of(&mgr, "evicted"), Some(100.0));
+        metrics::GROUP_RU_BASELINE
+            .with_label_values(&["evicted"])
+            .set(100.0);
+
+        // Traffic stops: advance past the window so every bucket is zero.
+        mgr.online_adjust_resource_quota_at(0.0, t0 + 2 * TEST_WINDOW_SECS);
+
+        assert!(
+            mgr.ru_trackers.get("evicted").is_none(),
+            "an idle tracker should be evicted"
+        );
+        assert_eq!(
+            metrics::GROUP_RU_BASELINE
+                .get_metric_with_label_values(&["evicted"])
+                .unwrap()
+                .get(),
+            0.0,
+            "the gauge must be dropped on eviction, not left holding its last value"
+        );
+    }
+
+    #[test]
+    fn test_select_noisy_groups_leaves_the_quiet_baseline_alone() {
+        // The reference comes from the last quiet tick, so naming a group is
+        // not what establishes it and must not disturb it.
+        let mgr = ResourceGroupManager::new(Config::default());
+        let t0 = RuTracker::now_secs();
+        seed_tracker(&mgr, "noisy", 100.0, 1000.0, t0);
+        seed_tracker(&mgr, "small", 100.0, 130.0, t0);
+
+        let selected = mgr.select_noisy_groups();
+        assert!(
+            selected.contains("noisy") && !selected.contains("small"),
+            "{selected:?}"
+        );
+
+        assert_eq!(baseline_of(&mgr, "noisy"), Some(100.0));
+        assert_eq!(baseline_of(&mgr, "small"), Some(100.0));
+    }
+
+    #[test]
+    fn test_named_group_survives_baseline_drift() {
+        // The failure this prevents: the live baseline absorbs the spike, the
+        // gate stops matching, and the culprit is released.
+        let mgr = ResourceGroupManager::new(Config::default());
+        let t0 = RuTracker::now_secs();
+        seed_tracker(&mgr, "noisy", 100.0, 1000.0, t0);
+
+        assert!(mgr.select_noisy_groups().contains("noisy"));
+        assert_eq!(baseline_of(&mgr, "noisy"), Some(100.0));
+        set_backpressure(&mgr, "noisy", true, true);
+
+        // current == hist, so the gate can no longer match.
+        mgr.ru_trackers
+            .get("noisy")
+            .unwrap()
+            .lock()
+            .unwrap()
+            .0
+            .cached_historical_rate = 1000.0;
+
+        assert!(
+            mgr.select_noisy_groups().contains("noisy"),
+            "latched group must stay selected after its baseline drifts up"
+        );
+        assert_eq!(baseline_of(&mgr, "noisy"), Some(100.0));
+    }
+
+    #[test]
+    fn test_a_group_back_at_its_frozen_baseline_takes_nobody_with_it() {
+        // The actuators have driven the group back to the baseline it was
+        // selected against. It stays named, since it is inside its gate only
+        // because they are holding it there, but the load it has given back
+        // must not pull anyone else in.
+        let mgr = ResourceGroupManager::new(Config::default());
+        let t0 = RuTracker::now_secs();
+        seed_tracker(&mgr, "noisy", 100.0, 1000.0, t0);
+        assert!(mgr.select_noisy_groups().contains("noisy"));
+        assert_eq!(baseline_of(&mgr, "noisy"), Some(100.0));
+        set_backpressure(&mgr, "noisy", true, true);
+
+        // Rate back at its baseline, and the live average has drifted up to
+        // meet it — neither can keep the group selected.
+        let t1 = t0 + 10 * RU_BUCKET_SECS;
+        seed_tracker(&mgr, "quiet", 100.0, 100.0, t1);
+        {
+            let e = mgr.ru_trackers.get("noisy").unwrap();
+            let mut tr = e.lock().unwrap();
+            tr.0.record_at(100 * RU_BUCKET_SECS, t1);
+            tr.0.cached_historical_rate = 900.0;
+            tr.0.cached_current_rate = 100.0;
+        }
+        let noisy = mgr.select_noisy_groups();
+        assert!(
+            noisy.contains("noisy"),
+            "a held group stays named however far its rate has come back down"
+        );
+        assert!(
+            !noisy.contains("quiet"),
+            "and the load it returned must not drag in a group inside its gate"
+        );
+    }
+
+    #[test]
+    fn test_quiet_baseline_needs_a_full_window_of_quiet() {
+        let mut tr = RuTracker::new(0, 30);
+        let window = tr.window_secs();
+        tr.cached_historical_rate = 200.0;
+
+        tr.refresh_quiet_baseline(true, 0);
+        assert_eq!(tr.quiet_baseline, None, "one quiet tick is not a window");
+        tr.refresh_quiet_baseline(true, window - 1);
+        assert_eq!(tr.quiet_baseline, None);
+        tr.refresh_quiet_baseline(true, window);
+        assert_eq!(tr.quiet_baseline, Some(200.0));
+
+        // The sliding average climbs as the overload is recorded. A tick above
+        // the gate must not take it, or the reference would drift up to absorb
+        // the very load it is used to judge.
+        tr.cached_historical_rate = 900.0;
+        tr.refresh_quiet_baseline(false, window + 10);
+        assert_eq!(tr.quiet_baseline, Some(200.0));
+        assert_eq!(
+            tr.effective_baseline(),
+            200.0,
+            "the clamp-down paths must see the pre-overload value"
+        );
+
+        // Quiet again, but the run restarts: for a window yet the ring buffer
+        // still holds the episode, so a sample would come back inflated.
+        tr.cached_historical_rate = 250.0;
+        tr.refresh_quiet_baseline(true, window + 20);
+        assert_eq!(tr.quiet_baseline, Some(200.0), "the run restarted");
+        tr.refresh_quiet_baseline(true, 2 * window + 19);
+        assert_eq!(tr.quiet_baseline, Some(200.0));
+        tr.refresh_quiet_baseline(true, 2 * window + 20);
+        assert_eq!(
+            tr.quiet_baseline,
+            Some(250.0),
+            "a full quiet window re-takes it, with no latch to drop"
+        );
+    }
+
+    #[test]
+    fn test_baseline_is_zero_before_any_quiet_window() {
+        // A tracker created mid-overload, or one on a node that never goes
+        // quiet, has no sample yet, and is judged on raw usage rather than
+        // against a live average that has already absorbed its own spike.
+        let mut tr = RuTracker::new(0, 30);
+        tr.cached_historical_rate = 400.0;
+        tr.refresh_quiet_baseline(false, 0);
+        assert_eq!(tr.quiet_baseline, None);
+        assert_eq!(tr.effective_baseline(), 0.0);
+        // Any traffic clears a zero gate, so such a group is always eligible.
+        tr.current_bucket.store(10, Ordering::Relaxed);
+        tr.refresh_cached_current_rate(1);
+        assert!(tr.is_over_burst_target(1.2));
+    }
+
+    #[test]
+    fn test_a_cold_tracker_never_takes_a_zero_baseline() {
+        // A zero would outlast the warm-up and, since the throttle needs a
+        // positive baseline, leave the group permanently unthrottleable.
+        let mut tr = RuTracker::new(0, 30);
+        let window = tr.window_secs();
+        tr.refresh_quiet_baseline(true, 0);
+        tr.refresh_quiet_baseline(true, window);
+        assert_eq!(tr.quiet_baseline, None, "nothing to sample yet");
+
+        tr.cached_historical_rate = 150.0;
+        tr.refresh_quiet_baseline(true, 2 * window);
+        assert_eq!(
+            tr.quiet_baseline,
+            Some(150.0),
+            "taken once there is history"
+        );
+    }
+
+    #[test]
+    fn test_quiet_gate_is_stricter_than_the_release_leeway() {
+        // Leeway decides when it is safe to hand capacity back; the quiet gate
+        // decides when a sample is representative of normal behaviour. A
+        // reference taken at the release point would already include the
+        // run-up to the episode.
+        assert!(BASELINE_QUIET_FACTOR < 1.0 - LEEWAY_FRACTION);
+    }
+
+    #[test]
+    fn test_held_credit_covers_target_and_spares_new_candidates() {
+        // A held group's credit keeps covering the target, sparing a small
+        // group that drifts over its gate.
+        let mgr = ResourceGroupManager::new(Config::default());
+        let t0 = RuTracker::now_secs();
+        seed_tracker(&mgr, "noisy", 100.0, 1000.0, t0);
+        assert!(mgr.select_noisy_groups().contains("noisy"));
+        set_backpressure(&mgr, "noisy", true, true);
+
+        // A small group is now marginally over its own baseline.
+        seed_tracker(&mgr, "small", 10.0, 20.0, t0);
+
+        let selected = mgr.select_noisy_groups();
+        assert!(selected.contains("noisy"), "{:?}", selected);
+        assert!(
+            !selected.contains("small"),
+            "latched credit should already cover the target: {:?}",
+            selected
+        );
+    }
+
+    #[test]
+    fn test_select_noisy_groups_credits_whole_share() {
         // Four groups each 1.25x their own baseline: excess 20 apiece, current
         // 100 apiece, total usage 400. Default threshold 70 → target is 20% of
-        // 400 = 80. Crediting excess needs all four to reach it; crediting the
-        // whole share, which is what phase 1 actually yields, needs one.
+        // 400 = 80. A selected group is credited with its whole share, so one
+        // covers the target; crediting only the excess would have taken all four.
         let mgr = ResourceGroupManager::new(Config::default());
         let t0 = RuTracker::now_secs();
         for name in ["g1", "g2", "g3", "g4"] {
             seed_tracker(&mgr, name, 80.0, 100.0, t0);
         }
 
-        assert_eq!(
-            mgr.select_noisy_groups(t0, NoisyRelief::Excess).len(),
-            4,
-            "excess credit only reclaims 20 per group, so the target needs all four"
-        );
-        assert_eq!(
-            mgr.select_noisy_groups(t0, NoisyRelief::Total).len(),
-            1,
-            "deprioritizing yields the whole 100, so one group covers the target"
-        );
+        assert_eq!(mgr.select_noisy_groups().len(), 1);
     }
 
     #[test]
@@ -2213,7 +3016,7 @@ pub(crate) mod tests {
         seed_tracker(&mgr, "mild", 500.0, 1000.0, t0);
         seed_tracker(&mgr, "steady", 1000.0, 1000.0, t0);
 
-        let selected = mgr.select_noisy_groups(t0, NoisyRelief::Excess);
+        let selected = mgr.select_noisy_groups();
         assert!(selected.contains("noisy"), "biggest mover must be selected");
         assert!(
             !selected.contains("mild"),
@@ -2234,7 +3037,7 @@ pub(crate) mod tests {
         seed_tracker(&mgr, "mild", 500.0, 1000.0, t0);
         seed_tracker(&mgr, "steady", 1000.0, 1000.0, t0);
 
-        let selected = mgr.select_noisy_groups(t0, NoisyRelief::Excess);
+        let selected = mgr.select_noisy_groups();
         assert!(
             selected.contains("mild"),
             "the only candidate must still be penalized"
@@ -2339,6 +3142,9 @@ pub(crate) mod tests {
 
         // Only "spike" (over its own baseline) is deprioritized; "steady"
         // (within baseline) is not.
+        set_sampled_rate(&mgr, "spike", 400.0);
+        mark_sustained(&mgr, "spike");
+        stage_noisy(&mgr);
         mgr.deprioritize_over_quota_groups();
         {
             let groups = ctl.resource_consumptions.read();
@@ -2419,6 +3225,9 @@ pub(crate) mod tests {
         // `adjust_group_throttling` on resource_control's own tick.
         mgr.online_adjust_resource_quota(0.0);
 
+        set_sampled_rate(&mgr, "spike", 400.0);
+        mark_sustained(&mgr, "spike");
+        stage_noisy(&mgr);
         mgr.deprioritize_over_quota_groups();
         assert!(
             ctl.resource_consumptions
@@ -2484,6 +3293,9 @@ pub(crate) mod tests {
         }
         mgr.online_adjust_resource_quota(0.0);
 
+        set_sampled_rate(&mgr, "spike", 400.0);
+        mark_sustained(&mgr, "spike");
+        stage_noisy(&mgr);
         mgr.deprioritize_over_quota_groups();
         assert!(
             ctl.resource_consumptions
@@ -2501,8 +3313,7 @@ pub(crate) mod tests {
         {
             let e = mgr.ru_trackers.get("spike").unwrap();
             let mut tr = e.lock().unwrap();
-            let now = RuTracker::now_secs();
-            tr.0.cached_historical_rate = tr.0.current_rate(now);
+            tr.0.cached_historical_rate = tr.0.current_rate();
         }
 
         // Calling deprioritize_over_quota_groups again must not clear the
@@ -2576,7 +3387,7 @@ pub(crate) mod tests {
 
         // Pressure is still tracked (adjust_group_scheduling is not gated)...
         mgr.set_bg_cpu_at_floor(true);
-        mgr.online_adjust_resource_quota(PEAK_CPU_PCT);
+        tick_until_engaged(&mgr, PEAK_CPU_PCT);
         assert_eq!(mgr.read_pool_cpu_pressure(), 1.0);
 
         // ...but it must not turn into a ceiling, or hold back scale-out.
@@ -2640,38 +3451,188 @@ pub(crate) mod tests {
         // Seed a historical floor of 0 cores (cold tracker), then engage
         // pressure (cpu_score == PEAK_CPU_PCT).
         mgr.set_bg_cpu_at_floor(true);
-        mgr.online_adjust_resource_quota(PEAK_CPU_PCT);
+        tick_until_engaged(&mgr, PEAK_CPU_PCT);
         assert_eq!(mgr.read_pool_cpu_pressure(), 1.0);
 
-        // Once engaged, the ceiling is 10% below the currently measured
+        // Once engaged, the ceiling is one step below the currently measured
         // usage instead of collapsing straight to the (cold, i.e. 0)
         // historical floor.
         let target_cpu = mgr.compute_read_pool_target_cpu(4.0, 10.0);
         assert!(
-            (target_cpu - 3.6).abs() < 1e-9,
-            "should be 10% below measured usage, got {target_cpu}"
+            (target_cpu - 3.4).abs() < 1e-9,
+            "should be 15% below measured usage, got {target_cpu}"
         );
 
         // Stateless: calling again with the same measured usage gives the
         // same result rather than ratcheting further down on its own.
         let target_cpu = mgr.compute_read_pool_target_cpu(4.0, 10.0);
         assert!(
-            (target_cpu - 3.6).abs() < 1e-9,
+            (target_cpu - 3.4).abs() < 1e-9,
             "repeated calls with unchanged usage should not ratchet further, got {target_cpu}"
         );
 
         // It does respond to a drop in measured usage (e.g. after the read
         // pool itself cut its thread count in response to the previous
         // tick's lower ceiling).
-        let target_cpu = mgr.compute_read_pool_target_cpu(3.6, 10.0);
+        let target_cpu = mgr.compute_read_pool_target_cpu(3.4, 10.0);
         assert!(
-            (target_cpu - 3.24).abs() < 1e-9,
-            "should track 10% below whatever usage is currently measured, got {target_cpu}"
+            (target_cpu - 2.89).abs() < 1e-9,
+            "should track 15% below whatever usage is currently measured, got {target_cpu}"
+        );
+    }
+
+    /// The pool gets at least one core, the counterpart of the 1 RU/s floor a
+    /// throttled group gets. Without it the ceiling is only 15% below current
+    /// on every tick, which compounds: the pool follows its own ceiling down
+    /// and the two spiral toward zero.
+    #[test]
+    fn test_read_pool_target_never_goes_below_one_core() {
+        let mut cfg = Config::default();
+        cfg.enable_fair_scheduling = true;
+        let mgr = ResourceGroupManager::new(cfg);
+        mgr.set_bg_cpu_at_floor(true);
+        tick_until_engaged(&mgr, PEAK_CPU_PCT);
+
+        // No quiet window has elapsed, so there is no sampled floor.
+        assert_eq!(mgr.quiet_read_pool_floor(), None);
+        // 15% below 1.0 would be 0.85; the floor holds it at one core.
+        let target = mgr.compute_read_pool_target_cpu(1.0, 10.0);
+        assert!(
+            (target - 1.0).abs() < 1e-9,
+            "should hold at one core, got {target}"
+        );
+        // And it does not spiral: feeding the target back in as the measured
+        // usage leaves it where it is.
+        let target = mgr.compute_read_pool_target_cpu(target, 10.0);
+        assert!(
+            (target - 1.0).abs() < 1e-9,
+            "should not ratchet, got {target}"
+        );
+
+        // Nor does the live average serve as the floor: build one well above a
+        // core and the target still comes down to the minimum. The average is
+        // computed over the overload being shed, so using it would float the
+        // floor up under the ratchet and stall the shedding.
+        let t0 = RuTracker::now_secs();
+        for i in 0..12 {
+            mgr.compute_read_pool_target_cpu_at(8.0, 10.0, t0 + 10 * i);
+        }
+        assert!(
+            mgr.read_pool_cpu_floor(0.0, 0.0) > 1.0,
+            "the live average should exceed a core for this to prove anything"
+        );
+        let target = mgr.compute_read_pool_target_cpu_at(1.0, 10.0, t0 + 120);
+        assert!(
+            (target - 1.0).abs() < 1e-9,
+            "the live average must not act as the floor, got {target}"
+        );
+
+        // A sampled floor under one core does not lower the floor either --
+        // this node's was 0.075 cores.
+        set_quiet_read_pool_floor(&mgr, 0.075);
+        let target = mgr.compute_read_pool_target_cpu(1.0, 10.0);
+        assert!(
+            (target - 1.0).abs() < 1e-9,
+            "a sub-core sampled floor is still one core, got {target}"
+        );
+
+        // A sampled floor above it still wins, which is the whole point of
+        // sampling one.
+        set_quiet_read_pool_floor(&mgr, 3.0);
+        let target = mgr.compute_read_pool_target_cpu(2.0, 10.0);
+        assert!(
+            (target - 3.0).abs() < 1e-9,
+            "the sampled floor should hold above the minimum, got {target}"
+        );
+    }
+
+    /// The release path measures against the live average, not the baseline,
+    /// and a group with no history at all reads zero there. Zero must still
+    /// reach INFINITY: a throttled group that has since gone idle would
+    /// otherwise ramp 10% a tick forever and never be handed back its limit.
+    #[test]
+    fn test_a_zero_history_group_is_still_released() {
+        let mgr = ResourceGroupManager::default();
+        mgr.add_resource_group(new_resource_group_ru("g1".into(), 1000, HIGH_PRIORITY));
+        let limiter = mgr.get_foreground_group_limiter("g1");
+        let now = RuTracker::now_secs();
+        // Traffic in the open bucket only: enough to keep the tracker from
+        // being evicted as idle, not enough to complete a bucket, so the
+        // historical rate stays at zero.
+        stage_open_bucket(&mgr, "g1", 1_000);
+        limiter.get_limiter(ResourceType::Cpu).set_rate_limit(500.0);
+        assert_eq!(
+            mgr.ru_trackers
+                .get("g1")
+                .unwrap()
+                .lock()
+                .unwrap()
+                .0
+                .cached_historical_rate,
+            0.0,
+            "no traffic has ever been recorded"
+        );
+
+        // Quiet enough to be recovering: below the leeway threshold.
+        // MIN_RAMP_UP_EPOCHS is local to the actuator, hence the literal.
+        for _ in 0..2 {
+            assert!(
+                limit_of(&mgr, "g1").is_finite(),
+                "not released before the epochs elapse"
+            );
+            mgr.online_adjust_resource_quota_at(10.0, now);
+        }
+        assert!(
+            limit_of(&mgr, "g1").is_infinite(),
+            "a zero live average releases on the same path as any other"
+        );
+    }
+
+    /// A group that has never had a quiet window has a baseline of zero, so
+    /// its burst target is zero and nothing clamps the decrease: it descends
+    /// to the 1 RU/s floor for as long as it stays named. On a node that is
+    /// never quiet, that is every group.
+    #[test]
+    fn test_a_zero_baseline_ratchets_to_the_floor() {
+        let mgr = ResourceGroupManager::default();
+        mgr.add_resource_group(new_resource_group_ru("g1".into(), 1000, HIGH_PRIORITY));
+        let limiter = mgr.get_foreground_group_limiter("g1");
+        let t0 = RuTracker::now_secs();
+        {
+            let entry = mgr.ru_trackers.get("g1").unwrap();
+            let mut guard = entry.lock().unwrap();
+            guard.0.record_at(6000, t0 + 30);
+            guard.0.record_at(0, t0 + 60);
+        }
+        mgr.set_bg_cpu_at_floor(true);
+        let now = t0 + 85;
+        stage_open_bucket(&mgr, "g1", 20_000);
+
+        assert_eq!(
+            mgr.ru_trackers
+                .get("g1")
+                .unwrap()
+                .lock()
+                .unwrap()
+                .0
+                .quiet_baseline,
+            None,
+            "no quiet window has elapsed"
+        );
+
+        mark_sustained(&mgr, "g1");
+        for _ in 0..120 {
+            mgr.online_adjust_resource_quota_at(90.0, now);
+        }
+        assert_eq!(
+            limiter.get_limiter(ResourceType::Cpu).get_rate_limit(),
+            1.0,
+            "a zero target leaves nothing to stop the ratchet"
         );
     }
 
     #[test]
-    fn test_adjust_group_throttling_decreases_by_10_percent_per_tick() {
+    fn test_adjust_group_throttling_decreases_by_15_percent_per_tick() {
         // fg_cpu_throttle_threshold=70, baseline_burst_pct=20 (defaults) ->
         // burst_factor = 1.2.
         let mgr = ResourceGroupManager::default();
@@ -2686,52 +3647,62 @@ pub(crate) mod tests {
             let entry = mgr.ru_trackers.get("g1").unwrap();
             let mut guard = entry.lock().unwrap();
             guard.0.record_at(6000, t0 + 30);
-            guard.0.record_at(0, t0 + 60); // closes bucket: hist ~= 6000/30 = 200/s
-            guard.0.record_at(120_000, t0 + 65); // open-bucket spike: current >> burst_target
+            guard.0.record_at(0, t0 + 60); // closes bucket, so hist is non-zero
         }
         mgr.set_bg_cpu_at_floor(true);
-        let now = t0 + 90;
+        let now = t0 + 85;
+        // Spike confined to the last tick, so it does not also raise hist.
+        stage_open_bucket(&mgr, "g1", 20_000);
+        // A target now comes only from a sampled quiet window, so freeze one:
+        // with no baseline the ratchet has nothing to stop at and runs to the
+        // floor, which `test_a_zero_baseline_ratchets_to_the_floor` covers.
+        let quiet_baseline = {
+            let entry = mgr.ru_trackers.get("g1").unwrap();
+            let mut guard = entry.lock().unwrap();
+            guard.0.refresh_cached_historical_rate(t0, now);
+            let hist = guard.0.cached_historical_rate;
+            guard.0.quiet_baseline = Some(hist);
+            hist
+        };
 
         // First tick: no limit set yet (starts at INFINITY), so the base is
-        // the measured current rate, tightened by 10% — not an interpolated
-        // jump straight to burst_target.
-        mgr.adjust_group_throttling(90.0, now);
+        // the measured current rate, tightened by one step — not an
+        // interpolated jump straight to burst_target.
+        mark_sustained(&mgr, "g1");
+        mgr.online_adjust_resource_quota_at(90.0, now);
         let after_tick1 = limiter.get_limiter(ResourceType::Cpu).get_rate_limit();
         let current_rate = {
             let entry = mgr.ru_trackers.get("g1").unwrap();
-            entry.lock().unwrap().0.current_rate(now)
+            let rate = entry.lock().unwrap().0.current_rate();
+            rate
         };
         assert!(
-            (after_tick1 - current_rate * 0.9).abs() < current_rate * 0.01,
-            "first tick should tighten 10% below measured current rate, got {after_tick1}, \
+            (after_tick1 - current_rate * 0.85).abs() < current_rate * 0.01,
+            "first tick should tighten 15% below measured current rate, got {after_tick1}, \
              expected ~{}",
-            current_rate * 0.9
+            current_rate * 0.85
         );
 
         // Second tick, same inputs: base is now the persisted current_limit
         // from tick 1 (not a freshly measured/interpolated value), so it
-        // tightens another 10% relative to itself rather than staying put
+        // tightens another step relative to itself rather than staying put
         // or jumping to burst_target.
-        mgr.adjust_group_throttling(90.0, now);
+        mgr.online_adjust_resource_quota_at(90.0, now);
         let after_tick2 = limiter.get_limiter(ResourceType::Cpu).get_rate_limit();
         assert!(
-            (after_tick2 - after_tick1 * 0.9).abs() < after_tick1 * 0.01,
-            "second tick should tighten another 10% relative to the previous tick's limit, \
+            (after_tick2 - after_tick1 * 0.85).abs() < after_tick1 * 0.01,
+            "second tick should tighten another 15% relative to the previous tick's limit, \
              got {after_tick2}, expected ~{}",
-            after_tick1 * 0.9
+            after_tick1 * 0.85
         );
 
         // Repeated ticks converge to and stop at burst_target = hist * 1.2,
         // never going below it.
         for _ in 0..60 {
-            mgr.adjust_group_throttling(90.0, now);
+            mgr.online_adjust_resource_quota_at(90.0, now);
         }
         let floored = limiter.get_limiter(ResourceType::Cpu).get_rate_limit();
-        let hist = {
-            let entry = mgr.ru_trackers.get("g1").unwrap();
-            entry.lock().unwrap().0.cached_historical_rate
-        };
-        let burst_target = hist * 1.2;
+        let burst_target = quiet_baseline * 1.2;
         assert!(
             (floored - burst_target).abs() < burst_target * 0.01,
             "should converge to and stop at burst_target ({burst_target}), got {floored}"
@@ -2842,8 +3813,9 @@ pub(crate) mod tests {
         const BUCKETS: usize = 15;
         let mut tracker = RuTracker::new(t0, BUCKETS);
         assert!(!tracker.is_warmed_up());
-        // No data at all: current_rate = (0 + 0) / (0 + 60) = 0.
-        assert_eq!(tracker.current_rate(t0), 0.0);
+        // No data at all, and no elapsed time to divide by.
+        tracker.refresh_cached_current_rate(t0);
+        assert_eq!(tracker.current_rate(), 0.0);
         assert_eq!(tracker.historical_rate(t0, t0), 0.0);
 
         // Record 6000 RU in the first 30s bucket.
@@ -2852,9 +3824,9 @@ pub(crate) mod tests {
         // Advance past the first bucket boundary (30s) — completes bucket 0.
         tracker.record_at(0, t0 + 30);
         assert_eq!(tracker.completed, 1);
-        // At t0+30: current_bucket=0, elapsed=0, last_completed=6000
-        // rate = (0 + 6000) / (0 + 30) = 200 RU/s
-        assert!((tracker.current_rate(t0 + 30) - 200.0).abs() < 0.01);
+        // 6000 RU over the 30s since the last sample = 200 RU/s.
+        tracker.refresh_cached_current_rate(t0 + 30);
+        assert!((tracker.current_rate() - 200.0).abs() < 0.01);
         assert!(!tracker.is_warmed_up()); // needs ≥2 buckets
 
         // Advance another 30s with 3000 RU — completes bucket 1.
@@ -2862,12 +3834,14 @@ pub(crate) mod tests {
         tracker.record_at(0, t0 + 60);
         assert_eq!(tracker.completed, 2);
         assert!(tracker.is_warmed_up());
-        // At t0+60: current_bucket=0, elapsed=0, last_completed=3000
-        // rate = (0 + 3000) / (0 + 30) = 100 RU/s
-        assert!((tracker.current_rate(t0 + 60) - 100.0).abs() < 0.01);
-        // At t0+75 (15s into next bucket, no new RU): current_bucket=0, elapsed=15
-        // rate = (0 + 3000) / (15 + 30) = 66.67 RU/s
-        assert!((tracker.current_rate(t0 + 75) - 66.67).abs() < 0.1);
+        // A further 3000 RU over the next 30s = 100 RU/s.
+        tracker.refresh_cached_current_rate(t0 + 60);
+        assert!((tracker.current_rate() - 100.0).abs() < 0.01);
+        // Nothing recorded since: the trailing window still holds the closed
+        // bucket, so the rate decays rather than dropping to zero on the tick
+        // traffic stops -- 3000 RU over the 45s the window now covers.
+        tracker.refresh_cached_current_rate(t0 + 75);
+        assert!((tracker.current_rate() - 66.667).abs() < 0.01);
         // historical_rate = (6000+3000) / (2*30) = 150 RU/s
         assert!((tracker.historical_rate(t0, t0 + 60) - 150.0).abs() < 0.01);
 
@@ -2900,15 +3874,16 @@ pub(crate) mod tests {
         let t0 = RuTracker::now_secs();
         mgr.record_ru_consumption("spike", 1);
 
-        // CPU below threshold → Allow (stays NO_LIMIT, no throttling).
+        // CPU below threshold → Allow (limit stays infinite, no throttling).
         mgr.online_adjust_resource_quota(50.0); // below 80%
         assert_eq!(
             mgr.admission_decision(true, &spike_limiter),
             AdmissionDecision::Allow
         );
 
-        // CPU above threshold but no warmed-up tracker data → stays NO_LIMIT → Allow.
-        mgr.online_adjust_resource_quota(90.0);
+        // CPU above threshold but no warmed-up tracker data → limit stays
+        // infinite → Allow.
+        tick_until_engaged(&mgr, 90.0);
         assert_eq!(
             mgr.admission_decision(true, &spike_limiter),
             AdmissionDecision::Allow
@@ -2923,14 +3898,13 @@ pub(crate) mod tests {
             guard.0.record_at(6000, t0 + 30);
             guard.0.record_at(0, t0 + 60); // close bucket 0: 6000 RU (baseline)
             guard.0.record_at(12000, t0 + 90); // open bucket: 12000 RU spike (left open)
-            // historical ≈ 6000/30 = 200 RU/s (only completed buckets), current
-            // ≈ 400
+            // historical ≈ 6000/30 = 200 RU/s (only completed buckets)
         }
-        // Now set CPU — first throttle entry: initializes fraction from spike ratio,
-        // then sets absolute rate = historical × fraction per group.
+        // ...and a spike in the last tick, giving current ≈ 400 RU/s.
+        stage_open_bucket(&mgr, "spike", 4_000);
         // bg_cpu_at_floor must be true for the throttle branch to fire.
         mgr.set_bg_cpu_at_floor(true);
-        mgr.online_adjust_resource_quota(90.0);
+        tick_until_engaged(&mgr, 90.0);
         // Consume a burst well above the rate to build token-bucket debt.
         {
             let entry = mgr.ru_trackers.get("spike").unwrap();
@@ -2968,16 +3942,16 @@ pub(crate) mod tests {
             mgr.release_delay_slot();
         }
 
-        // Drop CPU into leeway zone (72-80%): multiplier holds, still delays.
+        // Above the leeway threshold: no recovery, so the multiplier holds
+        // and requests still delay.
         mgr.online_adjust_resource_quota(75.0);
         assert!(matches!(
             mgr.admission_decision(true, &spike_limiter),
             AdmissionDecision::Delay(_)
         ));
 
-        // Drop CPU below leeway_start (72%): fraction ramps up ×1.1/tick.
-        // After enough ticks it reaches 5× → NO_LIMIT → rates set to infinity
-        // → token bucket debt clears → Allow.
+        // Drop CPU below the leeway threshold: the limit ramps up a step per
+        // tick until it is lifted to infinity, clearing the token-bucket debt.
         for _ in 0..60 {
             mgr.online_adjust_resource_quota(50.0);
         }
@@ -2988,12 +3962,699 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn test_current_rate_needs_no_warm_up() {
+        let t0: u64 = 1_000_000;
+        let mut tr = RuTracker::new(t0, 30);
+        // A steady 100 RU/s from the moment the tracker exists. With no closed
+        // bucket the open one is measured over its own elapsed time, so the
+        // first tick already reports the real rate instead of half of it.
+        for i in 0..10 {
+            tr.record_at(100, t0 + i);
+        }
+        tr.refresh_cached_current_rate(t0 + 10);
+        assert_eq!(tr.current_rate(), 100.0);
+        assert_eq!(tr.completed, 0, "no bucket needs to have closed");
+
+        // Reading or refreshing it again inside the same tick is free and
+        // stable: the window is derived from the ring, not consumed from it.
+        assert_eq!(tr.current_rate(), 100.0);
+        tr.refresh_cached_current_rate(t0 + 10);
+        assert_eq!(tr.current_rate(), 100.0, "a refresh must be idempotent");
+    }
+
+    #[test]
+    fn test_current_rate_does_not_follow_a_single_tick_of_traffic() {
+        let t0: u64 = 1_000_000;
+        let mut tr = RuTracker::new(t0, 30);
+        // One closed bucket at a steady 100 RU/s.
+        tr.record_at(3000, t0 + 15);
+        tr.record_at(0, t0 + 30);
+        tr.refresh_cached_current_rate(t0 + 30);
+        assert!((tr.current_rate() - 100.0).abs() < 0.01);
+
+        // Then a burst running at 200 RU/s for one 10s tick. The window is the
+        // closed bucket plus the open one over the 40s they cover, so the rate
+        // moves to 125, not to the 200 the burst is running at.
+        tr.record(2_000);
+        tr.refresh_cached_current_rate(t0 + 40);
+        assert!(
+            (tr.current_rate() - 125.0).abs() < 0.01,
+            "expected the 40s average, got {}",
+            tr.current_rate()
+        );
+    }
+
+    #[test]
+    fn test_lifecycle_zero_history_tenant_spikes_alone_and_both_recover() {
+        // tenant1 idle, tenant2 steady at 100. tenant1 jumps to 1000.
+        let mgr = ResourceGroupManager::new(Config::default());
+        let t0 = RuTracker::now_secs();
+        mgr.set_bg_cpu_at_floor(true);
+        seed_tracker(&mgr, "tenant1", 0.0, 1000.0, t0);
+        seed_tracker(&mgr, "tenant2", 100.0, 100.0, t0);
+
+        tick(&mgr, 90.0);
+        let noisy = mgr.noisy_groups();
+        assert!(
+            noisy.contains("tenant1") && noisy.len() == 1,
+            "the spike is tenant1's alone: {noisy:?}"
+        );
+        // Throttled off what it is consuming. With no history its target is
+        // zero, so the decrease step is unclamped — a first-ever spike is cut
+        // by the full step rather than being left alone.
+        assert!(
+            (limit_of(&mgr, "tenant1") - 1000.0 * THROTTLE_DECREASE_FACTOR).abs() < 1.0,
+            "one decrease step off 1000: {}",
+            limit_of(&mgr, "tenant1")
+        );
+        assert!(
+            limit_of(&mgr, "tenant2").is_infinite(),
+            "not named, untouched"
+        );
+
+        // It slows down, and its trailing average has now absorbed the spike.
+        set_sampled_rate(&mgr, "tenant1", 10.0);
+        set_baseline(&mgr, "tenant1", 500.0);
+        for i in 1..=3 {
+            tick(&mgr, 50.0);
+        }
+        assert!(
+            mgr.select_noisy_groups().is_empty(),
+            "neither tenant is noisy once the load is back down"
+        );
+        assert!(limit_of(&mgr, "tenant1").is_infinite());
+        assert!(limit_of(&mgr, "tenant2").is_infinite());
+    }
+
+    #[test]
+    fn test_zero_baseline_tenant_is_both_throttled_and_deprioritized() {
+        // A first-ever spike has no baseline, which is a target of zero rather
+        // than an exemption: both actuators reach it.
+        let mut cfg = Config::default();
+        cfg.enable_fair_scheduling = true;
+        let mgr = ResourceGroupManager::new(cfg);
+        mgr.add_resource_group(new_resource_group_ru("fresh".into(), 1000, MEDIUM_PRIORITY));
+        let ctl = mgr.derive_controller("read".into(), true);
+        let t0 = RuTracker::now_secs();
+        mgr.set_bg_cpu_at_floor(true);
+        seed_tracker(&mgr, "fresh", 0.0, 1000.0, t0);
+
+        tick(&mgr, 90.0);
+        assert!(mgr.noisy_groups().contains("fresh"), "named");
+        assert!(
+            limit_of(&mgr, "fresh").is_finite(),
+            "and throttled: a zero target does not clamp the decrease"
+        );
+
+        mgr.deprioritize_over_quota_groups();
+        assert!(
+            ctl.resource_consumptions
+                .read()
+                .get(b"fresh".as_ref())
+                .unwrap()
+                .is_over_baseline
+                .load(Ordering::Relaxed),
+            "the scheduler is the one actuator that does reach it"
+        );
+    }
+
+    #[test]
+    fn test_lifecycle_baseline_catching_up_does_not_release_the_culprit() {
+        // Three tenants, one spikes. Its own trailing average then rises to
+        // absorb the spike, which is exactly when the live baseline would let
+        // it go while it is still the cause.
+        let mgr = ResourceGroupManager::new(Config::default());
+        let t0 = RuTracker::now_secs();
+        mgr.set_bg_cpu_at_floor(true);
+        seed_tracker(&mgr, "tenant1", 100.0, 1000.0, t0);
+        seed_tracker(&mgr, "tenant2", 200.0, 200.0, t0);
+        seed_tracker(&mgr, "tenant3", 300.0, 300.0, t0);
+
+        tick(&mgr, 90.0);
+        assert!(mgr.noisy_groups().contains("tenant1"));
+        assert_eq!(
+            baseline_of(&mgr, "tenant1"),
+            Some(100.0),
+            "frozen pre-spike"
+        );
+        let first = limit_of(&mgr, "tenant1");
+        assert!(first.is_finite(), "throttled, since it has history");
+
+        // The live average catches up to the elevated rate.
+        set_baseline(&mgr, "tenant1", 1000.0);
+        tick(&mgr, 90.0);
+        assert!(
+            mgr.noisy_groups().contains("tenant1"),
+            "the frozen baseline keeps it named while its rate is still up"
+        );
+        assert!(limit_of(&mgr, "tenant1") < first, "and it keeps tightening");
+        assert!(!mgr.noisy_groups().contains("tenant2"));
+        assert!(!mgr.noisy_groups().contains("tenant3"));
+
+        // Recovery: load back to its (now higher) baseline, CPU below leeway.
+        set_sampled_rate(&mgr, "tenant1", 1000.0);
+        for i in 2..=40 {
+            tick(&mgr, 50.0);
+        }
+        assert!(
+            limit_of(&mgr, "tenant1").is_infinite(),
+            "the limit is handed back"
+        );
+        assert!(
+            mgr.select_noisy_groups().is_empty(),
+            "and nobody is noisy any more"
+        );
+    }
+
+    #[test]
+    fn test_lifecycle_a_throttled_culprit_keeps_the_blame_off_a_small_spike() {
+        // tenant1 spikes and is held. Its load comes back down, and tenant2
+        // then rises slightly. The relief tenant1 is already giving covers the
+        // target, so tenant2 must not be taken in its place.
+        let mgr = ResourceGroupManager::new(Config::default());
+        let t0 = RuTracker::now_secs();
+        mgr.set_bg_cpu_at_floor(true);
+        seed_tracker(&mgr, "tenant1", 300.0, 3000.0, t0);
+        seed_tracker(&mgr, "tenant2", 100.0, 100.0, t0);
+
+        tick(&mgr, 90.0);
+        assert!(
+            mgr.noisy_groups().contains("tenant1") && mgr.noisy_groups().len() == 1,
+            "tenant1 alone"
+        );
+
+        // The throttle has worked: tenant1 back inside its gate. tenant2 edges
+        // up just past its own.
+        set_sampled_rate(&mgr, "tenant1", 300.0);
+        set_sampled_rate(&mgr, "tenant2", 130.0);
+        tick(&mgr, 90.0);
+
+        let noisy = mgr.noisy_groups();
+        assert!(
+            noisy.contains("tenant1"),
+            "still held, so still named: {noisy:?}"
+        );
+        // Spared by the counter on this tick: one tick over its gate is not
+        // evidence, whatever else is going on.
+        assert!(!noisy.contains("tenant2"), "{noisy:?}");
+
+        // A second tick over its gate confirms it, so now it is a genuine
+        // candidate -- and must still be spared, because the relief tenant1 is
+        // already giving back covers the whole target.
+        tick(&mgr, 90.0);
+        let noisy = mgr.noisy_groups();
+        assert!(noisy.contains("tenant1"), "{noisy:?}");
+        assert!(
+            !noisy.contains("tenant2"),
+            "tenant1's relief covers the target, so the small riser is not \
+             taken to meet it: {noisy:?}"
+        );
+        assert!(limit_of(&mgr, "tenant2").is_infinite(), "and not throttled");
+    }
+
+    #[test]
+    fn test_the_cached_verdict_keeps_a_group_the_throttle_has_pushed_back_down() {
+        // The callers overwrite the cache wholesale each pressured tick, so a
+        // group dropping out of the verdict silently unnames it. Once the
+        // throttle has driven it back inside its gate that is exactly when it
+        // must stay named.
+        let mgr = ResourceGroupManager::new(Config::default());
+        let t0 = RuTracker::now_secs();
+        seed_tracker(&mgr, "spike", 100.0, 1000.0, t0);
+
+        *mgr.noisy_groups.write() = mgr.select_noisy_groups();
+        assert!(
+            mgr.noisy_groups().contains("spike"),
+            "named on the first tick"
+        );
+        set_backpressure(&mgr, "spike", true, true);
+
+        // Next tick: the throttle has worked and it is back inside its gate.
+        set_sampled_rate(&mgr, "spike", 100.0);
+        *mgr.noisy_groups.write() = mgr.select_noisy_groups();
+        assert!(
+            mgr.noisy_groups().contains("spike"),
+            "still held, so the cache must still name it"
+        );
+    }
+
+    #[test]
+    fn test_a_held_group_still_over_its_gate_is_credited_not_ignored() {
+        // A held group whose counter has been cleared -- by a tick inside its
+        // gate, or by one without node pressure -- while it is still above
+        // that gate. The actuators are on it, so its rate has to count toward
+        // the target; otherwise a confirmed neighbour is taken to make up a
+        // difference that is already being reclaimed.
+        let mgr = ResourceGroupManager::new(Config::default());
+        let t0 = RuTracker::now_secs();
+        seed_tracker(&mgr, "culprit", 300.0, 3000.0, t0);
+        seed_tracker(&mgr, "neighbour", 100.0, 130.0, t0);
+        {
+            let entry = mgr.ru_trackers.get("culprit").unwrap();
+            let mut guard = entry.lock().unwrap();
+            guard.0.over_baseline_ticks = 0;
+        }
+        set_backpressure(&mgr, "culprit", true, true);
+
+        let noisy = mgr.select_noisy_groups();
+        assert!(noisy.contains("culprit"), "held, so named: {noisy:?}");
+        assert!(
+            !noisy.contains("neighbour"),
+            "the held group's rate covers the target, so the neighbour is not \
+             taken to meet it: {noisy:?}"
+        );
+    }
+
+    /// Same fixture for both detection modes: `small` has moved 10x above its
+    /// own history but is tiny; `big` is the largest consumer but sits just
+    /// above its own history.
+    fn seed_mover_and_hog(mgr: &ResourceGroupManager, t0: u64) {
+        seed_tracker(mgr, "big", 990.0, 1000.0, t0);
+        seed_tracker(mgr, "small", 10.0, 100.0, t0);
+        mgr.set_bg_cpu_at_floor(true);
+    }
+
+    #[test]
+    fn test_baseline_detection_blames_the_group_that_moved() {
+        let mgr = ResourceGroupManager::new(Config::default());
+        let t0 = RuTracker::now_secs();
+        seed_mover_and_hog(&mgr, t0);
+
+        mgr.online_adjust_resource_quota_at(90.0, t0);
+        assert!(
+            mgr.noisy_groups().contains("small"),
+            "10x its own baseline outranks a larger group sitting on its: {:?}",
+            mgr.noisy_groups()
+        );
+    }
+
+    #[test]
+    fn test_current_usage_detection_blames_the_biggest_consumer() {
+        // Zeroing the baseline is the whole mode: the eligibility gate reduces
+        // to "has traffic" and `excess` becomes the raw rate, so the ranking is
+        // by consumption and the small mover is spared.
+        let cfg = Config {
+            noisy_detection: NoisyDetection::CurrentUsage,
+            ..Default::default()
+        };
+        let mgr = ResourceGroupManager::new(cfg);
+        let t0 = RuTracker::now_secs();
+        seed_mover_and_hog(&mgr, t0);
+
+        mgr.online_adjust_resource_quota_at(90.0, t0);
+        assert_eq!(baseline_of(&mgr, "big"), Some(0.0));
+        assert_eq!(
+            baseline_of(&mgr, "small"),
+            Some(0.0),
+            "the mode discards whatever history the fixture stated"
+        );
+
+        let noisy = mgr.noisy_groups();
+        assert!(
+            noisy.contains("big") && !noisy.contains("small"),
+            "the biggest consumer is blamed, not the biggest mover: {noisy:?}"
+        );
+
+        // The zero baseline does not exempt it from the throttle: one
+        // decrease step off what it is consuming, with nothing below to clamp
+        // at but the 1 RU/s minimum.
+        let limit = limit_of(&mgr, "big");
+        assert!(
+            (limit - 1000.0 * THROTTLE_DECREASE_FACTOR).abs() < 1.0,
+            "expected one decrease step off the sampled rate, got {limit}"
+        );
+        assert!(limit_of(&mgr, "small").is_infinite());
+    }
+
+    #[test]
+    fn test_switching_back_to_baseline_drops_the_stated_zero() {
+        let cfg = Config {
+            noisy_detection: NoisyDetection::CurrentUsage,
+            ..Default::default()
+        };
+        let mgr = ResourceGroupManager::new(cfg);
+        let t0 = RuTracker::now_secs();
+        seed_mover_and_hog(&mgr, t0);
+
+        mgr.online_adjust_resource_quota_at(90.0, t0);
+        assert_eq!(baseline_of(&mgr, "big"), Some(0.0));
+
+        // Switched back mid-episode, so the tick that follows is far too
+        // loaded to sample a replacement baseline. The zero still has to go:
+        // `None` records that this group has never had a quiet window, which
+        // a zero stated by the other mode does not.
+        mgr.get_config()
+            .update(|c| -> Result<(), ()> {
+                c.noisy_detection = NoisyDetection::Baseline;
+                Ok(())
+            })
+            .unwrap();
+        mgr.online_adjust_resource_quota_at(90.0, t0 + 10);
+
+        assert_eq!(
+            baseline_of(&mgr, "big"),
+            None,
+            "the zero was stated by the other mode, not sampled"
+        );
+    }
+
+    #[test]
+    fn test_a_group_over_its_target_for_one_tick_is_not_blamed() {
+        let mgr = ResourceGroupManager::default();
+        let t0 = RuTracker::now_secs();
+        seed_tracker(&mgr, "spike", 100.0, 1000.0, t0);
+        let burst_factor = 1.0 + mgr.get_config().value().baseline_burst_pct / 100.0;
+        let tick = || {
+            mgr.ru_trackers
+                .get("spike")
+                .unwrap()
+                .lock()
+                .unwrap()
+                .0
+                .update_over_baseline_ticks(burst_factor, true, false)
+        };
+        // Undo the fixture's claim, so the counter starts cold as it would on
+        // the first tick a group runs hot.
+        mgr.ru_trackers
+            .get("spike")
+            .unwrap()
+            .lock()
+            .unwrap()
+            .0
+            .over_baseline_ticks = 0;
+
+        tick();
+        assert!(
+            mgr.select_noisy_groups().is_empty(),
+            "one tick over target is not evidence"
+        );
+
+        tick();
+        let noisy = mgr.select_noisy_groups();
+        assert!(
+            noisy.contains("spike") && noisy.len() == 1,
+            "two consecutive ticks must blame the group, got {noisy:?}"
+        );
+    }
+
+    #[test]
+    fn test_a_score_hovering_on_the_threshold_keeps_the_evidence() {
+        // The failure this prevents: cpu_score alternating either side of the
+        // threshold wiped the count every other tick, so a node overloaded half
+        // the time never reached two and blamed nobody.
+        let mgr = ResourceGroupManager::default();
+        let t0 = RuTracker::now_secs();
+        seed_tracker(&mgr, "spike", 100.0, 1000.0, t0);
+        let burst_factor = 1.0 + mgr.get_config().value().baseline_burst_pct / 100.0;
+        let entry = mgr.ru_trackers.get("spike").unwrap();
+        let mut guard = entry.lock().unwrap();
+        guard.0.over_baseline_ticks = 0;
+
+        // Above the threshold: evidence.
+        guard
+            .0
+            .update_over_baseline_ticks(burst_factor, true, false);
+        assert_eq!(guard.0.over_baseline_ticks, 1);
+
+        // Below the threshold but above the leeway threshold: hold.
+        guard
+            .0
+            .update_over_baseline_ticks(burst_factor, false, false);
+        assert_eq!(
+            guard.0.over_baseline_ticks, 1,
+            "the band between the thresholds must hold, not wipe"
+        );
+
+        guard
+            .0
+            .update_over_baseline_ticks(burst_factor, true, false);
+        assert!(
+            guard.0.sustained_over_baseline(),
+            "so the next loaded tick confirms instead of starting over"
+        );
+    }
+
+    #[test]
+    fn test_pressure_clearing_wipes_the_evidence() {
+        let mgr = ResourceGroupManager::default();
+        let t0 = RuTracker::now_secs();
+        seed_tracker(&mgr, "spike", 100.0, 1000.0, t0);
+        let burst_factor = 1.0 + mgr.get_config().value().baseline_burst_pct / 100.0;
+        let entry = mgr.ru_trackers.get("spike").unwrap();
+        let mut guard = entry.lock().unwrap();
+        assert!(guard.0.sustained_over_baseline(), "fixture starts blamed");
+
+        // Below the leeway threshold the node is genuinely fine, so whatever
+        // the group is doing is not a problem worth blaming it for.
+        guard
+            .0
+            .update_over_baseline_ticks(burst_factor, false, true);
+        assert_eq!(guard.0.over_baseline_ticks, 0);
+    }
+
+    #[test]
+    fn test_the_tick_wires_the_load_bands_into_the_candidacy_counter() {
+        // Drives the real entry point, since the wiring is what is under test:
+        // that the counter keys off the load bands and not off the background
+        // gate. Threshold 70, so the leeway threshold is 63.
+        let mgr = ResourceGroupManager::default();
+        let t0 = RuTracker::now_secs();
+        seed_tracker(&mgr, "spike", 100.0, 1000.0, t0);
+        let count = |mgr: &ResourceGroupManager| {
+            mgr.ru_trackers
+                .get("spike")
+                .unwrap()
+                .lock()
+                .unwrap()
+                .0
+                .over_baseline_ticks
+        };
+        mgr.ru_trackers
+            .get("spike")
+            .unwrap()
+            .lock()
+            .unwrap()
+            .0
+            .over_baseline_ticks = 0;
+
+        // Background has not yielded yet, so nothing may be acted on — but the
+        // evidence has to accrue anyway. Folding `is_bg_cpu_at_floor` into the
+        // counter meant every tick of the background squeeze wiped it, making
+        // the engage delay the whole squeeze plus MIN_ENGAGE_TICKS.
+        mgr.set_bg_cpu_at_floor(false);
+        mgr.online_adjust_resource_quota_at(90.0, t0);
+        assert_eq!(count(&mgr), 1);
+        mgr.online_adjust_resource_quota_at(90.0, t0);
+        assert_eq!(
+            count(&mgr),
+            MIN_ENGAGE_TICKS,
+            "the background squeeze must not wipe the evidence"
+        );
+        assert!(
+            mgr.noisy_groups().is_empty(),
+            "but no group may be blamed before background is at its floor"
+        );
+
+        // Between the two thresholds: held, so a score hovering on the
+        // threshold cannot erase the evidence every other tick.
+        mgr.online_adjust_resource_quota_at(66.0, t0);
+        assert_eq!(count(&mgr), MIN_ENGAGE_TICKS, "the band must hold");
+
+        // Below the leeway threshold the node is genuinely fine.
+        mgr.online_adjust_resource_quota_at(50.0, t0);
+        assert_eq!(count(&mgr), 0);
+    }
+
+    #[test]
+    fn test_a_tick_inside_the_target_restarts_the_group_count() {
+        let mgr = ResourceGroupManager::default();
+        let t0 = RuTracker::now_secs();
+        seed_tracker(&mgr, "spike", 100.0, 1000.0, t0);
+        let burst_factor = 1.0 + mgr.get_config().value().baseline_burst_pct / 100.0;
+
+        let entry = mgr.ru_trackers.get("spike").unwrap();
+        let mut guard = entry.lock().unwrap();
+        assert!(guard.0.sustained_over_baseline(), "fixture starts blamed");
+        // A quiet tick has since raised its baseline, so this tick is inside
+        // the target.
+        guard.0.quiet_baseline = Some(10_000.0);
+        guard
+            .0
+            .update_over_baseline_ticks(burst_factor, true, false);
+        assert_eq!(
+            guard.0.over_baseline_ticks, 0,
+            "a tick inside the target must clear the count outright"
+        );
+    }
+
+    #[test]
     fn test_read_pool_cpu_floor_cold_tracker() {
         let mgr = ResourceGroupManager::default();
         let t0 = RuTracker::now_secs();
         // Cold tracker → historical rate 0 → floor == 0.0 cores.
         let floor = mgr.read_pool_cpu_floor_at(8.0, 10.0, t0);
         assert_eq!(floor, 0.0);
+    }
+
+    /// A quiet period of a sustained 1 core, then the pool's own window
+    /// (2 min = 4 x 30s) of quiet ticks so the floor is established.
+    fn seed_read_pool_floor(mgr: &ResourceGroupManager, t0: u64) -> (f64, u64) {
+        {
+            let mut tracker = mgr.read_pool_cpu_tracker.lock().unwrap();
+            for i in 1..=5 {
+                tracker.record_at(30_000_000, t0 + 30 * i);
+            }
+            tracker.refresh_cached_historical_rate(t0, t0 + 150);
+        }
+        let quiet = mgr
+            .read_pool_cpu_tracker
+            .lock()
+            .unwrap()
+            .cached_historical_rate
+            / 1e6;
+        assert!(quiet > 0.0 && quiet < 6.8, "{}", quiet);
+        let now = t0 + 150;
+        mgr.adjust_group_scheduling_at(10.0, false, now);
+        assert_eq!(
+            mgr.quiet_read_pool_floor(),
+            None,
+            "one quiet tick is not a window"
+        );
+        mgr.adjust_group_scheduling_at(10.0, false, now + 120);
+        let floor = mgr
+            .quiet_read_pool_floor()
+            .expect("a full quiet window establishes the floor");
+        assert!(
+            (floor - quiet).abs() < 1e-9,
+            "floor {} should be the pre-overload {}",
+            floor,
+            quiet
+        );
+        (floor, now + 120)
+    }
+
+    fn read_pool_live_floor(mgr: &ResourceGroupManager) -> f64 {
+        mgr.read_pool_cpu_tracker
+            .lock()
+            .unwrap()
+            .cached_historical_rate
+            / 1e6
+    }
+
+    #[test]
+    fn test_read_pool_floor_holds_through_an_overload() {
+        // Without the gate the floor climbs with the load and the ratchet
+        // stalls, since the tracker keeps recording the overload.
+        let cfg = Config {
+            historical_usage_window_mins: 2,
+            enable_fair_scheduling: true,
+            ..Default::default()
+        };
+        let mgr = ResourceGroupManager::new(cfg);
+        let (floor, engaged) = seed_read_pool_floor(&mgr, mgr.start_secs);
+
+        mgr.set_bg_cpu_at_floor(true);
+        mgr.adjust_group_scheduling_at(95.0, true, engaged);
+        assert!(mgr.read_pool_cpu_pressure() > 0.0);
+
+        // 8 cores through the pool: the live average climbs, the floor does
+        // not, so the ratchet keeps stepping down.
+        let mut target = f64::INFINITY;
+        for i in 1..=6 {
+            target = mgr.compute_read_pool_target_cpu_at(8.0, 10.0, engaged + 10 * i);
+        }
+        assert!(
+            (target - 6.8).abs() < 0.01,
+            "ratchet should hold at 0.85 * 8.0 above the floor, got {}",
+            target
+        );
+        assert!(
+            read_pool_live_floor(&mgr) > floor,
+            "the live average should have absorbed the overload"
+        );
+        assert_eq!(
+            mgr.quiet_read_pool_floor(),
+            Some(floor),
+            "the floor must not move while overload is engaged"
+        );
+    }
+
+    #[test]
+    fn test_read_pool_floor_is_not_re_taken_until_the_episode_ages_out() {
+        // The window after recovery is the hazard: the tracker still holds the
+        // episode, so re-taking the floor there would come back inflated by
+        // the very load that was shed.
+        let cfg = Config {
+            historical_usage_window_mins: 2,
+            enable_fair_scheduling: true,
+            ..Default::default()
+        };
+        let mgr = ResourceGroupManager::new(cfg);
+        let (floor, engaged) = seed_read_pool_floor(&mgr, mgr.start_secs);
+
+        mgr.set_bg_cpu_at_floor(true);
+        mgr.adjust_group_scheduling_at(95.0, true, engaged);
+        for i in 1..=6 {
+            mgr.compute_read_pool_target_cpu_at(8.0, 10.0, engaged + 10 * i);
+        }
+        let contaminated = read_pool_live_floor(&mgr);
+        assert!(contaminated > floor, "tracker should be contaminated");
+
+        let recovered = engaged + 60;
+        mgr.adjust_group_scheduling_at(10.0, false, recovered);
+        assert_eq!(
+            mgr.quiet_read_pool_floor(),
+            Some(floor),
+            "the contaminated average must not be taken at the moment of recovery"
+        );
+        mgr.adjust_group_scheduling_at(10.0, false, recovered + 119);
+        assert_eq!(mgr.quiet_read_pool_floor(), Some(floor));
+
+        mgr.adjust_group_scheduling_at(10.0, false, recovered + 120);
+        assert_ne!(
+            mgr.quiet_read_pool_floor(),
+            Some(floor),
+            "a full quiet window re-takes it, with no latch to drop"
+        );
+    }
+
+    #[test]
+    fn test_read_pool_floor_is_not_taken_in_the_mid_range_band() {
+        // Between the quiet gate (59.5) and the throttle threshold (70) the
+        // node is not engaged but not quiet either, and the tracker is still
+        // recording load. The run of quiet must not start there.
+        let cfg = Config {
+            historical_usage_window_mins: 2,
+            enable_fair_scheduling: true,
+            ..Default::default()
+        };
+        let mgr = ResourceGroupManager::new(cfg);
+        let t0 = mgr.start_secs;
+        {
+            let mut tracker = mgr.read_pool_cpu_tracker.lock().unwrap();
+            for i in 1..=5 {
+                tracker.record_at(30_000_000, t0 + 30 * i);
+            }
+            tracker.refresh_cached_historical_rate(t0, t0 + 150);
+        }
+        let now = t0 + 150;
+
+        mgr.adjust_group_scheduling_at(65.0, false, now);
+        mgr.adjust_group_scheduling_at(65.0, false, now + 1000);
+        assert_eq!(
+            mgr.quiet_read_pool_floor(),
+            None,
+            "the mid-range band is not quiet, however long it lasts"
+        );
+
+        // The run starts here, not before.
+        mgr.adjust_group_scheduling_at(10.0, false, now + 1000);
+        assert_eq!(mgr.quiet_read_pool_floor(), None);
+        mgr.adjust_group_scheduling_at(10.0, false, now + 1120);
+        assert!(
+            mgr.quiet_read_pool_floor().is_some(),
+            "a window of quiet from that point establishes it"
+        );
     }
 
     #[test]

--- a/components/resource_control/src/resource_group.rs
+++ b/components/resource_control/src/resource_group.rs
@@ -812,6 +812,22 @@ impl ResourceGroupManager {
         self.charge_request_base_cost(&ctx.resource_group_name);
     }
 
+    /// Map a client-supplied group name onto the bounded set of configured
+    /// groups, so it is safe to use as a metric label or a map key.
+    ///
+    /// The name arrives off the wire and is never validated, so an unknown or
+    /// empty one has to collapse to the default group. Used directly it would
+    /// let a caller mint a new label value -- and so a new permanently
+    /// retained metric series, or a new `ru_trackers` entry -- on every
+    /// request.
+    pub fn bounded_group_name<'a>(&self, group: &'a str) -> &'a str {
+        if self.resource_groups.contains_key(group) {
+            group
+        } else {
+            DEFAULT_RESOURCE_GROUP_NAME
+        }
+    }
+
     /// Charge `group` the fixed cost of a request arriving, whether or not it
     /// goes on to run. See `Config::request_base_cost_micros`.
     fn charge_request_base_cost(&self, group: &str) {
@@ -819,15 +835,7 @@ impl ResourceGroupManager {
         if micros == 0 {
             return;
         }
-        // `group` comes straight off the wire, so normalize it the way
-        // `get_resource_limiter` does: an unknown or removed group must not
-        // leak a `ru_trackers` entry.
-        let name = if self.resource_groups.contains_key(group) {
-            group
-        } else {
-            DEFAULT_RESOURCE_GROUP_NAME
-        };
-        self.record_ru_consumption(name, micros);
+        self.record_ru_consumption(self.bounded_group_name(group), micros);
     }
 
     /// Record `ru` units consumed by `group` into the sliding-window tracker
@@ -1445,12 +1453,7 @@ impl ResourceGroupManager {
         }
         // Only create a foreground limiter for known groups; unknown or removed
         // groups fall back to "default" to avoid leaking ru_trackers entries.
-        let group_name = if self.resource_groups.contains_key(rg) {
-            rg
-        } else {
-            DEFAULT_RESOURCE_GROUP_NAME
-        };
-        Some(self.get_foreground_group_limiter(group_name))
+        Some(self.get_foreground_group_limiter(self.bounded_group_name(rg)))
     }
 
     // return a ResourceLimiter for background tasks only.

--- a/components/resource_control/src/resource_group.rs
+++ b/components/resource_control/src/resource_group.rs
@@ -64,17 +64,21 @@ const RESET_VT_THRESHOLD: u64 = (u64::MAX >> 4) / 2;
 pub const CONTROL_TICK: Duration = Duration::from_secs(10);
 
 /// Margin below a setpoint before a controller trusts there is room to expand:
-/// `measured < (1 - LEEWAY_FRACTION) * setpoint`. Shared by the foreground
-/// throttle's release gate, the read pool's scale-up permission and scale-out
-/// band, and the background idle gate.
-pub const LEEWAY_PCT: f64 = 10.0;
+/// `measured < LEEWAY_FACTOR * setpoint`. Shared by the foreground throttle's
+/// release gate, the read pool's scale-up permission and scale-out band, and
+/// the background idle gate.
+const LEEWAY_PCT: f64 = 10.0;
+/// The margin itself. Only the scale-*in* band wants it in this form, as
+/// `1 + LEEWAY_FRACTION`; everything comparing downward wants
+/// [`LEEWAY_FACTOR`].
 pub const LEEWAY_FRACTION: f64 = LEEWAY_PCT / 100.0;
+pub const LEEWAY_FACTOR: f64 = 1.0 - LEEWAY_FRACTION;
 
 /// How far below `fg_cpu_throttle_threshold` the node must sit for a group's
 /// sliding average to be trusted as its baseline. Above that mark the baseline
 /// is left alone, so it holds the last quiet reading for the whole episode.
-/// Stricter than [`LEEWAY_PCT`]: that decides when to hand capacity back, this
-/// decides when a sample is representative.
+/// Stricter than [`LEEWAY_FACTOR`]: that decides when to hand capacity back,
+/// this decides when a sample is representative.
 const BASELINE_QUIET_PCT: f64 = 15.0;
 const BASELINE_QUIET_FACTOR: f64 = 1.0 - BASELINE_QUIET_PCT / 100.0;
 
@@ -146,9 +150,6 @@ pub struct RuTracker {
     /// which has climbed with the load and so keeps release conservative.
     /// `None` until the first quiet window.
     quiet_baseline: Option<f64>,
-    /// True while `adjust_group_throttling` holds a CPU rate limit on this
-    /// group.
-    throttle_backpressure: bool,
     /// True while this group is deprioritized in the read scheduler.
     scheduler_backpressure: bool,
     /// Consecutive ticks over this group's own burst target, saturating at
@@ -173,7 +174,6 @@ impl RuTracker {
             cached_historical_rate: 0.0,
             ramp_up_epochs: 0,
             quiet_baseline: None,
-            throttle_backpressure: false,
             scheduler_backpressure: false,
             over_baseline_ticks: 0,
             quiet_since_secs: u64::MAX,
@@ -381,10 +381,6 @@ impl RuTracker {
     }
 
     /// Records whether a CPU rate limit is applied to this group.
-    fn set_throttle_backpressure(&mut self, on: bool) {
-        self.throttle_backpressure = on;
-    }
-
     /// Records whether this group is deprioritized in the read scheduler.
     fn set_scheduler_backpressure(&mut self, on: bool) {
         self.scheduler_backpressure = on;
@@ -940,12 +936,10 @@ impl ResourceGroupManager {
     }
 
     /// Records `read_pool_cpu` (in cores) into the historical tracker and
-    /// returns the resulting live average, in cores.
-    pub fn read_pool_cpu_floor(&self, read_pool_cpu: f64, interval_secs: f64) -> f64 {
-        self.read_pool_cpu_floor_at(read_pool_cpu, interval_secs, RuTracker::now_secs())
-    }
-
-    fn read_pool_cpu_floor_at(&self, read_pool_cpu: f64, interval_secs: f64, now: u64) -> f64 {
+    /// returns the resulting live average, in cores. Not a floor: the floor is
+    /// `quiet_read_pool_floor`, and the live average is deliberately not used
+    /// as one -- see `compute_read_pool_target_cpu_at`.
+    fn record_read_pool_cpu_at(&self, read_pool_cpu: f64, interval_secs: f64, now: u64) -> f64 {
         let mut tracker = self.read_pool_cpu_tracker.lock().unwrap();
         tracker.advance(now);
         if interval_secs > 0.0 {
@@ -973,7 +967,7 @@ impl ResourceGroupManager {
         // counter holds.
         let threshold = self.config.value().fg_cpu_throttle_threshold;
         let loaded = cpu_score > threshold;
-        let cleared = cpu_score < threshold * (1.0 - LEEWAY_FRACTION);
+        let cleared = cpu_score < threshold * LEEWAY_FACTOR;
         let quiet = cpu_score < threshold * BASELINE_QUIET_FACTOR;
 
         // A group over its own average is no problem on an idle node, so both
@@ -1094,7 +1088,14 @@ impl ResourceGroupManager {
             let guard = entry.lock().unwrap();
             let baseline = guard.0.effective_baseline();
             let current = guard.0.current_rate();
-            let held = guard.0.throttle_backpressure || guard.0.scheduler_backpressure;
+            // A finite CPU rate limit *is* throttle backpressure, so read it
+            // off the limiter rather than a mirror of it that is a tick stale.
+            let throttled = guard
+                .1
+                .get_limiter(ResourceType::Cpu)
+                .get_rate_limit()
+                .is_finite();
+            let held = throttled || guard.0.scheduler_backpressure;
             let sustained = guard.0.sustained_over_baseline();
             drop(guard);
 
@@ -1139,7 +1140,7 @@ impl ResourceGroupManager {
         const MIN_RAMP_UP_EPOCHS: u32 = 2;
 
         let throttle_threshold = self.config.value().fg_cpu_throttle_threshold;
-        let leeway_threshold = throttle_threshold * (1.0 - LEEWAY_FRACTION);
+        let leeway_threshold = throttle_threshold * LEEWAY_FACTOR;
         let burst_factor = 1.0 + self.config.value().baseline_burst_pct / 100.0;
 
         // Live pressure, not the cache being non-empty: the cache outlives the
@@ -1155,36 +1156,33 @@ impl ResourceGroupManager {
                 // The quiet-tick baseline, so the throttle floor cannot drift
                 // up with the load being shed.
                 let hist = guard.0.effective_baseline();
+                // No zero special case: a zero baseline is a target of zero,
+                // not a reason to skip. A group with no history of its own,
+                // and every group under `current-usage` detection, is
+                // throttled on this same path -- the target simply stops
+                // clamping the decrease, so a named group keeps being cut
+                // while it stays named.
                 let burst_target = hist * burst_factor;
-                // `>=`: a zero baseline is a target of zero, not a reason to
-                // skip. A group with no history of its own, and every group
-                // under `current-usage` detection, is throttled on the same
-                // path — the target simply stops clamping the decrease, so a
-                // named group keeps being cut while it stays named.
-                if hist >= 0.0 {
-                    let current_limit = guard.1.get_limiter(ResourceType::Cpu).get_rate_limit();
-                    let base = if current_limit.is_infinite() {
-                        guard.0.current_rate()
-                    } else {
-                        current_limit
-                    };
-                    if base > burst_target {
-                        let rate = (base * THROTTLE_DECREASE_FACTOR).max(burst_target);
-                        guard.0.ramp_up_epochs = 0;
-                        guard
-                            .1
-                            .get_limiter(ResourceType::Cpu)
-                            .set_rate_limit(rate.max(1.0));
-                    }
+                let current_limit = guard.1.get_limiter(ResourceType::Cpu).get_rate_limit();
+                let base = if current_limit.is_infinite() {
+                    guard.0.current_rate()
+                } else {
+                    current_limit
+                };
+                if base > burst_target {
+                    let rate = (base * THROTTLE_DECREASE_FACTOR).max(burst_target);
+                    guard.0.ramp_up_epochs = 0;
+                    guard
+                        .1
+                        .get_limiter(ResourceType::Cpu)
+                        .set_rate_limit(rate.max(1.0));
                 }
             }
         }
 
-        // One pass over every group, not just the named ones: this both hands
-        // capacity back and clears `throttle_backpressure` once a limit is
-        // infinite again, and a group that has left the verdict still needs
-        // both. Skipping it would strand a finite limit and freeze its
-        // baseline for good.
+        // One pass over every group, not just the named ones: a group that
+        // has left the verdict still needs its capacity handed back. Skipping
+        // it would strand a finite limit and freeze its baseline for good.
         let recovering = !under_pressure && cpu_score < leeway_threshold;
         for entry in &self.ru_trackers {
             let mut guard = entry.lock().unwrap();
@@ -1218,10 +1216,7 @@ impl ResourceGroupManager {
                 }
             }
 
-            // Derived from the limiter so no transition is missed: finite =
-            // throttled.
             let limit = guard.1.get_limiter(ResourceType::Cpu).get_rate_limit();
-            guard.0.set_throttle_backpressure(limit.is_finite());
             let val = if limit.is_finite() {
                 (limit / 1_000_000.0) * 100.0
             } else {
@@ -1235,7 +1230,7 @@ impl ResourceGroupManager {
 
     fn adjust_group_scheduling_at(&self, cpu_score: f64, engaged: bool, now: u64) {
         let throttle_threshold = self.config.value().fg_cpu_throttle_threshold;
-        let leeway_threshold = throttle_threshold * (1.0 - LEEWAY_FRACTION);
+        let leeway_threshold = throttle_threshold * LEEWAY_FACTOR;
 
         // Reset to 0 whenever foreground is not under CPU pressure, so a
         // transient spike cannot pin the read pool down indefinitely.
@@ -1309,7 +1304,7 @@ impl ResourceGroupManager {
         interval_secs: f64,
         now: u64,
     ) -> f64 {
-        let historical_cpu = self.read_pool_cpu_floor_at(read_pool_cpu, interval_secs, now);
+        let historical_cpu = self.record_read_pool_cpu_at(read_pool_cpu, interval_secs, now);
         // The quiet-tick floor, or a fixed one core until there has been a
         // quiet tick -- not the live average, which keeps recording the
         // overload and so rises in step with the load being shed, floating the
@@ -2599,7 +2594,7 @@ pub(crate) mod tests {
     fn tick(mgr: &ResourceGroupManager, cpu_score: f64) {
         let cfg = mgr.get_config().value();
         let loaded = cpu_score > cfg.fg_cpu_throttle_threshold;
-        let cleared = cpu_score < cfg.fg_cpu_throttle_threshold * (1.0 - LEEWAY_FRACTION);
+        let cleared = cpu_score < cfg.fg_cpu_throttle_threshold * LEEWAY_FACTOR;
         let under_pressure = loaded && mgr.is_bg_cpu_at_floor();
         let burst_factor = 1.0 + cfg.baseline_burst_pct / 100.0;
         for entry in &mgr.ru_trackers {
@@ -2680,19 +2675,11 @@ pub(crate) mod tests {
     fn set_backpressure(mgr: &ResourceGroupManager, name: &str, throttle: bool, scheduler: bool) {
         let e = mgr.ru_trackers.get(name).unwrap();
         let mut tr = e.lock().unwrap();
-        tr.0.set_throttle_backpressure(throttle);
+        // Throttle backpressure is the limiter's own state: a finite CPU
+        // rate limit is what being throttled means.
+        tr.1.get_limiter(ResourceType::Cpu)
+            .set_rate_limit(if throttle { 1_000_000.0 } else { f64::INFINITY });
         tr.0.set_scheduler_backpressure(scheduler);
-    }
-
-    /// States the baseline a previous quiet tick would have taken for `name`.
-    fn set_quiet_baseline(mgr: &ResourceGroupManager, name: &str, hist: f64) {
-        mgr.ru_trackers
-            .get(name)
-            .unwrap()
-            .lock()
-            .unwrap()
-            .0
-            .quiet_baseline = Some(hist);
     }
 
     // seed_tracker builds a 30-bucket tracker, so one window is 15 minutes.
@@ -3003,7 +2990,7 @@ pub(crate) mod tests {
         // decides when a sample is representative of normal behaviour. A
         // reference taken at the release point would already include the
         // run-up to the episode.
-        assert!(BASELINE_QUIET_FACTOR < 1.0 - LEEWAY_FRACTION);
+        assert!(BASELINE_QUIET_FACTOR < LEEWAY_FACTOR);
     }
 
     #[test]
@@ -3556,7 +3543,7 @@ pub(crate) mod tests {
             mgr.compute_read_pool_target_cpu_at(8.0, 10.0, t0 + 10 * i);
         }
         assert!(
-            mgr.read_pool_cpu_floor(0.0, 0.0) > 1.0,
+            mgr.record_read_pool_cpu_at(0.0, 0.0, RuTracker::now_secs()) > 1.0,
             "the live average should exceed a core for this to prove anything"
         );
         let target = mgr.compute_read_pool_target_cpu_at(1.0, 10.0, t0 + 120);
@@ -4526,12 +4513,12 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn test_read_pool_cpu_floor_cold_tracker() {
+    fn test_read_pool_historical_cpu_cold_tracker() {
         let mgr = ResourceGroupManager::default();
         let t0 = RuTracker::now_secs();
-        // Cold tracker → historical rate 0 → floor == 0.0 cores.
-        let floor = mgr.read_pool_cpu_floor_at(8.0, 10.0, t0);
-        assert_eq!(floor, 0.0);
+        // Cold tracker → historical rate 0 → 0.0 cores.
+        let historical = mgr.record_read_pool_cpu_at(8.0, 10.0, t0);
+        assert_eq!(historical, 0.0);
     }
 
     /// A quiet period of a sustained 1 core, then the pool's own window
@@ -4696,7 +4683,7 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn test_read_pool_cpu_floor_matches_historical_usage() {
+    fn test_read_pool_historical_cpu_matches_usage() {
         // Small window (minimum 2 min = 4 buckets = 120s) so a handful of
         // directly-seeded buckets fully cover it, giving an exact,
         // non-ramping historical rate to assert against.
@@ -4721,9 +4708,9 @@ pub(crate) mod tests {
         }
         // system_uptime (150s) >= window_secs (120s) → historical_rate uses
         // the full window as denominator: 480_000_000 / 120 = 4_000_000 us/s
-        // = 4 cores → floor = 4.0.
-        let floor = mgr.read_pool_cpu_floor_at(4.0, 30.0, t0 + 150);
-        assert_eq!(floor, 4.0);
+        // = 4 cores.
+        let historical = mgr.record_read_pool_cpu_at(4.0, 30.0, t0 + 150);
+        assert_eq!(historical, 4.0);
     }
 
     /// RU sitting in the still-open bucket, which is where an arrival charge

--- a/components/resource_control/src/resource_group.rs
+++ b/components/resource_control/src/resource_group.rs
@@ -81,6 +81,17 @@ pub const LEEWAY_FACTOR: f64 = 1.0 - LEEWAY_FRACTION;
 /// this decides when a sample is representative.
 const BASELINE_QUIET_PCT: f64 = 15.0;
 const BASELINE_QUIET_FACTOR: f64 = 1.0 - BASELINE_QUIET_PCT / 100.0;
+// Leeway decides when it is safe to hand capacity back; the quiet gate decides
+// when a sample is representative of normal behaviour. A reference taken at the
+// release point would already include the run-up to the episode, so the quiet
+// gate has to stay the stricter of the two -- checked here so retuning either
+// percentage above cannot silently invert them.
+//
+// `assertions_on_constants` reads this as `assert!(true)` to be optimized out;
+// in a `const` item there is nothing to optimize out, the evaluation *is* the
+// check.
+#[allow(clippy::assertions_on_constants)]
+const _: () = assert!(BASELINE_QUIET_FACTOR < LEEWAY_FACTOR);
 
 /// Per-tick step that tightens an enforced rate while pressure is engaged: the
 /// per-group CPU limit and the read pool's CPU ceiling. Larger than the
@@ -3026,15 +3037,6 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn test_quiet_gate_is_stricter_than_the_release_leeway() {
-        // Leeway decides when it is safe to hand capacity back; the quiet gate
-        // decides when a sample is representative of normal behaviour. A
-        // reference taken at the release point would already include the
-        // run-up to the episode.
-        assert!(BASELINE_QUIET_FACTOR < LEEWAY_FACTOR);
-    }
-
-    #[test]
     fn test_held_credit_covers_target_and_spares_new_candidates() {
         // A held group's credit keeps covering the target, sparing a small
         // group that drifts over its gate.
@@ -3737,11 +3739,14 @@ pub(crate) mod tests {
         mark_sustained(&mgr, "g1");
         mgr.online_adjust_resource_quota_at(90.0, now);
         let after_tick1 = limiter.get_limiter(ResourceType::Cpu).get_rate_limit();
-        let current_rate = {
-            let entry = mgr.ru_trackers.get("g1").unwrap();
-            let rate = entry.lock().unwrap().0.current_rate();
-            rate
-        };
+        let current_rate = mgr
+            .ru_trackers
+            .get("g1")
+            .unwrap()
+            .lock()
+            .unwrap()
+            .0
+            .current_rate();
         assert!(
             (after_tick1 - current_rate * 0.85).abs() < current_rate * 0.01,
             "first tick should tighten 15% below measured current rate, got {after_tick1}, \
@@ -4101,7 +4106,7 @@ pub(crate) mod tests {
         // It slows down, and its trailing average has now absorbed the spike.
         set_sampled_rate(&mgr, "tenant1", 10.0);
         set_baseline(&mgr, "tenant1", 500.0);
-        for i in 1..=3 {
+        for _ in 1..=3 {
             tick(&mgr, 50.0);
         }
         assert!(
@@ -4179,7 +4184,7 @@ pub(crate) mod tests {
 
         // Recovery: load back to its (now higher) baseline, CPU below leeway.
         set_sampled_rate(&mgr, "tenant1", 1000.0);
-        for i in 2..=40 {
+        for _ in 2..=40 {
             tick(&mgr, 50.0);
         }
         assert!(

--- a/components/resource_control/src/resource_group.rs
+++ b/components/resource_control/src/resource_group.rs
@@ -514,6 +514,11 @@ pub struct ResourceGroupManager {
     // fraction, since the read pool only tests it against zero to drive its
     // thread-count scale-down. Encoded via `f64::to_bits`.
     read_pool_cpu_pressure: AtomicU64,
+    // `Config::request_base_cost_micros`, mirrored out of the config lock.
+    // Read once per request on the gRPC handler path, where taking a shared
+    // RwLock read on every gRPC thread is itself the contention. Refreshed by
+    // `refresh_cached_config`.
+    request_base_cost_micros: AtomicU64,
     // Sliding-window tracker of the unified read pool's actual CPU usage (in
     // µs of CPU time per tick). Its `quiet_baseline` is the floor: the pool
     // should never be scaled below the thread count needed to sustain what it
@@ -604,6 +609,7 @@ impl ResourceGroupManager {
         // 2 buckets per minute (30s each) to match RU_BUCKET_SECS, mirroring
         // the per-group ru_trackers window sizing in `record_ru_consumption`.
         let read_pool_num_buckets = (config.historical_usage_window_mins.max(2) as usize) * 2;
+        let request_base_cost_micros = config.request_base_cost_micros;
         let manager = Self {
             resource_groups: Default::default(),
             group_count: AtomicU64::new(0),
@@ -617,6 +623,7 @@ impl ResourceGroupManager {
             start_secs,
             bg_cpu_at_floor: AtomicBool::new(false),
             read_pool_cpu_pressure: AtomicU64::new(0.0f64.to_bits()),
+            request_base_cost_micros: AtomicU64::new(request_base_cost_micros),
             read_pool_cpu_tracker: Mutex::new(RuTracker::new(start_secs, read_pool_num_buckets)),
             read_pool_scale_up_allowed: AtomicBool::new(false),
             noisy_groups: RwLock::new(HashSet::new()),
@@ -831,22 +838,49 @@ impl ResourceGroupManager {
     /// Charge `group` the fixed cost of a request arriving, whether or not it
     /// goes on to run. See `Config::request_base_cost_micros`.
     fn charge_request_base_cost(&self, group: &str) {
-        let micros = self.config.value().request_base_cost_micros;
+        let micros = self.request_base_cost_micros.load(Ordering::Relaxed);
         if micros == 0 {
             return;
         }
         self.record_ru_consumption(self.bounded_group_name(group), micros);
     }
 
+    /// Re-read the config values the per-request path keeps cached outside the
+    /// config lock. Called from the config dispatcher so a change applies at
+    /// once, and again each tick so a config written straight through
+    /// `VersionTrack` -- tests, and any future path that bypasses the
+    /// dispatcher -- cannot leave the cache stale.
+    /// The cached arrival cost, for asserting the cache tracks the config.
+    #[cfg(test)]
+    pub fn cached_request_base_cost_micros(&self) -> u64 {
+        self.request_base_cost_micros.load(Ordering::Relaxed)
+    }
+
+    pub fn refresh_cached_config(&self) {
+        self.request_base_cost_micros.store(
+            self.config.value().request_base_cost_micros,
+            Ordering::Relaxed,
+        );
+    }
+
     /// Record `ru` units consumed by `group` into the sliding-window tracker
     /// and consume tokens from the group's rate limiter.
     pub fn record_ru_consumption(&self, group: &str, ru: u64) {
-        let now = RuTracker::now_secs();
-        // 2 buckets per minute (30s each) to match RU_BUCKET_SECS.
-        let num_buckets = (self.config.value().historical_usage_window_mins.max(2) as usize) * 2;
+        // Fast path: a shared shard read, no allocation, no config lock.
+        // `entry()` below takes the shard exclusively even when the key is
+        // already there, and needs an owned key to do it, so on the hot
+        // default group -- one key, every gRPC thread -- it would serialize
+        // what is otherwise a single atomic add.
+        if let Some(entry) = self.ru_trackers.get(group) {
+            entry.lock().unwrap().0.record(ru);
+            return;
+        }
         let entry = self.ru_trackers.entry(group.to_owned()).or_insert_with(|| {
+            // 2 buckets per minute (30s each) to match RU_BUCKET_SECS.
+            let num_buckets =
+                (self.config.value().historical_usage_window_mins.max(2) as usize) * 2;
             Mutex::new((
-                RuTracker::new(now, num_buckets),
+                RuTracker::new(RuTracker::now_secs(), num_buckets),
                 Arc::new(ResourceLimiter::new(
                     group.to_owned(),
                     f64::INFINITY,
@@ -933,6 +967,7 @@ impl ResourceGroupManager {
     /// than inside either actuator, so it runs exactly once per tick against
     /// one set of measurements, and both actuators act on the same verdict.
     fn online_adjust_resource_quota_at(&self, cpu_score: f64, now: u64) {
+        self.refresh_cached_config();
         // Three bands of the same score. Above the threshold is evidence,
         // below the leeway threshold clears it, and between them the candidacy
         // counter holds.
@@ -4689,5 +4724,77 @@ pub(crate) mod tests {
         // = 4 cores → floor = 4.0.
         let floor = mgr.read_pool_cpu_floor_at(4.0, 30.0, t0 + 150);
         assert_eq!(floor, 4.0);
+    }
+
+    /// RU sitting in the still-open bucket, which is where an arrival charge
+    /// lands before any tick closes the bucket.
+    fn open_bucket(mgr: &ResourceGroupManager, name: &str) -> u64 {
+        mgr.ru_trackers
+            .get(name)
+            .unwrap()
+            .lock()
+            .unwrap()
+            .0
+            .current_bucket
+            .load(Ordering::Relaxed)
+    }
+
+    /// The arrival cost is read from an `AtomicU64` cache rather than the
+    /// config lock, so the cache has to actually track the config.
+    #[test]
+    fn test_request_base_cost_follows_config() {
+        let mut cfg = Config::default();
+        cfg.request_base_cost_micros = 70;
+        let mgr = ResourceGroupManager::new(cfg);
+
+        let mut ctx = ResourceControlContext::default();
+        ctx.resource_group_name = DEFAULT_RESOURCE_GROUP_NAME.to_owned();
+        mgr.consume_penalty(&ctx);
+        assert_eq!(open_bucket(&mgr, DEFAULT_RESOURCE_GROUP_NAME), 70);
+
+        mgr.get_config()
+            .update::<_, _, ()>(|c| {
+                c.request_base_cost_micros = 0;
+                Ok(())
+            })
+            .unwrap();
+        mgr.refresh_cached_config();
+        mgr.consume_penalty(&ctx);
+        assert_eq!(
+            open_bucket(&mgr, DEFAULT_RESOURCE_GROUP_NAME),
+            70,
+            "0 disables the charge"
+        );
+    }
+
+    /// A name that is not a configured group must not open a tracker of its
+    /// own, or every request can mint one.
+    #[test]
+    fn test_request_base_cost_of_unknown_group_lands_on_default() {
+        let mut cfg = Config::default();
+        cfg.request_base_cost_micros = 40;
+        let mgr = ResourceGroupManager::new(cfg);
+
+        let mut ctx = ResourceControlContext::default();
+        ctx.resource_group_name = "never-configured".to_owned();
+        mgr.consume_penalty(&ctx);
+
+        assert!(mgr.ru_trackers.get("never-configured").is_none());
+        assert_eq!(open_bucket(&mgr, DEFAULT_RESOURCE_GROUP_NAME), 40);
+    }
+
+    /// `record_ru_consumption` takes a shared-read fast path when the group is
+    /// already there and falls back to `entry()` only to create one. Both
+    /// paths must accumulate into the same bucket.
+    #[test]
+    fn test_record_ru_consumption_creates_then_reuses_tracker() {
+        let mgr = ResourceGroupManager::default();
+        assert!(mgr.ru_trackers.get("g").is_none());
+
+        mgr.record_ru_consumption("g", 5);
+        assert_eq!(open_bucket(&mgr, "g"), 5);
+
+        mgr.record_ru_consumption("g", 7);
+        assert_eq!(open_bucket(&mgr, "g"), 12);
     }
 }

--- a/components/resource_control/src/resource_group.rs
+++ b/components/resource_control/src/resource_group.rs
@@ -1568,10 +1568,10 @@ impl ResourceGroupManager {
         if request_source.is_empty() || !self.has_background_groups() {
             return false;
         }
-        if let Some(group) = self.resource_groups.get(rg) {
-            if !group.fallback_default {
-                return group.is_background_source(request_source);
-            }
+        if let Some(group) = self.resource_groups.get(rg)
+            && !group.fallback_default
+        {
+            return group.is_background_source(request_source);
         }
         self.resource_groups
             .get(DEFAULT_RESOURCE_GROUP_NAME)

--- a/components/resource_control/src/resource_group.rs
+++ b/components/resource_control/src/resource_group.rs
@@ -569,6 +569,10 @@ pub struct ResourceGroupManager {
     // RwLock read on every gRPC thread is itself the contention. Refreshed by
     // `refresh_cached_config`.
     request_base_cost_micros: AtomicU64,
+    // Bucket count for a new per-group tracker. `historical_usage_window_mins`
+    // is not hot-reloadable, so it is resolved once here rather than read off
+    // the config lock on the tracker-creation path.
+    ru_num_buckets: usize,
     // Sliding-window tracker of the unified read pool's actual CPU usage (in
     // µs of CPU time per tick). Its `quiet_baseline` is the floor: the pool
     // should never be scaled below the thread count needed to sustain what it
@@ -656,9 +660,9 @@ impl ResourceGroupManager {
             true,
         ));
         let start_secs = RuTracker::now_secs();
-        // 2 buckets per minute (30s each) to match RU_BUCKET_SECS, mirroring
-        // the per-group ru_trackers window sizing in `record_ru_consumption`.
-        let read_pool_num_buckets = (config.historical_usage_window_mins.max(2) as usize) * 2;
+        // 2 buckets per minute (30s each) to match RU_BUCKET_SECS. Shared with
+        // the per-group ru_trackers, which size their window the same way.
+        let num_buckets = (config.historical_usage_window_mins.max(2) as usize) * 2;
         let request_base_cost_micros = config.request_base_cost_micros;
         let manager = Self {
             resource_groups: Default::default(),
@@ -670,11 +674,12 @@ impl ResourceGroupManager {
             has_background: AtomicBool::new(false),
             config: Arc::new(VersionTrack::new(config)),
             ru_trackers: Default::default(),
+            ru_num_buckets: num_buckets,
             start_secs,
             bg_cpu_at_floor: AtomicBool::new(false),
             read_pool_cpu_pressure: AtomicU64::new(0.0f64.to_bits()),
             request_base_cost_micros: AtomicU64::new(request_base_cost_micros),
-            read_pool_cpu_tracker: Mutex::new(RuTracker::new(start_secs, read_pool_num_buckets)),
+            read_pool_cpu_tracker: Mutex::new(RuTracker::new(start_secs, num_buckets)),
             read_pool_scale_up_allowed: AtomicBool::new(false),
             noisy_groups: RwLock::new(HashSet::new()),
         };
@@ -931,11 +936,8 @@ impl ResourceGroupManager {
             return;
         }
         let entry = self.ru_trackers.entry(group.to_owned()).or_insert_with(|| {
-            // 2 buckets per minute (30s each) to match RU_BUCKET_SECS.
-            let num_buckets =
-                (self.config.value().historical_usage_window_mins.max(2) as usize) * 2;
             RuTrackerSlot::new(
-                RuTracker::new(RuTracker::now_secs(), num_buckets),
+                RuTracker::new(RuTracker::now_secs(), self.ru_num_buckets),
                 Arc::new(ResourceLimiter::new(
                     group.to_owned(),
                     f64::INFINITY,
@@ -1504,13 +1506,11 @@ impl ResourceGroupManager {
     /// build token-bucket debt for pre-pool `admission_decision`.
     pub fn get_foreground_group_limiter(&self, group: &str) -> Arc<ResourceLimiter> {
         let now = RuTracker::now_secs();
-        // 2 buckets per minute (30s each) to match RU_BUCKET_SECS.
-        let num_buckets = (self.config.value().historical_usage_window_mins.max(2) as usize) * 2;
         self.ru_trackers
             .entry(group.to_owned())
             .or_insert_with(|| {
                 RuTrackerSlot::new(
-                    RuTracker::new(now, num_buckets),
+                    RuTracker::new(now, self.ru_num_buckets),
                     Arc::new(ResourceLimiter::new(
                         group.to_owned(),
                         f64::INFINITY,

--- a/components/resource_control/src/resource_group.rs
+++ b/components/resource_control/src/resource_group.rs
@@ -842,7 +842,7 @@ impl ResourceGroupManager {
         }
     }
 
-    pub fn consume_penalty(&self, ctx: &ResourceControlContext) {
+    pub fn consume_penalty(&self, ctx: &ResourceControlContext, request_source: &str) {
         for controller in self.registry.read().iter() {
             // FIXME: Should consume CPU time for read controller and write bytes for write
             // controller, once CPU process time of scheduler worker is tracked. Currently,
@@ -866,7 +866,13 @@ impl ResourceGroupManager {
         // The fixed arrival cost is charged here because this is the one place
         // that runs exactly once per request, at gRPC handler entry -- before
         // admission control, so a request that gets rejected still pays it.
-        self.charge_request_base_cost(&ctx.resource_group_name);
+        //
+        // A request routed to a background limiter is metered there, so it
+        // must not pay into the group's foreground tracker -- the same rule as
+        // the `!is_background()` guard in `future.rs`.
+        if !self.is_background_request(ctx.get_resource_group_name(), request_source) {
+            self.charge_request_base_cost(&ctx.resource_group_name);
+        }
     }
 
     /// Map a client-supplied group name onto the bounded set of configured
@@ -1553,6 +1559,25 @@ impl ResourceGroupManager {
             .0
     }
 
+    /// Whether a request from `rg` with `request_source` is routed to a
+    /// background limiter, without building one. Resolves the group the same
+    /// way `get_background_resource_limiter_with_priority` does, and returns
+    /// on the atomic before touching the map when no group configures
+    /// background job types at all.
+    pub fn is_background_request(&self, rg: &str, request_source: &str) -> bool {
+        if request_source.is_empty() || !self.has_background_groups() {
+            return false;
+        }
+        if let Some(group) = self.resource_groups.get(rg) {
+            if !group.fallback_default {
+                return group.is_background_source(request_source);
+            }
+        }
+        self.resource_groups
+            .get(DEFAULT_RESOURCE_GROUP_NAME)
+            .is_some_and(|g| g.is_background_source(request_source))
+    }
+
     fn get_background_resource_limiter_with_priority(
         &self,
         rg: &str,
@@ -1630,23 +1655,28 @@ impl ResourceGroup {
             .get_fill_rate()
     }
 
+    /// Whether `request_source` routes to this group's background limiter.
+    /// The one copy of the rule: `is_background_request` needs the verdict
+    /// without materializing the limiter.
+    fn is_background_source(&self, request_source: &str) -> bool {
+        // the source task name is the last part of `request_source` separated by "_"
+        // the request_source is
+        // {extrenal|internal}_{tidb_req_source}_{source_task_name}
+        self.limiter.is_some() && {
+            let source_task_name = request_source.rsplit('_').next().unwrap_or("");
+            !source_task_name.is_empty() && self.background_source_types.contains(source_task_name)
+        }
+    }
+
     fn get_background_resource_limiter(
         &self,
         request_source: &str,
     ) -> Option<Arc<ResourceLimiter>> {
-        self.limiter.as_ref().and_then(|limiter| {
-            // the source task name is the last part of `request_source` separated by "_"
-            // the request_source is
-            // {extrenal|internal}_{tidb_req_source}_{source_task_name}
-            let source_task_name = request_source.rsplit('_').next().unwrap_or("");
-            if !source_task_name.is_empty()
-                && self.background_source_types.contains(source_task_name)
-            {
-                Some(limiter.clone())
-            } else {
-                None
-            }
-        })
+        if self.is_background_source(request_source) {
+            self.limiter.clone()
+        } else {
+            None
+        }
     }
 }
 
@@ -4782,7 +4812,7 @@ pub(crate) mod tests {
 
         let mut ctx = ResourceControlContext::default();
         ctx.resource_group_name = DEFAULT_RESOURCE_GROUP_NAME.to_owned();
-        mgr.consume_penalty(&ctx);
+        mgr.consume_penalty(&ctx, "");
         assert_eq!(open_bucket(&mgr, DEFAULT_RESOURCE_GROUP_NAME), 70);
 
         mgr.get_config()
@@ -4792,12 +4822,43 @@ pub(crate) mod tests {
             })
             .unwrap();
         mgr.refresh_cached_config();
-        mgr.consume_penalty(&ctx);
+        mgr.consume_penalty(&ctx, "");
         assert_eq!(
             open_bucket(&mgr, DEFAULT_RESOURCE_GROUP_NAME),
             70,
             "0 disables the charge"
         );
+    }
+
+    /// A background-routed request is metered by its background limiter, so
+    /// it must not also pay the arrival cost into the group's foreground
+    /// tracker -- the same rule `future.rs` applies to measured CPU.
+    #[test]
+    fn test_request_base_cost_skips_background_requests() {
+        let mut cfg = Config::default();
+        cfg.request_base_cost_micros = 50;
+        let mgr = ResourceGroupManager::new(cfg);
+        mgr.add_resource_group(new_background_resource_group_ru(
+            "bg".into(),
+            1000,
+            LOW_PRIORITY,
+            vec!["br".into()],
+        ));
+
+        let mut ctx = ResourceControlContext::default();
+        ctx.resource_group_name = "bg".to_owned();
+
+        // The source task name is the last `_`-separated segment, so this
+        // routes to the group's background limiter.
+        mgr.consume_penalty(&ctx, "external_Br_br");
+        assert!(
+            mgr.ru_trackers.get("bg").is_none(),
+            "a background request must not open a foreground tracker"
+        );
+
+        // Same group, a source that matches no configured job type.
+        mgr.consume_penalty(&ctx, "external_Select_stmt");
+        assert_eq!(open_bucket(&mgr, "bg"), 50);
     }
 
     /// A name that is not a configured group must not open a tracker of its
@@ -4810,7 +4871,7 @@ pub(crate) mod tests {
 
         let mut ctx = ResourceControlContext::default();
         ctx.resource_group_name = "never-configured".to_owned();
-        mgr.consume_penalty(&ctx);
+        mgr.consume_penalty(&ctx, "");
 
         assert!(mgr.ru_trackers.get("never-configured").is_none());
         assert_eq!(open_bucket(&mgr, DEFAULT_RESOURCE_GROUP_NAME), 40);

--- a/components/resource_control/src/score.rs
+++ b/components/resource_control/src/score.rs
@@ -25,11 +25,12 @@ use tikv_util::{
     time::Instant,
 };
 
-/// Test-only: a cpu_score high enough to guarantee maximum pressure
-/// regardless of configured thresholds, used to drive foreground/read-pool
-/// throttling tests unconditionally into their "fully engaged" branch.
-#[cfg(test)]
-pub(crate) const TARGET_CPU: f64 = 90.0;
+/// CPU utilization a node is assumed to reach once foreground pressure is
+/// engaged. `resource_group.rs` measures the overshoot from
+/// `fg_cpu_throttle_threshold` up to this when sizing the noisy group set,
+/// and tests pass it as a `cpu_score` guaranteed to engage regardless of the
+/// configured threshold.
+pub(crate) const PEAK_CPU_PCT: f64 = 90.0;
 
 /// Shortest interval [`ThreadGroupCpuTracker::measure_cpu_cores`] will measure
 /// over; below this the tick count is too small to be meaningful and the cached

--- a/components/resource_control/src/worker.rs
+++ b/components/resource_control/src/worker.rs
@@ -26,7 +26,7 @@ use tikv_util::{
 
 use crate::{
     metrics::*,
-    resource_group::ResourceGroupManager,
+    resource_group::{ResourceGroupManager, LEEWAY_FRACTION, THROTTLE_INCREASE_FACTOR},
     resource_limiter::{GroupStatistics, ResourceLimiter, ResourceType},
     score::{
         ResourceCapacities, ResourceScoreInputs, ResourceScores, ThreadGroupCpuTracker,
@@ -34,22 +34,11 @@ use crate::{
     },
 };
 
-pub const QUOTA_ADJUST_DURATION: Duration = Duration::from_secs(10);
-
 const MICROS_PER_SEC: f64 = 1_000_000.0;
 // the minimal schedule wait duration due to the overhead of queue.
 // We should exclude this cause when calculate the estimated total wait
 // duration.
 const MINIMAL_SCHEDULE_WAIT_SECS: f64 = 0.000_005; //5us
-
-/// Per-tick multiplicative step used to ramp a limit back up once the system is
-/// no longer under pressure: +10% per tick rather than jumping straight to the
-/// ceiling.
-const RAMP_UP_FACTOR: f64 = 1.1;
-/// Fraction of the target below which a limit counts as "not yet recovered",
-/// and fraction of `bg_scale_start` below which the system counts as idle. A
-/// dead zone, so ramp-up doesn't fight the throttle branch tick by tick.
-const IDLE_LEEWAY_RATIO: f64 = 0.9;
 
 /// Bundles the two scale-range thresholds so they can be passed as a single
 /// argument to `background_adjust_resource_quota`.
@@ -467,11 +456,11 @@ impl<R: ResourceStatsProvider> GroupQuotaAdjustWorker<R> {
         } else if current_limit_score > target_score {
             // Background limit exceeds its allowed share; reset to target.
             target_score
-        } else if current_limit_score < IDLE_LEEWAY_RATIO * target_score
-            && resource_score < IDLE_LEEWAY_RATIO * bg_scale_start
+        } else if current_limit_score < (1.0 - LEEWAY_FRACTION) * target_score
+            && resource_score < (1.0 - LEEWAY_FRACTION) * bg_scale_start
         {
             // System is idle; increase limit incrementally from current limit.
-            current_limit_score * RAMP_UP_FACTOR
+            current_limit_score * THROTTLE_INCREASE_FACTOR
         } else {
             target_score
         }
@@ -493,7 +482,7 @@ impl<R: ResourceStatsProvider> GroupQuotaAdjustWorker<R> {
             if current_limit.is_infinite() || current_limit >= ceiling {
                 ceiling
             } else {
-                (current_limit * RAMP_UP_FACTOR).min(ceiling)
+                (current_limit * THROTTLE_INCREASE_FACTOR).min(ceiling)
             }
         } else {
             // Linear interpolation from ceiling to floor as pressure goes from
@@ -1590,25 +1579,33 @@ mod tests {
             5.6 * MICROS_PER_SEC,
         );
 
-        // Pressure drops to 0 (< threshold): one RAMP_UP_FACTOR step from floor.
+        // Pressure = 106 (>= threshold * 1.5 = 105): pressure_ratio clamped to 1.0 →
+        // floor.
+        compaction_pending_bytes_ratio.store(106, Ordering::Relaxed);
+        reset_quota(&mut worker, 0.0, 0.0, Duration::from_secs(1));
+        worker.adjust_quota();
+        check(limiter.get_write_io_limiter().get_rate_limit(), floor);
+
+        // Pressure drops to 0 (< threshold): one THROTTLE_INCREASE_FACTOR step from
+        // floor.
         compaction_pending_bytes_ratio.store(0, Ordering::Relaxed);
         reset_quota(&mut worker, 0.0, 0.0, Duration::from_secs(1));
         worker.adjust_quota();
-        let ramp1 = floor * RAMP_UP_FACTOR;
+        let ramp1 = floor * THROTTLE_INCREASE_FACTOR;
         check(limiter.get_write_io_limiter().get_rate_limit(), ramp1);
 
         // Pressure stays at 0: another ramp-up step.
         reset_quota(&mut worker, 0.0, 0.0, Duration::from_secs(1));
         worker.adjust_quota();
-        let ramp2 = ramp1 * RAMP_UP_FACTOR;
+        let ramp2 = ramp1 * THROTTLE_INCREASE_FACTOR;
         check(limiter.get_write_io_limiter().get_rate_limit(), ramp2);
 
         // Keep ramping until we hit ceiling.
         let mut current = ramp2;
-        while current * RAMP_UP_FACTOR < ceiling {
+        while current * THROTTLE_INCREASE_FACTOR < ceiling {
             reset_quota(&mut worker, 0.0, 0.0, Duration::from_secs(1));
             worker.adjust_quota();
-            current = (current * RAMP_UP_FACTOR).min(ceiling);
+            current = (current * THROTTLE_INCREASE_FACTOR).min(ceiling);
             check(limiter.get_write_io_limiter().get_rate_limit(), current);
         }
         // One more adjustment should cap at ceiling.

--- a/components/resource_control/src/worker.rs
+++ b/components/resource_control/src/worker.rs
@@ -26,7 +26,7 @@ use tikv_util::{
 
 use crate::{
     metrics::*,
-    resource_group::{LEEWAY_FRACTION, ResourceGroupManager, THROTTLE_INCREASE_FACTOR},
+    resource_group::{LEEWAY_FACTOR, ResourceGroupManager, THROTTLE_INCREASE_FACTOR},
     resource_limiter::{GroupStatistics, ResourceLimiter, ResourceType},
     score::{
         ResourceCapacities, ResourceScoreInputs, ResourceScores, ThreadGroupCpuTracker,
@@ -456,8 +456,8 @@ impl<R: ResourceStatsProvider> GroupQuotaAdjustWorker<R> {
         } else if current_limit_score > target_score {
             // Background limit exceeds its allowed share; reset to target.
             target_score
-        } else if current_limit_score < (1.0 - LEEWAY_FRACTION) * target_score
-            && resource_score < (1.0 - LEEWAY_FRACTION) * bg_scale_start
+        } else if current_limit_score < LEEWAY_FACTOR * target_score
+            && resource_score < LEEWAY_FACTOR * bg_scale_start
         {
             // System is idle; increase limit incrementally from current limit.
             current_limit_score * THROTTLE_INCREASE_FACTOR

--- a/components/resource_control/src/worker.rs
+++ b/components/resource_control/src/worker.rs
@@ -26,7 +26,7 @@ use tikv_util::{
 
 use crate::{
     metrics::*,
-    resource_group::{ResourceGroupManager, LEEWAY_FRACTION, THROTTLE_INCREASE_FACTOR},
+    resource_group::{LEEWAY_FRACTION, ResourceGroupManager, THROTTLE_INCREASE_FACTOR},
     resource_limiter::{GroupStatistics, ResourceLimiter, ResourceType},
     score::{
         ResourceCapacities, ResourceScoreInputs, ResourceScores, ThreadGroupCpuTracker,

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -715,7 +715,7 @@ where
         if let Some(resource_ctl) = &self.resource_manager {
             cfg_controller.register(
                 tikv::config::Module::ResourceControl,
-                Box::new(ResourceContrlCfgMgr::new(resource_ctl.get_config().clone())),
+                Box::new(ResourceContrlCfgMgr::new(resource_ctl.clone())),
             );
         }
 

--- a/components/server/src/server2.rs
+++ b/components/server/src/server2.rs
@@ -582,7 +582,7 @@ where
         if let Some(resource_ctl) = &self.resource_manager {
             cfg_controller.register(
                 tikv::config::Module::ResourceControl,
-                Box::new(ResourceContrlCfgMgr::new(resource_ctl.get_config().clone())),
+                Box::new(ResourceContrlCfgMgr::new(resource_ctl.clone())),
             );
         }
 

--- a/deny.toml
+++ b/deny.toml
@@ -107,6 +107,20 @@ ignore = [
     #
     # TODO: Remove after the legacy clients move off h2 0.3.
     "RUSTSEC-2026-0258",
+    # Ignore RUSTSEC-2026-0275 (legacy azure_core writes the `authorization`
+    # header value to logs). The disclosure is azure_core 0.18's
+    # `policies/transport.rs`, which `log::debug!`s the whole `Request` -- and
+    # `Request`'s `Debug` includes its headers. It emits through the `log` crate
+    # facade, and TiKV installs no `log` logger at all (no `set_boxed_logger`,
+    # `slog_stdlog::init` or `log::set_max_level` anywhere in the tree), so those
+    # records are discarded rather than written anywhere.
+    #
+    # No version resolves it: the fix is azure_core >= 0.22, but azure_storage,
+    # azure_storage_blobs and azure_security_keyvault are all abandoned at
+    # 0.21.0, still inside the affected range, and pin azure_core ^0.18.
+    #
+    # TODO: Remove after migrating to the renamed Azure 1.x crates.
+    "RUSTSEC-2026-0275",
 ]
 
 # TiKV is licensed under Apache 2.0, according to ASF 3RD PARTY LICENSE POLICY,

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -763,7 +763,8 @@ impl<E: Engine> Endpoint<E> {
             Duration::from_millis(req.get_context().get_busy_threshold_ms() as u64),
             req.get_context()
                 .get_resource_control_context()
-                .get_resource_group_name(),
+                .get_resource_group_name()
+                .as_bytes(),
         ) {
             let mut pb_error = errorpb::Error::new();
             pb_error.set_server_is_busy(busy_err);

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -759,9 +759,12 @@ impl<E: Engine> Endpoint<E> {
         });
         // Check the load of the read pool. If it's too busy, generate and return
         // error in the gRPC thread to avoid waiting in the queue of the read pool.
-        if let Err(busy_err) = self.read_pool.check_busy_threshold(Duration::from_millis(
-            req.get_context().get_busy_threshold_ms() as u64,
-        )) {
+        if let Err(busy_err) = self.read_pool.check_busy_threshold(
+            Duration::from_millis(req.get_context().get_busy_threshold_ms() as u64),
+            req.get_context()
+                .get_resource_control_context()
+                .get_resource_group_name(),
+        ) {
             let mut pb_error = errorpb::Error::new();
             pb_error.set_server_is_busy(busy_err);
             let resp = make_error_response(Error::Region(pb_error));

--- a/src/read_pool.rs
+++ b/src/read_pool.rs
@@ -153,14 +153,14 @@ async fn admission_and_enqueue(
                           "group" => limiter.name(),
                           "delay" => ?d);
                 }
-                Some((d, resource_manager))
+                Some(d)
             }
             AdmissionDecision::Allow => None,
         },
         _ => None,
     };
-    if let Some((d, slot)) = delay {
-        let mut _guard = slot.as_ref().map(|rm| rm.delay_slot_guard());
+    if let Some(d) = delay {
+        let mut _guard = resource_manager.as_ref().map(|rm| rm.delay_slot_guard());
         futures_timer::Delay::new(d).await;
         if let Some(guard) = _guard.as_mut() {
             guard.release();
@@ -170,13 +170,16 @@ async fn admission_and_enqueue(
     if gauge.get() as usize >= max_tasks {
         let rejected_group = {
             let meta = TaskMetadata::from(task_cell.mut_extras().metadata());
-            // The default group's metadata reports an empty name, so map it the
-            // same way `check_busy_threshold` does. Otherwise the two pre-pool
-            // rejection counters label the same group differently.
-            match std::str::from_utf8(meta.group_name()) {
-                Ok("") => DEFAULT_RESOURCE_GROUP_NAME.to_owned(),
-                Ok(name) => name.to_owned(),
-                Err(_) => "unknown".to_owned(),
+            // The name reaches us from the client, so bound it to the
+            // configured groups before it becomes a metric label -- see
+            // `ResourceGroupManager::bounded_group_name`. This also maps the
+            // default group's empty name onto "default", the label
+            // `check_busy_threshold` uses for the same group, so the two
+            // pre-pool rejection counters stay comparable.
+            let name = std::str::from_utf8(meta.group_name()).unwrap_or_default();
+            match resource_manager.as_deref() {
+                Some(rm) => rm.bounded_group_name(name).to_owned(),
+                None => DEFAULT_RESOURCE_GROUP_NAME.to_owned(),
             }
         };
         if let Some(ref _resource_ctl) = resource_ctl {
@@ -457,6 +460,20 @@ impl ReadPoolHandle {
             .map(|s| s * (self.get_queue_size_per_worker() as u32))
     }
 
+    /// Bound a wire-supplied resource group name for use as a metric label.
+    /// With no resource manager there are no configured groups to validate
+    /// against, so everything collapses to the default rather than letting an
+    /// unvalidated name reach the label.
+    fn bounded_group_label<'a>(&self, resource_group: &'a str) -> &'a str {
+        match self {
+            ReadPoolHandle::Yatp {
+                resource_manager: Some(rm),
+                ..
+            } => rm.bounded_group_name(resource_group),
+            _ => DEFAULT_RESOURCE_GROUP_NAME,
+        }
+    }
+
     pub fn check_busy_threshold(
         &self,
         busy_threshold: Duration,
@@ -475,14 +492,8 @@ impl ReadPoolHandle {
         let mut busy_err = errorpb::ServerIsBusy::default();
         busy_err.set_reason("estimated wait time exceeds threshold".to_owned());
         busy_err.estimated_wait_ms = u32::try_from(estimated_wait.as_millis()).unwrap_or(u32::MAX);
-        // A client that sends no resource group is the default group, the same
-        // way `TaskMetadata::group_name` reports it.
         UNIFIED_READ_POOL_BUSY_THRESHOLD_REJECTED
-            .with_label_values(&[if resource_group.is_empty() {
-                DEFAULT_RESOURCE_GROUP_NAME
-            } else {
-                resource_group
-            }])
+            .with_label_values(&[self.bounded_group_label(resource_group)])
             .inc();
         warn!("Already many pending tasks in the read queue, task is rejected";
             "busy_threshold" => ?&busy_threshold,
@@ -2303,13 +2314,15 @@ mod tests {
             max_tasks_per_worker: 100,
             ..Default::default()
         };
+        let resource_manager = Arc::new(ResourceGroupManager::default());
+        resource_manager.add_resource_group(new_resource_group_ru("noisy".into(), 5000, 1));
         let engine = TestEngineBuilder::new().build().unwrap();
         let pool = build_yatp_read_pool_with_name(
             &config,
             DummyReporter,
             engine,
             None,
-            None,
+            Some(resource_manager.clone()),
             CleanupMethod::InPlace,
             "test-busy-threshold".to_owned(),
             false,
@@ -2362,6 +2375,23 @@ mod tests {
             counter("quiet"),
             0,
             "rejection must be attributed to its own group"
+        );
+
+        // An unconfigured name arrives from the client and must not become a
+        // label of its own, or a caller mints a new series per request.
+        let default_before = counter(DEFAULT_RESOURCE_GROUP_NAME);
+        handle
+            .check_busy_threshold(Duration::from_millis(100), "../../etc/passwd\n{injected}")
+            .expect_err("the estimate is over the threshold");
+        assert_eq!(
+            counter("../../etc/passwd\n{injected}"),
+            0,
+            "an unconfigured group name must never reach the label"
+        );
+        assert_eq!(
+            counter(DEFAULT_RESOURCE_GROUP_NAME),
+            default_before + 1,
+            "it is counted against the default group instead"
         );
 
         running_tasks[0].sub(500);

--- a/src/read_pool.rs
+++ b/src/read_pool.rs
@@ -169,38 +169,41 @@ async fn admission_and_enqueue(
     }
     // After admission (and any sleep), check pool capacity and evict if needed.
     if gauge.get() as usize >= max_tasks {
-        let rejected_group = {
-            let meta = TaskMetadata::from(task_cell.mut_extras().metadata());
-            // The name reaches us from the client, so bound it to the
-            // configured groups before it becomes a metric label -- see
-            // `ResourceGroupManager::bounded_group_name`. Invalid UTF-8
-            // cannot name a configured group either, so it collapses the same
-            // way. `group_name()` already reports "default" for the default
-            // group, which is the label `check_busy_threshold` uses for it,
-            // so the two pre-pool counters agree there with no special case.
-            let name = std::str::from_utf8(meta.group_name()).unwrap_or_default();
-            match resource_manager.as_deref() {
-                Some(rm) => rm.bounded_group_name(name).to_owned(),
-                None => DEFAULT_RESOURCE_GROUP_NAME.to_owned(),
-            }
+        // Eviction is only available with a resource controller, and normally
+        // succeeds -- so nothing about the rejection is computed until the
+        // request is actually being rejected.
+        let evicted = if resource_ctl.is_some() {
+            remote.try_evict_lowest(estimated_priority)
+        } else {
+            None
         };
-        if let Some(ref _resource_ctl) = resource_ctl {
-            if let Some(mut evicted) = remote.try_evict_lowest(estimated_priority) {
+        match evicted {
+            Some(mut evicted) => {
                 let evicted_prio = priority_from_task_meta(evicted.mut_extras().metadata());
                 running_tasks[evicted_prio as usize].dec();
                 UNIFIED_READ_POOL_EVICTED_TASKS.inc();
                 drop(evicted);
-            } else {
+            }
+            None => {
+                let meta = TaskMetadata::from(task_cell.mut_extras().metadata());
+                // The name reaches us from the client, so bound it to the
+                // configured groups before it becomes a metric label -- see
+                // `ResourceGroupManager::bounded_group_name`. Invalid UTF-8
+                // cannot name a configured group either, so it collapses the
+                // same way. `group_name()` already reports "default" for the
+                // default group, which is the label `check_busy_threshold`
+                // uses for it, so the two pre-pool counters agree there with
+                // no special case.
+                let name = std::str::from_utf8(meta.group_name()).unwrap_or_default();
+                let label = match resource_manager.as_deref() {
+                    Some(rm) => rm.bounded_group_name(name),
+                    None => DEFAULT_RESOURCE_GROUP_NAME,
+                };
                 UNIFIED_READ_POOL_FULL_REJECTED
-                    .with_label_values(&[&rejected_group])
+                    .with_label_values(&[label])
                     .inc();
                 return Err(ReadPoolError::UnifiedReadPoolFull);
             }
-        } else {
-            UNIFIED_READ_POOL_FULL_REJECTED
-                .with_label_values(&[&rejected_group])
-                .inc();
-            return Err(ReadPoolError::UnifiedReadPoolFull);
         }
     }
     gauge.inc();
@@ -476,10 +479,14 @@ impl ReadPoolHandle {
         }
     }
 
+    /// `resource_group` is bytes rather than `&str` because most requests
+    /// return at one of the two gates below without ever needing the name:
+    /// a client that does not set `busy_threshold` never gets past the first.
+    /// Validating UTF-8 in the caller spent that work on every request.
     pub fn check_busy_threshold(
         &self,
         busy_threshold: Duration,
-        resource_group: &str,
+        resource_group: &[u8],
     ) -> Result<(), errorpb::ServerIsBusy> {
         if busy_threshold.is_zero() {
             return Ok(());
@@ -494,8 +501,9 @@ impl ReadPoolHandle {
         let mut busy_err = errorpb::ServerIsBusy::default();
         busy_err.set_reason("estimated wait time exceeds threshold".to_owned());
         busy_err.estimated_wait_ms = u32::try_from(estimated_wait.as_millis()).unwrap_or(u32::MAX);
+        let group = std::str::from_utf8(resource_group).unwrap_or_default();
         UNIFIED_READ_POOL_BUSY_THRESHOLD_REJECTED
-            .with_label_values(&[self.bounded_group_label(resource_group)])
+            .with_label_values(&[self.bounded_group_label(group)])
             .inc();
         warn!("Already many pending tasks in the read queue, task is rejected";
             "busy_threshold" => ?&busy_threshold,
@@ -2361,15 +2369,15 @@ mod tests {
         // Zero means the client asked for no gate; 1s is above the estimate.
         // Neither is a rejection.
         handle
-            .check_busy_threshold(Duration::ZERO, "noisy")
+            .check_busy_threshold(Duration::ZERO, b"noisy")
             .expect("a zero threshold disables the gate");
         handle
-            .check_busy_threshold(Duration::from_secs(1), "noisy")
+            .check_busy_threshold(Duration::from_secs(1), b"noisy")
             .expect("1s is above the 500ms estimate");
         assert_eq!(counter("noisy"), before);
 
         let err = handle
-            .check_busy_threshold(Duration::from_millis(100), "noisy")
+            .check_busy_threshold(Duration::from_millis(100), b"noisy")
             .expect_err("the estimate is over the threshold");
         assert_eq!(err.estimated_wait_ms, 500);
         assert_eq!(counter("noisy"), before + 1, "rejection must be counted");
@@ -2383,7 +2391,7 @@ mod tests {
         // label of its own, or a caller mints a new series per request.
         let default_before = counter(DEFAULT_RESOURCE_GROUP_NAME);
         handle
-            .check_busy_threshold(Duration::from_millis(100), "../../etc/passwd\n{injected}")
+            .check_busy_threshold(Duration::from_millis(100), b"../../etc/passwd\n{injected}")
             .expect_err("the estimate is over the threshold");
         assert_eq!(
             counter("../../etc/passwd\n{injected}"),

--- a/src/read_pool.rs
+++ b/src/read_pool.rs
@@ -20,8 +20,9 @@ use kvproto::{errorpb, kvrpcpb::CommandPri};
 use online_config::{ConfigChange, ConfigManager, ConfigValue, Result as CfgResult};
 use prometheus::{Histogram, IntCounter, IntGauge, core::Metric};
 use resource_control::{
-    AdmissionDecision, CONTROL_TICK, ControlledFuture, LEEWAY_FRACTION, READ_POOL_CPU_VEC,
-    ResourceController, ResourceGroupManager, ResourceLimiter, TaskPriority, with_resource_limiter,
+    AdmissionDecision, CONTROL_TICK, ControlledFuture, LEEWAY_FACTOR, LEEWAY_FRACTION,
+    READ_POOL_CPU_VEC, ResourceController, ResourceGroupManager, ResourceLimiter, TaskPriority,
+    with_resource_limiter,
 };
 use thiserror::Error;
 use tikv_util::{
@@ -963,7 +964,7 @@ impl ReadPoolConfigRunner {
             && running_tasks < self.cur_thread_count as i64 * RUNNING_TASKS_PER_THREAD_THRESHOLD;
 
         let busy_cpu_scale_in = read_pool_cpu > (1.0 + LEEWAY_FRACTION) * target_cpu_cores;
-        let busy_cpu_scale_out = read_pool_cpu < (1.0 - LEEWAY_FRACTION) * target_cpu_cores
+        let busy_cpu_scale_out = read_pool_cpu < LEEWAY_FACTOR * target_cpu_cores
             && self.cur_thread_count < self.core_thread_count
             && scale_out_allowed;
 

--- a/src/read_pool.rs
+++ b/src/read_pool.rs
@@ -21,8 +21,7 @@ use online_config::{ConfigChange, ConfigManager, ConfigValue, Result as CfgResul
 use prometheus::{Histogram, IntCounter, IntGauge, core::Metric};
 use resource_control::{
     AdmissionDecision, CONTROL_TICK, ControlledFuture, LEEWAY_FRACTION, READ_POOL_CPU_VEC,
-    ResourceController, ResourceGroupManager, ResourceLimiter, TaskPriority,
-    with_resource_limiter,
+    ResourceController, ResourceGroupManager, ResourceLimiter, TaskPriority, with_resource_limiter,
 };
 use thiserror::Error;
 use tikv_util::{
@@ -171,9 +170,14 @@ async fn admission_and_enqueue(
     if gauge.get() as usize >= max_tasks {
         let rejected_group = {
             let meta = TaskMetadata::from(task_cell.mut_extras().metadata());
-            std::str::from_utf8(meta.group_name())
-                .unwrap_or("unknown")
-                .to_owned()
+            // The default group's metadata reports an empty name, so map it the
+            // same way `check_busy_threshold` does. Otherwise the two pre-pool
+            // rejection counters label the same group differently.
+            match std::str::from_utf8(meta.group_name()) {
+                Ok("") => DEFAULT_RESOURCE_GROUP_NAME.to_owned(),
+                Ok(name) => name.to_owned(),
+                Err(_) => "unknown".to_owned(),
+            }
         };
         if let Some(ref _resource_ctl) = resource_ctl {
             if let Some(mut evicted) = remote.try_evict_lowest(estimated_priority) {
@@ -1303,11 +1307,33 @@ mod tests {
         block_on(handle.spawn(task2, CommandPri::Normal, 2, TaskMetadata::default(), None))
             .unwrap();
 
+        let full_rejected = || {
+            UNIFIED_READ_POOL_FULL_REJECTED
+                .with_label_values(&[DEFAULT_RESOURCE_GROUP_NAME])
+                .get()
+        };
+        let before = full_rejected();
+
         thread::sleep(Duration::from_millis(300));
         match block_on(handle.spawn(task3, CommandPri::Normal, 3, TaskMetadata::default(), None)) {
             Err(ReadPoolError::UnifiedReadPoolFull) => {}
             _ => panic!("should return full error"),
         }
+        // The metadata above carries no resource group. Its rejection has to be
+        // attributed to "default", the label `check_busy_threshold` uses for the
+        // same group, so the two pre-pool counters stay comparable.
+        assert!(
+            full_rejected() > before,
+            "the default group's full-pool rejection must be counted under \
+             {DEFAULT_RESOURCE_GROUP_NAME}"
+        );
+        assert_eq!(
+            UNIFIED_READ_POOL_FULL_REJECTED
+                .with_label_values(&[""])
+                .get(),
+            0,
+            "an empty group name must never reach the label"
+        );
         tx1.send(()).unwrap();
 
         thread::sleep(Duration::from_millis(300));

--- a/src/read_pool.rs
+++ b/src/read_pool.rs
@@ -946,14 +946,13 @@ impl ReadPoolConfigRunner {
 
         self.set_thread_count(new_thread_count);
 
-        // While we haven't scaled back up to core_thread_count, keep noisy
-        // resource groups deprioritized. Once recovered, release everyone —
-        // which also clears any flags left over from when fair scheduling was
-        // last enabled, since deprioritizing is a no-op while it is off.
+        // Only CPU pressure justifies penalizing a tenant — the thread ladder
+        // also scales in when the pool is merely oversized. Release at full
+        // recovery also clears flags left from when fair scheduling was off.
         if let Some(rm) = resource_manager.as_ref() {
-            if self.cur_thread_count < self.core_thread_count {
+            if busy_cpu_scale_in {
                 rm.deprioritize_over_quota_groups();
-            } else {
+            } else if self.cur_thread_count == self.core_thread_count {
                 rm.reset_group_priorities();
             }
         }

--- a/src/read_pool.rs
+++ b/src/read_pool.rs
@@ -20,12 +20,13 @@ use kvproto::{errorpb, kvrpcpb::CommandPri};
 use online_config::{ConfigChange, ConfigManager, ConfigValue, Result as CfgResult};
 use prometheus::{Histogram, IntCounter, IntGauge, core::Metric};
 use resource_control::{
-    AdmissionDecision, ControlledFuture, READ_POOL_CPU_VEC, ResourceController,
-    ResourceGroupManager, ResourceLimiter, TaskPriority, with_resource_limiter,
+    AdmissionDecision, CONTROL_TICK, ControlledFuture, LEEWAY_FRACTION, READ_POOL_CPU_VEC,
+    ResourceController, ResourceGroupManager, ResourceLimiter, TaskPriority,
+    with_resource_limiter,
 };
 use thiserror::Error;
 use tikv_util::{
-    resource_control::{TaskMetadata, priority_from_task_meta},
+    resource_control::{DEFAULT_RESOURCE_GROUP_NAME, TaskMetadata, priority_from_task_meta},
     sys::{SysQuota, cpu_time::ProcessStat},
     thread_name_prefix::{UNIFIED_READ_POOL_THREAD, matches_thread_name_prefix},
     time::Instant,
@@ -46,8 +47,6 @@ use crate::{
     storage::kv::{Engine, FlowStatsReporter, destroy_tls_engine, set_tls_engine},
 };
 
-// the duration to check auto-scale unified-thread-pool's thread
-const READ_POOL_THREAD_CHECK_DURATION: Duration = Duration::from_secs(10);
 // consider scale out read pool size if the average thread cpu usage is higher
 // than this threshold.
 const READ_POOL_THREAD_HIGH_THRESHOLD: f64 = 0.8;
@@ -139,7 +138,7 @@ async fn admission_and_enqueue(
     gauge: IntGauge,
     max_tasks: usize,
     remote: Remote<TaskCell>,
-    task_cell: TaskCell,
+    mut task_cell: TaskCell,
     running_tasks: Vec<IntGauge>,
     resource_ctl: Option<Arc<ResourceController>>,
     estimated_priority: u64,
@@ -170,6 +169,12 @@ async fn admission_and_enqueue(
     }
     // After admission (and any sleep), check pool capacity and evict if needed.
     if gauge.get() as usize >= max_tasks {
+        let rejected_group = {
+            let meta = TaskMetadata::from(task_cell.mut_extras().metadata());
+            std::str::from_utf8(meta.group_name())
+                .unwrap_or("unknown")
+                .to_owned()
+        };
         if let Some(ref _resource_ctl) = resource_ctl {
             if let Some(mut evicted) = remote.try_evict_lowest(estimated_priority) {
                 let evicted_prio = priority_from_task_meta(evicted.mut_extras().metadata());
@@ -177,9 +182,15 @@ async fn admission_and_enqueue(
                 UNIFIED_READ_POOL_EVICTED_TASKS.inc();
                 drop(evicted);
             } else {
+                UNIFIED_READ_POOL_FULL_REJECTED
+                    .with_label_values(&[&rejected_group])
+                    .inc();
                 return Err(ReadPoolError::UnifiedReadPoolFull);
             }
         } else {
+            UNIFIED_READ_POOL_FULL_REJECTED
+                .with_label_values(&[&rejected_group])
+                .inc();
             return Err(ReadPoolError::UnifiedReadPoolFull);
         }
     }
@@ -427,6 +438,13 @@ impl ReadPoolHandle {
         } = self
         {
             time_slice_inspector.update();
+            UNIFIED_READ_POOL_EWMA_TIME_SLICE_US
+                .set(time_slice_inspector.get_ewma_time_slice().as_micros() as i64);
+        }
+        // The input to `check_busy_threshold`. Sampled here rather than at the
+        // gate so it is reported even when no client sends a busy threshold.
+        if let Some(wait) = self.get_estimated_wait_duration() {
+            UNIFIED_READ_POOL_ESTIMATED_WAIT_US.set(wait.as_micros() as i64);
         }
     }
 
@@ -438,6 +456,7 @@ impl ReadPoolHandle {
     pub fn check_busy_threshold(
         &self,
         busy_threshold: Duration,
+        resource_group: &str,
     ) -> Result<(), errorpb::ServerIsBusy> {
         if busy_threshold.is_zero() {
             return Ok(());
@@ -452,6 +471,15 @@ impl ReadPoolHandle {
         let mut busy_err = errorpb::ServerIsBusy::default();
         busy_err.set_reason("estimated wait time exceeds threshold".to_owned());
         busy_err.estimated_wait_ms = u32::try_from(estimated_wait.as_millis()).unwrap_or(u32::MAX);
+        // A client that sends no resource group is the default group, the same
+        // way `TaskMetadata::group_name` reports it.
+        UNIFIED_READ_POOL_BUSY_THRESHOLD_REJECTED
+            .with_label_values(&[if resource_group.is_empty() {
+                DEFAULT_RESOURCE_GROUP_NAME
+            } else {
+                resource_group
+            }])
+            .inc();
         warn!("Already many pending tasks in the read queue, task is rejected";
             "busy_threshold" => ?&busy_threshold,
             "busy_err" => ?&busy_err,
@@ -918,9 +946,8 @@ impl ReadPoolConfigRunner {
             && thread_usage < (self.cur_thread_count - 1) as f64 * READ_POOL_THREAD_LOW_THRESHOLD
             && running_tasks < self.cur_thread_count as i64 * RUNNING_TASKS_PER_THREAD_THRESHOLD;
 
-        let leeway = 0.1;
-        let busy_cpu_scale_in = read_pool_cpu > (leeway + 1.0) * target_cpu_cores;
-        let busy_cpu_scale_out = read_pool_cpu < (1.0 - leeway) * target_cpu_cores
+        let busy_cpu_scale_in = read_pool_cpu > (1.0 + LEEWAY_FRACTION) * target_cpu_cores;
+        let busy_cpu_scale_out = read_pool_cpu < (1.0 - LEEWAY_FRACTION) * target_cpu_cores
             && self.cur_thread_count < self.core_thread_count
             && scale_out_allowed;
 
@@ -1014,7 +1041,7 @@ impl ReadPoolConfigManager {
         cpu_threshold: f64,
     ) -> Self {
         let runner = ReadPoolConfigRunner {
-            interval: READ_POOL_THREAD_CHECK_DURATION,
+            interval: CONTROL_TICK,
             sender,
             handle,
             cpu_time_tracker: ReadPoolCpuTimeTracker::new(&get_unified_read_pool_name()),
@@ -1099,6 +1126,34 @@ mod metrics {
         pub static ref UNIFIED_READ_POOL_EVICTED_TASKS: IntCounter = register_int_counter!(
             "tikv_unified_read_pool_evicted_tasks",
             "Number of tasks evicted from the unified read pool by higher-priority tasks"
+        )
+        .unwrap();
+        // Splits the two sources of `ServerIsBusy`: the estimated-wait gate in
+        // `check_busy_threshold` and the capacity gate in the spawn path. Both
+        // return the same error to the client, so without these the share of
+        // each is not recoverable from metrics.
+        pub static ref UNIFIED_READ_POOL_BUSY_THRESHOLD_REJECTED: IntCounterVec =
+            register_int_counter_vec!(
+                "tikv_unified_read_pool_busy_threshold_rejected_total",
+                "Requests rejected because the estimated read pool wait exceeded the client's busy threshold",
+                &["resource_group"]
+            )
+            .unwrap();
+        pub static ref UNIFIED_READ_POOL_FULL_REJECTED: IntCounterVec =
+            register_int_counter_vec!(
+                "tikv_unified_read_pool_full_rejected_total",
+                "Requests rejected because the unified read pool queue was at capacity",
+                &["resource_group"]
+            )
+            .unwrap();
+        pub static ref UNIFIED_READ_POOL_ESTIMATED_WAIT_US: IntGauge = register_int_gauge!(
+            "tikv_unified_read_pool_estimated_wait_us",
+            "Estimated queueing wait for a new unified read pool task, in microseconds"
+        )
+        .unwrap();
+        pub static ref UNIFIED_READ_POOL_EWMA_TIME_SLICE_US: IntGauge = register_int_gauge!(
+            "tikv_unified_read_pool_ewma_time_slice_us",
+            "EWMA of a single task poll duration in the unified read pool, in microseconds"
         )
         .unwrap();
     }
@@ -1612,7 +1667,7 @@ mod tests {
 
         // Repeated ticks keep reducing cur_thread_count relative to itself
         // each time (via the read pool's own cur_thread_count * ratio math),
-        // until it stabilizes at floor(0.9 * 4.0) = 3 — the target ceiling's
+        // until it stabilizes at floor(0.85 * 4.0) = 3 — the target ceiling's
         // own floor, since the fixed test reading never drops further to
         // push the ceiling down any more.
         for _ in 0..20 {
@@ -1712,8 +1767,6 @@ mod tests {
         auto_adjust: bool,
         resource_manager: Option<Arc<ResourceGroupManager>>,
     ) -> (ReadPoolConfigRunner, tikv_util::worker::Worker) {
-        use tikv_util::worker::Worker;
-
         let config = UnifiedReadPoolConfig {
             min_thread_count: 1,
             max_thread_count: 8,
@@ -2217,6 +2270,78 @@ mod tests {
     }
 
     #[test]
+    fn test_busy_threshold_rejection_is_counted() {
+        let config = UnifiedReadPoolConfig {
+            min_thread_count: 1,
+            max_thread_count: 1,
+            max_tasks_per_worker: 100,
+            ..Default::default()
+        };
+        let engine = TestEngineBuilder::new().build().unwrap();
+        let pool = build_yatp_read_pool_with_name(
+            &config,
+            DummyReporter,
+            engine,
+            None,
+            None,
+            CleanupMethod::InPlace,
+            "test-busy-threshold".to_owned(),
+            false,
+        );
+        let handle = pool.handle();
+
+        // The estimate is one poll's duration times the queued tasks per
+        // worker, so both have to be non-zero before the gate can fire at all.
+        let (inspector, running_tasks) = match &handle {
+            ReadPoolHandle::Yatp {
+                time_slice_inspector,
+                running_tasks,
+                ..
+            } => (time_slice_inspector, running_tasks),
+            _ => panic!("expected a yatp pool"),
+        };
+        inspector.atomic_ewma_nanos.store(
+            Duration::from_millis(1).as_nanos() as u64,
+            std::sync::atomic::Ordering::Release,
+        );
+        running_tasks[0].add(500);
+        assert_eq!(
+            handle.get_estimated_wait_duration(),
+            Some(Duration::from_millis(500)),
+            "500 queued tasks on one worker at 1ms per poll"
+        );
+
+        let counter = |g: &str| {
+            UNIFIED_READ_POOL_BUSY_THRESHOLD_REJECTED
+                .with_label_values(&[g])
+                .get()
+        };
+        let before = counter("noisy");
+        // Zero means the client asked for no gate; 1s is above the estimate.
+        // Neither is a rejection.
+        handle
+            .check_busy_threshold(Duration::ZERO, "noisy")
+            .expect("a zero threshold disables the gate");
+        handle
+            .check_busy_threshold(Duration::from_secs(1), "noisy")
+            .expect("1s is above the 500ms estimate");
+        assert_eq!(counter("noisy"), before);
+
+        let err = handle
+            .check_busy_threshold(Duration::from_millis(100), "noisy")
+            .expect_err("the estimate is over the threshold");
+        assert_eq!(err.estimated_wait_ms, 500);
+        assert_eq!(counter("noisy"), before + 1, "rejection must be counted");
+        assert_eq!(
+            counter("quiet"),
+            0,
+            "rejection must be attributed to its own group"
+        );
+
+        running_tasks[0].sub(500);
+    }
+
+    #[test]
     fn test_auto_adjust_disable_notifies_pool_size_change() {
         use std::sync::mpsc::sync_channel;
 
@@ -2249,7 +2374,7 @@ mod tests {
         };
 
         let mut runner = ReadPoolConfigRunner {
-            interval: READ_POOL_THREAD_CHECK_DURATION,
+            interval: CONTROL_TICK,
             sender: tx,
             handle,
             cpu_time_tracker: ReadPoolCpuTimeTracker::new("test"),

--- a/src/read_pool.rs
+++ b/src/read_pool.rs
@@ -172,10 +172,11 @@ async fn admission_and_enqueue(
             let meta = TaskMetadata::from(task_cell.mut_extras().metadata());
             // The name reaches us from the client, so bound it to the
             // configured groups before it becomes a metric label -- see
-            // `ResourceGroupManager::bounded_group_name`. This also maps the
-            // default group's empty name onto "default", the label
-            // `check_busy_threshold` uses for the same group, so the two
-            // pre-pool rejection counters stay comparable.
+            // `ResourceGroupManager::bounded_group_name`. Invalid UTF-8
+            // cannot name a configured group either, so it collapses the same
+            // way. `group_name()` already reports "default" for the default
+            // group, which is the label `check_busy_threshold` uses for it,
+            // so the two pre-pool counters agree there with no special case.
             let name = std::str::from_utf8(meta.group_name()).unwrap_or_default();
             match resource_manager.as_deref() {
                 Some(rm) => rm.bounded_group_name(name).to_owned(),

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -288,7 +288,7 @@ macro_rules! handle_request {
             let resource_control_ctx = req.get_context().get_resource_control_context();
             let mut resource_group_priority = ResourcePriority::unknown;
             if let Some(resource_manager) = &self.resource_manager {
-                resource_manager.consume_penalty(resource_control_ctx);
+                resource_manager.consume_penalty(resource_control_ctx, req.get_context().get_request_source());
                 resource_group_priority= ResourcePriority::from(resource_control_ctx.override_priority);
             }
             GRPC_RESOURCE_GROUP_COUNTER_VEC
@@ -594,7 +594,8 @@ impl<E: Engine, L: LockManager, F: KvFormat> Tikv for Service<E, L, F> {
         let resource_control_ctx = req.get_context().get_resource_control_context();
         let mut resource_group_priority = ResourcePriority::unknown;
         if let Some(resource_manager) = &self.resource_manager {
-            resource_manager.consume_penalty(resource_control_ctx);
+            resource_manager
+                .consume_penalty(resource_control_ctx, req.get_context().get_request_source());
             resource_group_priority =
                 ResourcePriority::from(resource_control_ctx.override_priority);
         }
@@ -641,7 +642,8 @@ impl<E: Engine, L: LockManager, F: KvFormat> Tikv for Service<E, L, F> {
         let resource_control_ctx = req.get_context().get_resource_control_context();
         let mut resource_group_priority = ResourcePriority::unknown;
         if let Some(resource_manager) = &self.resource_manager {
-            resource_manager.consume_penalty(resource_control_ctx);
+            resource_manager
+                .consume_penalty(resource_control_ctx, req.get_context().get_request_source());
             resource_group_priority =
                 ResourcePriority::from(resource_control_ctx.override_priority);
         }
@@ -739,7 +741,8 @@ impl<E: Engine, L: LockManager, F: KvFormat> Tikv for Service<E, L, F> {
         let resource_control_ctx = req.get_context().get_resource_control_context();
         let mut resource_group_priority = ResourcePriority::unknown;
         if let Some(resource_manager) = &self.resource_manager {
-            resource_manager.consume_penalty(resource_control_ctx);
+            resource_manager
+                .consume_penalty(resource_control_ctx, req.get_context().get_request_source());
             resource_group_priority =
                 ResourcePriority::from(resource_control_ctx.override_priority);
         }
@@ -1392,7 +1395,7 @@ fn handle_batch_commands_request<E: Engine, L: LockManager, F: KvFormat>(
                     let resource_control_ctx = req.get_context().get_resource_control_context();
                     let mut resource_group_priority = ResourcePriority::unknown;
                     if let Some(resource_manager) = resource_manager {
-                        resource_manager.consume_penalty(resource_control_ctx);
+                        resource_manager.consume_penalty(resource_control_ctx, req.get_context().get_request_source());
                         resource_group_priority = ResourcePriority::from(resource_control_ctx.override_priority);
                     }
 
@@ -1417,7 +1420,7 @@ fn handle_batch_commands_request<E: Engine, L: LockManager, F: KvFormat>(
                     let resource_control_ctx = req.get_context().get_resource_control_context();
                     let mut resource_group_priority = ResourcePriority::unknown;
                     if let Some(resource_manager) = resource_manager {
-                        resource_manager.consume_penalty(resource_control_ctx);
+                        resource_manager.consume_penalty(resource_control_ctx, req.get_context().get_request_source());
                         resource_group_priority = ResourcePriority::from(resource_control_ctx.override_priority);
                     }
                     GRPC_RESOURCE_GROUP_COUNTER_VEC
@@ -1441,7 +1444,7 @@ fn handle_batch_commands_request<E: Engine, L: LockManager, F: KvFormat>(
                     let resource_control_ctx = req.get_context().get_resource_control_context();
                     let mut resource_group_priority = ResourcePriority::unknown;
                     if let Some(resource_manager) = resource_manager {
-                        resource_manager.consume_penalty(resource_control_ctx);
+                        resource_manager.consume_penalty(resource_control_ctx, req.get_context().get_request_source());
                         resource_group_priority = ResourcePriority::from(resource_control_ctx.override_priority );
                     }
                     GRPC_RESOURCE_GROUP_COUNTER_VEC
@@ -1488,7 +1491,7 @@ fn handle_batch_commands_request<E: Engine, L: LockManager, F: KvFormat>(
                     let resource_control_ctx = req.get_context().get_resource_control_context();
                     let mut resource_group_priority = ResourcePriority::unknown;
                     if let Some(resource_manager) = resource_manager {
-                        resource_manager.consume_penalty(resource_control_ctx);
+                        resource_manager.consume_penalty(resource_control_ctx, req.get_context().get_request_source());
                         resource_group_priority = ResourcePriority::from(resource_control_ctx.override_priority);
                     }
                     GRPC_RESOURCE_GROUP_COUNTER_VEC

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -3385,10 +3385,9 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
         Fut: Future<Output = Result<T>> + Send + 'static,
         T: Send + 'static,
     {
-        let resource_group = std::str::from_utf8(metadata.group_name()).unwrap_or("unknown");
         if let Err(busy_err) = self
             .read_pool
-            .check_busy_threshold(busy_threshold, resource_group)
+            .check_busy_threshold(busy_threshold, metadata.group_name())
         {
             let mut err = kvproto::errorpb::Error::default();
             err.set_server_is_busy(busy_err);

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -3385,7 +3385,11 @@ impl<E: Engine, L: LockManager, F: KvFormat> Storage<E, L, F> {
         Fut: Future<Output = Result<T>> + Send + 'static,
         T: Send + 'static,
     {
-        if let Err(busy_err) = self.read_pool.check_busy_threshold(busy_threshold) {
+        let resource_group = std::str::from_utf8(metadata.group_name()).unwrap_or("unknown");
+        if let Err(busy_err) = self
+            .read_pool
+            .check_busy_threshold(busy_threshold, resource_group)
+        {
             let mut err = kvproto::errorpb::Error::default();
             err.set_server_is_busy(busy_err);
             return FuturesEither::Left(future::err(Error::from(ErrorInner::Kv(err.into()))));

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -24,7 +24,9 @@ use raftstore::{
     coprocessor::{Config as CopConfig, ConsistencyCheckMethod},
     store::Config as RaftstoreConfig,
 };
-use resource_control::config::{Config as ResourceControlConfig, PriorityCtlStrategy};
+use resource_control::config::{
+    Config as ResourceControlConfig, NoisyDetection, PriorityCtlStrategy,
+};
 use security::SecurityConfig;
 use slog::Level;
 use test_util::assert_eq_debug;
@@ -921,6 +923,7 @@ fn test_serde_custom_tikv_config() {
     value.resource_control = ResourceControlConfig {
         enabled: false,
         priority_ctl_strategy: PriorityCtlStrategy::Aggressive,
+        noisy_detection: NoisyDetection::CurrentUsage,
         bg_cpu_throttle_threshold: 60.0,
         fg_cpu_throttle_threshold: 70.0,
         bg_compaction_pressure_threshold: 70.0,
@@ -932,6 +935,7 @@ fn test_serde_custom_tikv_config() {
         historical_usage_window_mins: 15,
         baseline_burst_pct: 20.0,
         admission_max_delayed_count: 10_000,
+        request_base_cost_micros: 40,
     };
 
     let custom = read_file_in_project_dir("integrations/config/test-custom.toml");

--- a/tests/integrations/config/test-custom.toml
+++ b/tests/integrations/config/test-custom.toml
@@ -695,6 +695,7 @@ split.split-contained-score = 0.5
 [resource-control]
 enabled = false
 priority-ctl-strategy = "aggressive"
+noisy-detection = "current-usage"
 bg-cpu-throttle-threshold = 60.0
 fg-cpu-throttle-threshold = 70.0
 bg-compaction-pressure-threshold = 70.0
@@ -706,3 +707,4 @@ enable-write-admission-control = false
 historical-usage-window-mins = 15
 baseline-burst-pct = 20.0
 admission-max-delayed-count = 10000
+request-base-cost-micros = 40


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #20019

Problem Summary:

`adjust_group_throttling` and `deprioritize_over_quota_groups` each test one group at a time with `current > hist * burst_factor`, with no comparison between groups. Every group above its own burst target is clamped and deprioritized, however small its contribution to the overload — so a tenant whose rate rose 2x above its own baseline is penalized alongside one that rose 10x.

### What is changed and how it works?

Adds `ResourceGroupManager::select_noisy_groups`, which picks the groups actually responsible for the overload:

1. Sums `current_rate` across all groups to get total usage.
2. Keeps the existing `baseline_burst_pct` test as the eligibility gate, so a group inside its own headroom is never a candidate.
3. Sorts candidates by excess over their own baseline (`current - historical`), descending.
4. Takes from the top until that excess covers `PEAK_CPU_PCT - fg_cpu_throttle_threshold` percent of total usage.
5. Always takes the top candidate, so an overloaded tick never spares every group.

### Check List

Tests

- [x] Unit test

Three tests cover the selection: a large mover is picked while a 2x mover is spared once the target is met; the single candidate is still penalized when no group can cover the target on its own; and a group inside its burst target is never selected.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

The added work is one sort over the candidate groups per 10s tick.

### Release note

```release-note
Under foreground CPU pressure, resource control now throttles and deprioritizes only the resource groups whose usage rose furthest above their own baseline, instead of every group over its baseline.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable noisy-group detection modes and a base request cost setting.
  - Added per-resource-group visibility into rejection counts, estimated wait times, CPU baselines, and scheduling time slices.
  - Improved overload handling by selecting affected resource groups more fairly and avoiding unnecessary throttling of unaffected groups.

- **Bug Fixes**
  - Improved CPU pressure handling near peak capacity.
  - Enhanced resource-group attribution for busy and capacity-based request rejections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->