### PR TITLE
storage: expose scheduler write-latch memory usage

### DIFF
--- a/doc/maintenance-guides/src/storage.md
+++ b/doc/maintenance-guides/src/storage.md
@@ -147,6 +147,7 @@ High-risk contracts:
 ## Observability And Operational Signals
 
 - scheduler latency, latch wait, and pending-write signals
+- scheduler write-latch memory usage in `tikv_scheduler_latch_memory_usage`
 - MVCC conflict, read, and GC-related metrics
 - flow-control and memory-quota behavior
 - lock-wait and deadlock diagnostics

--- a/src/storage/metrics.rs
+++ b/src/storage/metrics.rs
@@ -657,4 +657,9 @@ lazy_static! {
         "The count of running scheduler commands"
     )
     .unwrap();
+    pub static ref SCHED_LATCH_MEMORY_USAGE_GAUGE: IntGauge = register_int_gauge!(
+        "tikv_scheduler_latch_memory_usage",
+        "Bytes of memory held by the scheduler write latches (fixed slot array plus per-slot waiting queues)."
+    )
+    .unwrap();
 }

--- a/src/storage/txn/latch.rs
+++ b/src/storage/txn/latch.rs
@@ -4,6 +4,7 @@
 use std::{
     collections::{VecDeque, hash_map::DefaultHasher},
     hash::{Hash, Hasher},
+    sync::atomic::{AtomicUsize, Ordering},
 };
 
 use crossbeam::utils::CachePadded;
@@ -11,6 +12,8 @@ use parking_lot::{Mutex, MutexGuard};
 
 const WAITING_LIST_SHRINK_SIZE: usize = 8;
 const WAITING_LIST_MAX_CAPACITY: usize = 16;
+const WAITING_ELEM_SIZE: usize = std::mem::size_of::<Option<(u64, u64)>>();
+const LATCH_SLOT_SIZE: usize = std::mem::size_of::<CachePadded<Mutex<Latch>>>();
 
 /// Latch which is used to serialize accesses to resources hashed to the same
 /// slot.
@@ -158,6 +161,7 @@ impl Lock {
 pub struct Latches {
     slots: Vec<CachePadded<Mutex<Latch>>>,
     size: usize,
+    waiting_queue_bytes: AtomicUsize,
 }
 
 impl Latches {
@@ -168,7 +172,36 @@ impl Latches {
         let size = usize::next_power_of_two(size);
         let mut slots = Vec::with_capacity(size);
         (0..size).for_each(|_| slots.push(Mutex::new(Latch::new()).into()));
-        Latches { slots, size }
+        Latches {
+            slots,
+            size,
+            waiting_queue_bytes: AtomicUsize::new(0),
+        }
+    }
+
+    fn account_capacity_change(&self, before: usize, after: usize) {
+        if after > before {
+            self.waiting_queue_bytes
+                .fetch_add((after - before) * WAITING_ELEM_SIZE, Ordering::Relaxed);
+        } else if before > after {
+            self.waiting_queue_bytes
+                .fetch_sub((before - after) * WAITING_ELEM_SIZE, Ordering::Relaxed);
+        } else {
+            return;
+        }
+        crate::storage::metrics::SCHED_LATCH_MEMORY_USAGE_GAUGE.set(self.memory_usage() as i64);
+    }
+
+    pub fn slot_memory_usage(&self) -> usize {
+        self.slots.capacity() * LATCH_SLOT_SIZE
+    }
+
+    pub fn waiting_queue_memory_usage(&self) -> usize {
+        self.waiting_queue_bytes.load(Ordering::Relaxed)
+    }
+
+    pub fn memory_usage(&self) -> usize {
+        self.slot_memory_usage() + self.waiting_queue_memory_usage()
     }
 
     /// Tries to acquire the latches specified by the `lock` for command with ID
@@ -182,19 +215,28 @@ impl Latches {
         let mut acquired_count: usize = 0;
         for &key_hash in &lock.required_hashes[lock.owned_count..] {
             let mut latch = self.lock_latch(key_hash);
-            match latch.get_first_req_by_hash(key_hash) {
+            let before = latch.waiting.capacity();
+            let should_break = match latch.get_first_req_by_hash(key_hash) {
                 Some(cid) => {
                     if cid == who {
                         acquired_count += 1;
+                        false
                     } else {
                         latch.wait_for_wake(key_hash, who);
-                        break;
+                        true
                     }
                 }
                 None => {
                     latch.wait_for_wake(key_hash, who);
                     acquired_count += 1;
+                    false
                 }
+            };
+            let after = latch.waiting.capacity();
+            drop(latch);
+            self.account_capacity_change(before, after);
+            if should_break {
+                break;
             }
         }
         lock.owned_count += acquired_count;
@@ -233,6 +275,7 @@ impl Latches {
         let mut wakeup_list: Vec<u64> = vec![];
         for &key_hash in &lock.required_hashes[..lock.owned_count] {
             let mut latch = self.lock_latch(key_hash);
+            let before = latch.waiting.capacity();
             let (v, front) = latch.pop_front(key_hash).unwrap();
             assert_eq!(front, who);
             assert_eq!(v, key_hash);
@@ -256,6 +299,9 @@ impl Latches {
             } else {
                 latch.push_preemptive(key_hash, keep_latches_for_cid.unwrap());
             }
+            let after = latch.waiting.capacity();
+            drop(latch);
+            self.account_capacity_change(before, after);
         }
 
         assert!(keep_latches_it.next().is_none());
@@ -274,6 +320,33 @@ mod tests {
     use std::iter::once;
 
     use super::*;
+
+    #[test]
+    fn test_latch_memory_usage() {
+        let latches = Latches::new(256);
+        assert_eq!(latches.slot_memory_usage(), 256 * LATCH_SLOT_SIZE);
+        assert_eq!(latches.waiting_queue_memory_usage(), 0);
+        assert_eq!(latches.memory_usage(), latches.slot_memory_usage());
+
+        let mut locks: Vec<Lock> = (0..64)
+            .map(|_| Lock::new(std::iter::once(&"same_key")))
+            .collect();
+        for (i, lock) in locks.iter_mut().enumerate() {
+            latches.acquire(lock, i as u64 + 1);
+        }
+
+        let peak = latches.waiting_queue_memory_usage();
+        assert!(peak > 0);
+        assert!(latches.memory_usage() > latches.slot_memory_usage());
+
+        latches.release(&locks[0], 1, None);
+        for (i, lock) in locks.iter_mut().enumerate().skip(1) {
+            let cid = i as u64 + 1;
+            assert!(latches.acquire(lock, cid));
+            latches.release(lock, cid, None);
+        }
+        assert!(latches.waiting_queue_memory_usage() < peak);
+    }
 
     #[test]
     fn test_wakeup() {

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -488,6 +488,7 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
             in_memory_instance_size_limit: dynamic_configs.in_memory_instance_size_limit,
         });
 
+        SCHED_LATCH_MEMORY_USAGE_GAUGE.set(inner.latches.memory_usage() as i64);
         SCHED_TXN_MEMORY_QUOTA
             .capacity
             .set(config.memory_quota.0 as i64);


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: ref #6717

Part of the "TiKV memory control" umbrella issue, which asks for the memory
usage of individual modules to be observable. The transaction module task
explicitly calls out the scheduler latches size.

The scheduler's write latches hold two kinds of memory, neither previously
visible in metrics:

- a **fixed slot array** — `scheduler-concurrency` rounded up to a power of
  two, each slot a cache-line-padded, mutex-guarded queue. With the default
  configuration this is on the order of 100+ MiB reserved at startup.
- **per-slot waiting queues** (`VecDeque<Option<(u64, u64)>>`) that grow on
  the heap under key contention.

This PR adds `Latches::memory_usage()`, summing the slot-array allocation and
the heap currently held by the waiting queues, and exports it as the
`tikv_scheduler_latch_memory_usage` gauge. The gauge is set when the
scheduler is constructed and refreshed whenever a waiting queue is resized.

Waiting-queue bytes are accounted with a single relaxed atomic that is only
updated when a queue's capacity actually changes (i.e. on reallocation,
which is already rare and comparatively expensive). The `acquire` / `release`
hot path therefore only gains two `VecDeque::capacity()` reads per touched
slot and no unconditional atomic write, addressing the issue's concern that
this metric must not hurt performance.

What's Changed:

```commit-message
storage: expose scheduler write-latch memory usage

Add Latches::memory_usage(), summing the fixed slot-array allocation and the
heap held by the per-slot VecDeque waiting queues. Waiting-queue bytes are
tracked with a single relaxed atomic that is only updated when a queue's
capacity changes, so the latch acquire/release hot path only gains two
VecDeque::capacity() reads per touched slot.

The total is exported as the tikv_scheduler_latch_memory_usage gauge,
initialized when the scheduler is built and refreshed whenever a waiting
queue is resized.

ref #6717
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests

- [x] Unit test

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note

```release-note
Add the `tikv_scheduler_latch_memory_usage` metric reporting memory held by the transaction scheduler write latches.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Prometheus metric to report memory used by scheduler write latches, including waiting queues.
  * Added the scheduler write-latch memory-usage signal to the observability documentation.
* **Bug Fixes**
  * Improved memory accounting as write-latch waiting queues grow and shrink.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->