### PR TITLE
resource_metering: re-resolve Unknown thread pool type in CpuRecorder (per-region read CPU lost under load)

### DIFF
--- a/components/resource_metering/src/recorder/sub_recorder/cpu.rs
+++ b/components/resource_metering/src/recorder/sub_recorder/cpu.rs
@@ -52,6 +52,18 @@ impl SubRecorder for CpuRecorder {
         let records = &mut records.records;
         let pid = thread::process_id();
         self.thread_stats.iter_mut().for_each(|(tid, thread_stat)| {
+            // `pool_type` is resolved from the thread name at `thread_created`
+            // time and cached. A unified-read-pool worker spawned on demand
+            // under load can register with resource_metering (and thus be
+            // created here) *before* its name lands in THREAD_NAME_HASHMAP, so
+            // it gets cached as `Unknown`. That silently routes its CPU into the
+            // record's total but not into `unified_read`, which zeroes the
+            // per-region unified-read CPU the PD hot-region scheduler ranks on.
+            // Re-resolve while still `Unknown` so the thread self-heals once its
+            // name is registered on a later tick.
+            if thread_stat.pool_type == ThreadPoolType::Unknown {
+                thread_stat.pool_type = detect_thread_pool_type(*tid);
+            }
             let cur_tag = thread_stat.attached_tag.load_full();
             if let Some(cur_tag) = cur_tag {
                 if let Ok(cur_stat) = thread::thread_stat(pid, *tid) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #19373, ref #19473

Under high read concurrency the per-region `cpu_stats.unified_read` reported in the store heartbeat collapses toward 0, so `balance-hot-region-scheduler`'s CPU dimension (and load-based-split by CPU) loses its per-region signal exactly when a store is CPU-hot.

Root cause: `CpuRecorder` resolves each thread's `ThreadPoolType` **once** at `thread_created` (`detect_thread_pool_type` reads the name from `THREAD_NAME_HASHMAP`) and caches it. A unified-read-pool worker spawned on demand under load can register with resource_metering (triggering `thread_created`) **before** its name is inserted into `THREAD_NAME_HASHMAP`, so it is cached as `Unknown` forever. `RawRecord::add_cpu_time` then counts that thread's CPU in the record **total** but not in `unified_read_cpu_time`, zeroing the per-region unified-read signal. Store-level read CPU stays correct because it is computed from the *live* thread name.

### What is changed and how it works?

In `CpuRecorder::tick`, re-resolve `pool_type` while it is still `Unknown` so a thread self-heals on a later tick once its name is registered. Only still-`Unknown` threads pay the extra `THREAD_NAME_HASHMAP` lookup; already-resolved threads are untouched.

### Evidence

Reproduced and fixed on an internal 8.5.6 backport of this feature (dev cluster, ~10 cores of unified-read CPU concentrated on one store, byte-cold high-qps index scans):

| | before | after |
|---|---|---|
| per-region `flow_cpu` (hot read) | 0 | 140–166 |
| `total_flow_cpu` vs `store_cpu` | 0 / ~1000 | 920 / 978 (~94% attributed) |
| `transfer-hot-read-leader` ops | 0 | 5 (leaders spread 6→1 off the hot store) |

### Check List

Tests

- [ ] Unit test (TODO): assert an `Unknown`-at-creation thread is re-typed once its name is registered. Draft — feedback welcome on the preferred approach.

### Release note

```release-note
Fix per-region read CPU (used by hot-region scheduling and load-based split) being under-counted under high concurrency, caused by unified-read-pool worker threads spawned on demand being cached as an Unknown resource-metering pool type.
```