### PR TITLE
expr: fix precision loss converting large JSON integers to DECIMAL

### DIFF
--- a/components/tidb_query_datatype/src/codec/mysql/decimal.rs
+++ b/components/tidb_query_datatype/src/codec/mysql/decimal.rs
@@ -1894,6 +1894,14 @@ impl ConvertTo<Decimal> for JsonRef<'_> {
                     Ok(Decimal::zero())
                 })
             }
+            // Convert integer JSON values directly, matching TiDB's
+            // ConvertJSONToDecimal. Routing through f64 (the previous
+            // catch-all path below) loses precision for magnitudes beyond
+            // 2^53, since f64 cannot represent every i64/u64 value exactly
+            // -- this could silently change which rows a pushed-down
+            // predicate selects for large integer JSON IDs.
+            JsonType::I64 => Ok(Decimal::from(self.get_i64())),
+            JsonType::U64 => Ok(Decimal::from(self.get_u64())),
             _ => {
                 let r: f64 = self.convert(ctx)?;
                 Decimal::from_f64(r)
@@ -2480,6 +2488,41 @@ mod tests {
             let dec: Decimal = num.into();
             let dec_str = dec.to_string_value();
             assert_eq!(dec_str, exp);
+        }
+    }
+
+    #[test]
+    fn test_json_i64_u64_to_decimal_exact() {
+        use super::super::json::Json;
+
+        // Values chosen at/near the i64/u64 boundary, where f64 (53-bit
+        // mantissa) can no longer represent every integer exactly. Routing
+        // these through f64 before Decimal::from_f64 silently rounds them,
+        // which could change which rows a pushed-down predicate comparing
+        // against an equal DECIMAL value selects.
+        let cases: Vec<(Json, &str)> = vec![
+            (
+                Json::from_i64(9007199254740991).unwrap(),
+                "9007199254740991",
+            ),
+            (
+                Json::from_i64(9007199254740993).unwrap(),
+                "9007199254740993",
+            ),
+            (
+                Json::from_i64(9223372036854775807).unwrap(),
+                "9223372036854775807",
+            ),
+            (
+                Json::from_u64(18446744073709551615).unwrap(),
+                "18446744073709551615",
+            ),
+        ];
+
+        let mut ctx = EvalContext::default();
+        for (json, expected) in cases {
+            let dec: Decimal = json.as_ref().convert(&mut ctx).unwrap();
+            assert_eq!(dec.to_string(), expected);
         }
     }
 

--- a/components/tidb_query_expr/src/impl_cast.rs
+++ b/components/tidb_query_expr/src/impl_cast.rs
@@ -5950,29 +5950,33 @@ mod tests {
                 Decimal::from_f64(10f64).unwrap(),
             ),
             (
+                // Json::from_i64/from_u64 now convert exactly via
+                // Decimal::from(i64)/Decimal::from(u64) rather than via a
+                // lossy f64 intermediate, so the expected value here must
+                // be computed the same exact way, not via Decimal::from_f64.
                 Json::from_i64(i64::MAX).unwrap(),
                 false,
                 false,
-                Decimal::from_f64(i64::MAX as f64).unwrap(),
+                Decimal::from(i64::MAX),
             ),
             (
                 Json::from_i64(i64::MIN).unwrap(),
                 false,
                 false,
-                Decimal::from_f64(i64::MIN as f64).unwrap(),
+                Decimal::from(i64::MIN),
             ),
             (Json::from_u64(0).unwrap(), false, false, Decimal::zero()),
             (
                 Json::from_u64(i64::MAX as u64).unwrap(),
                 false,
                 false,
-                Decimal::from_f64(i64::MAX as f64).unwrap(),
+                Decimal::from(i64::MAX as u64),
             ),
             (
                 Json::from_u64(u64::MAX).unwrap(),
                 false,
                 false,
-                Decimal::from_f64(u64::MAX as f64).unwrap(),
+                Decimal::from(u64::MAX),
             ),
             (
                 Json::from_f64(i64::MAX as f64).unwrap(),


### PR DESCRIPTION
Fixes #19886

ConvertTo<Decimal> for JsonRef routed JsonType::I64/U64 values through its catch-all branch, which converts to f64 first (via ConvertTo<f64>) before calling Decimal::from_f64. f64's 53-bit mantissa cannot represent every i64/u64 value exactly beyond 2^53, so this silently rounded large integer JSON values -- e.g. 9223372036854775807 and 18446744073709551615 (i64::MAX and u64::MAX) lost precision. Since this conversion backs predicates pushed down to the coprocessor (e.g. CAST(json_col AS DECIMAL(65,0)) = decimal_col), a query could select different rows than the same predicate evaluated at the TiDB root, which correctly constructs the decimal directly from the JSON int64/uint64 (matching TiDB's ConvertJSONToDecimal).

Added explicit JsonType::I64/U64 match arms that convert directly via Decimal::from(i64)/Decimal::from(u64), bypassing the lossy f64 intermediate. Added a regression test covering the boundary values from the reported reproduction, including i64::MAX and u64::MAX.

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #19886

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
expr: fix precision loss converting large JSON integers to DECIMAL
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Fix a bug where casting a large JSON integer (near or at `i64`/`u64` boundaries) to `DECIMAL` lost precision due to an intermediate `f64` conversion, when the cast was pushed down to TiKV's coprocessor. This could cause predicates comparing a JSON-derived decimal against an equal `DECIMAL` column to select different rows than the same query evaluated at the TiDB root.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved decimal conversion for signed and unsigned integer values.
  * Preserved exact values for large integers, including values beyond 53-bit precision.
  * Added regression coverage for boundary-value conversions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->