### PR TITLE
expr: fix decimal UNIX_TIMESTAMP adjusting DST spring-forward gaps

### DIFF
--- a/components/tidb_query_expr/src/impl_time.rs
+++ b/components/tidb_query_expr/src/impl_time.rs
@@ -1665,7 +1665,7 @@ fn unix_timestamp_to_mysql_unix_timestamp(
     Ok(value?)
 }
 
-fn get_micro_timestamp(time: &DateTime, tz: &Tz) -> Result<i64> {
+fn get_micro_timestamp(time: &DateTime, tz: &Tz, adjust_gap: bool) -> Result<i64> {
     let year = time.year() as i32;
     let month = time.month();
     let day = time.day();
@@ -1687,6 +1687,13 @@ fn get_micro_timestamp(time: &DateTime, tz: &Tz) -> Result<i64> {
     let res = match tz.from_local_datetime(&naive_datetime).earliest() {
         Some(val) => val,
         None => {
+            if !adjust_gap {
+                // Decimal UNIX_TIMESTAMP returns zero for a nonexistent
+                // local time in a DST spring-forward gap, matching TiDB's
+                // GoTime-based root evaluation, rather than adjusting to
+                // the nearest zone transition boundary.
+                return Ok(0);
+            }
             let chrono_tz = match tz.get_chrono_tz() {
                 Some(val) => val,
                 None => return Err(Error::incorrect_parameters("Can't get chrono tz").into()),
@@ -1709,7 +1716,7 @@ fn get_micro_timestamp(time: &DateTime, tz: &Tz) -> Result<i64> {
 #[rpn_fn(capture = [ctx])]
 #[inline]
 pub fn unix_timestamp_int(ctx: &mut EvalContext, time: &DateTime) -> Result<Option<i64>> {
-    let timestamp = get_micro_timestamp(time, &ctx.cfg.tz)?;
+    let timestamp = get_micro_timestamp(time, &ctx.cfg.tz, true)?;
 
     let res: std::result::Result<i64, Error> =
         unix_timestamp_to_mysql_unix_timestamp(ctx, timestamp, 1)?
@@ -1725,7 +1732,7 @@ pub fn unix_timestamp_decimal(
     extra: &RpnFnCallExtra,
     time: &DateTime,
 ) -> Result<Option<Decimal>> {
-    let timestamp = get_micro_timestamp(time, &ctx.cfg.tz)?;
+    let timestamp = get_micro_timestamp(time, &ctx.cfg.tz, false)?;
 
     let res = unix_timestamp_to_mysql_unix_timestamp(
         ctx,
@@ -4374,11 +4381,14 @@ mod tests {
                 Decimal::from_str("1253446359").unwrap(),
             ),
             (
+                // A nonexistent local time in a DST spring-forward gap.
+                // Decimal UNIX_TIMESTAMP returns zero here, unlike the
+                // integer signature, which adjusts to the zone transition.
                 "2020-03-29 03:45:03.123",
                 0,
                 "Europe/Vilnius",
                 0,
-                Decimal::from_str("1585443600").unwrap(),
+                Decimal::zero(),
             ),
         ];
 


### PR DESCRIPTION
Fixes #19889

get_micro_timestamp always resolved a local time in a DST spring-forward gap (a local time that never occurred) by adjusting it to the nearest zone transition boundary via find_zone_transition. This shared helper backed both UNIX_TIMESTAMP signatures identically.

TiDB's root evaluation differs by signature: the integer signature (AdjustedGoTime) adjusts the gap value, while the decimal signature (GoTime) returns zero. Routing both through the same always-adjust helper meant a decimal UNIX_TIMESTAMP predicate pushed down to the coprocessor could evaluate differently than the same predicate evaluated at the root -- in the reported case, a DELETE using a gap value deleted rows that should not have matched.

Add an explicit adjust_gap parameter to get_micro_timestamp: unix_timestamp_int passes true (preserving existing behavior), unix_timestamp_decimal passes false and returns 0 for a gap, matching TiDB's GoTime semantics. Corrected the existing Vilnius decimal test case, which had encoded the previous (incorrect) adjusted value as its expected result.

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #19889

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
expr: fix decimal UNIX_TIMESTAMP adjusting DST spring-forward gaps
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Fix a bug where decimal `UNIX_TIMESTAMP()` on a nonexistent local time in a DST spring-forward gap incorrectly adjusted to the nearest zone transition instead of returning zero, when the predicate was pushed down to TiKV's coprocessor. This could cause `DELETE`/`SELECT` predicates involving `UNIX_TIMESTAMP()` on gap values to match different rows than the same query evaluated at the TiDB root.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Unix timestamp handling for times occurring during daylight-saving time gaps.
  * Integer timestamps continue adjusting gap times, while decimal timestamps now correctly return zero.
  * Updated timestamp conversion test expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->