### PR TITLE
expr: fix Time::from_duration using UTC date instead of session date

### DIFF
--- a/components/tidb_query_datatype/src/codec/mysql/time/mod.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/time/mod.rs
@@ -4003,27 +4003,27 @@ mod tests {
         }
         Ok(())
     }
-
     #[test]
     fn test_from_duration_uses_session_timezone_date() -> Result<()> {
+        // 2020-02-01 16:00:00 UTC is 2020-02-02 00:00:00 in Asia/Shanghai
+        // (UTC+8) -- the UTC and session-local dates differ, which is the
+        // exact condition that exposes the bug this test guards against.
         let mut cfg = EvalConfig::default();
         cfg.set_time_zone_by_name("Asia/Shanghai")?;
-        let mut ctx = EvalContext::new(Arc::new(cfg));
+        let tz = cfg.tz;
 
-        let duration = Duration::parse(&mut ctx, "01:00:00", MAX_FSP)?;
-        let actual = Time::from_duration(&mut ctx, duration, TimeType::DateTime)?;
-
-        // The date component must match "today" as seen in the session time
-        // zone (Asia/Shanghai), not the UTC date -- these can differ near a
-        // local midnight boundary.
-        let expected_date = ctx
-            .cfg
-            .tz
-            .from_utc_datetime(&Utc::now().naive_utc())
+        let fixed_utc_now = Utc.with_ymd_and_hms(2020, 2, 1, 16, 0, 0).unwrap();
+        let local_date = tz
+            .from_utc_datetime(&fixed_utc_now.naive_utc())
             .naive_local()
             .date();
-        let c_datetime = actual.try_into_chrono_datetime(&mut ctx)?;
-        assert_eq!(c_datetime.date_naive(), expected_date);
+        assert_eq!(
+            local_date,
+            chrono::NaiveDate::from_ymd_opt(2020, 2, 2).unwrap()
+        );
+
+        let expected = local_date.and_hms_opt(1, 0, 0).unwrap();
+        assert_eq!(expected.to_string(), "2020-02-02 01:00:00");
 
         Ok(())
     }

--- a/components/tidb_query_datatype/src/codec/mysql/time/mod.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/time/mod.rs
@@ -2094,8 +2094,16 @@ impl Time {
                 .single()
                 .and_then(|t| t.checked_add_signed(dur))
         } else {
-            Utc::now()
-                .date_naive()
+            // Use today's date in the session time zone, not the UTC date,
+            // so that a TIME value cast to DATETIME lands on the same
+            // calendar day a client in that time zone would expect --
+            // otherwise, near a local midnight boundary where the local
+            // and UTC dates differ, the date could be off by one.
+            ctx.cfg
+                .tz
+                .from_utc_datetime(&Utc::now().naive_utc())
+                .naive_local()
+                .date()
                 .and_hms_opt(0, 0, 0)
                 .and_then(|t| t.and_local_timezone(Utc).single())
                 .and_then(|t| t.checked_add_signed(dur))
@@ -3993,6 +4001,30 @@ mod tests {
             let actual = Time::from_duration(&mut ctx, duration, TimeType::DateTime)?;
             assert_eq!(actual.to_string(), expected);
         }
+        Ok(())
+    }
+
+    #[test]
+    fn test_from_duration_uses_session_timezone_date() -> Result<()> {
+        let mut cfg = EvalConfig::default();
+        cfg.set_time_zone_by_name("Asia/Shanghai")?;
+        let mut ctx = EvalContext::new(Arc::new(cfg));
+
+        let duration = Duration::parse(&mut ctx, "01:00:00", MAX_FSP)?;
+        let actual = Time::from_duration(&mut ctx, duration, TimeType::DateTime)?;
+
+        // The date component must match "today" as seen in the session time
+        // zone (Asia/Shanghai), not the UTC date -- these can differ near a
+        // local midnight boundary.
+        let expected_date = ctx
+            .cfg
+            .tz
+            .from_utc_datetime(&Utc::now().naive_utc())
+            .naive_local()
+            .date();
+        let c_datetime = actual.try_into_chrono_datetime(&mut ctx)?;
+        assert_eq!(c_datetime.date_naive(), expected_date);
+
         Ok(())
     }
 

--- a/components/tidb_query_datatype/src/codec/mysql/time/mod.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/time/mod.rs
@@ -2089,25 +2089,26 @@ impl Time {
     ) -> Result<Self> {
         let dur = chrono::Duration::nanoseconds(duration.to_nanos());
 
-        let time = if unlikely(ctx.cfg.is_test) {
-            Utc.with_ymd_and_hms(2020, 2, 2, 0, 0, 0)
-                .single()
-                .and_then(|t| t.checked_add_signed(dur))
+        // Both branches convert a "now" instant into the session time zone
+        // before taking its date, so that is_test mode exercises the same
+        // time zone handling as production, differing only in using a
+        // fixed instant instead of a live clock read. Otherwise, near a
+        // local midnight boundary where the local and UTC dates differ,
+        // the date could be off by one.
+        let now = if unlikely(ctx.cfg.is_test) {
+            Utc.with_ymd_and_hms(2020, 2, 2, 0, 0, 0).unwrap()
         } else {
-            // Use today's date in the session time zone, not the UTC date,
-            // so that a TIME value cast to DATETIME lands on the same
-            // calendar day a client in that time zone would expect --
-            // otherwise, near a local midnight boundary where the local
-            // and UTC dates differ, the date could be off by one.
-            ctx.cfg
-                .tz
-                .from_utc_datetime(&Utc::now().naive_utc())
-                .naive_local()
-                .date()
-                .and_hms_opt(0, 0, 0)
-                .and_then(|t| t.and_local_timezone(Utc).single())
-                .and_then(|t| t.checked_add_signed(dur))
+            Utc::now()
         };
+        let time = ctx
+            .cfg
+            .tz
+            .from_utc_datetime(&now.naive_utc())
+            .naive_local()
+            .date()
+            .and_hms_opt(0, 0, 0)
+            .and_then(|t| t.and_local_timezone(Utc).single())
+            .and_then(|t| t.checked_add_signed(dur));
 
         let time = time.ok_or::<Error>(box_err!("parse from duration {} overflows", duration))?;
 
@@ -4003,27 +4004,24 @@ mod tests {
         }
         Ok(())
     }
+
     #[test]
     fn test_from_duration_uses_session_timezone_date() -> Result<()> {
-        // 2020-02-01 16:00:00 UTC is 2020-02-02 00:00:00 in Asia/Shanghai
-        // (UTC+8) -- the UTC and session-local dates differ, which is the
-        // exact condition that exposes the bug this test guards against.
+        // is_test uses a fixed instant of 2020-02-02 00:00:00 UTC. In a
+        // negative-offset zone such as America/Los_Angeles (UTC-8 in
+        // February, before DST), that instant falls on the previous local
+        // day -- exercising the exact condition this fix addresses: the
+        // session-local date differing from the UTC date. This calls the
+        // real Time::from_duration, not a standalone re-derivation of the
+        // conversion logic.
         let mut cfg = EvalConfig::default();
-        cfg.set_time_zone_by_name("Asia/Shanghai")?;
-        let tz = cfg.tz;
+        cfg.set_time_zone_by_name("America/Los_Angeles")?;
+        cfg.is_test = true;
+        let mut ctx = EvalContext::new(Arc::new(cfg));
 
-        let fixed_utc_now = Utc.with_ymd_and_hms(2020, 2, 1, 16, 0, 0).unwrap();
-        let local_date = tz
-            .from_utc_datetime(&fixed_utc_now.naive_utc())
-            .naive_local()
-            .date();
-        assert_eq!(
-            local_date,
-            chrono::NaiveDate::from_ymd_opt(2020, 2, 2).unwrap()
-        );
-
-        let expected = local_date.and_hms_opt(1, 0, 0).unwrap();
-        assert_eq!(expected.to_string(), "2020-02-02 01:00:00");
+        let duration = Duration::parse(&mut ctx, "01:00:00", MAX_FSP)?;
+        let actual = Time::from_duration(&mut ctx, duration, TimeType::DateTime)?;
+        assert_eq!(actual.to_string(), "2020-02-01 01:00:00.000000");
 
         Ok(())
     }


### PR DESCRIPTION
Fixes #19888 (timezone portion)

Time::from_duration computed today's date via Utc::now().date_naive(), ignoring the session time zone (ctx.cfg.tz) entirely. Near a local midnight boundary where the session time zone's date differs from the UTC date (e.g. Asia/Shanghai, which is a day ahead of UTC for part of each day), a TIME value cast to DATETIME landed on the wrong calendar day when the predicate was pushed down to the coprocessor, since TiDB's root evaluation correctly uses the session time zone.

Use ctx.cfg.tz to convert the current instant into the session time zone before taking its date, following the same pattern already used by the neighboring from_local_time function.

This fixes the timezone portion of the issue, which is sufficient to resolve the reported reproduction. The issue's fuller fix direction also calls for deriving a single stable statement timestamp from start_ts (already transported and TSO-decodable via txn_types::TimeStamp::physical()) instead of calling Utc::now() fresh per row, so that the result is stable across all rows in one statement. That is a separable, larger change (touches EvalContext/ EvalConfig construction) and is left as a follow-up.

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #19888

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
expr: fix Time::from_duration using UTC date instead of session date
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Fix a bug where `Time::from_duration` (used when casting a JSON TIME value to DATETIME) used the UTC date instead of the session time zone's date. This could cause a predicate pushed down to TiKV's coprocessor to classify rows by the wrong calendar day near a local midnight boundary, diverging from TiDB's root evaluation.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected date handling for time values near local midnight.
  * Time-based results now consistently respect the configured session time zone, including regional zones such as America/Los_Angeles and Asia/Shanghai.
  * Fixed cases where date conversion could incorrectly use UTC instead of the session’s local date.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->