### PR TITLE
cargo deny: temporarily mitigate RUSTSEC-2026-0275

### DIFF
--- a/components/tikv_util/src/logger/mod.rs
+++ b/components/tikv_util/src/logger/mod.rs
@@ -39,6 +39,21 @@ const TIMESTAMP_FORMAT: &str = "%Y/%m/%d %H:%M:%S%.3f %:z";
 
 static LOG_LEVEL: AtomicUsize = AtomicUsize::new(usize::MAX);
 
+// azure_core 0.18.0 can expose live Authorization headers through Debug/Trace
+// request logs, so suppress them here.
+// TODO: Remove this filter after the legacy Azure SDK is upgraded or patched.
+fn should_emit_log(module: &str, level: Level, disabled_targets: &[String]) -> bool {
+    let is_azure_core = module == "azure_core" || module.starts_with("azure_core::");
+    if is_azure_core && matches!(level, Level::Debug | Level::Trace) {
+        return false;
+    }
+    if disabled_targets.is_empty() {
+        return true;
+    }
+    let root_module = module.split("::").next().unwrap();
+    disabled_targets.iter().all(|target| target != root_module)
+}
+
 pub fn init_log<D>(
     drain: D,
     level: Level,
@@ -59,23 +74,10 @@ where
         disabled_targets.extend(extra_modules.split(',').map(ToOwned::to_owned));
     }
 
+    // The module name looks like `raftstore::store::fsm::store` or
+    // `grpcio::log_util`. Filtering uses its highest-level component.
     let filter = move |record: &Record<'_>| {
-        if !disabled_targets.is_empty() {
-            // The format of the returned value from module() would like this:
-            // ```
-            //  raftstore::store::fsm::store
-            //  tikv_util
-            //  tikv_util::config::check_data_dir
-            //  raft::raft
-            //  grpcio::log_util
-            //  ...
-            // ```
-            // Here get the highest level module name to check.
-            let module = record.module().split("::").next().unwrap();
-            disabled_targets.iter().all(|target| target != module)
-        } else {
-            true
-        }
+        should_emit_log(record.module(), record.level(), &disabled_targets)
     };
 
     fn build_log_drain<I>(
@@ -747,6 +749,48 @@ mod tests {
         fn flush(&mut self) -> io::Result<()> {
             self.0.lock().unwrap().flush()
         }
+    }
+
+    #[test]
+    fn test_filter_credential_bearing_azure_core_logs() {
+        let disabled_targets = vec![];
+        assert!(!should_emit_log(
+            "azure_core::policies::transport",
+            Level::Debug,
+            &disabled_targets,
+        ));
+        assert!(!should_emit_log(
+            "azure_core",
+            Level::Debug,
+            &disabled_targets,
+        ));
+        assert!(!should_emit_log(
+            "azure_core::policies::retry_policies::retry_policy",
+            Level::Trace,
+            &disabled_targets,
+        ));
+        assert!(should_emit_log(
+            "azure_core::policies::transport",
+            Level::Info,
+            &disabled_targets,
+        ));
+        assert!(should_emit_log(
+            "azure_core_extra",
+            Level::Debug,
+            &disabled_targets,
+        ));
+        assert!(should_emit_log(
+            "azure_storage::clients",
+            Level::Debug,
+            &disabled_targets,
+        ));
+
+        let disabled_targets = vec!["azure_storage".to_owned()];
+        assert!(!should_emit_log(
+            "azure_storage::clients",
+            Level::Info,
+            &disabled_targets,
+        ));
     }
 
     fn log_format_cases(logger: slog::Logger) {

--- a/deny.toml
+++ b/deny.toml
@@ -47,6 +47,10 @@ deny = [
     { crate = "h2:<0.3", reason = "not part of the temporary h2 0.3 exception" },
     { crate = "h2:>=0.3,<0.4", wrappers = ["aws-smithy-http-client", "hyper", "reqwest"], reason = "only the existing h2 0.3 dependency chains are temporarily accepted" },
     { crate = "h2:>=0.4,<0.4.16", reason = "upgrade h2 0.4 to at least 0.4.16" },
+    # Only the currently reviewed azure_core 0.18.0 release is covered by the
+    # temporary RUSTSEC-2026-0275 exception below.
+    { crate = "azure_core:<0.18.0", reason = "not part of the temporary azure_core 0.18.0 exception" },
+    { crate = "azure_core:>0.18.0,<0.22.0", reason = "upgrade to a patched azure_core release" },
 ]
 multiple-versions = "allow"
 
@@ -107,6 +111,14 @@ ignore = [
     #
     # TODO: Remove after the legacy clients move off h2 0.3.
     "RUSTSEC-2026-0258",
+    # Ignore RUSTSEC-2026-0275 temporarily while TiKV still uses the legacy Azure
+    # SDK. azure_core 0.18 can log live Authorization headers at Debug/Trace
+    # level. TiKV's logger blocks those records before they reach its log drains,
+    # including after an online log level change.
+    #
+    # TODO: Remove after the SDK is upgraded or patched, or another fix supersedes
+    # the temporary credential-log filter in TiKV.
+    "RUSTSEC-2026-0275",
 ]
 
 # TiKV is licensed under Apache 2.0, according to ASF 3RD PARTY LICENSE POLICY,

--- a/doc/maintenance-guides/components/server.md
+++ b/doc/maintenance-guides/components/server.md
@@ -101,6 +101,9 @@ High-risk config contracts:
   dependents drain.
 - Config validation must remain backward-compatible with persisted data layout
   and engine selection.
+- Forwarded third-party logs must not expose credentials. TiKV filters
+  Debug/Trace records from the affected legacy `azure_core` transport until
+  an SDK upgrade, patch, or logging fix replaces that temporary mitigation.
 - Service pause/resume must stay consistent with the small control plane in
   `components/service`.
 
@@ -147,6 +150,8 @@ Start triage with:
   reverse?
 - Does it alter graceful shutdown semantics?
 - Does it add expensive initialization to the critical startup path?
+- Does a change to third-party log forwarding expose credentials or remove
+  diagnostics needed for failure triage?
 
 ## Observability And Tests
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiKV!

If you haven't already, please read TiKV's [CONTRIBUTING](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md) document.

If you're unsure about anything, just ask; somebody should be along to answer within a day or two.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues.
-->

Issue Number: ref #20061

<!--
You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#format-of-the-commit-message.
-->
What's Changed:

```commit-message
Temporarily mitigate RUSTSEC-2026-0275 while TiKV still depends on the legacy Azure SDK.

Filter Debug and Trace records from azure_core 0.18.0 before they reach TiKV's log drains, preventing the SDK from writing live Authorization header values when verbose logging is enabled. Preserve Info and higher-severity Azure logs and keep the filter effective after online log-level changes.

Document the temporary cargo-deny exception and reject other affected azure_core versions so dependency drift cannot silently expand the exception. Record credential-safe third-party log forwarding in the server maintenance guide.
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:
- [ ] Need to cherry-pick to the release branch

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Release note
<!-- 
Compatibility change, improvement, bugfix, and new feature need a release note.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with None.
If this PR will be picked to release branch, then a release note is probably required.
-->

```release-note
Prevent the legacy Azure SDK from writing credential-bearing request details to TiKV logs at Debug or Trace level.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Sensitive Azure SDK request logs at Debug and Trace levels are now filtered to help prevent credential exposure.
  * Azure SDK versions are restricted to reviewed releases with known logging behavior.

* **Documentation**
  * Added guidance and review checks for safely forwarding third-party logs without exposing credentials or losing diagnostic information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->