### PR TITLE
resizable_threadpool: publish initial pool size to after_adjust callback

### DIFF
--- a/components/tikv_util/src/resizable_threadpool.rs
+++ b/components/tikv_util/src/resizable_threadpool.rs
@@ -117,6 +117,10 @@ impl ResizableRuntime {
             .expect("Failed to create runtime-keeper");
         let new_runtime = (replace_pool_rule)(thread_size, &init_name)
             .unwrap_or_else(|_| panic!("failed to create tokio runtime {}", thread_prefix));
+        // Notify `after_adjust` of the initial pool size so callers' metrics (e.g.
+        // BACKUP_THREAD_POOL_SIZE_GAUGE) are populated when the pool is constructed
+        // at its final size and is never resized afterwards.
+        after_adjust(thread_size);
 
         ResizableRuntime {
             size: thread_size,


### PR DESCRIPTION
## What this PR does

`ResizableRuntime::new()` constructs the pool at its final size but never invokes the `after_adjust` callback. Consumers that update a metric inside the callback — e.g. `BACKUP_THREAD_POOL_SIZE_GAUGE` (`tikv_backup_thread_pool_size`) in the backup component — therefore never observe the initial pool size when the pool is created at its final size and is never resized afterwards (which is the case since #17784 constructs it eagerly at the final size).

This PR notifies `after_adjust` of the initial size right after construction, so the gauge is populated at startup.

## Which issue(s) this PR fixes

Close #20045

## What changed

- `components/tikv_util/src/resizable_threadpool.rs`: call `after_adjust(thread_size)` in `new()` after the pool is constructed.

## Verification

- The existing unit test `test_adjust_thread_num` already asserts the counter equals `threads.size()` after construction, which now holds via the initial `after_adjust` call.
- Standalone Rust simulation confirms: before the fix the gauge stays 0 after `new()`; after the fix it is set to the initial size, and `adjust_with` resizing still updates it correctly.

Signed-off-by: waterWang <waterWang@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Initial thread-pool size observers are now updated immediately when the runtime is created.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->