### PR TITLE
expr: apply target length/truncation to JSON-to-CHAR cast pushdown

### DIFF
--- a/components/tidb_query_expr/src/impl_cast.rs
+++ b/components/tidb_query_expr/src/impl_cast.rs
@@ -1492,14 +1492,26 @@ fn cast_any_as_bytes<From: ConvertTo<Bytes> + Evaluable + EvaluableRet>(
     }
 }
 
-#[rpn_fn(nullable, capture = [ctx])]
+// Apply the same length/truncation/padding logic as TiDB's
+// ProduceStrWithSpecifiedTp (via cast_as_string_helper, already used by
+// cast_string_as_string below), rather than returning the full converted
+// JSON string unconditionally. Without this, a CAST(json AS CHAR(n))
+// pushed down to the coprocessor could accept overlong values that
+// TiDB's root evaluation would truncate (or reject under strict mode),
+// making a predicate over the cast result select different rows than
+// the same predicate evaluated at the root.
+#[rpn_fn(nullable, capture = [ctx, extra])]
 #[inline]
-fn cast_json_as_bytes(ctx: &mut EvalContext, val: Option<JsonRef>) -> Result<Option<Bytes>> {
+fn cast_json_as_bytes(
+    ctx: &mut EvalContext,
+    extra: &RpnFnCallExtra,
+    val: Option<JsonRef>,
+) -> Result<Option<Bytes>> {
     match val {
         None => Ok(None),
         Some(val) => {
             let val = val.convert(ctx)?;
-            Ok(Some(val))
+            cast_as_string_helper(ctx, extra, val)
         }
     }
 }
@@ -4669,7 +4681,7 @@ mod tests {
 
     #[test]
     fn test_json_as_string() {
-        test_none_with_ctx(cast_json_as_bytes);
+        test_none_with_ctx_and_extra(cast_json_as_bytes);
 
         // FIXME: this case is not exactly same as TiDB's,
         //  such as(left is TiKV, right is TiDB)
@@ -4728,11 +4740,34 @@ mod tests {
 
         for (input, expect) in cs {
             let mut ctx = EvalContext::default();
-            let r = cast_json_as_bytes(&mut ctx, Some(input.as_ref()));
+            let mut ret_field_type: FieldType = FieldType::default();
+            ret_field_type.set_flen(UNSPECIFIED_LENGTH as i32);
+            let extra = RpnFnCallExtra {
+                ret_field_type: &ret_field_type,
+            };
+            let r = cast_json_as_bytes(&mut ctx, &extra, Some(input.as_ref()));
             let r = r.map(|x| x.map(|x| unsafe { String::from_utf8_unchecked(x) }));
             let log = make_log(&input, &expect, &r);
             check_result(Some(&expect), &r, log.as_str());
         }
+
+        // Regression case for the reported issue: CAST(json AS CHAR(n))
+        // pushed down to the coprocessor must truncate to the target
+        // length, matching TiDB's root evaluation, rather than returning
+        // the full converted string unconditionally.
+        let mut ctx = EvalContext::default();
+        let mut ret_field_type: FieldType = FieldType::default();
+        ret_field_type.set_flen(4);
+        let extra = RpnFnCallExtra {
+            ret_field_type: &ret_field_type,
+        };
+        let input = Json::from_f64(1234.5).unwrap();
+        let r = cast_json_as_bytes(&mut ctx, &extra, Some(input.as_ref()));
+        assert!(
+            r.is_err(),
+            "expected CAST(1234.5 AS CHAR(4)) to error under strict mode, got: {:?}",
+            r
+        );
     }
 
     macro_rules! cast_closure_with_metadata {


### PR DESCRIPTION
Fixes #19883

cast_json_as_bytes captured only EvalContext and returned the full converted JSON string unconditionally, with no length or truncation handling. TiDB's builtinCastJSONAsStringSig applies ProduceStrWithSpecifiedTp using the return FieldType's flen, which can truncate the result or, under strict mode, abort the statement for an overlong value. Since this conversion backs predicates and DML pushed down to the coprocessor (e.g. CAST(json_col AS CHAR(n)) <> value), a query could select or mutate different rows than the same statement evaluated at the TiDB root -- in the reported case, a DELETE using an overlong cast value removed rows that TiDB's root evaluation would have aborted before touching.

Added extra: &RpnFnCallExtra to cast_json_as_bytes's capture list and routed the converted value through the existing cast_as_string_helper (already used by cast_string_as_string), which applies produce_str_with_specified_tp -- the same flen-based truncation/error logic TiDB uses. This is a pure wiring fix: ret_field_type was already transported via RpnFnCallExtra, just not consumed by this function.

Added a regression test using the exact reproduction value (1234.5 cast to CHAR(4)), confirming it now errors under strict mode rather than silently truncating.

<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: Close #19883

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
expr: apply target length/truncation to JSON-to-CHAR cast pushdown
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Fix a bug where casting a JSON value to `CHAR(n)` ignored the target length, when the cast was pushed down to TiKV's coprocessor. This could cause a query to select or modify different rows than the same statement evaluated at the TiDB root, since TiDB's root evaluation truncates or, under strict mode, aborts for an overlong value.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved JSON-to-string casting to match TiDB-compatible length limits, truncation, and binary padding.
  - Corrected handling of overlong JSON values cast to fixed-length character types.
  - Added strict-mode validation for oversized casts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->