### PR TITLE
config: support percentage specification for ReadableSize values (#19419)

### DIFF
--- a/components/tikv_util/src/config.rs
+++ b/components/tikv_util/src/config.rs
@@ -29,7 +29,7 @@ use serde_json::Value;
 use thiserror::Error;
 
 use super::time::Instant;
-use crate::slow_log;
+use crate::{slow_log, sys::SysQuota};
 
 #[derive(Debug, Error)]
 pub enum ConfigError {
@@ -271,6 +271,146 @@ impl<'de> Deserialize<'de> for ReadableSize {
         }
 
         deserializer.deserialize_any(SizeVisitor)
+    }
+}
+
+/// A size value that can also be specified as a percentage of system memory.
+///
+/// Unlike `ReadableSize`, this type accepts percentage strings like `"45%"`
+/// in TOML, which are resolved against system memory.
+/// This is only appropriate for memory-proportional config fields like
+/// `memory-usage-limit` and `storage.block-cache.capacity`.
+#[derive(Clone, Debug, Copy, PartialEq, PartialOrd, Default)]
+pub struct ReadableSizeOrPercent(pub u64);
+
+impl From<ReadableSizeOrPercent> for ConfigValue {
+    fn from(size: ReadableSizeOrPercent) -> ConfigValue {
+        ConfigValue::Size(size.0)
+    }
+}
+
+impl From<ConfigValue> for ReadableSizeOrPercent {
+    fn from(c: ConfigValue) -> ReadableSizeOrPercent {
+        if let ConfigValue::Size(s) = c {
+            ReadableSizeOrPercent(s)
+        } else {
+            panic!("expect: ConfigValue::Size, got: {:?}", c);
+        }
+    }
+}
+
+impl From<ReadableSize> for ReadableSizeOrPercent {
+    fn from(s: ReadableSize) -> ReadableSizeOrPercent {
+        ReadableSizeOrPercent(s.0)
+    }
+}
+
+impl From<ReadableSizeOrPercent> for ReadableSize {
+    fn from(s: ReadableSizeOrPercent) -> ReadableSize {
+        ReadableSize(s.0)
+    }
+}
+
+impl ReadableSizeOrPercent {
+    pub const fn kb(count: u64) -> Self {
+        Self(count * KIB)
+    }
+
+    pub const fn mb(count: u64) -> Self {
+        Self(count * MIB)
+    }
+
+    pub const fn gb(count: u64) -> Self {
+        Self(count * GIB)
+    }
+
+    pub const fn as_mb(self) -> u64 {
+        self.0 / MIB
+    }
+}
+
+impl fmt::Display for ReadableSizeOrPercent {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        ReadableSize(self.0).fmt(f)
+    }
+}
+
+impl Serialize for ReadableSizeOrPercent {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        ReadableSize(self.0).serialize(serializer)
+    }
+}
+
+impl FromStr for ReadableSizeOrPercent {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<ReadableSizeOrPercent, String> {
+        let size_str = s.trim();
+        // Check for percentage suffix
+        if let Some(num_str) = size_str.strip_suffix('%') {
+            let num_str = num_str.trim();
+            return match num_str.parse::<f64>() {
+                Ok(n) if (0.0..=100.0).contains(&n) => {
+                    let total_mem = SysQuota::memory_limit_in_bytes();
+                    let ratio = n / 100.0;
+                    Ok(ReadableSizeOrPercent((total_mem as f64 * ratio) as u64))
+                }
+                Ok(n) => Err(format!(
+                    "percentage value must be between 0 and 100, got {n}: {s:?}"
+                )),
+                Err(_) => Err(format!("invalid size string: {s:?}")),
+            };
+        }
+        // Delegate to ReadableSize for absolute values
+        ReadableSize::from_str(s).map(|rs| ReadableSizeOrPercent(rs.0))
+    }
+}
+
+impl<'de> Deserialize<'de> for ReadableSizeOrPercent {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct SizeOrPercentVisitor;
+
+        impl Visitor<'_> for SizeOrPercentVisitor {
+            type Value = ReadableSizeOrPercent;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("valid size or percentage")
+            }
+
+            fn visit_i64<E>(self, size: i64) -> Result<ReadableSizeOrPercent, E>
+            where
+                E: de::Error,
+            {
+                if size >= 0 {
+                    self.visit_u64(size as u64)
+                } else {
+                    Err(E::invalid_value(Unexpected::Signed(size), &self))
+                }
+            }
+
+            fn visit_u64<E>(self, size: u64) -> Result<ReadableSizeOrPercent, E>
+            where
+                E: de::Error,
+            {
+                Ok(ReadableSizeOrPercent(size))
+            }
+
+            fn visit_str<E>(self, size_str: &str) -> Result<ReadableSizeOrPercent, E>
+            where
+                E: de::Error,
+            {
+                size_str.parse().map_err(E::custom)
+            }
+        }
+
+        deserializer.deserialize_any(SizeOrPercentVisitor)
     }
 }
 
@@ -1946,6 +2086,79 @@ mod tests {
             let src_str = format!("s = {:?}", src);
             assert!(toml::from_str::<SizeHolder>(&src_str).is_err(), "{}", src);
         }
+    }
+
+    #[test]
+    fn test_parse_readable_size_percentage() {
+        let total_mem = SysQuota::memory_limit_in_bytes();
+
+        // String percentage format on ReadableSizeOrPercent
+        let cases = vec![
+            ("45%", (total_mem as f64 * 0.45) as u64),
+            ("100%", total_mem),
+            ("0%", 0),
+            ("45.5%", (total_mem as f64 * 0.455) as u64),
+            ("4.5e1%", (total_mem as f64 * 0.45) as u64),
+        ];
+        for (src, exp) in cases {
+            let res: ReadableSizeOrPercent = src.parse().unwrap();
+            assert_eq!(res.0, exp, "parsing {:?}", src);
+        }
+
+        // Whitespace handling
+        let res: ReadableSizeOrPercent = " 45% ".parse().unwrap();
+        assert_eq!(res.0, (total_mem as f64 * 0.45) as u64);
+        let res: ReadableSizeOrPercent = "45 %".parse().unwrap();
+        assert_eq!(res.0, (total_mem as f64 * 0.45) as u64);
+
+        // Error cases
+        "101%".parse::<ReadableSizeOrPercent>().unwrap_err();
+        "-1%".parse::<ReadableSizeOrPercent>().unwrap_err();
+        "abc%".parse::<ReadableSizeOrPercent>().unwrap_err();
+        "%".parse::<ReadableSizeOrPercent>().unwrap_err();
+
+        // Absolute sizes still work
+        let res: ReadableSizeOrPercent = "5GiB".parse().unwrap();
+        assert_eq!(res.0, 5 * GIB);
+
+        // ReadableSize now rejects percentages
+        "45%".parse::<ReadableSize>().unwrap_err();
+        "100%".parse::<ReadableSize>().unwrap_err();
+    }
+
+    #[test]
+    fn test_toml_readable_size_percentage() {
+        #[derive(Debug, Serialize, Deserialize)]
+        struct SizeOrPercentHolder {
+            s: ReadableSizeOrPercent,
+        }
+
+        let total_mem = SysQuota::memory_limit_in_bytes();
+
+        // TOML string format with percentage
+        let res: SizeOrPercentHolder = toml::from_str("s = \"45%\"").unwrap();
+        assert_eq!(res.s.0, (total_mem as f64 * 0.45) as u64);
+
+        // Float values should be rejected
+        toml::from_str::<SizeOrPercentHolder>("s = 0.45").unwrap_err();
+        toml::from_str::<SizeOrPercentHolder>("s = 0.0").unwrap_err();
+        toml::from_str::<SizeOrPercentHolder>("s = 1.0").unwrap_err();
+        toml::from_str::<SizeOrPercentHolder>("s = 1.5").unwrap_err();
+
+        // Serialization outputs absolute value (no percentage)
+        let holder = SizeOrPercentHolder {
+            s: ReadableSizeOrPercent((total_mem as f64 * 0.45) as u64),
+        };
+        let serialized = toml::to_string(&holder).unwrap();
+        assert!(!serialized.contains('%'));
+
+        // ReadableSize now rejects float ratio
+        #[derive(Debug, Serialize, Deserialize)]
+        struct SizeHolder {
+            s: ReadableSize,
+        }
+        toml::from_str::<SizeHolder>("s = 0.45").unwrap_err();
+        toml::from_str::<SizeHolder>("s = \"45%\"").unwrap_err();
     }
 
     #[test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -73,7 +73,7 @@ use serde_json::{Map, Value, to_value};
 use tikv_util::{
     config::{
         self, LogFormat, MIB, RaftDataStateMachine, ReadableDuration, ReadableSchedule,
-        ReadableSize, TomlWriter,
+        ReadableSize, ReadableSizeOrPercent, TomlWriter,
     },
     logger::{get_level_by_string, get_string_by_level, set_log_level},
     sys::SysQuota,
@@ -3504,7 +3504,7 @@ pub struct TikvConfig {
 
     #[doc(hidden)]
     #[online_config(skip)]
-    pub memory_usage_limit: Option<ReadableSize>,
+    pub memory_usage_limit: Option<ReadableSizeOrPercent>,
 
     #[doc(hidden)]
     #[online_config(skip)]
@@ -3796,7 +3796,7 @@ impl TikvConfig {
             } else {
                 (total_mem as f64) * BLOCK_CACHE_RATE
             };
-            self.storage.block_cache.capacity = Some(ReadableSize(capacity as u64));
+            self.storage.block_cache.capacity = Some(ReadableSizeOrPercent(capacity as u64));
         }
 
         // Validate for v2.
@@ -3960,7 +3960,7 @@ impl TikvConfig {
                         * MEMORY_USAGE_LIMIT_RATE) as u64,
                 );
             }
-            let limit = ReadableSize(cmp::min(limit, SysQuota::memory_limit_in_bytes()));
+            let limit = ReadableSizeOrPercent(cmp::min(limit, SysQuota::memory_limit_in_bytes()));
             let default = Self::suggested_memory_usage_limit();
             if limit > default {
                 warn!(
@@ -4339,7 +4339,7 @@ impl TikvConfig {
                         .map(|s| s.0)
                         .unwrap_or_default();
                     let sum = a.0 + b.0 + c.0 + d;
-                    self.storage.block_cache.capacity = Some(ReadableSize(sum));
+                    self.storage.block_cache.capacity = Some(ReadableSizeOrPercent(sum));
                 }
             }
         }
@@ -4516,10 +4516,10 @@ impl TikvConfig {
         Ok((cfg, tmp))
     }
 
-    fn suggested_memory_usage_limit() -> ReadableSize {
+    fn suggested_memory_usage_limit() -> ReadableSizeOrPercent {
         let total = SysQuota::memory_limit_in_bytes();
-        // Reserve some space for page cache. The
-        ReadableSize((total as f64 * MEMORY_USAGE_LIMIT_RATE) as u64)
+        // Reserve some space for page cache.
+        ReadableSizeOrPercent((total as f64 * MEMORY_USAGE_LIMIT_RATE) as u64)
     }
 
     pub fn build_shared_rocks_env(
@@ -6745,22 +6745,28 @@ mod tests {
         );
 
         // Test validating memory_usage_limit when it's greater than max.
-        cfg.memory_usage_limit = Some(ReadableSize(SysQuota::memory_limit_in_bytes() * 2));
+        cfg.memory_usage_limit = Some(ReadableSizeOrPercent(SysQuota::memory_limit_in_bytes() * 2));
         cfg.validate().unwrap_err();
 
         // Test memory_usage_limit is based on block cache size if it's not configured.
         cfg.memory_usage_limit = None;
-        cfg.storage.block_cache.capacity = Some(ReadableSize(3 * GIB));
+        cfg.storage.block_cache.capacity = Some(ReadableSizeOrPercent(3 * GIB));
         cfg.validate().unwrap();
-        assert_eq!(cfg.memory_usage_limit.unwrap(), ReadableSize(5 * GIB));
+        assert_eq!(
+            cfg.memory_usage_limit.unwrap(),
+            ReadableSizeOrPercent(5 * GIB)
+        );
 
         // Test memory_usage_limit will fallback to system memory capacity with huge
         // block cache.
         cfg.memory_usage_limit = None;
         let system = SysQuota::memory_limit_in_bytes();
-        cfg.storage.block_cache.capacity = Some(ReadableSize(system * 3 / 4));
+        cfg.storage.block_cache.capacity = Some(ReadableSizeOrPercent(system * 3 / 4));
         cfg.validate().unwrap();
-        assert_eq!(cfg.memory_usage_limit.unwrap(), ReadableSize(system));
+        assert_eq!(
+            cfg.memory_usage_limit.unwrap(),
+            ReadableSizeOrPercent(system)
+        );
 
         // Test raftstore.enable-partitioned-raft-kv-compatible-learner.
         let mut cfg = TikvConfig::default();
@@ -6793,6 +6799,50 @@ mod tests {
             invalid_cfg.validate().unwrap_err().to_string(),
             "Titan is unavailable for feature TTL"
         );
+    }
+
+    #[test]
+    fn test_config_percentage_values() {
+        let total_mem = SysQuota::memory_limit_in_bytes();
+
+        // Test block-cache.capacity with string percentage
+        let content = r#"
+            [storage.block-cache]
+            capacity = "45%"
+        "#;
+        let cfg: TikvConfig = toml::from_str(content).unwrap();
+        let expected = (total_mem as f64 * 0.45) as u64;
+        assert_eq!(cfg.storage.block_cache.capacity.unwrap().0, expected);
+
+        // Float values should be rejected for block-cache.capacity
+        let content = r#"
+            [storage.block-cache]
+            capacity = 0.45
+        "#;
+        toml::from_str::<TikvConfig>(content).unwrap_err();
+
+        // Test memory-usage-limit with string percentage
+        let content = r#"
+            memory-usage-limit = "75%"
+        "#;
+        let cfg: TikvConfig = toml::from_str(content).unwrap();
+        let expected_mem = (total_mem as f64 * 0.75) as u64;
+        assert_eq!(cfg.memory_usage_limit.unwrap().0, expected_mem);
+
+        // Float values should be rejected for memory-usage-limit
+        let content = r#"
+            memory-usage-limit = 0.75
+        "#;
+        toml::from_str::<TikvConfig>(content).unwrap_err();
+
+        // Full validation passes with percentage values
+        let content = r#"
+            memory-usage-limit = "75%"
+            [storage.block-cache]
+            capacity = "30%"
+        "#;
+        let mut cfg: TikvConfig = toml::from_str(content).unwrap();
+        cfg.validate().unwrap();
     }
 
     #[test]

--- a/src/storage/config.rs
+++ b/src/storage/config.rs
@@ -13,7 +13,7 @@ use kvproto::kvrpcpb::ApiVersion;
 use libc::c_int;
 use online_config::OnlineConfig;
 use tikv_util::{
-    config::{self, ReadableDuration, ReadableSize},
+    config::{self, ReadableDuration, ReadableSize, ReadableSizeOrPercent},
     sys::SysQuota,
 };
 
@@ -62,7 +62,7 @@ const DEFAULT_TXN_STATUS_CACHE_CAPACITY: usize = 40_000 * 128;
 
 // Block cache capacity used when TikvConfig isn't validated. It should only
 // occur in tests.
-const FALLBACK_BLOCK_CACHE_CAPACITY: ReadableSize = ReadableSize::mb(128);
+const FALLBACK_BLOCK_CACHE_CAPACITY: ReadableSizeOrPercent = ReadableSizeOrPercent::mb(128);
 
 pub const DEFAULT_ACTION_ON_INVALID_MAX_TS_UPDATE: &str = "error";
 
@@ -287,7 +287,7 @@ impl Default for FlowControlConfig {
 pub struct BlockCacheConfig {
     #[online_config(skip)]
     pub shared: Option<bool>,
-    pub capacity: Option<ReadableSize>,
+    pub capacity: Option<ReadableSizeOrPercent>,
     #[online_config(skip)]
     pub num_shard_bits: i32,
     #[online_config(skip)]

--- a/src/storage/config_manager.rs
+++ b/src/storage/config_manager.rs
@@ -11,7 +11,7 @@ use online_config::{ConfigChange, ConfigManager, ConfigValue, Result as CfgResul
 use strum::IntoEnumIterator;
 use tikv_kv::Engine;
 use tikv_util::{
-    config::{ReadableDuration, ReadableSize},
+    config::{ReadableDuration, ReadableSize, ReadableSizeOrPercent},
     worker::Scheduler,
 };
 
@@ -57,7 +57,7 @@ impl<EK: Engine, K: ConfigurableDb, L: LockManager> ConfigManager
         if let Some(ConfigValue::Module(mut block_cache)) = change.remove("block_cache") {
             if let Some(size) = block_cache.remove("capacity") {
                 if size != ConfigValue::None {
-                    let s: ReadableSize = size.into();
+                    let s: ReadableSizeOrPercent = size.into();
                     self.configurable_db
                         .set_shared_block_cache_capacity(s.0 as usize)?;
                     // Write config to metric

--- a/src/storage/kv/test_engine_builder.rs
+++ b/src/storage/kv/test_engine_builder.rs
@@ -94,7 +94,7 @@ impl TestEngineBuilder {
         let cfs = self.cfs.unwrap_or_else(|| ALL_CFS.to_vec());
         let mut cache_opt = BlockCacheConfig::default();
         if !enable_block_cache {
-            cache_opt.capacity = Some(ReadableSize::kb(0));
+            cache_opt.capacity = Some(ReadableSize::kb(0).into());
         }
         let shared =
             cfg_rocksdb.build_cf_resources(cache_opt.build_shared_cache(), Default::default());

--- a/tests/integrations/config/mod.rs
+++ b/tests/integrations/config/mod.rs
@@ -42,7 +42,9 @@ use tikv::{
         IoRateLimitConfig, MaxTsConfig,
     },
 };
-use tikv_util::config::{LogFormat, ReadableDuration, ReadableSchedule, ReadableSize};
+use tikv_util::config::{
+    LogFormat, ReadableDuration, ReadableSchedule, ReadableSize, ReadableSizeOrPercent,
+};
 
 mod dynamic;
 mod graceful_shutdown_config;
@@ -80,7 +82,7 @@ fn test_serde_custom_tikv_config() {
     value.slow_log_file = "slow_foo".to_owned();
     value.slow_log_threshold = ReadableDuration::secs(1);
     value.abort_on_panic = true;
-    value.memory_usage_limit = Some(ReadableSize::gb(10));
+    value.memory_usage_limit = Some(ReadableSizeOrPercent::gb(10));
     value.memory_usage_high_water = 0.65;
     value.memory.enable_heap_profiling = false;
     value.memory.profiling_sample_per_bytes = ReadableSize::mb(1);
@@ -757,7 +759,7 @@ fn test_serde_custom_tikv_config() {
         },
         block_cache: BlockCacheConfig {
             shared: None,
-            capacity: Some(ReadableSize::gb(40)),
+            capacity: Some(ReadableSizeOrPercent::gb(40)),
             num_shard_bits: 10,
             strict_capacity_limit: true,
             high_pri_pool_ratio: 0.8,


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: ref #19413

This is a manual cherry-pick of #19419 (merged to `master` as `871fb0d`) onto `release-8.5`,
so that clusters on the 8.5 LTS line can use percentage-based memory sizing without waiting
for the next major release. `release-8.5` HEAD is currently `a1fdd6a` (= `v8.5.8`), so this
would ship in v8.5.9 or later.

What's Changed:

`ReadableSize` config values can be given as a percentage of system memory, e.g.
`storage.block-cache.capacity = "45%"` or `memory-usage-limit = "60%"`, instead of a
hardcoded absolute size. The percentage is resolved against
`SysQuota::memory_limit_in_bytes()` at parse time, which lets VPA / dynamic-memory
deployments adapt automatically instead of recalculating byte values per pod size.

- `components/tikv_util/src/config.rs`: add `ReadableSizeOrPercent`, accepting `"45%"` via
  `FromStr`/`Deserialize` and serializing back as the resolved absolute size.
- `src/config/mod.rs`, `src/storage/config.rs`: `memory_usage_limit` and
  `storage.block_cache.capacity` switch to `ReadableSizeOrPercent`.

Compatibility: existing absolute values (`"8GB"`, `8589934592`) parse exactly as before, and
serialization still emits absolute bytes, so `tikv.toml` written by an older version keeps
working and dumped configs are unchanged in shape. Because the percentage is re-evaluated on
every start, a restart on a differently-sized machine picks up the new memory size.

```commit-message
config: support percentage specification for ReadableSize values (#19419)

Extend ReadableSize to accept "45%" string format, resolving to a percentage of system
memory at parse time. This allows configs like block_cache.capacity and memory_usage_limit
to adapt automatically to available system memory without manual recalculation, which is
useful for VPA and dynamic memory environments.
```

Cherry-pick notes:

- `git cherry-pick -x 871fb0d` applied to current `release-8.5` **with no conflicts**; the
  diff is identical to the master commit (6 files, +288/-23).
- No dependency on other master-only changes; `SysQuota::memory_limit_in_bytes()` already
  exists on `release-8.5`.
- This is an enhancement rather than a bug fix, so it needs cherry-pick approval from the
  release branch triage owners — happy to close it if the 8.5 line is fix-only.

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [x] Need to cherry-pick to the release branch
  > This PR *is* the cherry-pick of #19419 to `release-8.5`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
  - `cargo test -p tikv_util --lib config::` — 21 passed, 0 failed (includes the new `test_parse_readable_size_percentage` / `test_toml_readable_size_percentage`)
  - `cargo test -p tikv --lib config::` — 68 passed, 0 failed
- [x] Integration test
  - `cargo check -p tests --tests` — clean (`tests/integrations/config/mod.rs` is part of this change)
  - `cargo check -p tikv --lib --tests` — clean, i.e. the `ReadableSize` → `ReadableSizeOrPercent` field type change breaks no other user of `memory_usage_limit` / `storage.block_cache.capacity` on this branch
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note

```release-note
Support specifying `ReadableSize` config values (e.g., `storage.block-cache.capacity`, `memory-usage-limit`) as percentages of system memory using string format (`"45%"`), enabling automatic adaptation to available system memory in VPA and dynamic memory environments.
```
