### PR TITLE
resolved_ts: bound check-leader fallback

### DIFF
--- a/components/raftstore-v2/src/operation/command/admin/conf_change.rs
+++ b/components/raftstore-v2/src/operation/command/admin/conf_change.rs
@@ -201,7 +201,7 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
             .set_region(self.region(), true, &self.logger);
         // Update leader's peer list after conf change.
         self.read_progress()
-            .update_leader_info(self.leader_id(), self.term(), self.region());
+            .update_region_with_source("v2_conf_change", self.region());
         ctx.coprocessor_host.on_region_changed(
             self.region(),
             RegionChangeEvent::Update(RegionChangeReason::ChangePeer),

--- a/components/raftstore-v2/src/operation/ready/mod.rs
+++ b/components/raftstore-v2/src/operation/ready/mod.rs
@@ -1133,8 +1133,12 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
                 self.on_force_leader_fail();
             }
 
-            self.read_progress()
-                .update_leader_info(ss.leader_id, term, self.region());
+            self.read_progress().update_leader_info_with_source(
+                "v2_on_role_changed",
+                ss.leader_id,
+                term,
+                self.region(),
+            );
             let target = self.refresh_leader_transferee();
             ctx.coprocessor_host.on_role_change(
                 self.region(),

--- a/components/raftstore-v2/src/raft/peer.rs
+++ b/components/raftstore-v2/src/raft/peer.rs
@@ -325,9 +325,8 @@ impl<EK: KvEngine, ER: RaftEngine> Peer<EK, ER> {
             }
         }
 
-        // Update leader info
         self.read_progress
-            .update_leader_info(self.leader_id(), self.term(), self.region());
+            .update_region_with_source("v2_peer_set_region", self.region());
 
         self.txn_context
             .on_region_changed(self.term(), self.region());

--- a/components/raftstore/src/store/fsm/peer.rs
+++ b/components/raftstore/src/store/fsm/peer.rs
@@ -5751,11 +5751,10 @@ where
         assert_eq!(prev, Some(prev_region));
         drop(meta);
 
-        self.fsm.peer.read_progress.update_leader_info(
-            self.fsm.peer.leader_id(),
-            self.fsm.peer.term(),
-            &region,
-        );
+        self.fsm
+            .peer
+            .read_progress
+            .update_region_with_source("peer_fsm_on_ready_persist_snapshot", &region);
 
         for r in &persist_res.destroy_regions {
             if let Err(e) = self.ctx.router.force_send(

--- a/components/raftstore/src/store/peer.rs
+++ b/components/raftstore/src/store/peer.rs
@@ -1784,9 +1784,8 @@ where
         // follower becoming a leader.
         self.maybe_update_read_progress(reader, progress);
 
-        // Update leader info
         self.read_progress
-            .update_leader_info(self.leader_id(), self.term(), self.region());
+            .update_region_with_source("peer_set_region", self.region());
 
         {
             let mut pessimistic_locks = self.txn_ext.pessimistic_locks.write();
@@ -2625,8 +2624,12 @@ where
         // need to further consider a better solution.
         self.disable_apply_unpersisted_log(self.raft_group.raft.raft_log.last_index());
 
-        self.read_progress
-            .update_leader_info(leader_id, term, self.region());
+        self.read_progress.update_leader_info_with_source(
+            "peer_on_leader_changed",
+            leader_id,
+            term,
+            self.region(),
+        );
     }
 
     #[inline]

--- a/components/raftstore/src/store/util.rs
+++ b/components/raftstore/src/store/util.rs
@@ -35,6 +35,7 @@ use tikv_util::{
     debug, info,
     store::{find_peer_by_id, region},
     time::{Instant, Timespec, monotonic_raw_now},
+    warn,
 };
 use time::Duration;
 use tokio::sync::Notify;
@@ -48,6 +49,8 @@ use crate::{
 };
 
 const INVALID_TIMESTAMP: u64 = u64::MAX;
+const CHECK_LEADER_LOG_REGION_LIMIT: usize = 3;
+const CHECK_LEADER_REGISTRY_MUTATION_LIMIT: usize = 10;
 
 /// Check if key in region range (`start_key`, `end_key`).
 pub fn check_key_in_region_exclusive(key: &[u8], region: &metapb::Region) -> Result<()> {
@@ -1238,12 +1241,14 @@ impl Display for MsgType<'_> {
 #[derive(Clone)]
 pub struct RegionReadProgressRegistry {
     registry: Arc<Mutex<HashMap<u64, Arc<RegionReadProgress>>>>,
+    diagnostics: Arc<Mutex<CheckLeaderRegistryDiagnostics>>,
 }
 
 impl RegionReadProgressRegistry {
     pub fn new() -> RegionReadProgressRegistry {
         RegionReadProgressRegistry {
             registry: Arc::new(Mutex::new(HashMap::new())),
+            diagnostics: Arc::new(Mutex::new(CheckLeaderRegistryDiagnostics::new())),
         }
     }
 
@@ -1252,14 +1257,35 @@ impl RegionReadProgressRegistry {
         region_id: u64,
         read_progress: Arc<RegionReadProgress>,
     ) -> Option<Arc<RegionReadProgress>> {
-        self.registry
+        let previous = self
+            .registry
             .lock()
             .unwrap()
-            .insert(region_id, read_progress)
+            .insert(region_id, read_progress);
+        self.record_registry_mutation("insert", region_id, previous.is_some());
+        previous
     }
 
     pub fn remove(&self, region_id: &u64) -> Option<Arc<RegionReadProgress>> {
-        self.registry.lock().unwrap().remove(region_id)
+        let previous = self.registry.lock().unwrap().remove(region_id);
+        self.record_registry_mutation("remove", *region_id, previous.is_some());
+        previous
+    }
+
+    fn record_registry_mutation(
+        &self,
+        kind: &'static str,
+        region_id: u64,
+        had_previous_entry: bool,
+    ) {
+        self.diagnostics
+            .lock()
+            .unwrap()
+            .record(kind, region_id, had_previous_entry);
+    }
+
+    fn recent_registry_mutations(&self, region_id: u64) -> Vec<CheckLeaderRegistryMutation> {
+        self.diagnostics.lock().unwrap().recent_mutations(region_id)
     }
 
     pub fn get(&self, region_id: &u64) -> Option<Arc<RegionReadProgress>> {
@@ -1313,16 +1339,61 @@ impl RegionReadProgressRegistry {
         leaders: Vec<LeaderInfo>,
         coprocessor: &CoprocessorHost<E>,
     ) -> Vec<u64> {
+        let request_count = leaders.len();
         let mut regions = Vec::with_capacity(leaders.len());
-        let registry = self.registry.lock().unwrap();
-        let now = Some(Instant::now_coarse());
-        for leader_info in &leaders {
-            let region_id = leader_info.get_region_id();
-            if let Some(rp) = registry.get(&region_id) {
-                if rp.consume_leader_info(leader_info, coprocessor, now) {
-                    regions.push(region_id);
+        let mut registry_miss_count = 0;
+        let mut leader_info_mismatch_count = 0;
+        let mut unreturned_regions = Vec::new();
+        let mut unreturned_regions_truncated = false;
+        {
+            let registry = self.registry.lock().unwrap();
+            let now = Some(Instant::now_coarse());
+            for leader_info in &leaders {
+                let region_id = leader_info.get_region_id();
+                if let Some(rp) = registry.get(&region_id) {
+                    if let Some(mismatch_info) =
+                        rp.consume_leader_info_and_get_mismatch(leader_info, coprocessor, now)
+                    {
+                        leader_info_mismatch_count += 1;
+                        if unreturned_regions.len() < CHECK_LEADER_LOG_REGION_LIMIT {
+                            unreturned_regions.push(CheckLeaderUnreturnedRegion::new(
+                                leader_info,
+                                CheckLeaderUnreturnedReason::LeaderInfoMismatch {
+                                    leader_info_mismatch: mismatch_info,
+                                },
+                            ));
+                        } else {
+                            unreturned_regions_truncated = true;
+                        }
+                    } else {
+                        regions.push(region_id);
+                    }
+                } else {
+                    registry_miss_count += 1;
+                    if unreturned_regions.len() < CHECK_LEADER_LOG_REGION_LIMIT {
+                        unreturned_regions.push(CheckLeaderUnreturnedRegion::new(
+                            leader_info,
+                            CheckLeaderUnreturnedReason::RegistryMiss {
+                                registry_recent_mutations: self
+                                    .recent_registry_mutations(region_id),
+                            },
+                        ));
+                    } else {
+                        unreturned_regions_truncated = true;
+                    }
                 }
             }
+        }
+        if regions.len() < request_count {
+            warn!(
+                "[resolved-ts-stuck] check leader task returned partial regions";
+                "request_count" => request_count,
+                "response_count" => regions.len(),
+                "registry_miss_count" => registry_miss_count,
+                "leader_info_mismatch_count" => leader_info_mismatch_count,
+                "unreturned_regions" => ?unreturned_regions,
+                "unreturned_regions_truncated" => unreturned_regions_truncated,
+            );
         }
         regions
     }
@@ -1342,6 +1413,140 @@ impl RegionReadProgressRegistry {
 impl Default for RegionReadProgressRegistry {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[allow(dead_code)]
+#[derive(Debug)]
+enum CheckLeaderUnreturnedReason {
+    RegistryMiss {
+        registry_recent_mutations: Vec<CheckLeaderRegistryMutation>,
+    },
+    LeaderInfoMismatch {
+        leader_info_mismatch: CheckLeaderLeaderInfoMismatch,
+    },
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy)]
+struct CheckLeaderRegistryMutation {
+    kind: &'static str,
+    had_previous_entry: bool,
+}
+
+struct CheckLeaderRegistryDiagnostics {
+    recent_mutations_by_region: HashMap<u64, VecDeque<CheckLeaderRegistryMutation>>,
+}
+
+impl CheckLeaderRegistryDiagnostics {
+    fn new() -> Self {
+        Self {
+            recent_mutations_by_region: HashMap::default(),
+        }
+    }
+
+    fn record(&mut self, kind: &'static str, region_id: u64, had_previous_entry: bool) {
+        let recent_mutations = self
+            .recent_mutations_by_region
+            .entry(region_id)
+            .or_default();
+        if recent_mutations.len() >= CHECK_LEADER_REGISTRY_MUTATION_LIMIT {
+            recent_mutations.pop_front();
+        }
+        recent_mutations.push_back(CheckLeaderRegistryMutation {
+            kind,
+            had_previous_entry,
+        });
+    }
+
+    fn recent_mutations(&self, region_id: u64) -> Vec<CheckLeaderRegistryMutation> {
+        self.recent_mutations_by_region
+            .get(&region_id)
+            .map(|mutations| mutations.iter().copied().collect())
+            .unwrap_or_default()
+    }
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy)]
+struct CheckLeaderLeaderInfoSnapshot {
+    leader_id: u64,
+    leader_term: u64,
+    epoch_conf_ver: u64,
+    epoch_version: u64,
+    leader_store_id: Option<u64>,
+    peer_count: usize,
+}
+
+impl CheckLeaderLeaderInfoSnapshot {
+    fn from_local_info(local_info: &LocalLeaderInfo) -> Self {
+        Self {
+            leader_id: local_info.leader_id,
+            leader_term: local_info.leader_term,
+            epoch_conf_ver: local_info.epoch.get_conf_ver(),
+            epoch_version: local_info.epoch.get_version(),
+            leader_store_id: local_info.leader_store_id,
+            peer_count: local_info.peers.len(),
+        }
+    }
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy)]
+struct CheckLeaderLeaderInfoUpdate {
+    source: &'static str,
+    update_count: u64,
+    before: CheckLeaderLeaderInfoSnapshot,
+    after: CheckLeaderLeaderInfoSnapshot,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy)]
+struct CheckLeaderLeaderInfoMismatch {
+    leader_id_matched: bool,
+    leader_term_matched: bool,
+    region_epoch_matched: bool,
+    current: CheckLeaderLeaderInfoSnapshot,
+    last_update: Option<CheckLeaderLeaderInfoUpdate>,
+}
+
+impl CheckLeaderLeaderInfoMismatch {
+    fn from_core(core: &RegionReadProgressCore, leader_info: &LeaderInfo) -> Self {
+        Self {
+            leader_id_matched: core.leader_info.leader_id == leader_info.peer_id,
+            leader_term_matched: core.leader_info.leader_term == leader_info.term,
+            region_epoch_matched: is_region_epoch_equal(
+                &core.leader_info.epoch,
+                leader_info.get_region_epoch(),
+            ),
+            current: CheckLeaderLeaderInfoSnapshot::from_local_info(&core.leader_info),
+            last_update: core.last_leader_info_update,
+        }
+    }
+}
+
+#[allow(dead_code)]
+#[derive(Debug)]
+struct CheckLeaderUnreturnedRegion {
+    region_id: u64,
+    reason: CheckLeaderUnreturnedReason,
+    request_peer_id: u64,
+    request_term: u64,
+    request_epoch_conf_ver: u64,
+    request_epoch_version: u64,
+}
+
+impl CheckLeaderUnreturnedRegion {
+    fn new(leader_info: &LeaderInfo, reason: CheckLeaderUnreturnedReason) -> Self {
+        let region_epoch = leader_info.get_region_epoch();
+        Self {
+            region_id: leader_info.get_region_id(),
+            reason,
+            request_peer_id: leader_info.peer_id,
+            request_term: leader_info.term,
+            request_epoch_conf_ver: region_epoch.get_conf_ver(),
+            request_epoch_version: region_epoch.get_version(),
+        }
     }
 }
 
@@ -1479,6 +1684,16 @@ impl RegionReadProgress {
         coprocessor: &CoprocessorHost<E>,
         now: Option<Instant>,
     ) -> bool {
+        self.consume_leader_info_and_get_mismatch(leader_info, coprocessor, now)
+            .is_none()
+    }
+
+    fn consume_leader_info_and_get_mismatch<E: KvEngine>(
+        &self,
+        leader_info: &LeaderInfo,
+        coprocessor: &CoprocessorHost<E>,
+        now: Option<Instant>,
+    ) -> Option<CheckLeaderLeaderInfoMismatch> {
         let mut core = self.core.lock().unwrap();
         if matches!((core.last_instant_of_consume_leader, now), (None, Some(_)))
             || matches!((core.last_instant_of_consume_leader, now), (Some(l), Some(r)) if l < r)
@@ -1500,9 +1715,14 @@ impl RegionReadProgress {
             coprocessor.on_update_safe_ts(leader_info.region_id, self.safe_ts(), rs.get_safe_ts())
         }
         // whether the provided `LeaderInfo` is same as ours
-        core.leader_info.leader_term == leader_info.term
+        if core.leader_info.leader_term == leader_info.term
             && core.leader_info.leader_id == leader_info.peer_id
             && is_region_epoch_equal(&core.leader_info.epoch, leader_info.get_region_epoch())
+        {
+            None
+        } else {
+            Some(CheckLeaderLeaderInfoMismatch::from_core(&core, leader_info))
+        }
     }
 
     // Dump the `LeaderInfo` and the peer list
@@ -1515,19 +1735,33 @@ impl RegionReadProgress {
     }
 
     pub fn update_leader_info(&self, peer_id: u64, term: u64, region: &Region) {
+        self.update_leader_info_with_source("update_leader_info", peer_id, term, region)
+    }
+
+    pub fn update_leader_info_with_source(
+        &self,
+        source: &'static str,
+        peer_id: u64,
+        term: u64,
+        region: &Region,
+    ) {
         let mut core = self.core.lock().unwrap();
+        let before = CheckLeaderLeaderInfoSnapshot::from_local_info(&core.leader_info);
         core.leader_info.leader_id = peer_id;
         core.leader_info.leader_term = term;
-        if !is_region_epoch_equal(region.get_region_epoch(), &core.leader_info.epoch) {
-            core.leader_info.epoch = region.get_region_epoch().clone();
-        }
-        if core.leader_info.peers != region.get_peers() {
-            // In v2, we check peers and region epoch independently, because
-            // peers are incomplete but epoch is set correctly during split.
-            core.leader_info.peers = region.get_peers().to_vec();
-        }
-        core.leader_info.leader_store_id =
-            find_store_id(&core.leader_info.peers, core.leader_info.leader_id)
+        core.update_region(region);
+        core.record_leader_info_update(source, before);
+    }
+
+    pub fn update_region(&self, region: &Region) {
+        self.update_region_with_source("update_region", region);
+    }
+
+    pub fn update_region_with_source(&self, source: &'static str, region: &Region) {
+        let mut core = self.core.lock().unwrap();
+        let before = CheckLeaderLeaderInfoSnapshot::from_local_info(&core.leader_info);
+        core.update_region(region);
+        core.record_leader_info_update(source, before);
     }
 
     /// Reset `safe_ts` and `read_index_safe_ts` to 0 and stop updating them
@@ -1610,6 +1844,11 @@ pub struct RegionReadProgressCore {
     read_state: ReadState,
     // The local peer's acknowledge about the leader
     leader_info: LocalLeaderInfo,
+    // Number of in-memory updates to `leader_info`, used only for diagnosis.
+    leader_info_update_count: u64,
+    // Last in-memory update to `leader_info`, printed only by check-leader
+    // anomaly logs.
+    last_leader_info_update: Option<CheckLeaderLeaderInfoUpdate>,
     // `pending_items` is a *sorted* list of `(apply_index, safe_ts)` item
     pending_items: VecDeque<ReadState>,
     // After the region commit merged, the region's key range is extended and the region's
@@ -1695,6 +1934,8 @@ impl RegionReadProgressCore {
             applied_index,
             read_state: ReadState::default(),
             leader_info: LocalLeaderInfo::new(region),
+            leader_info_update_count: 0,
+            last_leader_info_update: None,
             pending_items: VecDeque::with_capacity(cap),
             last_merge_index: 0,
             pause: is_witness,
@@ -1703,6 +1944,33 @@ impl RegionReadProgressCore {
             last_instant_of_update_safe_ts: None,
             last_instant_of_consume_leader: None,
         }
+    }
+
+    fn update_region(&mut self, region: &Region) {
+        if !is_region_epoch_equal(region.get_region_epoch(), &self.leader_info.epoch) {
+            self.leader_info.epoch = region.get_region_epoch().clone();
+        }
+        if self.leader_info.peers != region.get_peers() {
+            // In v2, we check peers and region epoch independently, because
+            // peers are incomplete but epoch is set correctly during split.
+            self.leader_info.peers = region.get_peers().to_vec();
+        }
+        self.leader_info.leader_store_id =
+            find_store_id(&self.leader_info.peers, self.leader_info.leader_id);
+    }
+
+    fn record_leader_info_update(
+        &mut self,
+        source: &'static str,
+        before: CheckLeaderLeaderInfoSnapshot,
+    ) {
+        self.leader_info_update_count += 1;
+        self.last_leader_info_update = Some(CheckLeaderLeaderInfoUpdate {
+            source,
+            update_count: self.leader_info_update_count,
+            before,
+            after: CheckLeaderLeaderInfoSnapshot::from_local_info(&self.leader_info),
+        });
     }
 
     // Reset target region's `safe_ts` to min(`source_safe_ts`, `safe_ts`)
@@ -1905,7 +2173,7 @@ pub fn validate_split_region(
 
 #[cfg(test)]
 mod tests {
-    use std::thread;
+    use std::{sync::Arc, thread};
 
     use engine_test::kv::KvTestEngine;
     use kvproto::{
@@ -2520,6 +2788,113 @@ mod tests {
         assert_eq!(
             rrp.core.lock().unwrap().get_local_leader_info().peers,
             *region.get_peers(),
+        );
+    }
+
+    #[test]
+    fn test_check_leader_rejects_stale_epoch_after_peer_change() {
+        let coprocessor_host = CoprocessorHost::<KvTestEngine>::default();
+
+        let mut old_region = metapb::Region::default();
+        old_region.set_id(1);
+        old_region.mut_region_epoch().set_version(10);
+        old_region.mut_region_epoch().set_conf_ver(10);
+        old_region.set_peers(vec![new_peer(1, 1), new_peer(2, 2)].into());
+
+        let mut changed_region = old_region.clone();
+        changed_region.mut_region_epoch().set_conf_ver(11);
+        changed_region.mut_peers().push(new_peer(3, 3));
+
+        let leader_progress = RegionReadProgress::new(&changed_region, 10, 10, 1);
+        leader_progress.update_leader_info(1, 5, &changed_region);
+        let leader_info = leader_progress.core.lock().unwrap().get_leader_info();
+
+        let follower_progress = Arc::new(RegionReadProgress::new(&old_region, 10, 10, 2));
+        follower_progress.update_leader_info(1, 5, &old_region);
+
+        let registry = RegionReadProgressRegistry::new();
+        registry.insert(1, follower_progress.clone());
+
+        assert!(
+            registry
+                .handle_check_leaders(vec![leader_info.clone()], &coprocessor_host)
+                .is_empty()
+        );
+
+        follower_progress.update_leader_info(1, 5, &changed_region);
+        assert_eq!(
+            registry.handle_check_leaders(vec![leader_info], &coprocessor_host),
+            vec![1]
+        );
+    }
+
+    #[test]
+    fn test_check_leader_rejects_stale_leader_after_peer_change() {
+        let coprocessor_host = CoprocessorHost::<KvTestEngine>::default();
+
+        let mut changed_region = metapb::Region::default();
+        changed_region.set_id(1);
+        changed_region.mut_region_epoch().set_version(10);
+        changed_region.mut_region_epoch().set_conf_ver(11);
+        changed_region.set_peers(vec![new_peer(1, 1), new_peer(2, 2), new_peer(3, 3)].into());
+
+        let leader_progress = RegionReadProgress::new(&changed_region, 10, 10, 1);
+        leader_progress.update_leader_info(1, 6, &changed_region);
+        let leader_info = leader_progress.core.lock().unwrap().get_leader_info();
+
+        let follower_progress = Arc::new(RegionReadProgress::new(&changed_region, 10, 10, 3));
+        let registry = RegionReadProgressRegistry::new();
+        registry.insert(1, follower_progress.clone());
+
+        follower_progress.update_leader_info(raft::INVALID_ID, 6, &changed_region);
+        assert!(
+            registry
+                .handle_check_leaders(vec![leader_info.clone()], &coprocessor_host)
+                .is_empty()
+        );
+
+        follower_progress.update_leader_info(1, 5, &changed_region);
+        assert!(
+            registry
+                .handle_check_leaders(vec![leader_info.clone()], &coprocessor_host)
+                .is_empty()
+        );
+
+        follower_progress.update_leader_info(1, 6, &changed_region);
+        assert_eq!(
+            registry.handle_check_leaders(vec![leader_info], &coprocessor_host),
+            vec![1]
+        );
+    }
+
+    #[test]
+    fn test_region_update_keeps_resolved_ts_leader_after_peer_change() {
+        let coprocessor_host = CoprocessorHost::<KvTestEngine>::default();
+
+        let mut old_region = metapb::Region::default();
+        old_region.set_id(1);
+        old_region.mut_region_epoch().set_version(10);
+        old_region.mut_region_epoch().set_conf_ver(10);
+        old_region.set_peers(vec![new_peer(1, 1), new_peer(2, 2)].into());
+
+        let mut changed_region = old_region.clone();
+        changed_region.mut_region_epoch().set_conf_ver(11);
+        changed_region.mut_peers().push(new_peer(3, 3));
+
+        let leader_progress = RegionReadProgress::new(&changed_region, 10, 10, 1);
+        leader_progress.update_leader_info(1, 6, &changed_region);
+        let leader_info = leader_progress.core.lock().unwrap().get_leader_info();
+
+        let follower_progress = Arc::new(RegionReadProgress::new(&old_region, 10, 10, 2));
+        follower_progress.update_leader_info(1, 6, &old_region);
+        follower_progress.update_region(&changed_region);
+
+        let registry = RegionReadProgressRegistry::new();
+        registry.insert(1, follower_progress);
+
+        assert_eq!(
+            registry.handle_check_leaders(vec![leader_info], &coprocessor_host),
+            vec![1]
         );
     }
 

--- a/components/resolved_ts/src/advance.rs
+++ b/components/resolved_ts/src/advance.rs
@@ -36,6 +36,7 @@ use tikv_util::{
     thread_name_prefix::ADVANCED_TS_THREAD,
     time::{Instant, SlowTimer},
     timer::SteadyTimer,
+    warn,
     worker::Scheduler,
 };
 use tokio::{
@@ -51,6 +52,20 @@ const DEFAULT_GRPC_GZIP_COMPRESSION_LEVEL: usize = 2;
 const DEFAULT_GRPC_MIN_MESSAGE_SIZE_TO_COMPRESS: usize = 4096;
 const CHECK_LEADER_REQ_REGIONS_SHRINK_FACTOR: usize = 4;
 const CHECK_LEADER_REQ_REGIONS_MIN_RETAIN_CAPACITY: usize = 1024;
+const CHECK_LEADER_LOG_REGION_LIMIT: usize = 3;
+const CHECK_LEADER_READ_INDEX_FALLBACK_THRESHOLD: u64 = 3;
+const CHECK_LEADER_READ_INDEX_FALLBACK_REGION_LIMIT: usize = 16;
+
+#[allow(dead_code)]
+#[derive(Debug)]
+struct CheckLeaderStoreStatus {
+    to_store_id: u64,
+    requested_count: usize,
+    returned_count: usize,
+    unreturned_regions: Vec<u64>,
+    unreturned_regions_truncated: bool,
+    rpc_error: Option<String>,
+}
 
 pub struct AdvanceTsWorker {
     pd_client: Arc<dyn PdClient>,
@@ -91,13 +106,17 @@ impl AdvanceTsWorker {
 
 impl AdvanceTsWorker {
     // Advance ts asynchronously and register RegisterAdvanceEvent when its done.
-    pub fn advance_ts_for_regions(
+    pub fn advance_ts_for_regions<T, E>(
         &self,
         regions: Vec<u64>,
         mut leader_resolver: LeadershipResolver,
         advance_ts_interval: Duration,
         advance_notify: Arc<Notify>,
-    ) {
+        cdc_handle: T,
+    ) where
+        T: 'static + CdcHandle<E>,
+        E: KvEngine,
+    {
         let cm = self.concurrency_manager.clone();
         let pd_client = self.pd_client.clone();
         let scheduler = self.scheduler.clone();
@@ -106,6 +125,7 @@ impl AdvanceTsWorker {
             DEFAULT_CHECK_LEADER_TIMEOUT_DURATION,
             advance_ts_interval,
         ));
+        let fallback_timeout = cmp::min(DEFAULT_CHECK_LEADER_TIMEOUT_DURATION, advance_ts_interval);
 
         let last_pd_tso = self.last_pd_tso.clone();
         let fut = async move {
@@ -133,9 +153,58 @@ impl AdvanceTsWorker {
                 }
             }
 
-            let regions = leader_resolver
+            let mut regions = leader_resolver
                 .resolve(regions, min_ts, Some(advance_ts_interval))
                 .await;
+            let fallback_regions = leader_resolver.take_read_index_fallback_candidates();
+            if !fallback_regions.is_empty() {
+                let fallback_count = fallback_regions.len() as u64;
+                RTS_CHECK_LEADER_READ_INDEX_FALLBACK_COUNTER_VEC
+                    .with_label_values(&["scheduled"])
+                    .inc_by(fallback_count);
+                let fallback_timer = Instant::now_coarse();
+                let fallback_result = tokio::time::timeout(
+                    fallback_timeout,
+                    resolve_by_raft(fallback_regions.clone(), min_ts, cdc_handle.clone()),
+                )
+                .await;
+                RTS_CHECK_LEADER_READ_INDEX_FALLBACK_DURATION_HISTOGRAM
+                    .observe(fallback_timer.saturating_elapsed_secs());
+                match fallback_result {
+                    Ok(fallback_valid_regions) => {
+                        let fallback_valid_count = fallback_valid_regions.len() as u64;
+                        if fallback_valid_count > 0 {
+                            RTS_CHECK_LEADER_READ_INDEX_FALLBACK_COUNTER_VEC
+                                .with_label_values(&["success"])
+                                .inc_by(fallback_valid_count);
+                            regions.extend(fallback_valid_regions.iter().copied());
+                        }
+                        if fallback_valid_count < fallback_count {
+                            RTS_CHECK_LEADER_READ_INDEX_FALLBACK_COUNTER_VEC
+                                .with_label_values(&["failed"])
+                                .inc_by(fallback_count - fallback_valid_count);
+                            warn!(
+                                "[resolved-ts-stuck] read-index fallback returned partial regions";
+                                "requested_regions" => ?fallback_regions,
+                                "valid_regions" => ?fallback_valid_regions,
+                                "min_ts" => min_ts,
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        RTS_CHECK_LEADER_READ_INDEX_FALLBACK_COUNTER_VEC
+                            .with_label_values(&["timeout"])
+                            .inc_by(fallback_count);
+                        warn!(
+                            "[resolved-ts-stuck] read-index fallback timed out";
+                            "requested_regions" => ?fallback_regions,
+                            "timeout" => ?fallback_timeout,
+                            "err" => ?e,
+                            "min_ts" => min_ts,
+                        );
+                    }
+                }
+            }
             if !regions.is_empty() {
                 if let Err(e) = scheduler.schedule(Task::ResolvedTsAdvanced {
                     regions,
@@ -177,6 +246,8 @@ pub struct LeadershipResolver {
     progresses: HashMap<u64, RegionProgress>,
     checking_regions: HashSet<u64>,
     valid_regions: HashSet<u64>,
+    check_leader_failure_rounds: HashMap<u64, u64>,
+    read_index_fallback_candidates: Vec<u64>,
 
     gc_interval: Duration,
     last_gc_time: Instant,
@@ -203,6 +274,8 @@ impl LeadershipResolver {
             progresses: HashMap::default(),
             valid_regions: HashSet::default(),
             checking_regions: HashSet::default(),
+            check_leader_failure_rounds: HashMap::default(),
+            read_index_fallback_candidates: Vec::new(),
             last_gc_time: Instant::now_coarse(),
             gc_interval,
         }
@@ -215,6 +288,8 @@ impl LeadershipResolver {
             self.progresses = HashMap::default();
             self.valid_regions = HashSet::default();
             self.checking_regions = HashSet::default();
+            self.check_leader_failure_rounds = HashMap::default();
+            self.read_index_fallback_candidates = Vec::new();
             self.last_gc_time = now;
         }
     }
@@ -228,6 +303,11 @@ impl LeadershipResolver {
         }
         self.checking_regions.clear();
         self.valid_regions.clear();
+        self.read_index_fallback_candidates.clear();
+    }
+
+    fn take_read_index_fallback_candidates(&mut self) -> Vec<u64> {
+        std::mem::take(&mut self.read_index_fallback_candidates)
     }
 
     // Confirms leadership of region peer before trying to advance resolved ts.
@@ -320,6 +400,7 @@ impl LeadershipResolver {
             .map_or(0, |req| req.regions[0].compute_size());
         let mut check_leader_rpcs = Vec::with_capacity(store_req_map.len());
         let timeout = get_min_timeout(timeout, DEFAULT_CHECK_LEADER_TIMEOUT_DURATION);
+        let mut requested_regions_by_store = HashMap::default();
 
         for (store_id, req) in store_req_map {
             if req.regions.is_empty() {
@@ -328,6 +409,13 @@ impl LeadershipResolver {
             let env = env.clone();
             let to_store = *store_id;
             let region_num = req.regions.len() as u32;
+            requested_regions_by_store.insert(
+                to_store,
+                req.regions
+                    .iter()
+                    .map(|leader_info| leader_info.get_region_id())
+                    .collect::<Vec<_>>(),
+            );
             CHECK_LEADER_REQ_SIZE_HISTOGRAM.observe((leader_info_size * region_num) as f64);
             CHECK_LEADER_REQ_ITEM_COUNT_HISTOGRAM.observe(region_num as f64);
 
@@ -393,6 +481,8 @@ impl LeadershipResolver {
         });
 
         let rpc_count = check_leader_rpcs.len();
+        let mut returned_regions_by_store = HashMap::default();
+        let mut check_leader_errors = HashMap::default();
         for _ in 0..rpc_count {
             // Use `select_all` to avoid the process getting blocked when some
             // TiKVs were down.
@@ -400,6 +490,7 @@ impl LeadershipResolver {
             check_leader_rpcs = remains;
             match res {
                 Ok((to_store, resp)) => {
+                    returned_regions_by_store.insert(to_store, resp.get_regions().to_vec());
                     for region_id in resp.regions {
                         if let Some(prog) = progresses.get_mut(&region_id) {
                             if prog.resolved {
@@ -415,6 +506,7 @@ impl LeadershipResolver {
                 }
                 Err((to_store, reconnect, err)) => {
                     info!("check leader failed"; "error" => ?err, "to_store" => to_store);
+                    check_leader_errors.insert(to_store, err);
                     if reconnect {
                         self.tikv_clients.lock().await.remove(&to_store);
                     }
@@ -425,11 +517,40 @@ impl LeadershipResolver {
             }
         }
         let res: Vec<u64> = self.valid_regions.drain().collect();
+        let valid_region_set = res.iter().copied().collect::<HashSet<_>>();
+        let unresolved_region_set = checking_regions
+            .iter()
+            .filter(|region_id| !valid_region_set.contains(region_id))
+            .copied()
+            .collect::<HashSet<_>>();
+        let read_index_fallback_candidates = update_check_leader_failure_rounds(
+            &mut self.check_leader_failure_rounds,
+            checking_regions,
+            &valid_region_set,
+            &unresolved_region_set,
+        );
+        self.read_index_fallback_candidates = read_index_fallback_candidates;
+        if !unresolved_region_set.is_empty() {
+            RTS_CHECK_LEADER_UNRESOLVED_REGION_COUNTER.inc_by(unresolved_region_set.len() as u64);
+        }
         if res.len() != checking_regions.len() {
+            let (unresolved_regions, unresolved_regions_truncated) =
+                limited_region_list(unresolved_region_set.iter().copied());
+            let target_store_status = build_check_leader_store_status(
+                &requested_regions_by_store,
+                &returned_regions_by_store,
+                &check_leader_errors,
+                &unresolved_region_set,
+            );
             warn!(
-                "check leader returns valid regions different from checking regions";
-                "valid_regions" => res.len(),
-                "checking_regions" => checking_regions.len(),
+                "[resolved-ts-stuck] check leader unresolved regions";
+                "local_store_id" => self.store_id,
+                "valid_region_count" => res.len(),
+                "checking_region_count" => checking_regions.len(),
+                "unresolved_regions" => ?unresolved_regions,
+                "unresolved_regions_truncated" => unresolved_regions_truncated,
+                "target_store_status" => ?target_store_status,
+                "read_index_fallback_candidates" => ?self.read_index_fallback_candidates,
             );
         }
         res
@@ -447,6 +568,77 @@ fn reset_check_leader_request(req: &mut CheckLeaderRequest) {
         req.regions.clear();
     }
     req.ts = 0;
+}
+
+fn limited_region_list<I>(regions: I) -> (Vec<u64>, bool)
+where
+    I: IntoIterator<Item = u64>,
+{
+    let mut limited = Vec::with_capacity(CHECK_LEADER_LOG_REGION_LIMIT);
+    let mut truncated = false;
+    for region_id in regions {
+        if limited.len() == CHECK_LEADER_LOG_REGION_LIMIT {
+            truncated = true;
+            break;
+        }
+        limited.push(region_id);
+    }
+    (limited, truncated)
+}
+
+fn build_check_leader_store_status(
+    requested_regions_by_store: &HashMap<u64, Vec<u64>>,
+    returned_regions_by_store: &HashMap<u64, Vec<u64>>,
+    check_leader_errors: &HashMap<u64, String>,
+    unresolved_region_set: &HashSet<u64>,
+) -> Vec<CheckLeaderStoreStatus> {
+    let mut target_store_status = Vec::with_capacity(requested_regions_by_store.len());
+    for (to_store_id, requested_regions) in requested_regions_by_store {
+        let returned_regions = returned_regions_by_store.get(to_store_id);
+        let (unreturned_regions, unreturned_regions_truncated) = limited_region_list(
+            requested_regions
+                .iter()
+                .filter(|&&region_id| unresolved_region_set.contains(&region_id))
+                .filter(|&&region_id| {
+                    !returned_regions.is_some_and(|regions| regions.contains(&region_id))
+                })
+                .copied(),
+        );
+        target_store_status.push(CheckLeaderStoreStatus {
+            to_store_id: *to_store_id,
+            requested_count: requested_regions.len(),
+            returned_count: returned_regions.map_or(0, Vec::len),
+            unreturned_regions,
+            unreturned_regions_truncated,
+            rpc_error: check_leader_errors.get(to_store_id).cloned(),
+        });
+    }
+    target_store_status.sort_by_key(|status| status.to_store_id);
+    target_store_status
+}
+
+fn update_check_leader_failure_rounds(
+    failure_rounds: &mut HashMap<u64, u64>,
+    checking_regions: &HashSet<u64>,
+    valid_region_set: &HashSet<u64>,
+    unresolved_region_set: &HashSet<u64>,
+) -> Vec<u64> {
+    failure_rounds.retain(|region_id, _| checking_regions.contains(region_id));
+    for region_id in valid_region_set {
+        failure_rounds.remove(region_id);
+    }
+
+    let mut fallback_candidates = Vec::new();
+    for region_id in unresolved_region_set {
+        let failure_round = failure_rounds.entry(*region_id).or_insert(0);
+        *failure_round += 1;
+        if *failure_round >= CHECK_LEADER_READ_INDEX_FALLBACK_THRESHOLD
+            && fallback_candidates.len() < CHECK_LEADER_READ_INDEX_FALLBACK_REGION_LIMIT
+        {
+            fallback_candidates.push(*region_id);
+        }
+    }
+    fallback_candidates
 }
 
 pub async fn resolve_by_raft<T, E>(regions: Vec<u64>, min_ts: TimeStamp, cdc_handle: T) -> Vec<u64>
@@ -601,17 +793,24 @@ impl RegionProgress {
 mod tests {
     use std::{
         sync::{
-            Arc,
+            Arc, Mutex as StdMutex,
             mpsc::{Receiver, Sender, channel},
         },
         time::Duration,
     };
 
+    use engine_rocks::RocksEngine;
+    use engine_traits::KvEngine;
     use grpcio::{self, ChannelBuilder, EnvBuilder, Server, ServerBuilder};
-    use kvproto::{metapb::Region, tikvpb::Tikv, tikvpb_grpc::create_tikv};
+    use kvproto::{
+        metapb::Region, raft_cmdpb::RaftCmdResponse, tikvpb::Tikv, tikvpb_grpc::create_tikv,
+    };
     use pd_client::PdClient;
     use protobuf::RepeatedField;
-    use raftstore::store::util::RegionReadProgress;
+    use raftstore::{
+        errors::Result as RaftStoreResult,
+        store::{fsm::ChangeObserver, msg::Callback, util::RegionReadProgress},
+    };
     use tikv_util::store::new_peer;
 
     use super::*;
@@ -619,6 +818,7 @@ mod tests {
     #[derive(Clone)]
     struct MockTikv {
         req_tx: Sender<CheckLeaderRequest>,
+        resp_regions: Vec<u64>,
     }
 
     impl Tikv for MockTikv {
@@ -629,8 +829,12 @@ mod tests {
             sink: ::grpcio::UnarySink<CheckLeaderResponse>,
         ) {
             self.req_tx.send(req).unwrap();
+            let resp = CheckLeaderResponse {
+                regions: self.resp_regions.clone(),
+                ..Default::default()
+            };
             ctx.spawn(async {
-                sink.success(CheckLeaderResponse::default()).await.unwrap();
+                sink.success(resp).await.unwrap();
             })
         }
     }
@@ -638,9 +842,49 @@ mod tests {
     struct MockPdClient {}
     impl PdClient for MockPdClient {}
 
-    fn new_rpc_suite(env: Arc<Environment>) -> (Server, TikvClient, Receiver<CheckLeaderRequest>) {
+    #[derive(Clone, Default)]
+    struct MockCdcHandle {
+        valid_regions: Arc<StdMutex<HashSet<u64>>>,
+        checked_regions: Arc<StdMutex<Vec<u64>>>,
+    }
+
+    impl CdcHandle<RocksEngine> for MockCdcHandle {
+        fn capture_change(
+            &self,
+            _region_id: u64,
+            _region_epoch: kvproto::metapb::RegionEpoch,
+            _change_observer: ChangeObserver,
+            _callback: Callback<<RocksEngine as KvEngine>::Snapshot>,
+        ) -> RaftStoreResult<()> {
+            unreachable!("advance.rs tests only use check_leadership")
+        }
+
+        fn check_leadership(
+            &self,
+            region_id: u64,
+            callback: Callback<<RocksEngine as KvEngine>::Snapshot>,
+        ) -> RaftStoreResult<()> {
+            self.checked_regions.lock().unwrap().push(region_id);
+            let mut resp = RaftCmdResponse::default();
+            if !self.valid_regions.lock().unwrap().contains(&region_id) {
+                resp.mut_header()
+                    .mut_error()
+                    .set_message("not leader".to_owned());
+            }
+            callback.invoke_with_response(resp);
+            Ok(())
+        }
+    }
+
+    fn new_rpc_suite(
+        env: Arc<Environment>,
+        resp_regions: Vec<u64>,
+    ) -> (Server, TikvClient, Receiver<CheckLeaderRequest>) {
         let (tx, rx) = channel();
-        let tikv_service = MockTikv { req_tx: tx };
+        let tikv_service = MockTikv {
+            req_tx: tx,
+            resp_regions,
+        };
         let builder = ServerBuilder::new(env.clone()).register_service(create_tikv(tikv_service));
         let mut server = builder.bind("127.0.0.1", 0).build().unwrap();
         server.start();
@@ -666,7 +910,7 @@ mod tests {
     #[tokio::test]
     async fn test_resolve_leader_request_size() {
         let env = Arc::new(EnvBuilder::new().build());
-        let (mut server, tikv_client, rx) = new_rpc_suite(env.clone());
+        let (mut server, tikv_client, rx) = new_rpc_suite(env.clone(), vec![]);
 
         let mut region1 = Region::default();
         region1.id = 1;
@@ -727,7 +971,7 @@ mod tests {
     #[tokio::test]
     async fn test_resolve_request_capacity_ignores_registry_size() {
         let env = Arc::new(EnvBuilder::new().build());
-        let (mut server, tikv_client, rx) = new_rpc_suite(env.clone());
+        let (mut server, tikv_client, rx) = new_rpc_suite(env.clone(), vec![]);
 
         let mut leader_resolver = LeadershipResolver::new(
             1, // store id
@@ -768,7 +1012,7 @@ mod tests {
     #[tokio::test]
     async fn test_resolve_shrinks_oversized_request_buffer_on_reuse() {
         let env = Arc::new(EnvBuilder::new().build());
-        let (mut server, tikv_client, rx) = new_rpc_suite(env.clone());
+        let (mut server, tikv_client, rx) = new_rpc_suite(env.clone(), vec![]);
 
         let mut leader_resolver = LeadershipResolver::new(
             1, // store id
@@ -807,6 +1051,77 @@ mod tests {
         );
 
         let _ = server.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn test_read_index_fallback_after_repeated_check_leader_filtering() {
+        let env = Arc::new(EnvBuilder::new().build());
+        let (mut server2, tikv_client2, _rx2) = new_rpc_suite(env.clone(), vec![]);
+        let (mut server3, tikv_client3, _rx3) = new_rpc_suite(env.clone(), vec![]);
+
+        let mut region = Region {
+            id: 1,
+            ..Default::default()
+        };
+        region.mut_region_epoch().set_version(10);
+        region.mut_region_epoch().set_conf_ver(11);
+        region.peers.push(new_peer(1, 1));
+        region.peers.push(new_peer(2, 2));
+        region.peers.push(new_peer(3, 3));
+
+        let progress = RegionReadProgress::new(&region, 1, 1, 1);
+        progress.update_leader_info(1, 5, &region);
+
+        let mut leader_resolver = LeadershipResolver::new(
+            1,
+            Arc::new(MockPdClient {}),
+            env.clone(),
+            Arc::new(SecurityManager::default()),
+            RegionReadProgressRegistry::new(),
+            Duration::from_secs(1),
+        );
+        {
+            let mut tikv_clients = leader_resolver.tikv_clients.lock().await;
+            tikv_clients.insert(2, tikv_client2);
+            tikv_clients.insert(3, tikv_client3);
+        }
+        leader_resolver
+            .region_read_progress
+            .insert(1, Arc::new(progress));
+
+        for _ in 1..CHECK_LEADER_READ_INDEX_FALLBACK_THRESHOLD {
+            assert!(
+                leader_resolver
+                    .resolve(vec![1], TimeStamp::new(1), None)
+                    .await
+                    .is_empty()
+            );
+            assert!(
+                leader_resolver
+                    .take_read_index_fallback_candidates()
+                    .is_empty()
+            );
+        }
+
+        assert!(
+            leader_resolver
+                .resolve(vec![1], TimeStamp::new(1), None)
+                .await
+                .is_empty()
+        );
+        let fallback_regions = leader_resolver.take_read_index_fallback_candidates();
+        assert_eq!(fallback_regions, vec![1]);
+
+        let cdc_handle = MockCdcHandle::default();
+        cdc_handle.valid_regions.lock().unwrap().insert(1);
+        let fallback_valid_regions =
+            resolve_by_raft(fallback_regions, TimeStamp::new(1), cdc_handle.clone()).await;
+
+        assert_eq!(fallback_valid_regions, vec![1]);
+        assert_eq!(*cdc_handle.checked_regions.lock().unwrap(), vec![1]);
+
+        let _ = server2.shutdown().await;
+        let _ = server3.shutdown().await;
     }
 
     #[test]

--- a/components/resolved_ts/src/endpoint.rs
+++ b/components/resolved_ts/src/endpoint.rs
@@ -1014,6 +1014,7 @@ where
             leader_resolver,
             self.cfg.advance_ts_interval.0,
             self.advance_notify.clone(),
+            self.scanner_pool.cdc_handle(),
         );
     }
 

--- a/components/resolved_ts/src/metrics.rs
+++ b/components/resolved_ts/src/metrics.rs
@@ -128,6 +128,25 @@ lazy_static! {
         exponential_buckets(0.005, 2.0, 20).unwrap(),
     )
     .unwrap();
+    pub static ref RTS_CHECK_LEADER_UNRESOLVED_REGION_COUNTER: IntCounter = register_int_counter!(
+        "tikv_resolved_ts_check_leader_unresolved_region_total",
+        "Total number of region-rounds filtered by the check-leader fast path"
+    )
+    .unwrap();
+    pub static ref RTS_CHECK_LEADER_READ_INDEX_FALLBACK_COUNTER_VEC: IntCounterVec =
+        register_int_counter_vec!(
+            "tikv_resolved_ts_check_leader_read_index_fallback_total",
+            "Total number of region-rounds handled by the read-index fallback after check-leader fast-path failures",
+            &["result"]
+        )
+        .unwrap();
+    pub static ref RTS_CHECK_LEADER_READ_INDEX_FALLBACK_DURATION_HISTOGRAM: Histogram =
+        register_histogram!(
+            "tikv_resolved_ts_check_leader_read_index_fallback_duration_seconds",
+            "Bucketed histogram of resolved-ts read-index fallback duration",
+            exponential_buckets(0.005, 2.0, 20).unwrap(),
+        )
+        .unwrap();
     pub static ref RTS_TIKV_CLIENT_INIT_DURATION_HISTOGRAM: Histogram = register_histogram!(
         "tikv_resolved_ts_tikv_client_init_duration_seconds",
         "Bucketed histogram of resolved-ts tikv client initializing duration",

--- a/components/resolved_ts/src/scanner.rs
+++ b/components/resolved_ts/src/scanner.rs
@@ -105,6 +105,10 @@ impl<T: 'static + CdcHandle<E>, E: KvEngine> ScannerPool<T, E> {
         }
     }
 
+    pub fn cdc_handle(&self) -> T {
+        self.cdc_handle.clone()
+    }
+
     pub fn spawn_task(&self, mut task: ScanTask, concurrency_semaphore: Arc<Semaphore>) {
         let cdc_handle = self.cdc_handle.clone();
         let fut = async move {

--- a/doc/maintenance-guides/components/raftstore.md
+++ b/doc/maintenance-guides/components/raftstore.md
@@ -160,6 +160,11 @@ High-risk contracts:
   generation, transport, application, and cleanup are all coupled.
 - Local reads must only bypass raft when lease and read-progress guarantees are
   valid.
+- Resolved-ts `RegionReadProgress` has split ownership: region metadata paths
+  may refresh epoch/peers, but leader ID and term must be published by
+  Ready/leader-change handling. Do not copy a transient raw Raft leader view
+  into resolved-ts metadata while applying split/merge/conf-change or snapshot
+  metadata.
 - FSM messages must preserve ordering assumptions between peer/store/apply
   workers.
 - Store-to-peer broadcasts can fan out one peer message per region. Keep this
@@ -197,6 +202,10 @@ High-risk contracts:
 - Startup and online updates share the
   `consistency_check_interval_seconds` label; online updates must not create a
   separate `consistency_check_interval` series.
+- Resolved-ts CheckLeader anomalies should expose both sides of the decision:
+  leader-side unresolved region samples and per-target-store request/response
+  status, plus follower-side registry miss or cached leader tuple mismatch
+  details.
 
 Open these first when triaging:
 


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: ref #19768

What's Changed:

```commit-message
resolved_ts: bound check-leader fallback

Keep RegionReadProgress leader identity owned by role-change handling while allowing region metadata refreshes to update epoch and peer lists.

Add bounded read-index fallback after repeated CheckLeader filtering, plus metrics and diagnosis logs to expose leader-side unresolved regions and follower-side rejection reasons.
```

This PR fixes the known liveness class where resolved-ts can stay pinned when the CheckLeader fast path keeps filtering a region:

- split `RegionReadProgress` updates so metadata-changing paths only refresh epoch/peers, while leader id/term are updated by role-change handling;
- add a bounded ReadIndex fallback after a region is unresolved by CheckLeader for repeated rounds, so an unidentified stale-cache route cannot pin resolved-ts indefinitely;
- add CheckLeader diagnostics on both sides: leader-side unresolved-region/per-target-store status and follower-side registry miss or leader tuple mismatch details;
- add metrics for unresolved CheckLeader region-rounds and fallback scheduled/success/failed/timeout counts and latency.

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [x] Need to cherry-pick to the release branch

Expected follow-up target is release-8.5 if the approach is accepted. release-7.5 already has draft/fix work in #19769 for part of the same invariant.

### Check List

Tests

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Validation run:

- `cargo test -p resolved_ts --lib test_read_index_fallback_after_repeated_check_leader_filtering -- --nocapture`
- `cargo test -p raftstore --lib test_check_leader -- --nocapture`
- `cargo test -p raftstore --lib test_region_update_keeps_resolved_ts_leader_after_peer_change -- --nocapture`
- `cargo fmt --check`
- `cargo clippy -p resolved_ts --lib --tests`
- `cargo clippy -p raftstore --lib`
- `cargo clippy -p raftstore-v2 --lib`

`make clippy` was attempted, but it failed before Rust clippy while fetching the RustSec advisory DB: `failed to fetch advisory database https://github.com/RustSec/advisory-db`.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

The ReadIndex fallback is bounded and only scheduled after repeated CheckLeader filtering for the same unresolved region.

### Release note

```release-note
Fix an issue where resolved-ts may stop advancing when CheckLeader repeatedly filters a region due to stale resolved-ts leader metadata, and add diagnostics for unresolved CheckLeader regions.
```
