### PR TITLE
tikv-ctl: support dumping mvcc keys & values in a given region

### DIFF
--- a/cmd/tikv-ctl/src/cmd.rs
+++ b/cmd/tikv-ctl/src/cmd.rs
@@ -135,16 +135,24 @@ pub enum Cmd {
         #[clap(
             short = 'f',
             long,
+            required_unless_present = "region",
+            conflicts_with = "region",
             help = RAW_KEY_HINT,
         )]
-        from: String,
+        from: Option<String>,
 
         #[clap(
             short = 't',
             long,
+            conflicts_with = "region",
             help = RAW_KEY_HINT,
         )]
         to: Option<String>,
+
+        #[clap(short = 'r', long)]
+        /// Set the region id, print all mvcc keys & values in the range of the
+        /// region
+        region: Option<u64>,
 
         #[clap(long)]
         /// Set the scan limit
@@ -1012,6 +1020,38 @@ mod tests {
             Cmd::CompactLogBackup { cal_shift_ts, .. } => assert!(cal_shift_ts),
             cmd => panic!("unexpected command: {:?}", std::mem::discriminant(&cmd)),
         }
+    }
+
+    #[test]
+    fn scan_accepts_region_without_from() {
+        let opt = Opt::try_parse_from(["tikv-ctl", "scan", "-r", "2", "--limit", "10"]).unwrap();
+
+        match opt.cmd.unwrap() {
+            Cmd::Scan {
+                from,
+                region,
+                limit,
+                ..
+            } => {
+                assert_eq!(from, None);
+                assert_eq!(region, Some(2));
+                assert_eq!(limit, Some(10));
+            }
+            cmd => panic!("unexpected command: {:?}", std::mem::discriminant(&cmd)),
+        }
+    }
+
+    #[test]
+    fn scan_region_conflicts_with_from() {
+        assert!(
+            Opt::try_parse_from(["tikv-ctl", "scan", "-r", "2", "-f", "zk", "--limit", "10"])
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn scan_requires_from_or_region() {
+        assert!(Opt::try_parse_from(["tikv-ctl", "scan", "--limit", "10"]).is_err());
     }
 
     #[test]

--- a/cmd/tikv-ctl/src/executor.rs
+++ b/cmd/tikv-ctl/src/executor.rs
@@ -426,6 +426,38 @@ pub trait DebugExecutor {
         }
     }
 
+    /// Dump mvcc infos for all keys in the range of the given region.
+    fn dump_mvccs_infos_by_region(
+        &self,
+        region_id: u64,
+        limit: u64,
+        cfs: Vec<&str>,
+        start_ts: Option<u64>,
+        commit_ts: Option<u64>,
+    ) {
+        let region = match self.get_region_info(region_id).region_local_state {
+            Some(state) => state.get_region().clone(),
+            None => {
+                eprintln!("region {} doesn't exist on this store", region_id);
+                tikv_util::logger::exit_process_gracefully(-1);
+            }
+        };
+        let from = keys::data_key(region.get_start_key());
+        let to = if region.get_end_key().is_empty() {
+            Vec::new()
+        } else {
+            keys::data_key(region.get_end_key())
+        };
+        if to.is_empty() && limit == 0 {
+            eprintln!(
+                "the end key of region {} is unbounded, please specify --limit",
+                region_id
+            );
+            tikv_util::logger::exit_process_gracefully(-1);
+        }
+        self.dump_mvccs_infos(from, to, limit, cfs, start_ts, commit_ts);
+    }
+
     fn raw_scan(&self, from_key: &[u8], to_key: &[u8], limit: usize, cf: &str) {
         if !ALL_CFS.contains(&cf) {
             eprintln!("CF \"{}\" doesn't exist.", cf);

--- a/cmd/tikv-ctl/src/main.rs
+++ b/cmd/tikv-ctl/src/main.rs
@@ -604,20 +604,26 @@ fn main() {
                 Cmd::Scan {
                     from,
                     to,
+                    region,
                     limit,
                     show_cf,
                     start_ts,
                     commit_ts,
                 } => {
-                    let from = unescape(&from);
-                    let to = to.map_or_else(Vec::new, |to| unescape(&to));
                     let limit = limit.unwrap_or(0);
-                    if to.is_empty() && limit == 0 {
-                        println!(r#"please pass "to" or "limit""#);
-                        tikv_util::logger::exit_process_gracefully(-1);
-                    }
                     let cfs = show_cf.iter().map(AsRef::as_ref).collect();
-                    debug_executor.dump_mvccs_infos(from, to, limit, cfs, start_ts, commit_ts);
+                    if let Some(region) = region {
+                        debug_executor
+                            .dump_mvccs_infos_by_region(region, limit, cfs, start_ts, commit_ts);
+                    } else {
+                        let from = unescape(&from.unwrap());
+                        let to = to.map_or_else(Vec::new, |to| unescape(&to));
+                        if to.is_empty() && limit == 0 {
+                            println!(r#"please pass "to" or "limit""#);
+                            tikv_util::logger::exit_process_gracefully(-1);
+                        }
+                        debug_executor.dump_mvccs_infos(from, to, limit, cfs, start_ts, commit_ts);
+                    }
                 }
                 Cmd::RawScan {
                     from,


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: Close #3148

What's Changed:

```commit-message
Add a --region (-r) option to the `scan` subcommand of tikv-ctl. When
specified, tikv-ctl resolves the region's start & end keys from its
region local state (or via the debug service in remote mode) and dumps
all mvcc keys & values in that range, so users no longer need to look
up the region range manually (e.g. via r

What's Changed:

```commit-message
Add a --region (-r) option to the `scan`
specified, tikv-ctl resolves the region'
region local state (or via the debug service in remote mode) and dumps
all mvcc keys & values in that range, so
up the region range manually (e.g. via region-properties) before
scanning.

--region conflicts with --from/--to. For
end key) a --limit is required, matching
```

Usage:

```bash
# local mode
tikv-ctl --data-dir /path/to/tikv scan -r 2 --show-cf default,lock,write
# remote mode
tikv-ctl --host ip:port scan -r 2 --limi
```

### Related changes

- [ ] PR to update `pingcap/docs`/`pingc
- [ ] Need to cherry-pick to the release branch

### Check List

Tests

- [x] Unit test
- [x] Manual test (add detailed scripts or steps below)

Unit tests cover the new CLI parsing ruld
without `--from`, `--region` conflicts wl
requires one of `--from`/`--region`. `ca
(11 tests, 0 failures).

Manual test with the built binary:

```console
$ tikv-ctl scan --help          # shows the new -r/--region option
$ tikv-ctl scan -r 2 -f zk --limit 10
error: The argument '--region <REGION>' cannot be used with '--from <FROM>'
$ tikv-ctl scan --limit 10
error: The following required arguments
    --from <FROM>
```

Side effects

- (none)

