### PR TITLE
docs: fix typo implmentation -> implementation

### DIFF
--- a/components/cloud/src/blob.rs
+++ b/components/cloud/src/blob.rs
@@ -265,7 +265,7 @@ mod tests {
         Emitting,
     }
     /// ThrottleRead throttles a `Read` -- make it emits 2 chars for each
-    /// `read` call. This is copy & paste from the implmentation from s3.rs.
+    /// `read` call. This is copy & paste from the implementation from s3.rs.
     #[pin_project::pin_project]
     struct ThrottleRead<R> {
         #[pin]


### PR DESCRIPTION
Corrects the misspelling `implmentation` -> `implementation` in `components/cloud/src/blob.rs`.

Documentation only, no behaviour change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a typo in an internal test helper’s documentation.
  * No user-facing functionality was changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->