### PR TITLE
compact-log-backup: fix TSO date formatting

### DIFF
--- a/components/compact-log-backup/src/execute/mod.rs
+++ b/components/compact-log-backup/src/execute/mod.rs
@@ -24,6 +24,7 @@ use tokio::{
 use tokio_stream::Stream;
 use tracing::trace_span;
 use tracing_active_tree::{frame, root};
+use txn_types::TimeStamp;
 
 use self::hooking::AbortedCtx;
 use super::{
@@ -203,7 +204,8 @@ impl slog::KV for ExecutionConfig {
             serializer.emit_u64("shard.total", shard.total)?;
         }
         let date = |pts| {
-            chrono::DateTime::<Utc>::from_timestamp_millis(pts as i64)
+            let ts = TimeStamp::new(pts).physical();
+            chrono::DateTime::<Utc>::from_timestamp_millis(ts as i64)
                 .map(|dt| dt.to_string())
                 .unwrap_or_else(|| format!("invalid_ts({pts})"))
         };


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: close #20037

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
PR #19367 migrated compact-log-backup's chrono timestamp construction and
accidentally removed the TSO-to-physical-milliseconds conversion from the
readable log date formatter. The same regression was later backported to
release-8.5 by PR #19933.

This PR restores the original TimeStamp::new(pts).physical() conversion while
keeping the newer chrono::DateTime::<Utc>::from_timestamp_millis API. The
numeric TSO fields used for compaction are unchanged; this only fixes the
printed shift_date, from_date, and until_date fields.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [x] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Manual test:

```shell
cargo fmt --all
git diff --check
CARGO_TARGET_DIR=target/codex-compact-log-backup-check cargo check -p compact-log-backup
```

`make clippy` was also started and passed the repository pre-checks and
cargo-deny. It was stopped by a local 120-second timeout during `clippy-all`
without reporting a lint error.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected timestamp formatting in compact log backup output to ensure displayed dates accurately reflect the timestamp’s physical value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->