### PR TITLE
coprocessor: prevent signed minimum modulo panic

### DIFF
--- a/components/tidb_query_expr/src/impl_arithmetic.rs
+++ b/components/tidb_query_expr/src/impl_arithmetic.rs
@@ -221,7 +221,7 @@ impl ArithmeticOp for IntIntMod {
         if *rhs == 0i64 {
             return Ok(None);
         }
-        Ok(Some(lhs % rhs))
+        Ok(Some(lhs.overflowing_rem(*rhs).0))
     }
 }
 
@@ -747,6 +747,7 @@ mod tests {
             (Some(-11), Some(0), None),
             (Some(i64::MAX), Some(i64::MIN), Some(i64::MAX)),
             (Some(i64::MIN), Some(i64::MAX), Some(-1)),
+            (Some(i64::MIN), Some(-1), Some(0)),
         ];
 
         for (lhs, rhs, expected) in tests {


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: close #20053

What's Changed:

The coprocessor panics when signed modulo evaluates `i64::MIN % -1`. This is the case reported in https://github.com/pingcap/tidb/issues/63661.

Use Rust's overflowing remainder operation so this input returns `0`, matching SQL modulo semantics, while preserving all other results.

```commit-message
Rust's signed remainder panics for i64::MIN % -1.
Use overflowing remainder so SQL modulo returns zero.
```

### Related changes

- [x] No documentation PR is needed.
- [x] No release branch cherry-pick is requested.

### Check List

Tests

- [x] Unit test: the focused modulo tests and full `tidb_query_expr` crate passed.
- Integration test: not run. The unit test directly exercises the failing arithmetic operator.
- Manual test: not run. The SQL reproducer requires a TiDB and TiKV cluster.
- No code: not applicable.

<details>
<summary>Regression evidence</summary>

Current `master` at `8be5cfa5232e6de6ae4cdf61f2f40d8e3f6e1d78`, with the regression row added:

```text
$ CMAKE_POLICY_VERSION_MINIMUM=3.5 cargo test -p tidb_query_expr test_mod_int -- --nocapture
thread 'impl_arithmetic::tests::test_mod_int' panicked at components/tidb_query_expr/src/impl_arithmetic.rs:224:17:
attempt to calculate the remainder with overflow
test result: FAILED. 0 passed; 1 failed
```

After the fix:

```text
$ CMAKE_POLICY_VERSION_MINIMUM=3.5 cargo test -p tidb_query_expr test_mod_int -- --nocapture
test result: ok. 2 passed; 0 failed

$ CMAKE_POLICY_VERSION_MINIMUM=3.5 cargo test -p tidb_query_expr
test result: ok. 408 passed; 0 failed
```

</details>

Side effects

- [x] No CPU or memory regression is expected.
- [x] No backward-incompatible behavior is introduced.

### Release note

```release-note
Fix a TiKV coprocessor panic when evaluating the minimum signed 64-bit integer modulo -1.
```
