### PR TITLE
raftstore: add testing-only option to skip raft log fsync

### DIFF
--- a/components/raftstore/src/store/async_io/write.rs
+++ b/components/raftstore/src/store/async_io/write.rs
@@ -863,7 +863,7 @@ where
             last_raft_append_success_at_millis,
             last_kv_sync_success_at_millis,
 
-            unsafe_no_raft_log_fsync: cfg.value().unsafe_no_raft_log_fsync,
+            unsafe_no_raft_log_fsync: cfg.value().unsafe_no_raft_log_fsync(),
 
             // Adaptive batching initialization
             adaptive_batch_enabled: cfg.value().adaptive_batch_enabled,
@@ -1315,7 +1315,7 @@ where
         // update config
         if let Some(incoming) = self.cfg_tracker.any_new() {
             self.raft_write_size_limit = incoming.raft_write_size_limit.0 as usize;
-            self.unsafe_no_raft_log_fsync = incoming.unsafe_no_raft_log_fsync;
+            self.unsafe_no_raft_log_fsync = incoming.unsafe_no_raft_log_fsync();
             self.adaptive_batch_enabled = incoming.adaptive_batch_enabled;
             self.adaptive_high_qps_threshold = incoming.adaptive_high_qps_threshold;
             self.metrics.waterfall_metrics = incoming.waterfall_metrics;

--- a/components/raftstore/src/store/async_io/write.rs
+++ b/components/raftstore/src/store/async_io/write.rs
@@ -563,6 +563,12 @@ where
     pub readies: HashMap<u64, (u64, u64)>,
     pub(crate) raft_wb_split_size: usize,
     recorder: WriteTaskBatchRecorder,
+    /// Whether this batch contains a task that changed hard state (term or
+    /// vote) or included a snapshot. Such batches must always be synced,
+    /// regardless of `Config::unsafe_no_raft_log_fsync`, since raft requires
+    /// hard-state durability before responding to RPCs, and snapshot
+    /// metadata cannot be replayed.
+    pub needs_sync: bool,
 }
 
 impl<EK, ER> WriteTaskBatch<EK, ER>
@@ -585,6 +591,7 @@ where
             readies: HashMap::default(),
             raft_wb_split_size: RAFT_WB_SPLIT_SIZE,
             recorder: WriteTaskBatchRecorder::new(write_batch_size_hint, write_wait_duration),
+            needs_sync: false,
         }
     }
 
@@ -632,6 +639,7 @@ where
             .unwrap();
 
         if let Some(raft_state) = task.raft_state.take() {
+            self.needs_sync = true;
             if self
                 .raft_states
                 .insert(task.region_id, raft_state)
@@ -639,6 +647,9 @@ where
             {
                 self.state_size += std::mem::size_of::<RaftLocalState>();
             }
+        }
+        if task.has_snapshot {
+            self.needs_sync = true;
         }
         self.extra_batch_write.merge(&mut task.extra_write);
 
@@ -679,6 +690,7 @@ where
         self.tasks.clear();
         self.readies.clear();
         self.recorder.reset_wait_count();
+        self.needs_sync = false;
     }
 
     #[inline]
@@ -788,6 +800,9 @@ where
     last_raft_append_success_at_millis: Arc<AtomicU64>,
     last_kv_sync_success_at_millis: Arc<AtomicU64>,
 
+    /// Testing only. See `Config::unsafe_no_raft_log_fsync`.
+    unsafe_no_raft_log_fsync: bool,
+
     // Adaptive batching related fields
     adaptive_batch_enabled: bool,
     /// Configurable QPS threshold for high concurrency detection.
@@ -847,6 +862,8 @@ where
             pending_latency_inspect: vec![],
             last_raft_append_success_at_millis,
             last_kv_sync_success_at_millis,
+
+            unsafe_no_raft_log_fsync: cfg.value().unsafe_no_raft_log_fsync,
 
             // Adaptive batching initialization
             adaptive_batch_enabled: cfg.value().adaptive_batch_enabled,
@@ -1165,11 +1182,15 @@ where
 
             let now = Instant::now();
             self.perf_context.start_observe();
+            let sync = !self.unsafe_no_raft_log_fsync || self.batch.needs_sync;
+            STORE_WRITE_RAFT_LOG_FSYNC_COUNTER_VEC
+                .with_label_values(&[if sync { "synced" } else { "skipped" }])
+                .inc();
             for i in 0..self.batch.raft_wbs.len() {
                 self.raft_engine
                     .consume_and_shrink(
                         &mut self.batch.raft_wbs[i],
-                        true,
+                        sync,
                         RAFT_WB_SHRINK_SIZE,
                         RAFT_WB_DEFAULT_SIZE,
                     )
@@ -1294,6 +1315,7 @@ where
         // update config
         if let Some(incoming) = self.cfg_tracker.any_new() {
             self.raft_write_size_limit = incoming.raft_write_size_limit.0 as usize;
+            self.unsafe_no_raft_log_fsync = incoming.unsafe_no_raft_log_fsync;
             self.adaptive_batch_enabled = incoming.adaptive_batch_enabled;
             self.adaptive_high_qps_threshold = incoming.adaptive_high_qps_threshold;
             self.metrics.waterfall_metrics = incoming.waterfall_metrics;

--- a/components/raftstore/src/store/async_io/write_tests.rs
+++ b/components/raftstore/src/store/async_io/write_tests.rs
@@ -675,6 +675,62 @@ fn test_worker() {
 }
 
 #[test]
+fn test_unsafe_no_raft_log_fsync_skips_sync_for_pure_append() {
+    let path = Builder::new().prefix("async-io-worker").tempdir().unwrap();
+    let engines = new_temp_engine(&path);
+    let mut cfg = Config::default();
+    cfg.unsafe_no_raft_log_fsync = true;
+    let mut t = TestWorker::new(&cfg, &engines);
+
+    let before_skipped = STORE_WRITE_RAFT_LOG_FSYNC_COUNTER_VEC
+        .with_label_values(&["skipped"])
+        .get();
+
+    // A pure-append task: no raft_state, no snapshot.
+    let mut task = WriteTask::<KvTestEngine, RaftTestEngine>::new(1, 1, 10);
+    init_write_batch(&engines, &mut task);
+    task.entries.append(&mut vec![new_entry(5, 5)]);
+
+    t.worker.batch.add_write_task(&engines.raft, task);
+    assert!(!t.worker.batch.needs_sync);
+    t.worker.write_to_db(true);
+
+    let after_skipped = STORE_WRITE_RAFT_LOG_FSYNC_COUNTER_VEC
+        .with_label_values(&["skipped"])
+        .get();
+    assert!(after_skipped > before_skipped);
+}
+
+#[test]
+fn test_unsafe_no_raft_log_fsync_still_syncs_on_hard_state_change() {
+    let path = Builder::new().prefix("async-io-worker").tempdir().unwrap();
+    let engines = new_temp_engine(&path);
+    let mut cfg = Config::default();
+    cfg.unsafe_no_raft_log_fsync = true;
+    let mut t = TestWorker::new(&cfg, &engines);
+
+    let before_synced = STORE_WRITE_RAFT_LOG_FSYNC_COUNTER_VEC
+        .with_label_values(&["synced"])
+        .get();
+
+    // A task with a hard-state change: must always sync, even with the
+    // option enabled.
+    let mut task = WriteTask::<KvTestEngine, RaftTestEngine>::new(1, 1, 10);
+    init_write_batch(&engines, &mut task);
+    task.entries.append(&mut vec![new_entry(5, 5)]);
+    task.raft_state = Some(new_raft_state(5, 123, 5, 5));
+
+    t.worker.batch.add_write_task(&engines.raft, task);
+    assert!(t.worker.batch.needs_sync);
+    t.worker.write_to_db(true);
+
+    let after_synced = STORE_WRITE_RAFT_LOG_FSYNC_COUNTER_VEC
+        .with_label_values(&["synced"])
+        .get();
+    assert!(after_synced > before_synced);
+}
+
+#[test]
 fn test_worker_split_raft_wb() {
     let path = Builder::new().prefix("async-io-worker").tempdir().unwrap();
     let engines = new_temp_engine(&path);

--- a/components/raftstore/src/store/config.rs
+++ b/components/raftstore/src/store/config.rs
@@ -112,16 +112,6 @@ pub struct Config {
     /// deployed on different mount points). The default is 1 minute. Set it
     /// to `0s` to disable fail-fast disk hang detection explicitly. Any
     /// non-zero value must be at least 30 seconds.
-
-    /// Testing only. When enabled, raft log write batches that only append
-    /// entries (no term/vote change, no snapshot) skip fsync. Batches that
-    /// change hard state or contain a snapshot always sync regardless of
-    /// this option, since raft requires the former to be durable before
-    /// responding to RPCs and the latter's metadata cannot be replayed.
-    ///
-    /// This gives up durability and must never be enabled in production.
-    #[doc(hidden)]
-    pub unsafe_no_raft_log_fsync: bool,
     pub disk_hang_timeout: Option<ReadableDuration>,
     #[doc(hidden)]
     #[online_config(hidden)]
@@ -292,6 +282,17 @@ pub struct Config {
     /// change. Keep the configuration only for convenient test.
     #[cfg(any(test, feature = "testexport"))]
     pub allow_remove_leader: bool,
+
+    /// Testing only. When enabled, raft log write batches that only append
+    /// entries (no term/vote change, no snapshot) skip fsync. Batches that
+    /// change hard state or contain a snapshot always sync regardless of
+    /// this option, since raft requires the former to be durable before
+    /// responding to RPCs and the latter's metadata cannot be replayed.
+    ///
+    /// This gives up durability and must never be enabled in production.
+    /// Keep the configuration only for convenient test.
+    #[cfg(any(test, feature = "testexport"))]
+    pub unsafe_no_raft_log_fsync: bool,
 
     /// Max log gap allowed to propose merge.
     #[online_config(hidden)]
@@ -565,6 +566,7 @@ impl Default for Config {
             follower_read_max_log_gap: 100,
             raft_log_reserve_max_ticks: 6,
             raft_engine_purge_interval: ReadableDuration::secs(10),
+            #[cfg(any(test, feature = "testexport"))]
             unsafe_no_raft_log_fsync: false,
             disk_hang_timeout: Some(ReadableDuration::minutes(1)),
             max_manual_flush_rate: 3.0,
@@ -763,6 +765,16 @@ impl Config {
 
     #[cfg(not(any(test, feature = "testexport")))]
     pub fn allow_remove_leader(&self) -> bool {
+        false
+    }
+
+    #[cfg(any(test, feature = "testexport"))]
+    pub fn unsafe_no_raft_log_fsync(&self) -> bool {
+        self.unsafe_no_raft_log_fsync
+    }
+
+    #[cfg(not(any(test, feature = "testexport")))]
+    pub fn unsafe_no_raft_log_fsync(&self) -> bool {
         false
     }
 

--- a/components/raftstore/src/store/config.rs
+++ b/components/raftstore/src/store/config.rs
@@ -112,6 +112,16 @@ pub struct Config {
     /// deployed on different mount points). The default is 1 minute. Set it
     /// to `0s` to disable fail-fast disk hang detection explicitly. Any
     /// non-zero value must be at least 30 seconds.
+
+    /// Testing only. When enabled, raft log write batches that only append
+    /// entries (no term/vote change, no snapshot) skip fsync. Batches that
+    /// change hard state or contain a snapshot always sync regardless of
+    /// this option, since raft requires the former to be durable before
+    /// responding to RPCs and the latter's metadata cannot be replayed.
+    ///
+    /// This gives up durability and must never be enabled in production.
+    #[doc(hidden)]
+    pub unsafe_no_raft_log_fsync: bool,
     pub disk_hang_timeout: Option<ReadableDuration>,
     #[doc(hidden)]
     #[online_config(hidden)]
@@ -555,6 +565,7 @@ impl Default for Config {
             follower_read_max_log_gap: 100,
             raft_log_reserve_max_ticks: 6,
             raft_engine_purge_interval: ReadableDuration::secs(10),
+            unsafe_no_raft_log_fsync: false,
             disk_hang_timeout: Some(ReadableDuration::minutes(1)),
             max_manual_flush_rate: 3.0,
             raft_entry_cache_life_time: ReadableDuration::secs(30),

--- a/components/raftstore/src/store/metrics.rs
+++ b/components/raftstore/src/store/metrics.rs
@@ -407,6 +407,13 @@ lazy_static! {
             "Bucketed histogram of store write task wait time duration.",
             exponential_buckets(0.00001, 2.0, 26).unwrap()
         ).unwrap();
+
+    pub static ref STORE_WRITE_RAFT_LOG_FSYNC_COUNTER_VEC: IntCounterVec =
+        register_int_counter_vec!(
+            "tikv_raftstore_write_raft_log_fsync_total",
+            "Total number of raft write batches, grouped by whether they were fsynced or skipped due to unsafe_no_raft_log_fsync.",
+            &["type"]
+        ).unwrap();
     pub static ref STORE_WRITE_HANDLE_MSG_DURATION_HISTOGRAM: Histogram =
         register_histogram!(
             "tikv_raftstore_store_write_handle_msg_duration_secs",


### PR DESCRIPTION
Add raftstore.unsafe-no-raft-log-fsync, default off and online changeable. When enabled, write batches that only append raft log entries skip fsync at the point they are consumed by the raft engine. Batches that change hard state (term or vote) or contain a snapshot always sync regardless of this option, since raft requires the former to be durable before responding to RPCs, and snapshot metadata cannot be replayed.

This gives a way to measure how much of write latency the fsync itself accounts for. The option gives up durability and must never be enabled in production.

- Add WriteTaskBatch::needs_sync, set when a merged task carries a raft_state (hard state change) or has_snapshot, computed before those fields are drained during batch construction.
- Gate the sync flag passed to consume_and_shrink on !unsafe_no_raft_log_fsync || batch.needs_sync.
- Add STORE_WRITE_RAFT_LOG_FSYNC_COUNTER_VEC, labeled by "synced" / "skipped", so the effect is observable.
- Add regression tests covering both the skip and always-sync paths.

Closes #19971

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #19971

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```
raftstore: add testing-only option to skip raft log fsync
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->


- [x] Unit test

- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Add a testing-only `raftstore.unsafe-no-raft-log-fsync` config option (default off) that skips fsync for raft log write batches that only append entries, to help measure fsync's contribution to write latency. This option gives up durability and must never be enabled in production.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added an optional configuration to skip synchronization for Raft log-only writes.
  * Writes containing critical state changes or snapshots continue to synchronize.
  * Added metrics distinguishing synchronized and skipped Raft log writes.
* **Tests**
  * Added coverage verifying synchronization behavior and metric reporting for both write types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->