### PR TITLE
coprocessor, tikv_alloc: model unary handler outputs for result merging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4414,7 +4414,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git#af1ad1bef5b9dd611af5282711f47dbc31a42530"
+source = "git+https://github.com/pingcap/kvproto.git#623e58e60fa95c26b356cc6b9c266b0418a08710"
 dependencies = [
  "bytes",
  "futures 0.3.15",

--- a/components/tikv_alloc/src/trace.rs
+++ b/components/tikv_alloc/src/trace.rs
@@ -263,6 +263,19 @@ impl<T: Default> MemoryTraceGuard<T> {
         }
         std::mem::take(&mut self.item)
     }
+
+    /// Adjusts the traced size to `size`, e.g. after replacing the item with
+    /// one of a different size. Does nothing if the guard traces no memory.
+    pub fn retrace(&mut self, size: usize) {
+        if let Some(node) = &self.node {
+            if size > self.size {
+                node.trace(TraceEvent::Add(size - self.size));
+            } else if size < self.size {
+                node.trace(TraceEvent::Sub(self.size - size));
+            }
+            self.size = size;
+        }
+    }
 }
 
 impl<T: Default> Drop for MemoryTraceGuard<T> {
@@ -370,5 +383,27 @@ mod tests {
             TraceEvent::Reset(3) + TraceEvent::Sub(1),
             TraceEvent::Reset(2)
         );
+    }
+
+    #[test]
+    fn test_trace_guard_retrace() {
+        let trace = mem_trace!(root);
+        let mut guard = trace.trace_guard(vec![0u8; 4], 4);
+        assert_eq!(trace.sum(), 4);
+        guard.retrace(10);
+        assert_eq!(trace.sum(), 10);
+        guard.retrace(2);
+        assert_eq!(trace.sum(), 2);
+        drop(guard);
+        assert_eq!(trace.sum(), 0);
+
+        // A guard without a trace node ignores retrace.
+        let mut guard = crate::trace::MemoryTraceGuard::from(vec![0u8; 4]);
+        assert!(guard.node.is_none());
+        assert_eq!(guard.size, 0);
+        guard.retrace(10);
+        assert!(guard.node.is_none());
+        assert_eq!(guard.size, 0);
+        drop(guard);
     }
 }

--- a/src/coprocessor/cache.rs
+++ b/src/coprocessor/cache.rs
@@ -2,7 +2,6 @@
 
 use async_trait::async_trait;
 use kvproto::coprocessor::Response;
-use tikv_alloc::trace::MemoryTraceGuard;
 use tikv_kv::SnapshotExt;
 
 use crate::{
@@ -28,12 +27,12 @@ impl CachedRequestHandler {
 
 #[async_trait]
 impl RequestHandler for CachedRequestHandler {
-    async fn handle_request(&mut self) -> Result<MemoryTraceGuard<Response>> {
+    async fn handle_request(&mut self) -> Result<HandlerOutput> {
         let mut resp = Response::default();
         resp.set_is_cache_hit(true);
         if let Some(v) = self.data_version {
             resp.set_cache_last_version(v);
         }
-        Ok(resp.into())
+        Ok(HandlerOutput::ready(resp))
     }
 }

--- a/src/coprocessor/checksum.rs
+++ b/src/coprocessor/checksum.rs
@@ -8,7 +8,6 @@ use tidb_query_common::storage::{
     Range,
     scanner::{RangesScanner, RangesScannerOptions},
 };
-use tikv_alloc::trace::MemoryTraceGuard;
 use tipb::{ChecksumAlgorithm, ChecksumRequest, ChecksumResponse};
 
 use crate::{
@@ -56,7 +55,7 @@ impl<S: Snapshot> ChecksumContext<S> {
 
 #[async_trait]
 impl<S: Snapshot> RequestHandler for ChecksumContext<S> {
-    async fn handle_request(&mut self) -> Result<MemoryTraceGuard<Response>> {
+    async fn handle_request(&mut self) -> Result<HandlerOutput> {
         let algorithm = self.req.get_algorithm();
         if algorithm != ChecksumAlgorithm::Crc64Xor {
             return Err(box_err!("unknown checksum algorithm {:?}", algorithm));
@@ -94,7 +93,7 @@ impl<S: Snapshot> RequestHandler for ChecksumContext<S> {
 
         let mut resp = Response::default();
         resp.set_data(data);
-        Ok(resp.into())
+        Ok(HandlerOutput::ready(resp))
     }
 
     fn collect_scan_statistics(&mut self, dest: &mut Statistics) {

--- a/src/coprocessor/dag/mod.rs
+++ b/src/coprocessor/dag/mod.rs
@@ -16,12 +16,11 @@ use tidb_query_common::{
     storage,
     storage::{FindRegionResult, IntervalRange, RegionStorageAccessor},
 };
-use tikv_alloc::trace::MemoryTraceGuard;
 use tipb::{DagRequest, SelectResponse, StreamResponse};
 
 pub use self::storage_impl::TikvStorage;
 use crate::{
-    coprocessor::{Deadline, RequestHandler, Result, metrics::*},
+    coprocessor::{Deadline, HandlerOutput, RequestHandler, Result, metrics::*},
     storage::{Statistics, Store},
     tikv_util::quota_limiter::QuotaLimiter,
 };
@@ -198,9 +197,10 @@ impl BatchDagHandler {
 
 #[async_trait]
 impl RequestHandler for BatchDagHandler {
-    async fn handle_request(&mut self) -> Result<MemoryTraceGuard<Response>> {
+    async fn handle_request(&mut self) -> Result<HandlerOutput> {
         let result = self.runner.handle_request().await;
-        handle_qe_response(result, self.runner.can_be_cached(), self.data_version).map(|x| x.into())
+        handle_qe_response(result, self.runner.can_be_cached(), self.data_version)
+            .map(HandlerOutput::ready)
     }
 
     async fn handle_streaming_request(&mut self) -> Result<(Option<Response>, bool)> {

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -6,7 +6,8 @@ use std::{
 };
 
 use ::tracker::{
-    GLOBAL_TRACKERS, RequestInfo, RequestType, set_tls_tracker_token, track, with_tls_tracker,
+    GLOBAL_TRACKERS, RequestInfo, RequestType, get_tls_tracker_token, set_tls_tracker_token, track,
+    with_tls_tracker,
 };
 use anyhow::anyhow;
 use api_version::{KvFormat, dispatch_api_version};
@@ -627,15 +628,10 @@ impl<E: Engine> Endpoint<E> {
         tracker.collect_storage_statistics(storage_stats);
         let mut output = match result {
             Ok(output) => {
-                let resp_size = output.response.data.len() as u64;
-                COPR_RESP_SIZE.inc_by(resp_size);
-                record_network_out_bytes(resp_size);
-                with_tls_tracker(|tracker| {
-                    tracker.metrics.coprocessor_response_bytes = tracker
-                        .metrics
-                        .coprocessor_response_bytes
-                        .saturating_add(resp_size);
-                });
+                record_coprocessor_response_size(
+                    output.response.get_data().len() as u64,
+                    get_tls_tracker_token(),
+                );
                 output
             }
             Err(e) => {

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -584,19 +584,36 @@ impl<E: Engine> Endpoint<E> {
         tracker.on_begin_all_items();
 
         let deadline = tracker.req_ctx.deadline;
-        let handle_request_future = check_deadline(handler.handle_request(), deadline);
-        let handle_request_future = track(handle_request_future, tracker.as_mut());
+        let handle_request_future = handler.handle_request();
+        let process_future = async move {
+            let output = handle_request_future.await?;
+            match output.into_response() {
+                Ok(response) => Ok(HandlerOutput {
+                    response,
+                    state: HandlerOutputState::Ready,
+                }),
+                Err(ResponseMaterializationFailure {
+                    error,
+                    partial_response,
+                }) => {
+                    drop(partial_response);
+                    Err(error)
+                }
+            }
+        };
+        let process_future = check_deadline(process_future, deadline);
+        let process_future = track(process_future, tracker.as_mut());
 
         let deadline_res = if let Some(semaphore) = &semaphore {
             limit_concurrency(
-                handle_request_future,
+                process_future,
                 semaphore,
                 semaphore_group,
                 LIGHT_TASK_THRESHOLD,
             )
             .await
         } else {
-            handle_request_future.await
+            process_future.await
         };
         let result = deadline_res.map_err(Error::from).and_then(|res| res);
 
@@ -709,6 +726,9 @@ impl<E: Engine> Endpoint<E> {
                 rx.map_err(|_| Error::MaxPendingTasksExceeded).await??;
             match state {
                 HandlerOutputState::Ready => Ok(response),
+                HandlerOutputState::Mergeable(_) => {
+                    unreachable!("unary response must be materialized in the read pool")
+                }
             }
         }
     }

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -31,7 +31,6 @@ use tidb_query_common::{
     execute_stats::ExecSummary,
     storage::{FindRegionResult, RegionStorageAccessor, Result as StorageResult},
 };
-use tikv_alloc::trace::MemoryTraceGuard;
 use tikv_kv::{ExtraRegionOverride, SnapshotExt};
 use tikv_util::{
     DeferContext,
@@ -535,7 +534,7 @@ impl<E: Engine> Endpoint<E> {
         semaphore_group: SemaphoreGroup,
         mut tracker: Box<Tracker<E>>,
         handler_builder: RequestHandlerBuilder<E::IMSnap>,
-    ) -> Result<MemoryTraceGuard<coppb::Response>> {
+    ) -> Result<HandlerOutput> {
         with_tls_tracker(|tracker1| {
             record_network_in_bytes(tracker1.metrics.grpc_req_size);
         });
@@ -609,9 +608,9 @@ impl<E: Engine> Endpoint<E> {
         let mut storage_stats = Statistics::default();
         handler.collect_scan_statistics(&mut storage_stats);
         tracker.collect_storage_statistics(storage_stats);
-        let mut resp = match result {
-            Ok(resp) => {
-                let resp_size = resp.data.len() as u64;
+        let mut output = match result {
+            Ok(output) => {
+                let resp_size = output.response.data.len() as u64;
                 COPR_RESP_SIZE.inc_by(resp_size);
                 record_network_out_bytes(resp_size);
                 with_tls_tracker(|tracker| {
@@ -620,7 +619,7 @@ impl<E: Engine> Endpoint<E> {
                         .coprocessor_response_bytes
                         .saturating_add(resp_size);
                 });
-                resp
+                output
             }
             Err(e) => {
                 if let Error::DefaultNotFound(errmsg) = &e {
@@ -629,16 +628,16 @@ impl<E: Engine> Endpoint<E> {
                         "reqCtx" => ?&tracker.req_ctx,
                     );
                 }
-                make_error_response(e).into()
+                HandlerOutput::ready(make_error_response(e))
             }
         };
         let (exec_details, exec_details_v2) = tracker.get_exec_details();
         tracker.on_finish_all_items();
         record_logical_read_bytes(exec_details_v2.get_scan_detail_v2().processed_versions_size);
-        resp.set_exec_details(exec_details);
-        resp.set_exec_details_v2(exec_details_v2);
-        resp.set_latest_buckets_version(buckets_version);
-        Ok(resp)
+        output.response.set_exec_details(exec_details);
+        output.response.set_exec_details_v2(exec_details_v2);
+        output.response.set_latest_buckets_version(buckets_version);
+        Ok(output)
     }
 
     /// Handle a unary request and run on the read pool.
@@ -648,7 +647,7 @@ impl<E: Engine> Endpoint<E> {
     fn handle_unary_request(
         &self,
         r: ParseCopRequestResult<E::IMSnap>,
-    ) -> impl Future<Output = Result<MemoryTraceGuard<coppb::Response>>> {
+    ) -> impl Future<Output = Result<TracedResponse>> {
         let ParseCopRequestResult {
             req_tag,
             req_ctx,
@@ -706,7 +705,11 @@ impl<E: Engine> Endpoint<E> {
         );
         async move {
             spawn_fut_result?.await?;
-            rx.map_err(|_| Error::MaxPendingTasksExceeded).await?
+            let HandlerOutput { response, state } =
+                rx.map_err(|_| Error::MaxPendingTasksExceeded).await??;
+            match state {
+                HandlerOutputState::Ready => Ok(response),
+            }
         }
     }
 
@@ -718,7 +721,7 @@ impl<E: Engine> Endpoint<E> {
         &self,
         mut req: coppb::Request,
         peer: Option<String>,
-    ) -> impl Future<Output = MemoryTraceGuard<coppb::Response>> {
+    ) -> impl Future<Output = TracedResponse> {
         let tracker = GLOBAL_TRACKERS.insert(::tracker::Tracker::new(RequestInfo::new(
             req.get_context(),
             RequestType::Unknown,
@@ -1433,7 +1436,7 @@ mod tests {
 
     #[async_trait]
     impl RequestHandler for UnaryFixture {
-        async fn handle_request(&mut self) -> Result<MemoryTraceGuard<coppb::Response>> {
+        async fn handle_request(&mut self) -> Result<HandlerOutput> {
             if self.yieldable {
                 // We split the task into small executions of 100 milliseconds.
                 for _ in 0..self.handle_duration.as_millis() as u64 / 100 {
@@ -1447,7 +1450,7 @@ mod tests {
                 thread::sleep(self.handle_duration);
             }
 
-            self.result.take().unwrap().map(|x| x.into())
+            self.result.take().unwrap().map(HandlerOutput::ready)
         }
     }
 
@@ -1469,7 +1472,7 @@ mod tests {
 
     #[async_trait]
     impl RequestHandler for HeavyYieldingUnaryFixture {
-        async fn handle_request(&mut self) -> Result<MemoryTraceGuard<coppb::Response>> {
+        async fn handle_request(&mut self) -> Result<HandlerOutput> {
             for _ in 0..self.yields {
                 let poll_duration = self.poll_duration;
                 let mut first_poll = true;
@@ -1486,7 +1489,7 @@ mod tests {
                 .await;
             }
 
-            self.result.take().unwrap().map(|x| x.into())
+            self.result.take().unwrap().map(HandlerOutput::ready)
         }
     }
 
@@ -2042,9 +2045,10 @@ mod tests {
             .recv_timeout(Duration::from_secs(1))
             .unwrap()
             .unwrap();
-        shared_rx
-            .recv_timeout(Duration::from_millis(250))
-            .unwrap_err();
+        assert!(matches!(
+            shared_rx.recv_timeout(Duration::from_millis(250)),
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout)
+        ));
         drop(shared_permits);
         shared_rx
             .recv_timeout(Duration::from_secs(1))

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -653,14 +653,12 @@ impl<E: Engine> Endpoint<E> {
         Ok(output)
     }
 
-    /// Handle a unary request and run on the read pool.
-    ///
-    /// Returns `Err(err)` if the read pool is full. Returns `Ok(future)` in
-    /// other cases. The future inside may be an error however.
-    fn handle_unary_request(
+    /// Schedules a unary request on the read pool and returns its handler
+    /// output.
+    fn schedule_unary_request(
         &self,
         r: ParseCopRequestResult<E::IMSnap>,
-    ) -> impl Future<Output = Result<TracedResponse>> {
+    ) -> impl Future<Output = Result<HandlerOutput>> {
         let ParseCopRequestResult {
             req_tag,
             req_ctx,
@@ -718,8 +716,19 @@ impl<E: Engine> Endpoint<E> {
         );
         async move {
             spawn_fut_result?.await?;
-            let HandlerOutput { response, state } =
-                rx.map_err(|_| Error::MaxPendingTasksExceeded).await??;
+            rx.map_err(|_| Error::MaxPendingTasksExceeded).await?
+        }
+    }
+
+    /// Handles a unary request whose response is materialized in its read pool
+    /// task.
+    fn handle_unary_request(
+        &self,
+        r: ParseCopRequestResult<E::IMSnap>,
+    ) -> impl Future<Output = Result<TracedResponse>> {
+        let future = self.schedule_unary_request(r);
+        async move {
+            let HandlerOutput { response, state } = future.await?;
             match state {
                 HandlerOutputState::Ready => Ok(response),
                 HandlerOutputState::Mergeable(_) => {

--- a/src/coprocessor/metrics.rs
+++ b/src/coprocessor/metrics.rs
@@ -2,6 +2,7 @@
 
 use std::{cell::RefCell, mem, sync::Arc};
 
+use ::tracker::{GLOBAL_TRACKERS, TrackerToken};
 use collections::HashMap;
 use kvproto::{metapb, pdpb::QueryKind};
 use lazy_static::lazy_static;
@@ -9,6 +10,7 @@ use pd_client::{BucketMeta, RegionWriteCfCopDetail};
 use prometheus::*;
 use prometheus_static_metric::*;
 use raftstore::store::{ReadStats, util::build_key_range};
+use resource_metering::record_network_out_bytes;
 use tikv_util::memory::MemoryQuota;
 
 use crate::{
@@ -310,6 +312,19 @@ impl From<GcKeysDetail> for ScanKind {
             GcKeysDetail::cache_missing_range => ScanKind::cache_missing_range,
         }
     }
+}
+
+/// Records response data against the coprocessor metrics and request identified
+/// by `tracker`.
+pub fn record_coprocessor_response_size(resp_size: u64, tracker: TrackerToken) {
+    COPR_RESP_SIZE.inc_by(resp_size);
+    record_network_out_bytes(resp_size);
+    GLOBAL_TRACKERS.with_tracker(tracker, |tracker| {
+        tracker.metrics.coprocessor_response_bytes = tracker
+            .metrics
+            .coprocessor_response_bytes
+            .saturating_add(resp_size);
+    });
 }
 
 pub fn tls_flush<R: FlowStatsReporter>(reporter: &R) {

--- a/src/coprocessor/mod.rs
+++ b/src/coprocessor/mod.rs
@@ -62,11 +62,45 @@ pub const REQ_FLAG_TIDB_SYSSESSION: u64 = 2048;
 
 type HandlerStreamStepResult = Result<(Option<coppb::Response>, bool)>;
 
+/// A coprocessor response together with its response-data memory trace.
+pub type TracedResponse = MemoryTraceGuard<coppb::Response>;
+
+/// The output of handling a unary request. It always owns the response and
+/// records separately whether its data is ready for transport.
+pub struct HandlerOutput {
+    response: TracedResponse,
+    state: HandlerOutputState,
+}
+
+/// Whether the response data is ready for transport.
+enum HandlerOutputState {
+    Ready,
+}
+
+impl HandlerOutput {
+    /// Creates an untraced ready response.
+    pub fn ready(response: coppb::Response) -> Self {
+        Self {
+            response: response.into(),
+            state: HandlerOutputState::Ready,
+        }
+    }
+
+    /// Creates a ready response whose data is attributed to `trace`.
+    pub fn ready_with_trace(response: coppb::Response, trace: &Arc<MemoryTrace>) -> Self {
+        let data_capacity = response.data.capacity();
+        Self {
+            response: trace.trace_guard(response, data_capacity),
+            state: HandlerOutputState::Ready,
+        }
+    }
+}
+
 /// An interface for all kind of Coprocessor request handlers.
 #[async_trait]
 pub trait RequestHandler: Send {
-    /// Processes current request and produces a response.
-    async fn handle_request(&mut self) -> Result<MemoryTraceGuard<coppb::Response>> {
+    /// Processes current request and produces a unary output.
+    async fn handle_request(&mut self) -> Result<HandlerOutput> {
         panic!("unary request is not supported for this handler");
     }
 

--- a/src/coprocessor/mod.rs
+++ b/src/coprocessor/mod.rs
@@ -241,6 +241,19 @@ pub struct ReqContextInner {
     pub allowed_in_flashback: bool,
 }
 
+#[inline]
+fn deadline_from_request_context(
+    context: &kvrpcpb::Context,
+    default_max_handle_duration: Duration,
+) -> Deadline {
+    let duration = if context.max_execution_duration_ms > 0 {
+        Duration::from_millis(context.max_execution_duration_ms)
+    } else {
+        default_max_handle_duration
+    };
+    Deadline::from_now(duration)
+}
+
 impl ReqContextInner {
     #[inline]
     pub fn new(
@@ -254,11 +267,7 @@ impl ReqContextInner {
         perf_level: PerfLevel,
         allowed_in_flashback: bool,
     ) -> Self {
-        let mut deadline_duration = max_handle_duration;
-        if context.max_execution_duration_ms > 0 {
-            deadline_duration = Duration::from_millis(context.max_execution_duration_ms);
-        }
-        let deadline = Deadline::from_now(deadline_duration);
+        let deadline = deadline_from_request_context(&context, max_handle_duration);
         let bypass_locks = TsSet::from_u64s(context.take_resolved_locks());
         let access_locks = TsSet::from_u64s(context.take_committed_locks());
         let lower_bound = match ranges.first().as_ref() {

--- a/src/coprocessor/mod.rs
+++ b/src/coprocessor/mod.rs
@@ -62,8 +62,9 @@ pub const REQ_FLAG_TIDB_SYSSESSION: u64 = 2048;
 
 type HandlerStreamStepResult = Result<(Option<coppb::Response>, bool)>;
 
-/// A task result that can be combined with results of the same request and
-/// serialized after merging.
+/// A task result that a `RequestHandler` returns unserialized, so that the
+/// endpoint can merge the results of a batched request's tasks (one per region)
+/// and serialize the merged result only once.
 pub trait MergeableResult: Any + Send {
     /// Merges another result of the same concrete type. Callers may choose any
     /// merge order, so implementations must produce the same logical result
@@ -79,15 +80,23 @@ pub trait MergeableResult: Any + Send {
 pub type TracedResponse = MemoryTraceGuard<coppb::Response>;
 
 /// The output of handling a unary request. It always owns the response and
-/// records separately whether its data is ready for transport.
+/// records separately whether its data is ready or still mergeable.
 pub struct HandlerOutput {
     response: TracedResponse,
     state: HandlerOutputState,
 }
 
-/// Whether the response data is ready for transport.
+/// Whether the response data is ready or still mergeable and unserialized.
 enum HandlerOutputState {
     Ready,
+    Mergeable(Box<dyn MergeableResult>),
+}
+
+/// A serialization failure that retains the partial response's trace guard so
+/// batch finalization can reuse it when constructing an error response.
+struct ResponseMaterializationFailure {
+    error: Error,
+    partial_response: Box<TracedResponse>,
 }
 
 impl HandlerOutput {
@@ -100,11 +109,49 @@ impl HandlerOutput {
     }
 
     /// Creates a ready response whose data is attributed to `trace`.
-    pub fn ready_with_trace(response: coppb::Response, trace: &Arc<MemoryTrace>) -> Self {
-        let data_capacity = response.data.capacity();
+    pub fn ready_with_trace(mut response: coppb::Response, trace: &Arc<MemoryTrace>) -> Self {
+        // Trace the capacity: it is what the allocation holds, and the data
+        // buffer may carry spare capacity beyond its length.
+        let data_capacity = response.mut_data().capacity();
         Self {
             response: trace.trace_guard(response, data_capacity),
             state: HandlerOutputState::Ready,
+        }
+    }
+
+    /// Creates a mergeable output whose eventual response data is attributed
+    /// to `trace`.
+    pub fn mergeable_with_trace(
+        partial_response: coppb::Response,
+        result: Box<dyn MergeableResult>,
+        trace: &Arc<MemoryTrace>,
+    ) -> Self {
+        debug_assert!(partial_response.get_data().is_empty());
+        Self {
+            response: trace.trace_guard(partial_response, 0),
+            state: HandlerOutputState::Mergeable(result),
+        }
+    }
+
+    fn into_response(self) -> std::result::Result<TracedResponse, ResponseMaterializationFailure> {
+        let Self {
+            mut response,
+            state,
+        } = self;
+        match state {
+            HandlerOutputState::Ready => Ok(response),
+            HandlerOutputState::Mergeable(result) => match result.into_data() {
+                Ok(data) => {
+                    let data_capacity = data.capacity();
+                    response.set_data(data);
+                    response.retrace(data_capacity);
+                    Ok(response)
+                }
+                Err(error) => Err(ResponseMaterializationFailure {
+                    error,
+                    partial_response: Box::new(response),
+                }),
+            },
         }
     }
 }
@@ -112,7 +159,8 @@ impl HandlerOutput {
 /// An interface for all kind of Coprocessor request handlers.
 #[async_trait]
 pub trait RequestHandler: Send {
-    /// Processes current request and produces a unary output.
+    /// Processes current request and produces either a ready response or a
+    /// result kept unserialized for merging.
     async fn handle_request(&mut self) -> Result<HandlerOutput> {
         panic!("unary request is not supported for this handler");
     }

--- a/src/coprocessor/mod.rs
+++ b/src/coprocessor/mod.rs
@@ -35,7 +35,7 @@ pub mod readpool_impl;
 mod statistics;
 mod tracker;
 
-use std::{ops::Deref, sync::Arc};
+use std::{any::Any, ops::Deref, sync::Arc};
 
 use async_trait::async_trait;
 pub use checksum::checksum_crc64_xor;
@@ -61,6 +61,19 @@ pub const REQ_TYPE_CHECKSUM: i64 = 105;
 pub const REQ_FLAG_TIDB_SYSSESSION: u64 = 2048;
 
 type HandlerStreamStepResult = Result<(Option<coppb::Response>, bool)>;
+
+/// A task result that can be combined with results of the same request and
+/// serialized after merging.
+pub trait MergeableResult: Any + Send {
+    /// Merges another result of the same concrete type. Callers may choose any
+    /// merge order, so implementations must produce the same logical result
+    /// independent of that order.
+    fn merge(&mut self, other: Box<dyn MergeableResult>);
+
+    /// Serializes the result into response data. The result must keep any
+    /// memory it holds tracked until it is merged away or serialized.
+    fn into_data(self: Box<Self>) -> Result<Vec<u8>>;
+}
 
 /// A coprocessor response together with its response-data memory trace.
 pub type TracedResponse = MemoryTraceGuard<coppb::Response>;

--- a/src/coprocessor/statistics/analyze.rs
+++ b/src/coprocessor/statistics/analyze.rs
@@ -1,10 +1,11 @@
 // Copyright 2017 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::{cmp::Reverse, collections::BinaryHeap, hash::Hasher, mem, sync::Arc};
+use std::{any::Any, cmp::Reverse, collections::BinaryHeap, hash::Hasher, mem, sync::Arc};
 
 use api_version::KvFormat;
 use kvproto::coprocessor::KeyRange;
 use mur3::Hasher128;
+use protobuf::Message;
 use rand::{Rng, rngs::StdRng};
 use tidb_query_datatype::{
     FieldTypeAccessor,
@@ -239,8 +240,12 @@ impl<S: Snapshot, F: KvFormat> RowSampleBuilder<S, F> {
     }
 }
 
-trait RowSampleCollector: Send {
+trait RowSampleCollector: Any + Send {
     fn mut_base(&mut self) -> &mut BaseRowSampleCollector;
+    /// Merges another collector into this one. Both collectors are built from
+    /// the same analyze request, so they always have the same concrete type
+    /// and implementations may downcast `other` infallibly.
+    fn merge_collector(&mut self, other: Box<dyn RowSampleCollector>);
     fn collect_column_group(
         &mut self,
         columns_val: &[Vec<u8>],
@@ -256,11 +261,11 @@ trait RowSampleCollector: Send {
     );
     fn sampling(&mut self, data: &[Vec<u8>]);
     fn to_proto(&mut self) -> tipb::RowSampleCollector;
-    #[allow(dead_code)]
+    #[cfg(test)]
     fn get_reported_memory_usage(&mut self) -> usize {
         self.mut_base().reported_memory_usage
     }
-    #[allow(dead_code)]
+    #[cfg(test)]
     fn get_memory_usage(&mut self) -> usize {
         self.mut_base().memory_usage
     }
@@ -291,6 +296,10 @@ impl Default for BaseRowSampleCollector {
     }
 }
 
+fn row_sample_memory_usage(row: &[Vec<u8>]) -> usize {
+    row.iter().map(Vec::capacity).sum()
+}
+
 impl BaseRowSampleCollector {
     fn new(max_fm_sketch_size: usize, col_and_group_len: usize) -> BaseRowSampleCollector {
         BaseRowSampleCollector {
@@ -301,6 +310,24 @@ impl BaseRowSampleCollector {
             total_sizes: vec![0; col_and_group_len],
             memory_usage: 0,
             reported_memory_usage: 0,
+        }
+    }
+
+    fn merge_from(&mut self, other: &mut BaseRowSampleCollector) {
+        // Collectors of one request share the layout derived from the shared
+        // request; a mismatch would silently truncate the zips below.
+        debug_assert_eq!(self.null_count.len(), other.null_count.len());
+        debug_assert_eq!(self.total_sizes.len(), other.total_sizes.len());
+        debug_assert_eq!(self.fm_sketches.len(), other.fm_sketches.len());
+        self.count += other.count;
+        for (dst, src) in self.null_count.iter_mut().zip(&other.null_count) {
+            *dst += src;
+        }
+        for (dst, src) in self.total_sizes.iter_mut().zip(&other.total_sizes) {
+            *dst += src;
+        }
+        for (sketch, other_sketch) in self.fm_sketches.iter_mut().zip(&other.fm_sketches) {
+            sketch.merge(other_sketch);
         }
     }
 
@@ -371,6 +398,11 @@ impl BaseRowSampleCollector {
         proto_collector.set_total_size(self.total_sizes.clone());
     }
 
+    fn release_reported_memory_usage(&mut self) {
+        self.memory_usage = 0;
+        self.report_memory_usage(true);
+    }
+
     fn report_memory_usage(&mut self, on_finish: bool) {
         let diff = self.memory_usage as isize - self.reported_memory_usage as isize;
         if on_finish || diff.abs() > 1024 * 1024 {
@@ -404,6 +436,13 @@ impl BernoulliRowSampleCollector {
             sample_rate,
         }
     }
+
+    fn samples_memory_usage(&self) -> usize {
+        self.samples
+            .iter()
+            .map(|row| row_sample_memory_usage(row))
+            .sum()
+    }
 }
 
 impl Default for BernoulliRowSampleCollector {
@@ -420,6 +459,21 @@ impl RowSampleCollector for BernoulliRowSampleCollector {
     fn mut_base(&mut self) -> &mut BaseRowSampleCollector {
         &mut self.base
     }
+
+    fn merge_collector(&mut self, other: Box<dyn RowSampleCollector>) {
+        // Collectors of one request always have the same concrete type.
+        let mut other = (other as Box<dyn Any>)
+            .downcast::<BernoulliRowSampleCollector>()
+            .unwrap();
+        let sample_memory_usage = other.samples_memory_usage();
+        self.samples.append(&mut other.samples);
+        self.base.memory_usage += sample_memory_usage;
+        self.base.report_memory_usage(false);
+
+        other.base.release_reported_memory_usage();
+        self.base.merge_from(&mut other.base);
+    }
+
     fn collect_column_group(
         &mut self,
         columns_val: &[Vec<u8>],
@@ -455,8 +509,7 @@ impl RowSampleCollector for BernoulliRowSampleCollector {
         self.samples.push(sample);
     }
     fn to_proto(&mut self) -> tipb::RowSampleCollector {
-        self.base.memory_usage = 0;
-        self.base.report_memory_usage(true);
+        self.base.release_reported_memory_usage();
         let mut s = tipb::RowSampleCollector::default();
         let samples = mem::take(&mut self.samples)
             .into_iter()
@@ -491,12 +544,49 @@ impl ReservoirRowSampleCollector {
             max_sample_size,
         }
     }
+
+    fn should_keep_weight(&self, weight: i64) -> bool {
+        // A zero `max_sample_size` keeps no samples. Without this early
+        // return, the `peek().unwrap()` below would panic on the empty heap.
+        if self.max_sample_size == 0 {
+            return false;
+        }
+        self.samples.len() < self.max_sample_size || self.samples.peek().unwrap().0.0 < weight
+    }
+
+    fn push_weighted_sample(&mut self, weight: i64, sample: Vec<Vec<u8>>) {
+        if self.samples.len() >= self.max_sample_size {
+            let (_, evicted) = self.samples.pop().unwrap().0;
+            let evicted_memory_usage = row_sample_memory_usage(&evicted);
+            debug_assert!(self.base.memory_usage >= evicted_memory_usage);
+            self.base.memory_usage = self.base.memory_usage.saturating_sub(evicted_memory_usage);
+        }
+        self.base.memory_usage += row_sample_memory_usage(&sample);
+        self.samples.push(Reverse((weight, sample)));
+    }
 }
 
 impl RowSampleCollector for ReservoirRowSampleCollector {
     fn mut_base(&mut self) -> &mut BaseRowSampleCollector {
         &mut self.base
     }
+
+    fn merge_collector(&mut self, other: Box<dyn RowSampleCollector>) {
+        // Collectors of one request always have the same concrete type.
+        let mut other = (other as Box<dyn Any>)
+            .downcast::<ReservoirRowSampleCollector>()
+            .unwrap();
+        for Reverse((weight, sample)) in mem::take(&mut other.samples) {
+            if self.should_keep_weight(weight) {
+                self.push_weighted_sample(weight, sample);
+            }
+        }
+        self.base.report_memory_usage(false);
+
+        other.base.release_reported_memory_usage();
+        self.base.merge_from(&mut other.base);
+    }
+
     fn collect_column_group(
         &mut self,
         columns_val: &[Vec<u8>],
@@ -524,31 +614,15 @@ impl RowSampleCollector for ReservoirRowSampleCollector {
     }
 
     fn sampling(&mut self, data: &[Vec<u8>]) {
-        // We should tolerate the abnormal case => `self.max_sample_size == 0`.
-        if self.max_sample_size == 0 {
-            return;
-        }
-        let mut need_push = false;
         let cur_rng = self.base.rng.gen_range(0, i64::MAX);
-        if self.samples.len() < self.max_sample_size {
-            need_push = true;
-        } else if self.samples.peek().unwrap().0.0 < cur_rng {
-            need_push = true;
-            let (_, evicted) = self.samples.pop().unwrap().0;
-            self.base.memory_usage -= evicted.iter().map(|x| x.capacity()).sum::<usize>();
-        }
-
-        if need_push {
-            let sample = data.to_vec();
-            self.base.memory_usage += sample.iter().map(|x| x.capacity()).sum::<usize>();
+        if self.should_keep_weight(cur_rng) {
+            self.push_weighted_sample(cur_rng, data.to_vec());
             self.base.report_memory_usage(false);
-            self.samples.push(Reverse((cur_rng, sample)));
         }
     }
 
     fn to_proto(&mut self) -> tipb::RowSampleCollector {
-        self.base.memory_usage = 0;
-        self.base.report_memory_usage(true);
+        self.base.release_reported_memory_usage();
         let mut s = tipb::RowSampleCollector::default();
         let samples = mem::take(&mut self.samples)
             .into_iter()
@@ -567,8 +641,7 @@ impl RowSampleCollector for ReservoirRowSampleCollector {
 
 impl Drop for BaseRowSampleCollector {
     fn drop(&mut self) {
-        self.memory_usage = 0;
-        self.report_memory_usage(true);
+        self.release_reported_memory_usage();
     }
 }
 
@@ -843,6 +916,23 @@ impl AnalyzeSamplingResult {
     }
 }
 
+impl MergeableResult for AnalyzeSamplingResult {
+    fn merge(&mut self, other: Box<dyn MergeableResult>) {
+        // Results of one request have the same concrete type by the
+        // `MergeableResult::merge` contract, so the downcast cannot fail.
+        let other = (other as Box<dyn std::any::Any>)
+            .downcast::<AnalyzeSamplingResult>()
+            .unwrap();
+        self.row_sample_collector
+            .merge_collector(other.row_sample_collector);
+    }
+
+    fn into_data(self: Box<Self>) -> Result<Vec<u8>> {
+        let resp: tipb::AnalyzeColumnsResp = (*self).into();
+        Ok(box_try!(resp.write_to_bytes()))
+    }
+}
+
 impl From<AnalyzeSamplingResult> for tipb::AnalyzeColumnsResp {
     fn from(mut result: AnalyzeSamplingResult) -> tipb::AnalyzeColumnsResp {
         let pb_collector = result.row_sample_collector.to_proto();
@@ -1100,6 +1190,108 @@ mod tests {
             }
             assert_eq!(collector.samples.len(), 0);
         }
+    }
+
+    fn sorted_hashset(sketch: &tipb::FmSketch) -> Vec<u64> {
+        let mut hashes = sketch.get_hashset().to_vec();
+        hashes.sort_unstable();
+        hashes
+    }
+
+    fn test_sampling_result(
+        count: u64,
+        null_count: i64,
+        total_size: i64,
+        sample_weights: &[i64],
+        ndv_hashes: &[u64],
+    ) -> AnalyzeSamplingResult {
+        let mut collector = ReservoirRowSampleCollector::new(2, 1000, 1);
+        collector.base.count = count;
+        collector.base.null_count[0] = null_count;
+        collector.base.total_sizes[0] = total_size;
+        for hash in ndv_hashes {
+            collector.base.fm_sketches[0].insert_hash_value(*hash);
+        }
+        for weight in sample_weights {
+            collector.push_weighted_sample(*weight, vec![vec![*weight as u8]]);
+        }
+        AnalyzeSamplingResult::new(Box::new(collector))
+    }
+
+    #[test]
+    fn test_analyze_sampling_result_merge() {
+        let a = 10;
+        let b = 20;
+        let c = 30;
+        let mut result = test_sampling_result(2, 1, 10, &[1, 3], &[a, b]);
+        result.merge(Box::new(test_sampling_result(2, 2, 20, &[4], &[a, c])));
+
+        let resp: tipb::AnalyzeColumnsResp = result.into();
+        let collector = resp.get_row_collector();
+        assert_eq!(collector.get_count(), 4);
+        assert_eq!(collector.get_null_counts(), &[3]);
+        assert_eq!(collector.get_total_size(), &[30]);
+
+        let mut sample_weights: Vec<_> = collector
+            .get_samples()
+            .iter()
+            .map(|sample| sample.get_weight())
+            .collect();
+        sample_weights.sort_unstable();
+        assert_eq!(sample_weights, vec![3, 4]);
+        assert_eq!(sorted_hashset(&collector.get_fm_sketch()[0]), vec![a, b, c]);
+    }
+
+    fn test_bernoulli_sampling_result(
+        count: u64,
+        null_count: i64,
+        total_size: i64,
+        samples: &[u8],
+        ndv_hashes: &[u64],
+    ) -> AnalyzeSamplingResult {
+        let mut collector = BernoulliRowSampleCollector::new(1.0, 1000, 1);
+        collector.base.count = count;
+        collector.base.null_count[0] = null_count;
+        collector.base.total_sizes[0] = total_size;
+        for hash in ndv_hashes {
+            collector.base.fm_sketches[0].insert_hash_value(*hash);
+        }
+        for sample in samples {
+            collector.samples.push(vec![vec![*sample]]);
+            collector.base.memory_usage += 1;
+        }
+        AnalyzeSamplingResult::new(Box::new(collector))
+    }
+
+    #[test]
+    fn test_analyze_bernoulli_sampling_result_merge() {
+        // Rate-based sampling keeps every sampled row, so merging
+        // concatenates the sample sets instead of re-reducing them.
+        let a = 10;
+        let b = 20;
+        let c = 30;
+        let mut result = test_bernoulli_sampling_result(2, 1, 10, &[1, 3], &[a, b]);
+        result.merge(Box::new(test_bernoulli_sampling_result(
+            2,
+            2,
+            20,
+            &[4],
+            &[a, c],
+        )));
+
+        let resp: tipb::AnalyzeColumnsResp = result.into();
+        let collector = resp.get_row_collector();
+        assert_eq!(collector.get_count(), 4);
+        assert_eq!(collector.get_null_counts(), &[3]);
+        assert_eq!(collector.get_total_size(), &[30]);
+        let mut samples: Vec<_> = collector
+            .get_samples()
+            .iter()
+            .map(|sample| sample.get_row()[0][0])
+            .collect();
+        samples.sort_unstable();
+        assert_eq!(samples, vec![1, 3, 4]);
+        assert_eq!(sorted_hashset(&collector.get_fm_sketch()[0]), vec![a, b, c]);
     }
 }
 

--- a/src/coprocessor/statistics/analyze_context.rs
+++ b/src/coprocessor/statistics/analyze_context.rs
@@ -21,7 +21,8 @@ use crate::{
         MEMTRACE_ANALYZE,
         dag::TikvStorage,
         statistics::analyze::{
-            AnalyzeIndexResult, AnalyzeMixedResult, RowSampleBuilder, SampleBuilder,
+            AnalyzeIndexResult, AnalyzeMixedResult, AnalyzeSamplingResult, RowSampleBuilder,
+            SampleBuilder,
         },
         *,
     },
@@ -119,13 +120,10 @@ impl<S: Snapshot, F: KvFormat> AnalyzeContext<S, F> {
         Ok(res_data)
     }
 
-    async fn handle_full_sampling(builder: &mut RowSampleBuilder<S, F>) -> Result<Vec<u8>> {
-        let sample_res = builder.collect_column_stats().await?;
-        let res_data = {
-            let res: tipb::AnalyzeColumnsResp = sample_res.into();
-            box_try!(res.write_to_bytes())
-        };
-        Ok(res_data)
+    async fn handle_full_sampling(
+        builder: &mut RowSampleBuilder<S, F>,
+    ) -> Result<AnalyzeSamplingResult> {
+        builder.collect_column_stats().await
     }
 
     // handle_index is used to handle `AnalyzeIndexReq`,
@@ -221,6 +219,11 @@ impl<S: Snapshot, F: KvFormat> AnalyzeContext<S, F> {
 #[async_trait]
 impl<S: Snapshot, F: KvFormat> RequestHandler for AnalyzeContext<S, F> {
     async fn handle_request(&mut self) -> Result<HandlerOutput> {
+        let ready = |data| {
+            let mut response = Response::default();
+            response.set_data(data);
+            HandlerOutput::ready_with_trace(response, &MEMTRACE_ANALYZE)
+        };
         let ret = match self.req.get_tp() {
             AnalyzeType::TypeIndex | AnalyzeType::TypeCommonHandle => {
                 let req = self.req.take_idx_req();
@@ -244,7 +247,7 @@ impl<S: Snapshot, F: KvFormat> RequestHandler for AnalyzeContext<S, F> {
                 )
                 .await;
                 scanner.collect_storage_stats(&mut self.storage_stats);
-                res
+                res.map(ready)
             }
 
             AnalyzeType::TypeColumn => {
@@ -254,7 +257,7 @@ impl<S: Snapshot, F: KvFormat> RequestHandler for AnalyzeContext<S, F> {
                 let mut builder = SampleBuilder::<_, F>::new(col_req, None, storage, ranges)?;
                 let res = AnalyzeContext::handle_column(&mut builder).await;
                 builder.data.collect_storage_stats(&mut self.storage_stats);
-                res
+                res.map(ready)
             }
 
             // Type mixed is analyze common handle and columns by scan table rows once.
@@ -267,7 +270,7 @@ impl<S: Snapshot, F: KvFormat> RequestHandler for AnalyzeContext<S, F> {
                     SampleBuilder::<_, F>::new(col_req, Some(idx_req), storage, ranges)?;
                 let res = AnalyzeContext::handle_mixed(&mut builder).await;
                 builder.data.collect_storage_stats(&mut self.storage_stats);
-                res
+                res.map(ready)
             }
 
             AnalyzeType::TypeFullSampling => {
@@ -285,7 +288,13 @@ impl<S: Snapshot, F: KvFormat> RequestHandler for AnalyzeContext<S, F> {
 
                 let res = AnalyzeContext::handle_full_sampling(&mut builder).await;
                 builder.merge_storage_stats_into(&mut self.storage_stats);
-                res
+                res.map(|sampling_result| {
+                    HandlerOutput::mergeable_with_trace(
+                        Response::default(),
+                        Box::new(sampling_result),
+                        &MEMTRACE_ANALYZE,
+                    )
+                })
             }
 
             AnalyzeType::TypeSampleIndex => Err(Error::Other(
@@ -293,11 +302,7 @@ impl<S: Snapshot, F: KvFormat> RequestHandler for AnalyzeContext<S, F> {
             )),
         };
         match ret {
-            Ok(data) => {
-                let mut resp = Response::default();
-                resp.set_data(data);
-                Ok(HandlerOutput::ready_with_trace(resp, &MEMTRACE_ANALYZE))
-            }
+            Ok(output) => Ok(output),
             Err(Error::Other(e)) => {
                 let mut resp = Response::default();
                 resp.set_other_error(e);

--- a/src/coprocessor/statistics/analyze_context.rs
+++ b/src/coprocessor/statistics/analyze_context.rs
@@ -12,7 +12,6 @@ use tidb_query_common::storage::{
 };
 use tidb_query_datatype::codec::{datum::split_datum, table};
 use tidb_query_executors::interface::BatchExecutor;
-use tikv_alloc::trace::MemoryTraceGuard;
 use tikv_util::quota_limiter::QuotaLimiter;
 use tipb::{self, AnalyzeIndexReq, AnalyzeReq, AnalyzeType};
 
@@ -221,7 +220,7 @@ impl<S: Snapshot, F: KvFormat> AnalyzeContext<S, F> {
 
 #[async_trait]
 impl<S: Snapshot, F: KvFormat> RequestHandler for AnalyzeContext<S, F> {
-    async fn handle_request(&mut self) -> Result<MemoryTraceGuard<Response>> {
+    async fn handle_request(&mut self) -> Result<HandlerOutput> {
         let ret = match self.req.get_tp() {
             AnalyzeType::TypeIndex | AnalyzeType::TypeCommonHandle => {
                 let req = self.req.take_idx_req();
@@ -295,15 +294,14 @@ impl<S: Snapshot, F: KvFormat> RequestHandler for AnalyzeContext<S, F> {
         };
         match ret {
             Ok(data) => {
-                let memory_size = data.capacity();
                 let mut resp = Response::default();
                 resp.set_data(data);
-                Ok(MEMTRACE_ANALYZE.trace_guard(resp, memory_size))
+                Ok(HandlerOutput::ready_with_trace(resp, &MEMTRACE_ANALYZE))
             }
             Err(Error::Other(e)) => {
                 let mut resp = Response::default();
                 resp.set_other_error(e);
-                Ok(resp.into())
+                Ok(HandlerOutput::ready(resp))
             }
             Err(e) => Err(e),
         }

--- a/src/coprocessor/statistics/fmsketch.rs
+++ b/src/coprocessor/statistics/fmsketch.rs
@@ -79,6 +79,16 @@ impl FmSketch {
             self.mask = mask;
         }
     }
+
+    pub fn merge(&mut self, other: &FmSketch) {
+        if self.mask < other.mask {
+            self.mask = other.mask;
+            self.hash_set.retain(|&x| x & self.mask == 0);
+        }
+        for hash in &other.hash_set {
+            self.insert_hash_value(*hash);
+        }
+    }
 }
 
 impl From<FmSketch> for tipb::FmSketch {
@@ -185,5 +195,29 @@ mod tests {
         assert_eq!(sketch.hash_set.len(), max_size);
         sketch.insert_hash_value(4);
         assert_eq!(sketch.hash_set.len(), max_size);
+    }
+
+    #[test]
+    fn test_merge() {
+        // Sketches over halves of the data merge into the same sketch as one
+        // built over all of it, whether the mask grows on the left (small
+        // max_size forces levels) or the right side.
+        let data = TestData::default();
+        let max_size = 100;
+        let whole = build_fmsketch(&data.samples, max_size).unwrap();
+        let (left, right) = data.samples.split_at(data.samples.len() / 2);
+        let mut merged = build_fmsketch(left, max_size).unwrap();
+        merged.merge(&build_fmsketch(right, max_size).unwrap());
+        assert_eq!(merged.mask, whole.mask);
+        assert_eq!(merged.ndv(), whole.ndv());
+
+        // Merging a leveled-up sketch (bigger mask) prunes the receiver.
+        let small = build_fmsketch(&data.samples, 2).unwrap();
+        let mut receiver = FmSketch::new(2);
+        receiver.insert_hash_value(1);
+        assert_eq!(receiver.mask, 0);
+        receiver.merge(&small);
+        assert!(receiver.mask >= small.mask);
+        assert!(receiver.hash_set.iter().all(|h| h & receiver.mask == 0));
     }
 }

--- a/tests/integrations/coprocessor/test_analyze.rs
+++ b/tests/integrations/coprocessor/test_analyze.rs
@@ -1,15 +1,17 @@
 // Copyright 2017 TiKV Project Authors. Licensed under Apache-2.0.
 
 use kvproto::{
-    coprocessor::{KeyRange, Request},
+    coprocessor::{KeyRange, Request, StoreBatchTask},
     kvrpcpb::{Context, IsolationLevel},
 };
 use protobuf::Message;
 use test_coprocessor::*;
+use test_storage::*;
 use tipb::{
     AnalyzeColumnGroup, AnalyzeColumnsReq, AnalyzeColumnsResp, AnalyzeIndexReq, AnalyzeIndexResp,
     AnalyzeReq, AnalyzeType,
 };
+use txn_types::Key;
 
 pub const REQ_TYPE_ANALYZE: i64 = 104;
 
@@ -354,4 +356,83 @@ fn test_invalid_range() {
     req.set_ranges(vec![key_range].into());
     let resp = handle_request(&endpoint, req);
     assert!(!resp.get_other_error().is_empty());
+}
+
+#[test]
+fn test_batched_full_sampling_responses() {
+    let data = vec![
+        (1, Some("name:0"), 2),
+        (2, Some("name:4"), 3),
+        (4, Some("name:3"), 1),
+        (5, Some("name:1"), 4),
+        (9, Some("name:8"), 7),
+        (10, Some("name:6"), 8),
+    ];
+    let product = ProductTable::new();
+    let (mut cluster, raft_engine, ctx) = new_raft_engine(1, "");
+    let (_, endpoint, _) =
+        init_data_with_engine_and_commit(ctx, raft_engine, &product, &data, true);
+
+    // The region is split into [1, 2], [4, 5], [9, 10].
+    let region =
+        cluster.get_region(Key::from_raw(&product.get_record_range(1, 1).start).as_encoded());
+    let split_key = Key::from_raw(&product.get_record_range(3, 3).start);
+    cluster.must_split(&region, split_key.as_encoded());
+    let second_region =
+        cluster.get_region(Key::from_raw(&product.get_record_range(4, 4).start).as_encoded());
+    let second_split_key = Key::from_raw(&product.get_record_range(8, 8).start);
+    cluster.must_split(&second_region, second_split_key.as_encoded());
+
+    let mut col_req = AnalyzeColumnsReq::default();
+    col_req.set_columns_info(product.columns_info().into());
+    // A sample rate of one keeps every row, so each response is
+    // deterministic.
+    col_req.set_sample_rate(1.0);
+    col_req.set_sketch_size(1000);
+    let mut analyze_req = AnalyzeReq::default();
+    analyze_req.set_tp(AnalyzeType::TypeFullSampling);
+    analyze_req.set_col_req(col_req);
+
+    let top_range = product.get_record_range(1, 2);
+    let top_region = cluster.get_region(Key::from_raw(&top_range.start).as_encoded());
+    let mut top_ctx = Context::default();
+    top_ctx.set_region_id(top_region.get_id());
+    top_ctx.set_region_epoch(top_region.get_region_epoch().clone());
+    top_ctx.set_peer(cluster.leader_of_region(top_region.get_id()).unwrap());
+
+    let mut req = Request::default();
+    req.set_tp(REQ_TYPE_ANALYZE);
+    req.set_data(analyze_req.write_to_bytes().unwrap());
+    req.set_ranges(vec![top_range].into());
+    req.set_start_ts(100);
+    req.set_context(top_ctx);
+    for (task_id, (start, end)) in [(1, (4, 5)), (2, (9, 10))] {
+        let range = product.get_record_range(start, end);
+        let batch_region = cluster.get_region(Key::from_raw(&range.start).as_encoded());
+        let mut task = StoreBatchTask::new();
+        task.set_region_id(batch_region.get_id());
+        task.set_region_epoch(batch_region.get_region_epoch().clone());
+        task.set_peer(cluster.leader_of_region(batch_region.get_id()).unwrap());
+        task.set_ranges(vec![range].into());
+        task.set_task_id(task_id);
+        req.tasks.push(task);
+    }
+
+    let parse_collector = |data: &[u8]| -> tipb::RowSampleCollector {
+        let mut resp = AnalyzeColumnsResp::default();
+        resp.merge_from_bytes(data).unwrap();
+        resp.take_row_collector()
+    };
+
+    // Existing clients receive one full-sampling result per region.
+    let mut resp = handle_request(&endpoint, req);
+    assert!(!resp.has_region_error(), "{:?}", resp);
+    assert!(resp.get_other_error().is_empty(), "{:?}", resp);
+    assert_eq!(parse_collector(resp.get_data()).get_count(), 2);
+    let batch_resps = resp.take_batch_responses();
+    assert_eq!(batch_resps.len(), 2);
+    for (batch_resp, task_id) in batch_resps.iter().zip([1, 2]) {
+        assert_eq!(batch_resp.get_task_id(), task_id);
+        assert_eq!(parse_collector(batch_resp.get_data()).get_count(), 2);
+    }
 }


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: https://github.com/pingcap/tidb/issues/67449

Split out of #19854. Pure preparation, no behavior change.

What's Changed:

- Model unary handler results as a `HandlerOutput` that can carry either a materialized response or an unserialized `MergeableResult`, and let full-sampling analyze defer serialization to the endpoint.
- Add the full-sampling collector and FM sketch merge routines that batch merging will build on.
- Support retracing a `MemoryTraceGuard` so a response can be re-accounted after late serialization.
- Mechanical cleanups: centralize response byte accounting and request deadline construction; split read-pool scheduling from response extraction.
- Update kvproto to pingcap/kvproto@623e58e6 (includes pingcap/kvproto#1497: the opt-in batch merge protocol fields; unused by this PR).

The first commit adds characterization tests pinning the current per-task batched analyze wire behavior; they pass unchanged at the tip of this PR.

Each commit is an identical patch of its original in #19854:

| This PR | Original in #19854 |
|---|---|
| characterize full-sampling batches | [`8db3d3f93`](https://github.com/tikv/tikv/pull/19854/commits/8db3d3f9305fcca391d3198e995eb11ea5c12ce4) |
| model unary handler outputs | [`4e5c30d4a`](https://github.com/tikv/tikv/pull/19854/commits/4e5c30d4aebc3ff8e1f93e4bf816b7978b737af4) |
| merge full-sampling collectors | [`019410f00`](https://github.com/tikv/tikv/pull/19854/commits/019410f00ccd377d910b087e309d057b18a96e76) |
| support retracing guarded memory | [`23d88df0f`](https://github.com/tikv/tikv/pull/19854/commits/23d88df0f79d2609073568fedaf18313b9b7867d) |
| defer full-sampling result serialization | [`931e0180e`](https://github.com/tikv/tikv/pull/19854/commits/931e0180eb74e80f90ac6fb6630a44f3fa50733f) |
| centralize response byte accounting | [`df0682fed`](https://github.com/tikv/tikv/pull/19854/commits/df0682fedec48453ca088f14a218dbd13579950e) |
| centralize request deadline construction | [`bac630b7a`](https://github.com/tikv/tikv/pull/19854/commits/bac630b7aa718e85da8408585062383337326846) |
| expose scheduled unary handler outputs | [`b4eb83f8f`](https://github.com/tikv/tikv/pull/19854/commits/b4eb83f8fd73636f5719d386d898a089249de2df) |
| add batch merge protocol fields | [`6e74cf729`](https://github.com/tikv/tikv/pull/19854/commits/6e74cf7299663e07aef170a2da5704a320b4ba41) |

```commit-message
Model unary handler outputs so a handler can return an unserialized
mergeable result, and add the collector merge routines and memory
retracing support that batched analyze result merging builds on.
No behavior change.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests

- [x] Unit test
- [x] Integration test

Side effects

Release note

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added support for combining parallel analysis results, including sketches, samples, and statistics.
- Added batched full-sampling responses for multi-region analysis requests.
- Improved coprocessor response handling and response-size/network-byte tracking.

## Bug Fixes
- Improved memory accounting during response resizing, serialization, merging, and cleanup.
- Preserved partial results when response serialization encounters an error.
- Improved handling of traced response size adjustments.

## Tests
- Added coverage for merged sampling results, sketch merging, memory cleanup, and batched analysis responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->