### PR TITLE
*: update kvproto to include batch merge protocol fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4414,7 +4414,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git#059694ae4472276644613acccefa24cbc89d959f"
+source = "git+https://github.com/pingcap/kvproto.git#623e58e60fa95c26b356cc6b9c266b0418a08710"
 dependencies = [
  "bytes",
  "futures 0.3.15",


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: None

Split out of #19854: identical patch to [`02bec386f`](https://github.com/tikv/tikv/pull/19854/commits/02bec386f841407b52546ce98f420cf17f3ea36e) from that PR.

What's Changed:

Update kvproto to pingcap/kvproto@623e58e6, which includes pingcap/kvproto#1497: opt-in request flags for batch result merging and serial task execution, plus the per-task merged acknowledgement. The default-false fields let TiKV and its clients upgrade independently. No TiKV code uses the new fields yet.

```commit-message
Update kvproto for the opt-in request flags for batch result merging
and serial task execution, plus the per-task merged acknowledgement.
The default-false fields let TiKV and its clients upgrade
independently.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests

- [x] Unit test

Side effects

Release note

```release-note
None
```
