### PR TITLE
tikv_util: fix undefined behavior in RangeLatchGuard's Drop impl

### DIFF
--- a/components/tikv_util/src/range_latch.rs
+++ b/components/tikv_util/src/range_latch.rs
@@ -1,11 +1,45 @@
 use std::{
+    cell::RefCell,
     collections::{
         BTreeMap,
         Bound::{Excluded, Unbounded},
     },
-    mem::ManuallyDrop,
-    sync::{Arc, Mutex},
+    marker::PhantomData,
+    sync::{Arc, Condvar, Mutex},
 };
+
+#[derive(Debug)]
+struct RangeLatchLock {
+    held: Mutex<bool>,
+    released: Condvar,
+}
+
+impl RangeLatchLock {
+    fn new() -> Self {
+        Self {
+            held: Mutex::new(true),
+            released: Condvar::new(),
+        }
+    }
+
+    fn wait(&self) {
+        let mut held = self.held.lock().unwrap();
+        while *held {
+            held = self.released.wait(held).unwrap();
+        }
+    }
+
+    fn release(&self) {
+        *self.held.lock().unwrap() = false;
+        self.released.notify_all();
+    }
+}
+
+thread_local! {
+    /// Keeps removed latch allocations alive until the releasing thread next
+    /// enters `RangeLatch::acquire`, after the guard's drop frame has returned.
+    static RETIRED_RANGE_LATCHES: RefCell<Vec<Arc<RangeLatchLock>>> = RefCell::new(Vec::new());
+}
 /// A structure used to manage range-based latch with mutual exclusion.
 ///
 /// Currently used to ensure mutual exclusion between compaction filter and
@@ -41,10 +75,10 @@ pub struct RangeLatch {
     /// A BTreeMap storing active range latches.
     /// Key: The start key of the range (sorted order).
     /// Value: A tuple of:
-    ///   - `Arc<Mutex<()>>`: The latch object for this range.
+    ///   - `Arc<RangeLatchLock>`: The latch object for this range.
     ///   - `(Vec<u8>, Vec<u8>)`: The actual range definition (start_key,
     ///     end_key).
-    range_latches: Mutex<BTreeMap<Vec<u8>, (Arc<Mutex<()>>, (Vec<u8>, Vec<u8>))>>,
+    range_latches: Mutex<BTreeMap<Vec<u8>, (Arc<RangeLatchLock>, (Vec<u8>, Vec<u8>))>>,
 }
 
 impl RangeLatch {
@@ -74,6 +108,8 @@ impl RangeLatch {
     /// Deadlocks cannot occur in the current scenario, as each caller thread
     /// holds at most one lock at a time.
     pub fn acquire(self: &Arc<Self>, start_key: Vec<u8>, end_key: Vec<u8>) -> RangeLatchGuard<'_> {
+        RETIRED_RANGE_LATCHES.with(|retired| retired.borrow_mut().clear());
+
         loop {
             let mut range_latches = self.range_latches.lock().unwrap();
 
@@ -88,38 +124,24 @@ impl RangeLatch {
 
             // If no conflicts, insert the new range and return the guard
             if overlapping_ranges.is_empty() {
-                let mutex = Arc::new(Mutex::new(()));
+                let latch = Arc::new(RangeLatchLock::new());
                 let previous_value = range_latches.insert(
                     start_key.clone(),
-                    (mutex.clone(), (start_key.clone(), end_key.clone())),
+                    (latch, (start_key.clone(), end_key.clone())),
                 );
                 debug_assert!(previous_value.is_none());
 
-                // Now acquire the latch after releasing the write guard
-                let mutex_guard = mutex.lock().unwrap();
-                // Safety: `transmute` just change the lifetime, do not change
-                // the type.
-                // `_mutex_guard` points to the `Mutex<()>`
-                // We need to make sure it will be dropped before the
-                // `Arc<Mutex<()>>` and the `RangeLatch` while `drop`.
-                // Then we can make sure the mutex guard doesn't point to
-                // released memory.
-                // We use `ManuallyDrop` to promise it.
-
-                #[allow(clippy::missing_transmute_annotations)]
-                let mutex_guard = unsafe { std::mem::transmute(mutex_guard) };
-
                 return RangeLatchGuard {
                     start_key,
-                    _mutex_guard: ManuallyDrop::new(mutex_guard),
                     handle: self,
+                    _not_send: PhantomData,
                 };
             }
             drop(range_latches);
 
             // Wait for all overlapping ranges to be released
-            for (_, (mutex, (..))) in overlapping_ranges {
-                let _guard = mutex.lock().unwrap();
+            for (_, (latch, (..))) in overlapping_ranges {
+                latch.wait();
             }
         }
     }
@@ -129,29 +151,33 @@ impl RangeLatch {
 #[derive(Debug)]
 pub struct RangeLatchGuard<'a> {
     start_key: Vec<u8>,
-    /// Hold the mutex guard to prevent concurrent access to the same range.
-    ///
-    /// Use `ManuallyDrop` to promise:
-    /// `_mutex_guard` will be dropped before the `Arc<Mutex<()>>` and the
-    /// `RangeLatch` while `drop`.
-    _mutex_guard: ManuallyDrop<std::sync::MutexGuard<'a, ()>>,
     /// Holds a reference to RangeLatch to release the latch when the guard is
     /// dropped.
     handle: &'a RangeLatch,
+    /// Preserve the original guard's `!Send` behavior without storing a
+    /// self-referential `MutexGuard`.
+    _not_send: PhantomData<std::sync::MutexGuard<'a, ()>>,
 }
 
 impl Drop for RangeLatchGuard<'_> {
     fn drop(&mut self) {
-        // Safety: we call `ManuallyDrop::drop` to drop the mutex guard
-        // once and only once.
-        // So `_mutex_guard` will be released earlier than the
-        // `Arc<Mutex<()>>`. We drop `_mutex_guard` by hand, so dropping order
-        // depends on declaration order no longer matters.
-        unsafe { ManuallyDrop::drop(&mut self._mutex_guard) };
-        let mut range_latches = self.handle.range_latches.lock().unwrap();
-        // `range_latches.remove(&self.start_key);` will cause
-        // `Arc<Mutex()>>` dropped.
-        range_latches.remove(&self.start_key);
+        let latch = self
+            .handle
+            .range_latches
+            .lock()
+            .unwrap()
+            .remove(&self.start_key);
+
+        if let Some((latch, _)) = latch {
+            // Removing the entry makes the range available immediately. Wake
+            // waiters so they can retry against the updated map.
+            latch.release();
+
+            // Do not free the latch allocation inside this drop frame. A
+            // thread-local reference prevents another thread from performing
+            // the final Arc drop; this thread drains it on its next acquire.
+            RETIRED_RANGE_LATCHES.with(|retired| retired.borrow_mut().push(latch));
+        }
     }
 }
 


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: Close #19957

`RangeLatchGuard`'s `Drop` impl held a `std::mem::transmute`-extended `MutexGuard` into the `Arc<Mutex<()>>` stored in `RangeLatch`'s internal map. When the guard dropped, it unlocked that mutex and then removed the map entry, dropping the last `Arc` reference and freeing the mutex's backing allocation — all inside the guard's own drop frame. Under Miri's Stacked Borrows / Tree Borrows model, the value being dropped keeps its allocation "strongly protected" for the duration of the drop frame, so freeing it before the frame returns is undefined behavior (LLVM `dereferenceable`-style assumptions), even though the existing `ManuallyDrop` dance already fixed the drop *order*.

Per the issue reporter's analysis, deferring the free to a *shared* retire list isn't sufficient either — another thread could reclaim it while the releasing thread is still inside its own drop frame. The free has to happen strictly after the releasing thread's drop frame returns.

**Fix:** Replace the transmuted `MutexGuard` with a safe `Condvar`-based `RangeLatchLock`. `RangeLatchGuard::drop` now removes the map entry and releases waiters synchronously (external mutual-exclusion behavior is unchanged — waiters are still woken immediately), but pushes the removed `Arc<RangeLatchLock>` onto a **thread-local retire list** instead of letting it drop in place. That retire list is drained at the start of `RangeLatch::acquire` on the same thread, i.e. outside any guard's drop frame, which is where the final `Arc` — and any resulting deallocation — actually happens. This removes the `unsafe` transmute entirely.

What's Changed:

```commit-message
tikv_util: fix undefined behavior in RangeLatchGuard's Drop impl

Miri (issue #19957) flags UB when RangeLatchGuard::drop removes the range's
Arc<Mutex<()>> entry from the map: this frees the mutex allocation while the
guard's own lifetime-transmuted MutexGuard still strongly protects it, inside
the same drop frame. The prior ManuallyDrop dance fixed drop order but not
this problem.

Replace the transmuted MutexGuard with a safe Condvar-based RangeLatchLock.
RangeLatchGuard::drop now removes the entry and releases waiters
synchronously (mutual exclusion semantics are unchanged), but defers the
final Arc drop to a thread-local retire list that is drained on that
thread's next RangeLatch::acquire call, i.e. safely outside any guard's
drop frame. This removes the unsafe transmute entirely.
```

### Miri verification

`components/tikv_util/src/range_latch.rs` only depends on `std`, so it was verified by copying it verbatim into a standalone crate (the real `tikv_util` crate can't run under Miri directly — it pulls in `grpcio` and other FFI-heavy deps Miri can't interpret).

**Before fix** — ran both the file's own 4 tests and the exact minimal repro from the issue (`acquire_drop`: single acquire + drop) under `cargo +nightly miri test`. On the toolchain available in this environment (a newer nightly than the one originally used to file the issue), both passed cleanly with 0 Miri errors — this appears to be a Miri-version discrepancy in how the protector/Stacked-Borrows rule is enforced, not evidence the bug is invalid; the underlying reasoning in the issue (freeing a "strongly protected" allocation inside its own drop frame is UB per Rust's aliasing model) holds independent of whether this particular Miri build flags it. Reported here for transparency rather than fabricating a failing run.

**After fix** — same standalone-crate setup, `cargo +nightly miri test`:

```
running 4 tests
test tests::test_concurrent_random_ranges_many_latches ... ok
test tests::test_concurrent_random_ranges_many_threads ... ok
test tests::test_single_thread_non_overlapping_ranges ... ok
test tests::test_two_threads_overlapping_ranges ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 307.96s
```

Plain (non-Miri) `cargo test` was also run on the standalone copy and passed (4/4). A full `cargo test -p tikv_util` was attempted but this environment can't build `tikv_util` at all (Miri or not) due to a pre-existing, unrelated native-toolchain gap (`grpcio-sys`'s CMake build needs OpenSSL dev libraries not installed here) — not something introduced by this change.

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Reliability**
  - Improved coordination when multiple operations access overlapping data ranges.
  - Waiting operations are now signaled more efficiently as range locks are released.
  - Reduced risk of lock-related failures during concurrent processing.

- **Performance**
  - Streamlined range-lock management to reduce unnecessary synchronization overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->