### PR TITLE
expr: fix WEEK() treating a NULL mode as NULL instead of mode 0

### DIFF
--- a/components/tidb_query_expr/src/impl_time.rs
+++ b/components/tidb_query_expr/src/impl_time.rs
@@ -93,16 +93,21 @@ pub fn week_with_mode(
     t: Option<&DateTime>,
     m: Option<&Int>,
 ) -> Result<Option<Int>> {
-    if t.is_none() || m.is_none() {
-        return Ok(None);
-    }
-    let (t, m) = (t.unwrap(), m.unwrap());
+    // A NULL date has no well-defined week; a NULL mode defaults to mode 0,
+    // matching TiDB's root-level evalInt semantics (builtinWeekWithModeSig)
+    // so that predicates pushed down to the coprocessor produce the same
+    // result as evaluation at the root.
+    let t = match t {
+        Some(t) => t,
+        None => return Ok(None),
+    };
+    let m = m.copied().unwrap_or(0);
     if t.invalid_zero() {
         return ctx
             .handle_invalid_time_error(Error::incorrect_datetime_value(t))
             .map(|_| Ok(None))?;
     }
-    let week = t.week(WeekMode::from_bits_truncate(*m as u32));
+    let week = t.week(WeekMode::from_bits_truncate(m as u32));
     Ok(Some(i64::from(week)))
 }
 
@@ -2131,7 +2136,9 @@ mod tests {
             ("2017-12-31", Some(6), Some(1i64)),
             ("2017-12-31", Some(7), Some(52i64)),
             ("2017-12-31", Some(14), Some(1i64)),
-            ("2017-12-31", None::<Int>, None),
+            // A NULL mode defaults to mode 0, matching TiDB's root-level
+            // evalInt semantics, so this must equal the Some(0) case above.
+            ("2017-12-31", None::<Int>, Some(53i64)),
             ("0000-00-00", Some(0), None),
             ("2018-12-00", Some(0), None),
             ("2018-00-03", Some(0), None),


### PR DESCRIPTION
Fixes #19890

week_with_mode short-circuited to a NULL result whenever either the date or the mode argument was NULL. TiDB's root-level evalInt (builtinWeekWithModeSig) instead treats a NULL mode as mode 0, per documented MySQL-compatible semantics. This mismatch meant a WEEK() predicate pushed down to the coprocessor could evaluate differently than the same predicate evaluated at the root, which in the reported case caused a DELETE ... WHERE WEEK(d, mode) IS NULL to delete rows that should not have matched.

Only short-circuit on a NULL date now; default a NULL mode to 0 before computing the week, matching TiDB's semantics. Updated the existing unit test case that encoded the previous (incorrect) behavior.

year_week_with_mode is not affected: its mode parameter is not nullable at the RPN-function level, so it is a different code path.

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #19890

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
expr: fix WEEK() treating a NULL mode as NULL instead of mode 0
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Fix a bug where `WEEK(date, mode)` with a `NULL` mode argument, when pushed down to TiKV's coprocessor, incorrectly returned `NULL` instead of defaulting to mode 0. This could cause `DELETE`/`SELECT` predicates using `WEEK(..., NULL)` to match different rows than the same query evaluated at the TiDB root.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated week calculations so a missing mode uses the default week-numbering behavior.
  - Week calculations now return `NULL` only when the date itself is `NULL`.
  - Corrected results for dates near year boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->