### PR TITLE
expr: fix f64-to-uint rounding using round-away-from-zero instead of round-to-even

### DIFF
--- a/components/tidb_query_datatype/src/codec/convert.rs
+++ b/components/tidb_query_datatype/src/codec/convert.rs
@@ -332,7 +332,14 @@ impl ToInt for f64 {
     /// anymore.
     #[allow(clippy::float_cmp)]
     fn to_uint(&self, ctx: &mut EvalContext, tp: FieldTypeTp) -> Result<u64> {
-        let val = self.round();
+        // Match TiDB's ConvertFloatToUint (and the sibling to_int method
+        // above), which rounds half to even rather than away from zero.
+        // Using a different rounding mode here than to_int -- and than
+        // TiDB's root evaluation -- could make a cast pushed down to the
+        // coprocessor select different rows than the same cast evaluated
+        // at the root for values exactly halfway between two integers
+        // (e.g. 0.5, 2.5).
+        let val = self.round_ties_even();
         if val < 0f64 {
             ctx.handle_overflow_err(overflow(val, tp))?;
             if ctx.should_clip_to_zero() {
@@ -1662,17 +1669,27 @@ mod tests {
             (256.6, FieldTypeTp::Short, Some(257)),
             (65535.5, FieldTypeTp::Short, None),
             (65536.1, FieldTypeTp::Int24, Some(65536)),
-            (65536.5, FieldTypeTp::Int24, Some(65537)),
+            (65536.5, FieldTypeTp::Int24, Some(65536)), // round-to-even: 65536 is even
             (16777215.4, FieldTypeTp::Int24, Some(16777215)),
             (16777216.1, FieldTypeTp::Int24, None),
             (8388610.4, FieldTypeTp::Long, Some(8388610)),
-            (8388610.5, FieldTypeTp::Long, Some(8388611)),
+            (8388610.5, FieldTypeTp::Long, Some(8388610)), // round-to-even: 8388610 is even
             (4294967296.8, FieldTypeTp::Long, None),
             (4294967296.8, FieldTypeTp::LongLong, Some(4294967297)),
             (4294967297.1, FieldTypeTp::LongLong, Some(4294967297)),
             (-4294967297.1, FieldTypeTp::LongLong, None),
             (f64::MAX, FieldTypeTp::LongLong, None),
             (f64::MIN, FieldTypeTp::LongLong, None),
+            // Round-half-to-even cases, matching TiDB's ConvertFloatToUint.
+            // 0 and 2 are even, so ties round down to them; 1 and 3 are
+            // odd, so ties round up away from them.
+            (0.5, FieldTypeTp::LongLong, Some(0)),
+            (1.5, FieldTypeTp::LongLong, Some(2)),
+            (2.5, FieldTypeTp::LongLong, Some(2)),
+            (3.5, FieldTypeTp::LongLong, Some(4)),
+            // Non-tie values are unaffected by the rounding mode change.
+            (0.4, FieldTypeTp::LongLong, Some(0)),
+            (1.4, FieldTypeTp::LongLong, Some(1)),
         ];
 
         let mut ctx = EvalContext::default();
@@ -1874,7 +1891,7 @@ mod tests {
             ("[]", 0u64),
             ("3", 3u64),
             ("4.1", 4u64),
-            ("4.5", 5u64),
+            ("4.5", 4u64), // round-to-even: 4 is even
             ("true", 1u64),
             ("false", 0u64),
             ("null", 0u64),

--- a/components/tidb_query_expr/src/impl_cast.rs
+++ b/components/tidb_query_expr/src/impl_cast.rs
@@ -2316,7 +2316,7 @@ mod tests {
         // no clip to zero
         let cs = vec![
             // (origin, expect, overflow)
-            (10.5, 11u64, false),
+            (10.5, 10u64, false), // round-to-even: 10 is even
             (10.4, 10u64, false),
             (
                 ((1u64 << 63) + (1u64 << 62)) as f64,


### PR DESCRIPTION
…round-to-even

Fixes #19885

ToInt::to_uint for f64 used self.round(), which rounds exact halves away from zero, while the sibling to_int method already used self.round_ties_even() -- an inconsistency between the two methods in the same impl block. TiDB's ConvertFloatToUint uses math.RoundToEven, so this made a cast pushed down to the coprocessor (e.g. CAST(x AS UNSIGNED) for a DOUBLE column) select different rows than the same cast evaluated at the TiDB root for values exactly halfway between two integers, e.g. 0.5 rounds to 1 under the previous behavior but stays 0 under round-to-even, matching TiDB.

Align to_uint with to_int's rounding mode. This required correcting several pre-existing test cases whose hardcoded expected values encoded the old (incorrect) rounding behavior for exact-half inputs (e.g. 65536.5 -> 65537, 10.5 -> 11, JSON "4.5" -> 5), and added explicit half-tie regression cases (0.5, 1.5, 2.5, 3.5), including the exact reproduction from the issue.

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #19885

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
expr: fix f64-to-uint rounding using round-away-from-zero instead of round-to-even
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Fix a bug where casting a `DOUBLE` to `UNSIGNED` used round-half-away-from-zero instead of round-half-to-even, when the cast was pushed down to TiKV's coprocessor. This could cause a predicate comparing the cast result against a fixed value to select different rows than the same query evaluated at the TiDB root, for values exactly halfway between two integers (e.g. `0.5`, `2.5`).
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated unsigned floating-point conversions to use round-half-to-even behavior, aligning results with signed conversions and TiDB.
  * Corrected `.5` conversion outcomes, including real-to-unsigned integer and JSON-to-unsigned conversions.
  * Added coverage for tie and non-tie rounding scenarios to improve conversion accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->