### PR TITLE
*: extend Top SQL resource dimensions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4404,7 +4404,11 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
+<<<<<<< HEAD
 source = "git+https://github.com/pingcap/kvproto.git?branch=release-8.5#07aa8c6a46fab0a4cd577119c249c9c8e718c553"
+=======
+source = "git+https://github.com/pingcap/kvproto.git#af1ad1bef5b9dd611af5282711f47dbc31a42530"
+>>>>>>> 49e7a1179d (*: extend Top SQL resource dimensions (#19953))
 dependencies = [
  "bytes",
  "futures 0.3.15",

--- a/components/engine_panic/src/perf_context.rs
+++ b/components/engine_panic/src/perf_context.rs
@@ -1,6 +1,6 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
-use engine_traits::{PerfContext, PerfContextExt, PerfContextKind, PerfLevel};
+use engine_traits::{PerfContext, PerfContextDelta, PerfContextExt, PerfContextKind, PerfLevel};
 use tracker::TrackerToken;
 
 use crate::engine::PanicEngine;
@@ -20,7 +20,7 @@ impl PerfContext for PanicPerfContext {
         panic!()
     }
 
-    fn report_metrics(&mut self, _: &[TrackerToken]) {
+    fn report_metrics(&mut self, _: &[TrackerToken]) -> PerfContextDelta {
         panic!()
     }
 }

--- a/components/engine_rocks/src/perf_context.rs
+++ b/components/engine_rocks/src/perf_context.rs
@@ -1,6 +1,6 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
-use engine_traits::{PerfContext, PerfContextExt, PerfContextKind, PerfLevel};
+use engine_traits::{PerfContext, PerfContextDelta, PerfContextExt, PerfContextKind, PerfLevel};
 use tracker::TrackerToken;
 
 use crate::{engine::RocksEngine, perf_context_impl::PerfContextStatistics};
@@ -31,7 +31,7 @@ impl PerfContext for RocksPerfContext {
         self.stats.start()
     }
 
-    fn report_metrics(&mut self, trackers: &[TrackerToken]) {
+    fn report_metrics(&mut self, trackers: &[TrackerToken]) -> PerfContextDelta {
         self.stats.report(trackers)
     }
 }

--- a/components/engine_rocks/src/perf_context_impl.rs
+++ b/components/engine_rocks/src/perf_context_impl.rs
@@ -3,7 +3,7 @@
 use std::{fmt::Debug, marker::PhantomData, mem, ops::Sub, time::Duration};
 
 use derive_more::{Add, AddAssign, Sub, SubAssign};
-use engine_traits::{PerfContextKind, PerfLevel};
+use engine_traits::{PerfContextDelta, PerfContextKind, PerfLevel};
 use lazy_static::lazy_static;
 use slog_derive::KV;
 use tikv_util::time::Instant;
@@ -205,7 +205,7 @@ impl PerfContextStatistics {
         self.apply_perf_settings();
     }
 
-    pub fn report(&mut self, trackers: &[TrackerToken]) {
+    pub fn report(&mut self, trackers: &[TrackerToken]) -> PerfContextDelta {
         match self.kind {
             PerfContextKind::RaftstoreApply => {
                 report_write_perf_context!(self, APPLY_PERF_CONTEXT_TIME_HISTOGRAM_STATIC);
@@ -217,6 +217,7 @@ impl PerfContextStatistics {
                         t.metrics.apply_write_memtable_nanos = self.write.write_memtable_time;
                     });
                 }
+                PerfContextDelta::default()
             }
             PerfContextKind::RaftstoreStore => {
                 report_write_perf_context!(self, STORE_PERF_CONTEXT_TIME_HISTOGRAM_STATIC);
@@ -228,14 +229,20 @@ impl PerfContextStatistics {
                         t.metrics.store_write_memtable_nanos = self.write.write_memtable_time;
                     });
                 }
+                PerfContextDelta::default()
             }
             PerfContextKind::Storage(_) | PerfContextKind::Coprocessor(_) => {
+                if self.perf_level == PerfLevel::Disable {
+                    return PerfContextDelta::default();
+                }
                 let perf_context = ReadPerfContext::capture();
+                let block_read_count = perf_context.block_read_count;
                 for token in trackers {
                     GLOBAL_TRACKERS.with_tracker(*token, |t| perf_context.report_to_tracker(t));
                 }
                 self.read += perf_context;
                 self.flush_read_metrics();
+                PerfContextDelta { block_read_count }
             }
         }
     }

--- a/components/engine_tirocks/src/perf_context.rs
+++ b/components/engine_tirocks/src/perf_context.rs
@@ -161,7 +161,7 @@ impl engine_traits::PerfContext for RocksPerfContext {
         self.stats.start()
     }
 
-    fn report_metrics(&mut self, trackers: &[TrackerToken]) {
+    fn report_metrics(&mut self, trackers: &[TrackerToken]) -> engine_traits::PerfContextDelta {
         self.stats.report(trackers)
     }
 }
@@ -291,7 +291,7 @@ impl PerfContextStatistics {
         self.apply_perf_settings();
     }
 
-    pub fn report(&mut self, trackers: &[TrackerToken]) {
+    pub fn report(&mut self, trackers: &[TrackerToken]) -> engine_traits::PerfContextDelta {
         match self.kind {
             engine_traits::PerfContextKind::RaftstoreApply => {
                 report_write_perf_context!(self, APPLY_PERF_CONTEXT_TIME_HISTOGRAM_STATIC);
@@ -303,6 +303,7 @@ impl PerfContextStatistics {
                         t.metrics.apply_write_memtable_nanos = self.write.write_memtable_time;
                     });
                 }
+                engine_traits::PerfContextDelta::default()
             }
             engine_traits::PerfContextKind::RaftstoreStore => {
                 report_write_perf_context!(self, STORE_PERF_CONTEXT_TIME_HISTOGRAM_STATIC);
@@ -314,15 +315,21 @@ impl PerfContextStatistics {
                         t.metrics.store_write_memtable_nanos = self.write.write_memtable_time;
                     });
                 }
+                engine_traits::PerfContextDelta::default()
             }
             engine_traits::PerfContextKind::Storage(_)
             | engine_traits::PerfContextKind::Coprocessor(_) => {
+                if self.perf_level == engine_traits::PerfLevel::Disable {
+                    return engine_traits::PerfContextDelta::default();
+                }
                 let perf_context = ReadPerfContext::capture();
+                let block_read_count = perf_context.block_read_count;
                 for token in trackers {
                     GLOBAL_TRACKERS.with_tracker(*token, |t| perf_context.report_to_tracker(t));
                 }
                 self.read += perf_context;
                 self.maybe_flush_read_metrics();
+                engine_traits::PerfContextDelta { block_read_count }
             }
         }
     }

--- a/components/engine_traits/src/perf_context.rs
+++ b/components/engine_traits/src/perf_context.rs
@@ -23,6 +23,18 @@ numeric_enum_serializing_mod! {perf_level_serde PerfLevel {
     OutOfBounds = 6,
 }}
 
+/// Lightweight, engine-agnostic PerfContext delta captured during the current
+/// observation window.
+///
+/// Currently only `block_read_count` is reported. Resource metering exposes it
+/// as `rocksdb_block_read_count` for the downstream `read_iops` dimension and
+/// uses it for relative attribution; it is not a device-level IOPS measurement.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct PerfContextDelta {
+    /// RocksDB block read delta used for the downstream `read_iops` dimension.
+    pub block_read_count: u64,
+}
+
 /// Extensions for measuring engine performance.
 ///
 /// A PerfContext is created with a specific measurement level,
@@ -63,6 +75,10 @@ pub trait PerfContext: Send {
     /// Reinitializes statistics and the perf level
     fn start_observe(&mut self);
 
-    /// Reports the current collected metrics to prometheus and trackers
-    fn report_metrics(&mut self, trackers: &[TrackerToken]);
+    /// Reports the current collected metrics to prometheus and trackers.
+    ///
+    /// The returned delta covers the observation window started by the most
+    /// recent `start_observe` call. Callers should invoke this once per window
+    /// and attribute the returned values directly.
+    fn report_metrics(&mut self, trackers: &[TrackerToken]) -> PerfContextDelta;
 }

--- a/components/raft_log_engine/src/perf_context.rs
+++ b/components/raft_log_engine/src/perf_context.rs
@@ -11,7 +11,7 @@ impl engine_traits::PerfContext for RaftEnginePerfContext {
         raft_engine::set_perf_context(Default::default());
     }
 
-    fn report_metrics(&mut self, trackers: &[TrackerToken]) {
+    fn report_metrics(&mut self, trackers: &[TrackerToken]) -> engine_traits::PerfContextDelta {
         let perf_context = get_perf_context();
         for token in trackers {
             GLOBAL_TRACKERS.with_tracker(*token, |t| {
@@ -25,5 +25,6 @@ impl engine_traits::PerfContext for RaftEnginePerfContext {
                     perf_context.apply_duration.as_nanos() as u64;
             });
         }
+        engine_traits::PerfContextDelta::default()
     }
 }

--- a/components/raftstore-v2/src/operation/command/mod.rs
+++ b/components/raftstore-v2/src/operation/command/mod.rs
@@ -873,7 +873,7 @@ impl<EK: KvEngine, R: ApplyResReporter> Apply<EK, R> {
                     .iter()
                     .flat_map(|(v, _)| v.write_trackers().flat_map(|t| t.as_tracker_token()))
                     .collect();
-                self.perf_context().report_metrics(&tokens);
+                let _ = self.perf_context().report_metrics(&tokens);
             }
         }
         let mut apply_res = ApplyRes::default();

--- a/components/raftstore/src/store/async_io/write.rs
+++ b/components/raftstore/src/store/async_io/write.rs
@@ -944,7 +944,7 @@ where
                 .iter()
                 .flat_map(|task| task.trackers.iter().flat_map(|t| t.as_tracker_token()))
                 .collect();
-            self.perf_context.report_metrics(&trackers);
+            let _ = self.perf_context.report_metrics(&trackers);
             write_raft_time = duration_to_sec(now.saturating_elapsed());
             STORE_WRITE_RAFTDB_DURATION_HISTOGRAM.observe(write_raft_time);
             // Record the last confirmed raft-log append progress on a monotonic

--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -627,7 +627,7 @@ where
                 .flat_map(|(cb, _)| cb.write_trackers())
                 .flat_map(|trackers| trackers.as_tracker_token())
                 .collect();
-            self.perf_context.report_metrics(&trackers);
+            let _ = self.perf_context.report_metrics(&trackers);
             self.sync_log_hint = false;
             let data_size = self.kv_wb().data_size();
             if data_size > APPLY_WB_SHRINK_SIZE {

--- a/components/raftstore/src/store/worker/pd.rs
+++ b/components/raftstore/src/store/worker/pd.rs
@@ -3521,6 +3521,7 @@ mod tests {
                             network_out_bytes: 0,
                             logical_read_bytes: 0,
                             logical_write_bytes: 0,
+                            rocksdb_block_read_count: 0,
                         },
                     );
                     records
@@ -3683,6 +3684,7 @@ mod tests {
                             network_out_bytes: 0,
                             logical_read_bytes: 0,
                             logical_write_bytes: 0,
+                            rocksdb_block_read_count: 0,
                         },
                     );
                     records

--- a/components/resource_metering/src/config.rs
+++ b/components/resource_metering/src/config.rs
@@ -1,6 +1,9 @@
 // Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::{error::Error, sync::atomic::AtomicBool};
+use std::{
+    error::Error,
+    sync::atomic::{AtomicU8, Ordering::Relaxed},
+};
 
 use online_config::{ConfigChange, OnlineConfig};
 use serde_derive::{Deserialize, Serialize};
@@ -16,9 +19,59 @@ const MAX_PRECISION: ReadableDuration = ReadableDuration::hours(1);
 const MAX_MAX_RESOURCE_GROUPS: usize = 5_000;
 const MIN_REPORT_RECEIVER_INTERVAL: ReadableDuration = ReadableDuration::millis(500);
 const DEFAULT_ENABLE_NETWORK_IO_COLLECTION: bool = false;
+const DEFAULT_ENABLE_DETAILED_IO_COLLECTION: bool = false;
+const NETWORK_IO_COLLECTION_ENABLED: u8 = 1 << 0;
+const DETAILED_IO_COLLECTION_ENABLED: u8 = 1 << 1;
 
-pub static ENABLE_NETWORK_IO_COLLECTION: AtomicBool =
-    AtomicBool::new(DEFAULT_ENABLE_NETWORK_IO_COLLECTION);
+/// An atomically published snapshot of the runtime I/O collection switches.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct IoCollectionConfigSnapshot(u8);
+
+impl IoCollectionConfigSnapshot {
+    const fn new(enable_network_io_collection: bool, enable_detailed_io_collection: bool) -> Self {
+        let mut state = 0;
+        if enable_network_io_collection {
+            state |= NETWORK_IO_COLLECTION_ENABLED;
+            if enable_detailed_io_collection {
+                state |= DETAILED_IO_COLLECTION_ENABLED;
+            }
+        }
+        Self(state)
+    }
+
+    pub fn network_io_collection_enabled(self) -> bool {
+        self.0 & NETWORK_IO_COLLECTION_ENABLED != 0
+    }
+
+    pub fn detailed_io_collection_enabled(self) -> bool {
+        self.0 & DETAILED_IO_COLLECTION_ENABLED != 0
+    }
+}
+
+static IO_COLLECTION_CONFIG: AtomicU8 = AtomicU8::new(
+    IoCollectionConfigSnapshot::new(
+        DEFAULT_ENABLE_NETWORK_IO_COLLECTION,
+        DEFAULT_ENABLE_DETAILED_IO_COLLECTION,
+    )
+    .0,
+);
+
+/// Loads both runtime I/O collection switches from one atomic snapshot.
+#[inline]
+pub fn io_collection_config() -> IoCollectionConfigSnapshot {
+    IoCollectionConfigSnapshot(IO_COLLECTION_CONFIG.load(Relaxed))
+}
+
+pub(crate) fn set_io_collection_config(
+    enable_network_io_collection: bool,
+    enable_detailed_io_collection: bool,
+) {
+    let config = IoCollectionConfigSnapshot::new(
+        enable_network_io_collection,
+        enable_detailed_io_collection,
+    );
+    IO_COLLECTION_CONFIG.store(config.0, Relaxed);
+}
 
 /// Public configuration of resource metering module.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, OnlineConfig)]
@@ -31,7 +84,14 @@ pub struct Config {
     /// Data reporting interval.
     pub report_receiver_interval: ReadableDuration,
 
-    /// The maximum number of groups by [ResourceMeteringTag].
+    /// The maximum number of candidate groups by [ResourceMeteringTag] for
+    /// each resource dimension.
+    ///
+    /// With network IO collection enabled, the reported groups are the union of
+    /// candidates selected by CPU, network IO, and logical IO. When detailed IO
+    /// collection is also enabled, logical IO is split into logical read and
+    /// logical write, and RocksDB block read count is added as a fifth
+    /// dimension. The union can exceed this value.
     ///
     /// [ResourceMeteringTag]: crate::ResourceMeteringTag
     pub max_resource_groups: usize,
@@ -39,8 +99,15 @@ pub struct Config {
     /// Sampling window. (only for cpu module)
     pub precision: ReadableDuration,
 
-    /// Whether to collect network traffic and logical io
+    /// Whether to collect network traffic and logical IO.
     pub enable_network_io_collection: bool,
+
+    /// Whether to collect and attribute detailed IO for `read_iops` analysis.
+    ///
+    /// This controls RocksDB block read count collection and separate TopN
+    /// selection for logical reads, logical writes, and RocksDB block reads. It
+    /// is effective only when `enable_network_io_collection` is also enabled.
+    pub enable_detailed_io_collection: bool,
 }
 
 impl Default for Config {
@@ -51,11 +118,17 @@ impl Default for Config {
             max_resource_groups: 100,
             precision: ReadableDuration::secs(1),
             enable_network_io_collection: DEFAULT_ENABLE_NETWORK_IO_COLLECTION,
+            enable_detailed_io_collection: DEFAULT_ENABLE_DETAILED_IO_COLLECTION,
         }
     }
 }
 
 impl Config {
+    /// Returns whether detailed IO collection is effective for this config.
+    pub fn detailed_io_collection_enabled(&self) -> bool {
+        self.enable_network_io_collection && self.enable_detailed_io_collection
+    }
+
     /// Check whether the configuration is legal.
     pub fn validate(&self) -> Result<(), Box<dyn Error>> {
         if !self.receiver_address.is_empty() {
@@ -148,6 +221,7 @@ mod tests {
             max_resource_groups: 2000,
             precision: ReadableDuration::secs(1),
             enable_network_io_collection: false,
+            enable_detailed_io_collection: false,
         };
         cfg.validate().unwrap();
         let cfg = Config {
@@ -156,6 +230,7 @@ mod tests {
             max_resource_groups: 2000,
             precision: ReadableDuration::secs(1),
             enable_network_io_collection: false,
+            enable_detailed_io_collection: false,
         };
         cfg.validate().unwrap_err();
         let cfg = Config {
@@ -164,6 +239,7 @@ mod tests {
             max_resource_groups: usize::MAX, // invalid
             precision: ReadableDuration::secs(1),
             enable_network_io_collection: false,
+            enable_detailed_io_collection: false,
         };
         cfg.validate().unwrap_err();
         let cfg = Config {
@@ -172,7 +248,29 @@ mod tests {
             max_resource_groups: 2000,
             precision: ReadableDuration::days(999), // invalid
             enable_network_io_collection: false,
+            enable_detailed_io_collection: false,
         };
         cfg.validate().unwrap_err();
+    }
+
+    #[test]
+    fn test_detailed_io_collection_enabled() {
+        for (network, detailed, expected) in [
+            (false, false, false),
+            (false, true, false),
+            (true, false, false),
+            (true, true, true),
+        ] {
+            let cfg = Config {
+                enable_network_io_collection: network,
+                enable_detailed_io_collection: detailed,
+                ..Default::default()
+            };
+            assert_eq!(cfg.detailed_io_collection_enabled(), expected);
+
+            let snapshot = IoCollectionConfigSnapshot::new(network, detailed);
+            assert_eq!(snapshot.network_io_collection_enabled(), network);
+            assert_eq!(snapshot.detailed_io_collection_enabled(), expected);
+        }
     }
 }

--- a/components/resource_metering/src/lib.rs
+++ b/components/resource_metering/src/lib.rs
@@ -5,24 +5,24 @@
 #![allow(internal_features)]
 #![feature(core_intrinsics)]
 
+#[cfg(test)]
+use std::sync::atomic::Ordering::Relaxed;
 use std::{
     intrinsics::unlikely,
     pin::Pin,
-    sync::{
-        Arc,
-        atomic::Ordering::{Relaxed, SeqCst},
-    },
+    sync::{Arc, atomic::Ordering::SeqCst},
     task::{Context, Poll},
 };
 
 pub use collector::Collector;
-pub use config::{Config, ConfigManager, ENABLE_NETWORK_IO_COLLECTION};
+pub use config::{Config, ConfigManager, IoCollectionConfigSnapshot, io_collection_config};
 pub use model::*;
 pub use recorder::{
     CollectorGuard, CollectorId, CollectorRegHandle,
     ConfigChangeNotifier as RecorderConfigChangeNotifier, CpuRecorder, Recorder, RecorderBuilder,
     SummaryRecorder, init_recorder, record_logical_read_bytes, record_logical_write_bytes,
-    record_network_in_bytes, record_network_out_bytes, record_read_keys, record_write_keys,
+    record_network_in_bytes, record_network_out_bytes, record_read_keys,
+    record_rocksdb_block_read_count, record_write_keys,
 };
 use recorder::{LocalStorage, LocalStorageRef, STORAGE};
 pub use reporter::{
@@ -121,6 +121,35 @@ pub struct Guard;
 // will never be cleaned up, so here we need to make some restrictions.
 const MAX_SUMMARY_RECORDS_LEN: usize = 1000;
 
+#[cfg(test)]
+pub(crate) static IO_COLLECTION_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+#[cfg(test)]
+pub(crate) struct IoCollectionConfigGuard {
+    config: IoCollectionConfigSnapshot,
+}
+
+#[cfg(test)]
+impl IoCollectionConfigGuard {
+    pub(crate) fn set(network: bool, detailed: bool) -> Self {
+        let guard = Self {
+            config: io_collection_config(),
+        };
+        config::set_io_collection_config(network, detailed);
+        guard
+    }
+}
+
+#[cfg(test)]
+impl Drop for IoCollectionConfigGuard {
+    fn drop(&mut self) {
+        config::set_io_collection_config(
+            self.config.network_io_collection_enabled(),
+            self.config.detailed_io_collection_enabled(),
+        );
+    }
+}
+
 impl Drop for Guard {
     fn drop(&mut self) {
         STORAGE.with(|s| {
@@ -147,10 +176,7 @@ impl Drop for Guard {
                 return;
             }
             let cur_record = ls.summary_cur_record.take_and_reset();
-            if cur_record.read_keys.load(Relaxed) == 0
-                && cur_record.logical_read_bytes.load(Relaxed) == 0
-                && cur_record.logical_write_bytes.load(Relaxed) == 0
-            {
+            if cur_record.is_empty() {
                 return;
             }
             let mut records = ls.summary_records.lock().unwrap();
@@ -372,6 +398,52 @@ mod tests {
                 let ls = s.borrow_mut();
                 let local_tag = ls.attached_tag.swap(None);
                 assert!(local_tag.is_none());
+            });
+        })
+        .join()
+        .unwrap();
+    }
+
+    #[test]
+    fn test_guard_keeps_block_read_only_record() {
+        let _test_guard = IO_COLLECTION_TEST_LOCK.lock().unwrap();
+        let _config_guard = IoCollectionConfigGuard::set(true, true);
+        std::thread::spawn(|| {
+            let resource_tag_factory = ResourceTagFactory::new_for_test();
+            let tag = ResourceMeteringTag {
+                infos: Arc::new(TagInfos {
+                    store_id: 1,
+                    region_id: 2,
+                    peer_id: 3,
+                    key_ranges: vec![],
+                    extra_attachment: Arc::new(b"block-read-only".to_vec()),
+                }),
+                resource_tag_factory,
+            };
+            STORAGE.with(|s| {
+                let ls = s.borrow_mut();
+                ls.summary_enable.store(true, SeqCst);
+                ls.summary_records.lock().unwrap().clear();
+                ls.summary_cur_record.reset();
+            });
+
+            {
+                let _guard = tag.attach();
+                record_rocksdb_block_read_count(9);
+            }
+
+            STORAGE.with(|s| {
+                let ls = s.borrow();
+                let records = ls.summary_records.lock().unwrap();
+                assert_eq!(records.len(), 1);
+                assert_eq!(
+                    records
+                        .get(&tag.infos)
+                        .unwrap()
+                        .rocksdb_block_read_count
+                        .load(Relaxed),
+                    9
+                );
             });
         })
         .join()

--- a/components/resource_metering/src/model.rs
+++ b/components/resource_metering/src/model.rs
@@ -22,10 +22,13 @@ thread_local! {
     static STATIC_CPU_BUF: Cell<Vec<u32>> = const {Cell::new(vec![])};
     static STATIC_NETWORK_BUF: Cell<Vec<u64>> = const {Cell::new(vec![])};
     static STATIC_LOGICAL_IO_BUF: Cell<Vec<u64>> = const {Cell::new(vec![])};
+    static STATIC_LOGICAL_READ_BUF: Cell<Vec<u64>> = const {Cell::new(vec![])};
+    static STATIC_LOGICAL_WRITE_BUF: Cell<Vec<u64>> = const {Cell::new(vec![])};
+    static STATIC_ROCKSDB_BLOCK_READ_BUF: Cell<Vec<u64>> = const {Cell::new(vec![])};
 }
 
 /// Find the kth values in the iterator, returns (kth_cpu_time,
-/// kth_network_traffic, kth_logical_io)
+/// kth_network_traffic, kth_logical_io).
 pub fn find_kth_values<'a, T: 'a>(
     iter: impl Iterator<Item = (&'a T, &'a RawRecord)>,
     k: usize,
@@ -54,6 +57,58 @@ pub fn find_kth_values<'a, T: 'a>(
     STATIC_LOGICAL_IO_BUF.with(move |b| b.set(logical_io_buf));
 
     (kth_cpu, kth_network, kth_logical_io)
+}
+
+/// Find the kth values for detailed IO selection, returning CPU, network,
+/// logical read, logical write, and RocksDB block read thresholds.
+pub fn find_kth_detailed_io_values<'a, T: 'a>(
+    iter: impl Iterator<Item = (&'a T, &'a RawRecord)>,
+    k: usize,
+) -> (u32, u64, u64, u64, u64) {
+    let mut cpu_buf = STATIC_CPU_BUF.with(|b| b.take());
+    let mut network_buf = STATIC_NETWORK_BUF.with(|b| b.take());
+    let mut logical_read_buf = STATIC_LOGICAL_READ_BUF.with(|b| b.take());
+    let mut logical_write_buf = STATIC_LOGICAL_WRITE_BUF.with(|b| b.take());
+    let mut rocksdb_block_read_buf = STATIC_ROCKSDB_BLOCK_READ_BUF.with(|b| b.take());
+    cpu_buf.clear();
+    network_buf.clear();
+    logical_read_buf.clear();
+    logical_write_buf.clear();
+    rocksdb_block_read_buf.clear();
+    for (_, record) in iter {
+        cpu_buf.push(record.cpu_time);
+        network_buf.push(record.network_in_bytes + record.network_out_bytes);
+        logical_read_buf.push(record.logical_read_bytes);
+        logical_write_buf.push(record.logical_write_bytes);
+        rocksdb_block_read_buf.push(record.rocksdb_block_read_count);
+    }
+    pdqselect::select_by(&mut cpu_buf, k, |a, b| b.cmp(a));
+    let kth_cpu = cpu_buf[k];
+    STATIC_CPU_BUF.with(move |b| b.set(cpu_buf));
+
+    pdqselect::select_by(&mut network_buf, k, |a, b| b.cmp(a));
+    let kth_network = network_buf[k];
+    STATIC_NETWORK_BUF.with(move |b| b.set(network_buf));
+
+    pdqselect::select_by(&mut logical_read_buf, k, |a, b| b.cmp(a));
+    let kth_logical_read = logical_read_buf[k];
+    STATIC_LOGICAL_READ_BUF.with(move |b| b.set(logical_read_buf));
+
+    pdqselect::select_by(&mut logical_write_buf, k, |a, b| b.cmp(a));
+    let kth_logical_write = logical_write_buf[k];
+    STATIC_LOGICAL_WRITE_BUF.with(move |b| b.set(logical_write_buf));
+
+    pdqselect::select_by(&mut rocksdb_block_read_buf, k, |a, b| b.cmp(a));
+    let kth_rocksdb_block_read = rocksdb_block_read_buf[k];
+    STATIC_ROCKSDB_BLOCK_READ_BUF.with(move |b| b.set(rocksdb_block_read_buf));
+
+    (
+        kth_cpu,
+        kth_network,
+        kth_logical_read,
+        kth_logical_write,
+        kth_rocksdb_block_read,
+    )
 }
 
 /// Find the kth cpu time in the iterator.
@@ -113,6 +168,36 @@ pub fn get_iter_for_cpu_network_io<'a, T: 'a>(
     )
 }
 
+/// Get picked and unpicked iterators for detailed IO TopN selection.
+pub fn get_iter_for_detailed_io<'a, T: 'a>(
+    records: &'a HashMap<T, RawRecord>,
+    kth_cpu: u32,
+    kth_network: u64,
+    kth_logical_read: u64,
+    kth_logical_write: u64,
+    kth_rocksdb_block_read: u64,
+) -> (
+    impl Iterator<Item = (&'a T, &'a RawRecord)>,
+    impl Iterator<Item = (&'a T, &'a RawRecord)>,
+) {
+    (
+        records.iter().filter(move |(_, v)| {
+            v.cpu_time > kth_cpu
+                || v.network_in_bytes + v.network_out_bytes > kth_network
+                || v.logical_read_bytes > kth_logical_read
+                || v.logical_write_bytes > kth_logical_write
+                || v.rocksdb_block_read_count > kth_rocksdb_block_read
+        }),
+        records.iter().filter(move |(_, v)| {
+            v.cpu_time <= kth_cpu
+                && v.network_in_bytes + v.network_out_bytes <= kth_network
+                && v.logical_read_bytes <= kth_logical_read
+                && v.logical_write_bytes <= kth_logical_write
+                && v.rocksdb_block_read_count <= kth_rocksdb_block_read
+        }),
+    )
+}
+
 /// Append raw_record to records[key] at timestamp ts.
 fn append_impl<T>(records: &mut HashMap<T, Record>, ts: u64, key: &T, raw_record: &RawRecord)
 where
@@ -132,6 +217,7 @@ where
                 logical_write_bytes_list: vec![raw_record.logical_write_bytes],
                 network_in_bytes_list: vec![raw_record.network_in_bytes],
                 network_out_bytes_list: vec![raw_record.network_out_bytes],
+                rocksdb_block_read_count_list: vec![raw_record.rocksdb_block_read_count],
             },
         );
         return;
@@ -146,6 +232,8 @@ where
         *record.logical_write_bytes_list.last_mut().unwrap() += raw_record.logical_write_bytes;
         *record.network_in_bytes_list.last_mut().unwrap() += raw_record.network_in_bytes;
         *record.network_out_bytes_list.last_mut().unwrap() += raw_record.network_out_bytes;
+        *record.rocksdb_block_read_count_list.last_mut().unwrap() +=
+            raw_record.rocksdb_block_read_count;
     } else {
         record.timestamps.push(ts);
         record.cpu_time_list.push(raw_record.cpu_time);
@@ -163,16 +251,18 @@ where
         record
             .network_out_bytes_list
             .push(raw_record.network_out_bytes);
+        record
+            .rocksdb_block_read_count_list
+            .push(raw_record.rocksdb_block_read_count);
     }
 }
 
-/// Pick top n agged raw records, then append picked topN records and merge
-/// unpicked ones to others. If enable_network_io_collection is true, pick top n
-/// records by cpu_time, network_io and logical_io, otherwise, pick top n
-/// records by cpu_time only.
+/// Pick top n candidate raw records per effective resource dimension, append
+/// their union, and merge unpicked records into others.
 pub fn handle_records_impl<'a, K, T>(
     records: &'a mut T,
     enable_network_io_collection: bool,
+    enable_detailed_io_collection: bool,
     agg_map: &'a HashMap<K, crate::RawRecord>,
     ts: u64,
     n: usize,
@@ -184,7 +274,20 @@ pub fn handle_records_impl<'a, K, T>(
         records.append(ts, agg_map.iter());
         return;
     }
-    if enable_network_io_collection {
+    if enable_network_io_collection && enable_detailed_io_collection {
+        let (kth_cpu, kth_network, kth_logical_read, kth_logical_write, kth_rocksdb_block_read) =
+            find_kth_detailed_io_values(agg_map.iter(), n);
+        let (picked_iter, unpicked_iter) = get_iter_for_detailed_io(
+            agg_map,
+            kth_cpu,
+            kth_network,
+            kth_logical_read,
+            kth_logical_write,
+            kth_rocksdb_block_read,
+        );
+        records.append(ts, picked_iter);
+        records.merge_other(ts, unpicked_iter);
+    } else if enable_network_io_collection {
         let (kth_cpu, kth_network, kth_logical_io) = find_kth_values(agg_map.iter(), n);
         let (picked_iter, unpicked_iter) =
             get_iter_for_cpu_network_io(agg_map, kth_cpu, kth_network, kth_logical_io);
@@ -249,6 +352,9 @@ pub struct RawRecord {
     pub logical_write_bytes: u64,
     pub network_in_bytes: u64,
     pub network_out_bytes: u64,
+    /// RocksDB block reads used for the downstream `read_iops` dimension. This
+    /// is a relative attribution signal, not device-level IOPS.
+    pub rocksdb_block_read_count: u64,
 }
 
 impl RawRecord {
@@ -276,6 +382,7 @@ impl RawRecord {
         self.logical_write_bytes += other.logical_write_bytes;
         self.network_in_bytes += other.network_in_bytes;
         self.network_out_bytes += other.network_out_bytes;
+        self.rocksdb_block_read_count += other.rocksdb_block_read_count;
     }
 
     pub fn merge_summary(&mut self, r: &SummaryRecord) {
@@ -285,6 +392,7 @@ impl RawRecord {
         self.logical_write_bytes += r.logical_write_bytes.load(Relaxed);
         self.network_in_bytes += r.network_in_bytes.load(Relaxed);
         self.network_out_bytes += r.network_out_bytes.load(Relaxed);
+        self.rocksdb_block_read_count += r.rocksdb_block_read_count.load(Relaxed);
     }
 }
 
@@ -382,6 +490,7 @@ pub struct Record {
     pub logical_write_bytes_list: Vec<u64>,
     pub network_in_bytes_list: Vec<u64>,
     pub network_out_bytes_list: Vec<u64>,
+    pub rocksdb_block_read_count_list: Vec<u64>,
     pub total_cpu_time: u32,
 }
 
@@ -398,6 +507,7 @@ impl From<Record> for Vec<GroupTagRecordItem> {
             item.set_logical_write_bytes(record.logical_write_bytes_list[n]);
             item.set_network_in_bytes(record.network_in_bytes_list[n]);
             item.set_network_out_bytes(record.network_out_bytes_list[n]);
+            item.set_rocksdb_block_read_count(record.rocksdb_block_read_count_list[n]);
             items.push(item);
         }
         items
@@ -413,6 +523,7 @@ impl Record {
             && self.timestamps.len() == self.logical_write_bytes_list.len()
             && self.timestamps.len() == self.network_in_bytes_list.len()
             && self.timestamps.len() == self.network_out_bytes_list.len()
+            && self.timestamps.len() == self.rocksdb_block_read_count_list.len()
     }
 }
 
@@ -468,6 +579,7 @@ impl From<Records> for Vec<ResourceUsageRecord> {
                     logical_write_bytes,
                     network_in_bytes,
                     network_out_bytes,
+                    rocksdb_block_read_count,
                     ..
                 },
             ) in records.others
@@ -481,6 +593,7 @@ impl From<Records> for Vec<ResourceUsageRecord> {
                 item.set_logical_write_bytes(logical_write_bytes);
                 item.set_network_in_bytes(network_in_bytes);
                 item.set_network_out_bytes(network_out_bytes);
+                item.set_rocksdb_block_read_count(rocksdb_block_read_count);
                 items.push(item);
             }
             let mut tag_record = GroupTagRecord::new();
@@ -636,6 +749,7 @@ impl From<RegionRecords> for Vec<ResourceUsageRecord> {
                     logical_write_bytes,
                     network_in_bytes,
                     network_out_bytes,
+                    rocksdb_block_read_count,
                     ..
                 },
             ) in records.others
@@ -649,6 +763,7 @@ impl From<RegionRecords> for Vec<ResourceUsageRecord> {
                 item.set_logical_write_bytes(logical_write_bytes);
                 item.set_network_in_bytes(network_in_bytes);
                 item.set_network_out_bytes(network_out_bytes);
+                item.set_rocksdb_block_read_count(rocksdb_block_read_count);
                 items.push(item);
             }
             let mut region_record = RegionRecord::new();
@@ -736,6 +851,10 @@ pub struct SummaryRecord {
 
     /// Network output bytes.
     pub network_out_bytes: AtomicU64,
+
+    /// RocksDB block reads used for the downstream `read_iops` dimension. This
+    /// is a relative attribution signal, not device-level IOPS.
+    pub rocksdb_block_read_count: AtomicU64,
 }
 
 impl Clone for SummaryRecord {
@@ -747,6 +866,7 @@ impl Clone for SummaryRecord {
             logical_write_bytes: AtomicU64::new(self.logical_write_bytes.load(Relaxed)),
             network_in_bytes: AtomicU64::new(self.network_in_bytes.load(Relaxed)),
             network_out_bytes: AtomicU64::new(self.network_out_bytes.load(Relaxed)),
+            rocksdb_block_read_count: AtomicU64::new(self.rocksdb_block_read_count.load(Relaxed)),
         }
     }
 }
@@ -760,6 +880,7 @@ impl SummaryRecord {
         self.logical_write_bytes.store(0, Relaxed);
         self.network_in_bytes.store(0, Relaxed);
         self.network_out_bytes.store(0, Relaxed);
+        self.rocksdb_block_read_count.store(0, Relaxed);
     }
 
     /// Add two items.
@@ -776,6 +897,8 @@ impl SummaryRecord {
             .fetch_add(other.network_in_bytes.load(Relaxed), Relaxed);
         self.network_out_bytes
             .fetch_add(other.network_out_bytes.load(Relaxed), Relaxed);
+        self.rocksdb_block_read_count
+            .fetch_add(other.rocksdb_block_read_count.load(Relaxed), Relaxed);
     }
 
     /// Gets the value and writes it to zero.
@@ -788,7 +911,21 @@ impl SummaryRecord {
             logical_write_bytes: AtomicU64::new(self.logical_write_bytes.swap(0, Relaxed)),
             network_in_bytes: AtomicU64::new(self.network_in_bytes.swap(0, Relaxed)),
             network_out_bytes: AtomicU64::new(self.network_out_bytes.swap(0, Relaxed)),
+            rocksdb_block_read_count: AtomicU64::new(
+                self.rocksdb_block_read_count.swap(0, Relaxed),
+            ),
         }
+    }
+
+    /// Returns true if all fields are zero.
+    pub fn is_empty(&self) -> bool {
+        self.read_keys.load(Relaxed) == 0
+            && self.write_keys.load(Relaxed) == 0
+            && self.logical_read_bytes.load(Relaxed) == 0
+            && self.logical_write_bytes.load(Relaxed) == 0
+            && self.network_in_bytes.load(Relaxed) == 0
+            && self.network_out_bytes.load(Relaxed) == 0
+            && self.rocksdb_block_read_count.load(Relaxed) == 0
     }
 }
 
@@ -796,8 +933,25 @@ impl SummaryRecord {
 mod tests {
     use std::sync::atomic::Ordering::Relaxed;
 
+    use collections::HashSet;
+
     use super::*;
     use crate::TagInfos;
+
+    fn record_with_block_read_count(block_read_count: u64) -> Record {
+        Record {
+            timestamps: vec![1],
+            cpu_time_list: vec![2],
+            read_keys_list: vec![3],
+            write_keys_list: vec![4],
+            logical_read_bytes_list: vec![5],
+            logical_write_bytes_list: vec![6],
+            network_in_bytes_list: vec![7],
+            network_out_bytes_list: vec![8],
+            rocksdb_block_read_count_list: vec![block_read_count],
+            total_cpu_time: 2,
+        }
+    }
 
     #[test]
     fn test_summary_record() {
@@ -808,6 +962,7 @@ mod tests {
             network_out_bytes: AtomicU64::new(20),
             logical_read_bytes: AtomicU64::new(100),
             logical_write_bytes: AtomicU64::new(200),
+            rocksdb_block_read_count: AtomicU64::new(300),
         };
         assert_eq!(record.read_keys.load(Relaxed), 1);
         assert_eq!(record.write_keys.load(Relaxed), 2);
@@ -815,6 +970,7 @@ mod tests {
         assert_eq!(record.network_out_bytes.load(Relaxed), 20);
         assert_eq!(record.logical_read_bytes.load(Relaxed), 100);
         assert_eq!(record.logical_write_bytes.load(Relaxed), 200);
+        assert_eq!(record.rocksdb_block_read_count.load(Relaxed), 300);
         let record2 = record.clone();
         assert_eq!(record2.read_keys.load(Relaxed), 1);
         assert_eq!(record2.write_keys.load(Relaxed), 2);
@@ -822,6 +978,7 @@ mod tests {
         assert_eq!(record2.network_out_bytes.load(Relaxed), 20);
         assert_eq!(record2.logical_read_bytes.load(Relaxed), 100);
         assert_eq!(record2.logical_write_bytes.load(Relaxed), 200);
+        assert_eq!(record2.rocksdb_block_read_count.load(Relaxed), 300);
         record.merge(&SummaryRecord {
             read_keys: AtomicU32::new(3),
             write_keys: AtomicU32::new(4),
@@ -829,6 +986,7 @@ mod tests {
             network_out_bytes: AtomicU64::new(40),
             logical_read_bytes: AtomicU64::new(300),
             logical_write_bytes: AtomicU64::new(400),
+            rocksdb_block_read_count: AtomicU64::new(500),
         });
         assert_eq!(record.read_keys.load(Relaxed), 4);
         assert_eq!(record.write_keys.load(Relaxed), 6);
@@ -836,6 +994,7 @@ mod tests {
         assert_eq!(record.network_out_bytes.load(Relaxed), 60);
         assert_eq!(record.logical_read_bytes.load(Relaxed), 400);
         assert_eq!(record.logical_write_bytes.load(Relaxed), 600);
+        assert_eq!(record.rocksdb_block_read_count.load(Relaxed), 800);
         let record2 = record.take_and_reset();
         assert_eq!(record.read_keys.load(Relaxed), 0);
         assert_eq!(record.write_keys.load(Relaxed), 0);
@@ -843,12 +1002,14 @@ mod tests {
         assert_eq!(record.network_out_bytes.load(Relaxed), 0);
         assert_eq!(record.logical_read_bytes.load(Relaxed), 0);
         assert_eq!(record.logical_write_bytes.load(Relaxed), 0);
+        assert_eq!(record.rocksdb_block_read_count.load(Relaxed), 0);
         assert_eq!(record2.read_keys.load(Relaxed), 4);
         assert_eq!(record2.write_keys.load(Relaxed), 6);
         assert_eq!(record2.network_in_bytes.load(Relaxed), 40);
         assert_eq!(record2.network_out_bytes.load(Relaxed), 60);
         assert_eq!(record2.logical_read_bytes.load(Relaxed), 400);
         assert_eq!(record2.logical_write_bytes.load(Relaxed), 600);
+        assert_eq!(record2.rocksdb_block_read_count.load(Relaxed), 800);
         record2.reset();
         assert_eq!(record2.read_keys.load(Relaxed), 0);
         assert_eq!(record2.write_keys.load(Relaxed), 0);
@@ -856,6 +1017,75 @@ mod tests {
         assert_eq!(record2.network_out_bytes.load(Relaxed), 0);
         assert_eq!(record2.logical_read_bytes.load(Relaxed), 0);
         assert_eq!(record2.logical_write_bytes.load(Relaxed), 0);
+        assert_eq!(record2.rocksdb_block_read_count.load(Relaxed), 0);
+    }
+
+    #[test]
+    fn test_summary_record_is_empty_checks_every_field() {
+        let record = SummaryRecord::default();
+        assert!(record.is_empty());
+
+        record.read_keys.store(1, Relaxed);
+        assert!(!record.is_empty());
+        record.reset();
+        record.write_keys.store(1, Relaxed);
+        assert!(!record.is_empty());
+        record.reset();
+        record.logical_read_bytes.store(1, Relaxed);
+        assert!(!record.is_empty());
+        record.reset();
+        record.logical_write_bytes.store(1, Relaxed);
+        assert!(!record.is_empty());
+        record.reset();
+        record.network_in_bytes.store(1, Relaxed);
+        assert!(!record.is_empty());
+        record.reset();
+        record.network_out_bytes.store(1, Relaxed);
+        assert!(!record.is_empty());
+        record.reset();
+        record.rocksdb_block_read_count.store(1, Relaxed);
+        assert!(!record.is_empty());
+    }
+
+    #[test]
+    fn test_block_read_count_proto_for_others_and_regions() {
+        let mut records = Records::default();
+        records.others.insert(
+            1,
+            RawRecord {
+                rocksdb_block_read_count: 11,
+                ..Default::default()
+            },
+        );
+        let records: Vec<ResourceUsageRecord> = records.into();
+        assert_eq!(records.len(), 1);
+        assert_eq!(
+            records[0].get_record().get_items()[0].get_rocksdb_block_read_count(),
+            11
+        );
+
+        let mut regions = RegionRecords::default();
+        regions.records.insert(42, record_with_block_read_count(22));
+        regions.others.insert(
+            1,
+            RawRecord {
+                rocksdb_block_read_count: 33,
+                ..Default::default()
+            },
+        );
+        let mut regions: Vec<ResourceUsageRecord> = regions.into();
+        regions.sort_by_key(|record| record.get_region_record().get_region_id());
+        assert_eq!(regions.len(), 2);
+        assert_eq!(regions[0].get_region_record().get_region_id(), 0);
+        assert_eq!(
+            regions[0].get_region_record().get_items()[0].get_rocksdb_block_read_count(),
+            33
+        );
+        assert_eq!(regions[1].get_region_record().get_region_id(), 42);
+        assert_eq!(
+            regions[1].get_region_record().get_items()[0].get_rocksdb_block_read_count(),
+            22
+        );
     }
 
     #[test]
@@ -893,6 +1123,7 @@ mod tests {
                 network_out_bytes: 2222,
                 logical_read_bytes: 3333,
                 logical_write_bytes: 4444,
+                rocksdb_block_read_count: 55,
                 ..Default::default()
             },
         );
@@ -906,6 +1137,7 @@ mod tests {
                 network_out_bytes: 5555,
                 logical_read_bytes: 6666,
                 logical_write_bytes: 7777,
+                rocksdb_block_read_count: 66,
                 ..Default::default()
             },
         );
@@ -919,6 +1151,7 @@ mod tests {
                 network_out_bytes: 8888,
                 logical_read_bytes: 9999,
                 logical_write_bytes: 11110,
+                rocksdb_block_read_count: 77,
                 ..Default::default()
             },
         );
@@ -931,6 +1164,150 @@ mod tests {
         assert_eq!(records.records.len(), 0);
         records.append(raw.begin_unix_time_secs, agg_map.iter());
         assert_eq!(records.records.len(), 3);
+
+        let mut report: Vec<ResourceUsageRecord> = records.into();
+        report.sort_by_key(|record| record.get_record().get_resource_group_tag().to_vec());
+        assert_eq!(report.len(), 3);
+        assert_eq!(
+            report[0].get_record().get_items()[0].get_rocksdb_block_read_count(),
+            55
+        );
+        assert_eq!(
+            report[1].get_record().get_items()[0].get_rocksdb_block_read_count(),
+            66
+        );
+        assert_eq!(
+            report[2].get_record().get_items()[0].get_rocksdb_block_read_count(),
+            77
+        );
+    }
+
+    #[test]
+    fn test_pick_top_k_rocksdb_block_read() {
+        let mut records = HashMap::default();
+        for (tag, block_read_count) in [(b"a", 100), (b"b", 80), (b"c", 5), (b"d", 5), (b"e", 5)] {
+            records.insert(
+                Arc::new(tag.to_vec()),
+                RawRecord {
+                    rocksdb_block_read_count: block_read_count,
+                    ..Default::default()
+                },
+            );
+        }
+
+        let (kth_cpu, kth_network, kth_logical_read, kth_logical_write, kth_rocksdb_block_read) =
+            find_kth_detailed_io_values(records.iter(), 2);
+        assert_eq!(kth_rocksdb_block_read, 5);
+        let (picked, evicted) = get_iter_for_detailed_io(
+            &records,
+            kth_cpu,
+            kth_network,
+            kth_logical_read,
+            kth_logical_write,
+            kth_rocksdb_block_read,
+        );
+        let picked: HashMap<_, _> = picked.collect();
+        assert_eq!(picked.len(), 2);
+        assert!(picked.contains_key(&Arc::new(b"a".to_vec())));
+        assert!(picked.contains_key(&Arc::new(b"b".to_vec())));
+        assert_eq!(evicted.count(), 3);
+    }
+
+    #[test]
+    fn test_pick_top_k_separates_logical_read_and_write() {
+        let mut records = HashMap::default();
+        records.insert(
+            Arc::new(b"read".to_vec()),
+            RawRecord {
+                logical_read_bytes: 100,
+                ..Default::default()
+            },
+        );
+        records.insert(
+            Arc::new(b"write".to_vec()),
+            RawRecord {
+                logical_read_bytes: 1,
+                logical_write_bytes: 10,
+                ..Default::default()
+            },
+        );
+        records.insert(
+            Arc::new(b"middle".to_vec()),
+            RawRecord {
+                logical_read_bytes: 50,
+                ..Default::default()
+            },
+        );
+
+        let (kth_cpu, kth_network, kth_logical_read, kth_logical_write, kth_rocksdb_block_read) =
+            find_kth_detailed_io_values(records.iter(), 1);
+        let (picked, _) = get_iter_for_detailed_io(
+            &records,
+            kth_cpu,
+            kth_network,
+            kth_logical_read,
+            kth_logical_write,
+            kth_rocksdb_block_read,
+        );
+        let picked: HashMap<_, _> = picked.collect();
+        assert_eq!(picked.len(), 2);
+        assert!(picked.contains_key(&Arc::new(b"read".to_vec())));
+        assert!(picked.contains_key(&Arc::new(b"write".to_vec())));
+    }
+
+    #[test]
+    fn test_handle_records_respects_detailed_io_scope() {
+        let mut raw = HashMap::default();
+        raw.insert(
+            Arc::new(b"read".to_vec()),
+            RawRecord {
+                logical_read_bytes: 100,
+                ..Default::default()
+            },
+        );
+        raw.insert(
+            Arc::new(b"write".to_vec()),
+            RawRecord {
+                logical_write_bytes: 90,
+                ..Default::default()
+            },
+        );
+        raw.insert(
+            Arc::new(b"combined".to_vec()),
+            RawRecord {
+                logical_read_bytes: 60,
+                logical_write_bytes: 60,
+                ..Default::default()
+            },
+        );
+        raw.insert(
+            Arc::new(b"block".to_vec()),
+            RawRecord {
+                rocksdb_block_read_count: 1_000,
+                ..Default::default()
+            },
+        );
+
+        let picked = |network, detailed| {
+            let mut records = Records::default();
+            handle_records_impl(&mut records, network, detailed, &raw, 1, 1);
+            records.records.keys().cloned().collect::<HashSet<_>>()
+        };
+
+        assert!(picked(false, false).is_empty());
+        assert!(picked(false, true).is_empty());
+        let legacy = [Arc::new(b"combined".to_vec())]
+            .into_iter()
+            .collect::<HashSet<_>>();
+        assert_eq!(picked(true, false), legacy);
+        let detailed = [
+            Arc::new(b"read".to_vec()),
+            Arc::new(b"write".to_vec()),
+            Arc::new(b"block".to_vec()),
+        ]
+        .into_iter()
+        .collect::<HashSet<_>>();
+        assert_eq!(picked(true, true), detailed);
     }
 
     #[test]

--- a/components/resource_metering/src/recorder/mod.rs
+++ b/components/resource_metering/src/recorder/mod.rs
@@ -2,7 +2,7 @@
 
 use std::{
     fmt::{self, Display, Formatter},
-    sync::{Arc, atomic::Ordering::Relaxed},
+    sync::Arc,
     time::Duration,
 };
 
@@ -16,8 +16,7 @@ use tikv_util::{
 
 use self::{collector_reg::CollectorReg, sub_recorder::SubRecorder};
 use crate::{
-    Config, RawRecords, ResourceTagFactory, collector::Collector,
-    config::ENABLE_NETWORK_IO_COLLECTION,
+    Config, RawRecords, ResourceTagFactory, collector::Collector, config::set_io_collection_config,
 };
 mod collector_reg;
 mod localstorage;
@@ -30,7 +29,8 @@ pub use self::{
         cpu::CpuRecorder,
         summary::{
             SummaryRecorder, record_logical_read_bytes, record_logical_write_bytes,
-            record_network_in_bytes, record_network_out_bytes, record_read_keys, record_write_keys,
+            record_network_in_bytes, record_network_out_bytes, record_read_keys,
+            record_rocksdb_block_read_count, record_write_keys,
         },
     },
 };
@@ -128,7 +128,10 @@ impl Recorder {
 
     fn handle_config_change(&mut self, config: Config) {
         self.precision_ms = config.precision.as_millis();
-        ENABLE_NETWORK_IO_COLLECTION.store(config.enable_network_io_collection, Relaxed);
+        set_io_collection_config(
+            config.enable_network_io_collection,
+            config.enable_detailed_io_collection,
+        );
     }
 
     fn tick(&mut self) {
@@ -302,14 +305,15 @@ impl ConfigChangeNotifier {
 pub fn init_recorder(
     precision_ms: u64,
     enable_network_io_collection: bool,
+    enable_detailed_io_collection: bool,
 ) -> (
     ConfigChangeNotifier,
     CollectorRegHandle,
     ResourceTagFactory,
     Box<LazyWorker<Task>>,
 ) {
-    // initialize the global flag for network io collection
-    ENABLE_NETWORK_IO_COLLECTION.store(enable_network_io_collection, Relaxed);
+    // Initialize the global IO collection switches.
+    set_io_collection_config(enable_network_io_collection, enable_detailed_io_collection);
     let recorder = RecorderBuilder::default()
         .precision_ms(precision_ms)
         .add_sub_recorder(Box::<CpuRecorder>::default())

--- a/components/resource_metering/src/recorder/sub_recorder/summary.rs
+++ b/components/resource_metering/src/recorder/sub_recorder/summary.rs
@@ -6,7 +6,7 @@ use collections::HashMap;
 use tikv_util::sys::thread::Pid;
 
 use crate::{
-    ENABLE_NETWORK_IO_COLLECTION, RawRecords,
+    RawRecords, io_collection_config,
     recorder::{
         SubRecorder,
         localstorage::{LocalStorage, STORAGE},
@@ -35,7 +35,8 @@ pub fn record_write_keys(count: u32) {
 
 /// Records how many bytes have been received in the current context.
 pub fn record_network_in_bytes(bytes: u64) {
-    if !ENABLE_NETWORK_IO_COLLECTION.load(Relaxed) {
+    let config = io_collection_config();
+    if !config.network_io_collection_enabled() {
         return;
     }
     STORAGE.with(|s| {
@@ -48,7 +49,8 @@ pub fn record_network_in_bytes(bytes: u64) {
 
 /// Records how many bytes have been sent in the current context.
 pub fn record_network_out_bytes(bytes: u64) {
-    if !ENABLE_NETWORK_IO_COLLECTION.load(Relaxed) {
+    let config = io_collection_config();
+    if !config.network_io_collection_enabled() {
         return;
     }
     STORAGE.with(|s| {
@@ -61,7 +63,8 @@ pub fn record_network_out_bytes(bytes: u64) {
 
 /// Records how many bytes have been read in the current context.
 pub fn record_logical_read_bytes(bytes: u64) {
-    if !ENABLE_NETWORK_IO_COLLECTION.load(Relaxed) {
+    let config = io_collection_config();
+    if !config.network_io_collection_enabled() {
         return;
     }
     STORAGE.with(|s| {
@@ -74,7 +77,8 @@ pub fn record_logical_read_bytes(bytes: u64) {
 
 /// Records how many bytes have been written in the current context.
 pub fn record_logical_write_bytes(bytes: u64) {
-    if !ENABLE_NETWORK_IO_COLLECTION.load(Relaxed) {
+    let config = io_collection_config();
+    if !config.network_io_collection_enabled() {
         return;
     }
     STORAGE.with(|s| {
@@ -82,6 +86,26 @@ pub fn record_logical_write_bytes(bytes: u64) {
             .summary_cur_record
             .logical_write_bytes
             .fetch_add(bytes, Relaxed);
+    })
+}
+
+/// Records RocksDB block reads used as the per-request `read_iops` signal.
+///
+/// This is a relative attribution signal for Top SQL, not a device-level IOPS
+/// measurement.
+pub fn record_rocksdb_block_read_count(count: u64) {
+    if count == 0 {
+        return;
+    }
+    let config = io_collection_config();
+    if !config.detailed_io_collection_enabled() {
+        return;
+    }
+    STORAGE.with(|s| {
+        s.borrow()
+            .summary_cur_record
+            .rocksdb_block_read_count
+            .fetch_add(count, Relaxed);
     })
 }
 
@@ -146,5 +170,45 @@ impl SubRecorder for SummaryRecorder {
 
     fn thread_created(&mut self, _id: Pid, store: &LocalStorage) {
         store.summary_enable.store(self.enabled, SeqCst);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::Ordering::Relaxed;
+
+    use super::*;
+    use crate::{
+        IO_COLLECTION_TEST_LOCK, IoCollectionConfigGuard, config::set_io_collection_config,
+    };
+
+    #[test]
+    fn test_record_rocksdb_block_read_count_respects_config() {
+        let _test_guard = IO_COLLECTION_TEST_LOCK.lock().unwrap();
+        let _config_guard = IoCollectionConfigGuard::set(false, false);
+        std::thread::spawn(|| {
+            for (network, detailed, expected) in [
+                (false, false, 0),
+                (false, true, 0),
+                (true, false, 0),
+                (true, true, 7),
+            ] {
+                set_io_collection_config(network, detailed);
+                STORAGE.with(|s| s.borrow().summary_cur_record.reset());
+                record_rocksdb_block_read_count(7);
+                record_rocksdb_block_read_count(0);
+                STORAGE.with(|s| {
+                    assert_eq!(
+                        s.borrow()
+                            .summary_cur_record
+                            .rocksdb_block_read_count
+                            .load(Relaxed),
+                        expected
+                    );
+                });
+            }
+        })
+        .join()
+        .unwrap();
     }
 }

--- a/components/resource_metering/src/reporter/mod.rs
+++ b/components/resource_metering/src/reporter/mod.rs
@@ -98,12 +98,27 @@ impl Reporter {
         let ts = records.begin_unix_time_secs;
         let n = self.config.max_resource_groups;
         if self.config.enable_network_io_collection {
+            let enable_detailed_io_collection = self.config.detailed_io_collection_enabled();
             let (agg_tag_map, agg_region_map) = records.aggregate_by_extra_tag_and_region();
-            handle_records_impl(&mut self.records, true, &agg_tag_map, ts, n);
-            handle_records_impl(&mut self.region_records, true, &agg_region_map, ts, n);
+            handle_records_impl(
+                &mut self.records,
+                true,
+                enable_detailed_io_collection,
+                &agg_tag_map,
+                ts,
+                n,
+            );
+            handle_records_impl(
+                &mut self.region_records,
+                true,
+                enable_detailed_io_collection,
+                &agg_region_map,
+                ts,
+                n,
+            );
         } else {
             let agg_map = records.aggregate_by_extra_tag();
-            handle_records_impl(&mut self.records, false, &agg_map, ts, n);
+            handle_records_impl(&mut self.records, false, false, &agg_map, ts, n);
         }
     }
 
@@ -300,6 +315,7 @@ mod tests {
             max_resource_groups: 3000,
             precision: ReadableDuration::secs(2),
             enable_network_io_collection: false,
+            enable_detailed_io_collection: false,
         }));
         assert_eq!(r.get_interval(), Duration::from_secs(120));
         let mut records = HashMap::default();
@@ -420,6 +436,7 @@ mod tests {
             max_resource_groups: 3000,
             precision: ReadableDuration::secs(2),
             enable_network_io_collection: true,
+            enable_detailed_io_collection: false,
         }));
         assert_eq!(r.get_interval(), Duration::from_secs(120));
         let mut records = HashMap::default();

--- a/components/resource_metering/tests/recorder_test.rs
+++ b/components/resource_metering/tests/recorder_test.rs
@@ -179,7 +179,8 @@ mod tests {
 
     #[test]
     fn test_cpu_recorder_heavy_single_thread() {
-        let (_, collector_reg_handle, resource_tag_factory, worker) = init_recorder(1000, false);
+        let (_, collector_reg_handle, resource_tag_factory, worker) =
+            init_recorder(1000, false, false);
 
         let collector = DummyCollector::default();
         let _handle = collector_reg_handle.register(Box::new(collector.clone()), false);
@@ -198,7 +199,8 @@ mod tests {
 
     #[test]
     fn test_cpu_recorder_sleep_single_thread() {
-        let (_, collector_reg_handle, resource_tag_factory, worker) = init_recorder(1000, false);
+        let (_, collector_reg_handle, resource_tag_factory, worker) =
+            init_recorder(1000, false, false);
 
         let collector = DummyCollector::default();
         let _handle = collector_reg_handle.register(Box::new(collector.clone()), false);
@@ -217,7 +219,8 @@ mod tests {
 
     #[test]
     fn test_cpu_recorder_hybrid_single_thread() {
-        let (_, collector_reg_handle, resource_tag_factory, worker) = init_recorder(1000, false);
+        let (_, collector_reg_handle, resource_tag_factory, worker) =
+            init_recorder(1000, false, false);
 
         // Hybrid workload with 1 thread
         let collector = DummyCollector::default();
@@ -245,7 +248,8 @@ mod tests {
 
     #[test]
     fn test_cpu_recorder_heavy_multiple_threads() {
-        let (_, collector_reg_handle, resource_tag_factory, worker) = init_recorder(1000, false);
+        let (_, collector_reg_handle, resource_tag_factory, worker) =
+            init_recorder(1000, false, false);
 
         // Heavy CPU with 3 threads
         let collector = DummyCollector::default();
@@ -277,7 +281,8 @@ mod tests {
 
     #[test]
     fn test_cpu_recorder_hybrid_multiple_threads() {
-        let (_, collector_reg_handle, resource_tag_factory, worker) = init_recorder(1000, false);
+        let (_, collector_reg_handle, resource_tag_factory, worker) =
+            init_recorder(1000, false, false);
 
         // Hybrid workload with 3 threads
         let collector = DummyCollector::default();

--- a/components/resource_metering/tests/summary_test.rs
+++ b/components/resource_metering/tests/summary_test.rs
@@ -47,8 +47,11 @@ fn test_summary() {
         ..Default::default()
     };
 
-    let (_, collector_reg_handle, resource_tag_factory, mut recorder_worker) =
-        init_recorder(cfg.precision.as_millis(), cfg.enable_network_io_collection);
+    let (_, collector_reg_handle, resource_tag_factory, mut recorder_worker) = init_recorder(
+        cfg.precision.as_millis(),
+        cfg.enable_network_io_collection,
+        cfg.enable_detailed_io_collection,
+    );
     let (_, data_sink_reg_handle, mut reporter_worker) = init_reporter(cfg, collector_reg_handle);
 
     let data_sink = MockDataSink::default();

--- a/components/server/src/server.rs
+++ b/components/server/src/server.rs
@@ -670,6 +670,10 @@ where
                     .config
                     .resource_metering
                     .enable_network_io_collection,
+                self.core
+                    .config
+                    .resource_metering
+                    .enable_detailed_io_collection,
             );
         self.core.to_stop.push(recorder_worker);
         let (reporter_notifier, data_sink_reg_handle, reporter_worker) =

--- a/components/server/src/server2.rs
+++ b/components/server/src/server2.rs
@@ -541,6 +541,10 @@ where
                     .config
                     .resource_metering
                     .enable_network_io_collection,
+                self.core
+                    .config
+                    .resource_metering
+                    .enable_detailed_io_collection,
             );
         self.core.to_stop.push(recorder_worker);
         let (reporter_notifier, data_sink_reg_handle, reporter_worker) =

--- a/components/test_raftstore-v2/src/server.rs
+++ b/components/test_raftstore-v2/src/server.rs
@@ -776,6 +776,7 @@ impl<EK: KvEngine> ServerCluster<EK> {
             resource_metering::init_recorder(
                 cfg.precision.as_millis(),
                 cfg.enable_network_io_collection,
+                cfg.enable_detailed_io_collection,
             );
         let (_, data_sink_reg_handle, reporter_worker) =
             resource_metering::init_reporter(cfg.clone(), collector_reg_handle.clone());

--- a/components/test_raftstore/src/server.rs
+++ b/components/test_raftstore/src/server.rs
@@ -258,6 +258,7 @@ impl ServerCluster {
             resource_metering::init_recorder(
                 cfg.precision.as_millis(),
                 cfg.enable_network_io_collection,
+                cfg.enable_detailed_io_collection,
             );
         let (_, data_sink_reg_handle, reporter_worker) =
             resource_metering::init_reporter(cfg.clone(), collector_reg_handle.clone());

--- a/doc/maintenance-guides/src/coprocessor.md
+++ b/doc/maintenance-guides/src/coprocessor.md
@@ -1,0 +1,245 @@
+# `src/coprocessor` Maintenance Guide
+
+## Purpose And Scope
+
+This module implements the classic TiDB coprocessor path for built-in request
+types:
+
+- DAG requests
+- analyze requests
+- checksum requests
+
+It is a read-heavy hot path and directly impacts query latency.
+
+## Architectural Views
+
+### Request pipeline view
+
+- parse protobuf request
+- build request context
+- get snapshot
+- build request handler
+- execute in read pool
+- collect stats and emit response
+
+## Process Lifecycle And Startup Sequencing
+
+- Endpoint and read pools are created during server startup.
+- Runtime behavior depends on read-pool setup, memory quota, concurrency
+  controls, and storage snapshot access already being available.
+- The main runtime anchors are:
+  `src/coprocessor/readpool_impl.rs::build_read_pool`,
+  `src/coprocessor/endpoint.rs::Endpoint::new`, and
+  `src/server/service/kv.rs` as the RPC entry path.
+- On the Yatp path, unary and streaming heavy tasks are admitted through
+  semaphores created in `Endpoint::new`: a shared semaphore for ordinary
+  coprocessor work and a dedicated semaphore for Analyze requests that are
+  intentionally throttled by the background quota limiter.
+- The shared semaphore is controlled by
+  `server.end-point-max-concurrency`. The dedicated background-limited
+  semaphore is enabled only when
+  `server.end-point-max-bg-concurrency` is explicitly set to a positive value;
+  its capacity is then controlled by that value.
+- When the dedicated setting is absent or `0`, Analyze and ordinary Cop
+  requests share the legacy semaphore. When it is positive, the two semaphores
+  are independent and both lanes can make progress concurrently.
+- The dedicated cap does not automatically track unified read-pool worker
+  autoscaling at runtime.
+- `build_read_pool` sets TLS engine state and marks threads as
+  `IoType::ForegroundRead`. Any change that moves blocking work into or out of
+  this path should be reviewed against foreground IO expectations.
+- Online config is limited but real: `Endpoint::config_manager()` exposes
+  `CopConfigManager`, which currently updates memory quota. If config scope
+  expands, update lifecycle and operational sections in this guide together.
+
+## Data Model And Metadata Contracts
+
+- `ReqContext` is the key runtime metadata contract:
+  context, ranges, deadline, peer, start ts, lock-bypass sets, bounds, cache
+  version, perf level.
+- Request parsing contract differs by request type:
+  DAG, analyze, checksum.
+- `ReqContextInner::new` is where deadline, bypass/access locks, and derived
+  lower/upper bounds are normalized. Reviewers should treat changes there as
+  cross-cutting request-semantic changes.
+- `endpoint.rs::parse_request_and_check_memory_locks` is the main admission and
+  normalization contract. Request parsing, memory-lock checks, API-version
+  dispatch, and handler construction are deliberately coupled there.
+- The hot request handlers differ materially:
+  DAG requests use `dag/*`, analyze requests use `statistics/analyze_context.rs`
+  and `statistics/analyze.rs`, and checksum requests use `checksum.rs`.
+- Cache-match version, flashback allowance, and lock-bypass/access sets are all
+  correctness-sensitive metadata, not optional optimization flags.
+
+## Start Here
+
+- `src/coprocessor/mod.rs`
+- `src/coprocessor/endpoint.rs`
+- `src/coprocessor/readpool_impl.rs`
+- `src/coprocessor/dag/*`
+- `src/coprocessor/statistics/*`
+- `src/coprocessor/interceptors/*`
+- `src/coprocessor/config_manager.rs`
+
+## Must-Read File Order
+
+1. `src/coprocessor/mod.rs`
+2. `src/coprocessor/endpoint.rs`
+3. `src/coprocessor/tracker.rs`
+4. `src/coprocessor/readpool_impl.rs`
+5. `src/coprocessor/interceptors/deadline.rs`
+6. `src/coprocessor/interceptors/concurrency_limiter.rs`
+7. `src/coprocessor/dag/mod.rs`
+8. `src/coprocessor/statistics/analyze_context.rs`
+
+## Main Responsibilities
+
+- parse coprocessor protobuf payloads
+- build `ReqContext`
+- acquire snapshots and perform memory-lock checks
+- construct request handlers
+- execute handlers on read pools
+- enforce request deadlines, concurrency limits, and memory quotas
+- collect execution stats and produce coprocessor responses
+
+## Critical Invariants
+
+- Range bounds in `ReqContext` must stay aligned with the actual request.
+- Memory-lock checks must happen before serving reads that could violate lock
+  semantics.
+- Handler execution must respect request deadline and cancellation behavior.
+- Memory quota and concurrency limiters must remain cheap and correct.
+- Request parsing and admission must stay aligned: when the dedicated setting
+  is enabled, a request class that reports quota samples to the background
+  quota limiter should use the dedicated background-limited semaphore instead
+  of bypassing heavy-task admission. With the setting disabled, it intentionally
+  shares the ordinary semaphore.
+- When enabled, the dedicated background-limited semaphore protects all
+  Analyze variants, including index, common-handle, column, mixed, and
+  full-sampling Analyze, from unlimited fan-out. It is not part of the ordinary
+  shared heavy-task budget; when disabled, these requests intentionally use the
+  shared semaphore.
+- Streaming and unary response handling must preserve stats and partial-progress
+  semantics.
+
+## Observability And Operational Signals
+
+- wait-time and snapshot-time metrics
+- request-type metrics and execution summaries
+- slow-log behavior driven by endpoint thresholds
+- Resource metering / TopSQL records the per-request RocksDB PerfContext
+  `block_read_count` delta as `rocksdb_block_read_count` when both
+  `resource-metering.enable-network-io-collection` and
+  `resource-metering.enable-detailed-io-collection` are enabled. The field is
+  used for the downstream `read_iops` dimension and relative attribution; it is
+  not a device-level IOPS measurement. Unary and streaming handler futures must
+  keep this PerfContext accounting poll-scoped so TLS metrics cannot be
+  attributed to another request. Keep that poll observer separate from the
+  streaming item lifecycle: one item can span multiple polls, but its
+  `ExecDetails` process time must still cover the complete item.
+- Start with `src/coprocessor/metrics.rs`. High-value signals include:
+  `tikv_coprocessor_request_duration_seconds` family,
+  `tikv_coprocessor_request_wait_seconds`,
+  `tikv_coprocessor_request_handler_build_seconds`,
+  `tikv_coprocessor_request_error`,
+  `tikv_coprocessor_scan_keys`,
+  `tikv_coprocessor_scan_details`,
+  `tikv_coprocessor_response_bytes`,
+  `tikv_coprocessor_waiting_for_semaphore`, and
+  `tikv_coprocessor_semaphore_wait_time_duration_seconds`.
+- The semaphore wait metrics use `group=shared|background_limited` to
+  distinguish ordinary Cop request pressure from Analyze background-limited
+  throttling. Dashboard queries should preserve this label when diagnosing an
+  individual lane and aggregate it only when displaying total semaphore
+  pressure.
+- `tracker.rs` is the best place to understand slow logs, exec details, request
+  lifetime accounting, and the distinction between schedule wait, snapshot
+  wait, suspend time, and processing time.
+- Triage starting points:
+  `endpoint.rs`, `tracker.rs`, `readpool_impl.rs`, `metrics.rs`,
+  `interceptors/deadline.rs`, `interceptors/concurrency_limiter.rs`.
+
+## Change Management Guidance
+
+- If `ReqContext`, request parsing, timeout behavior, or resource-control
+  integration changes, update this guide in the same patch.
+- Hot-path changes should be reviewed together with performance-critical-path
+  expectations.
+- Treat `endpoint.rs` as both a correctness and latency hotspot. Extra parsing,
+  allocation, or logging there needs justification.
+- If lock checking or extra snapshot access logic changes, review the change
+  with `src/storage` and concurrency-manager semantics in mind, not as a
+  coprocessor-only patch.
+- If a new request type or major execution mode is added, document its parser,
+  handler builder, resource admission path, and observability surface here.
+
+## Change-Impact Matrix
+
+- Request parsing or context changes:
+  inspect `mod.rs`, `endpoint.rs`, and request-type-specific builders
+- Timeout or concurrency admission changes:
+  inspect interceptors, `tracker.rs`, metrics, and read-pool behavior
+- DAG execution changes:
+  inspect `dag/*`, snapshot/store setup, and query-side statistics paths
+- Analyze or checksum changes:
+  inspect `statistics/*` or `checksum.rs` plus exec-detail accounting
+
+## Review Checklist
+
+- Does the change touch `endpoint.rs` parsing or request-type dispatch?
+- Does it affect `ReqContext`, deadline handling, or lock bypass/access sets?
+- Does it change read-pool wiring or per-request resource control?
+- Does it add extra allocation, parsing, or logging to the hot path?
+- Does it change handler stats collection or slow-log behavior?
+
+## Observability And Tests
+
+- Inline tests exist across handler and statistics modules.
+- Performance-sensitive behavior often needs bench or end-to-end query testing.
+- Metrics live in `metrics.rs`, trackers, and read-pool tickers.
+- `endpoint.rs` itself contains many targeted tests for parsing, lock checking,
+  timeout, and snapshot-access behavior. It is one of the most important files
+  to consult when changing request admission semantics.
+
+## Common Failure Modes
+
+- wrong request classification or parser fallback
+- lock-check bypass on paths that should block
+- deadline handling drift between streaming and unary paths
+- memory quota leaks on early-return/error paths
+- concurrency limiter behavior only applied to one pool mode
+
+## Reading Map And Companion Docs
+
+Suggested reading order:
+
+1. `mod.rs`
+2. `endpoint.rs`
+3. `readpool_impl.rs`
+4. `dag/mod.rs`
+5. `statistics/analyze_context.rs`
+6. `interceptors/*`
+
+Companion docs:
+
+- `repo-overview.md`
+- `src/server.md`
+- `src/storage.md`
+
+## Glossary
+
+- DAG request:
+  built-in coprocessor request for pushed-down query execution
+- ReqContext:
+  immutable runtime request context shared through execution
+- Light task threshold:
+  the execution-time budget before a coprocessor future must acquire a
+  semaphore permit in the Yatp path
+- Snapshot wait:
+  request time spent between scheduling and obtaining the storage snapshot
+
+## Related Components
+
+- `src/server/service/kv.rs` is the RPC entry point.
+- `src/storage` provides snapshots and the lock-related behavior.
+- `components/in_memory_engine` can accelerate snapshot-backed reads indirectly.

--- a/doc/maintenance-guides/src/storage.md
+++ b/doc/maintenance-guides/src/storage.md
@@ -1,0 +1,280 @@
+# `src/storage` Maintenance Guide
+
+## Purpose And Scope
+
+`src/storage` is TiKV's transaction and storage layer. It is one of the most
+important maintenance surfaces in the repository. It owns:
+
+- the `Storage` API
+- transactional command scheduling
+- MVCC
+- raw KV operations
+- latches and lock waiting
+- flow control
+- storage-related dynamic config
+
+## Architectural Views
+
+### Layer view
+
+- top-level `Storage` API
+- command scheduler
+- MVCC reader/writer logic
+- raw KV logic
+- lock waiting and flow control
+
+### Request execution view
+
+- RPC edge calls `Storage`
+- scheduler admits the command
+- MVCC/raw execution happens on snapshots and engines
+- callbacks complete back to RPC or higher layers
+
+## Process Lifecycle And Startup Sequencing
+
+- Storage is constructed during server startup after engines, read pools,
+  concurrency manager, quota limiter, and relevant runtime helpers exist.
+- Runtime config managers update storage-side behavior after startup.
+- Shutdown must preserve callback and worker ownership safety until all strong
+  references are gone.
+
+Concrete runtime anchors:
+
+- storage construction in server bootstrap
+- scheduler execution in `txn/scheduler.rs`
+- dynamic config side effects in `config_manager.rs`
+
+## Data Model And Metadata Contracts
+
+- MVCC data model across default, lock, and write CFs
+- scheduler task metadata and latch ownership
+- lock-wait metadata and tokens
+- raw KV encoding and optional API-version behavior
+- resource-control metadata consumed during scheduling
+
+High-risk contracts:
+
+- MVCC relationships across default/lock/write CFs
+- `ProcessResult` and callback completion semantics
+- `TxnStatusCache` and max-ts related assumptions
+- raw KV API version and TTL rules from `config.rs`
+
+## Start Here
+
+- `src/storage/mod.rs`
+- `src/storage/txn/scheduler.rs`
+- `src/storage/txn/mod.rs`
+- `src/storage/txn/commands/mod.rs`
+- `src/storage/mvcc/mod.rs`
+- `src/storage/txn/store.rs`
+- `src/storage/raw/store.rs`
+- `src/storage/config.rs`
+- `src/storage/config_manager.rs`
+
+## Must-Read File Order
+
+1. `src/storage/mod.rs`
+2. `src/storage/config.rs`
+3. `src/storage/txn/mod.rs`
+4. `src/storage/txn/scheduler.rs`
+5. `src/storage/txn/commands/mod.rs`
+6. `src/storage/mvcc/mod.rs`
+7. `src/storage/mvcc/reader/reader.rs`
+8. `src/storage/txn/store.rs`
+9. `src/storage/lock_manager/mod.rs`
+10. `src/storage/config_manager.rs`
+
+## Internal Structure
+
+### Top-level API
+
+- `mod.rs` defines `Storage` and many public operations.
+- This is the coordination layer that ties together scheduler, read pool,
+  concurrency manager, quota limiter, and resource control.
+
+### Scheduler and command execution
+
+- `txn/scheduler.rs` owns command admission, latches, task tracking, and worker
+  handoff.
+- `txn/commands/*` defines concrete transactional commands.
+- `txn/task.rs`, `txn/sched_pool.rs`, and `txn/tracker.rs` support execution.
+- `txn/sched_pool.rs` selects the priority queue only for customized resource
+  groups. Background-only control stays on the vanilla queue and throttles
+  matching long-running tasks inside the pool.
+- `txn/sched_pool.rs` accumulates MVCC read flow from non-readonly scheduler
+  commands, including reads performed by foreground writes, and reports
+  region-level `ReadStats` to the raftstore reporter during ticker and worker
+  shutdown flushes. Key ranges and bucket deltas are unavailable on this path.
+
+### MVCC
+
+- `mvcc/mod.rs` defines MVCC errors and public surface.
+- `mvcc/reader/*` owns reads, scanners, point getters, and conflict detection.
+- `mvcc/txn.rs` owns write-side MVCC mutation handling.
+
+### Raw KV
+
+- `raw/*` implements raw-key APIs and their optional MVCC wrappers.
+
+### Waiting and flow control
+
+- `lock_manager/*` defines storage-side lock-wait contracts and local wait-queue
+  helpers.
+- The live waiter-manager workers, deadlock detector, and lock-manager RPC
+  service live under `src/server/lock_manager/*`.
+- `txn/flow_controller/*` controls write pressure behavior.
+
+### Max-ts dynamic configuration
+
+- `config.rs` validates `max_ts.max_drift` against `cache_sync_interval` using
+  their effective whole-millisecond values.
+- `config_manager.rs` dispatches the exact duration to `ConcurrencyManager`.
+- `ConcurrencyManager` deliberately stores the allowance in whole milliseconds
+  because TSO physical timestamps are millisecond-based. For example, a valid
+  configured value of `15s1us` has an effective enforcement allowance of
+  `15000ms`; this is a domain boundary, not online-config truncation.
+
+## Critical Invariants
+
+- Command callbacks must complete exactly once with the correct error/result
+  semantics.
+- Latch ownership must serialize conflicting commands without deadlocking the
+  scheduler.
+- MVCC readers and writers must preserve lock, write, and default-CF
+  relationships.
+- Region bounds, snapshot context, and flashback/max-ts safety must remain
+  enforced.
+- Max-ts relational validation must use the same whole-millisecond precision as
+  runtime TSO enforcement.
+- Memory quota and pending-write thresholds must remain operationally effective.
+
+## Observability And Operational Signals
+
+- scheduler latency, latch wait, and pending-write signals
+- MVCC conflict, read, and GC-related metrics
+- flow-control and memory-quota behavior
+- lock-wait and deadlock diagnostics
+- PD read-flow reports include reads performed by foreground write commands;
+  inspect `txn/sched_pool.rs` when PD read bytes do not match the read-pool
+  workload.
+- Resource metering / TopSQL records logical IO when
+  `resource-metering.enable-network-io-collection` is enabled. With
+  `resource-metering.enable-detailed-io-collection` also enabled, logical reads
+  and writes are selected independently and the foreground SQL request's
+  RocksDB PerfContext delta is recorded as `rocksdb_block_read_count`. This
+  field feeds the downstream `read_iops` dimension for relative attribution; it
+  is not a device-level IOPS measurement. Storage command boundaries in
+  `metrics.rs` own this attribution for read-only commands and read phases of
+  write commands. In particular, transactional writes and
+  `raw_compare_and_swap` must retain the `Storage` PerfContext because CAS reads
+  the prior value before deciding whether to write. Resumed pessimistic-lock
+  batches can contain work from multiple requests. TopSQL intentionally uses
+  the synthetic command's first context as the representative for the whole
+  batch, including logical writes and the single detailed-I/O PerfContext
+  observation. Mixed-tag batches therefore have approximate attribution,
+  avoiding per-item work on the lock-wakeup path. Do not attribute Raftstore
+  apply/store write-worker activity to the request: those paths use write-only
+  PerfContext metrics and may batch work from multiple requests.
+
+Start triage with:
+
+- `src/storage/metrics.rs`
+- `txn/scheduler.rs`
+- `lock_manager/*`
+- `config_manager.rs`
+
+## Change Management Guidance
+
+- Any change to `Storage` API, callback semantics, MVCC contracts, or dynamic
+  config side effects should update this guide in the same patch.
+- Server and raftstore bridges should be audited whenever storage semantics or
+  error mapping changes.
+- If a change updates config values without updating `config_manager.rs` side
+  effects, the change is usually incomplete.
+
+## Change-Impact Matrix
+
+- Public `Storage` API or callback changes:
+  inspect `mod.rs`, `txn/scheduler.rs`, and RPC-facing callers in `src/server`
+- Scheduler, latch, or task-flow changes:
+  inspect `txn/scheduler.rs`, `txn/task.rs`, `txn/sched_pool.rs`, and metrics
+- MVCC read/write or conflict changes:
+  inspect `mvcc/*`, `txn/store.rs`, and transactional commands
+- Raw KV changes:
+  inspect `raw/*`, API-version handling, and coprocessor_v2 storage adapter
+- Lock-wait or flow-control changes:
+  inspect `lock_manager/*`, `txn/flow_controller/*`, and runtime workers in
+  `src/server`
+- Dynamic config changes:
+  inspect `config.rs`, `config_manager.rs`, and runtime side-effect consumers
+
+## Review Checklist
+
+- Does the change affect `Storage` API behavior or callback contract?
+- Does it touch `txn/scheduler.rs`, latches, or lock-wait queues?
+- Does it modify MVCC conflict detection, lock resolution, or commit-ts rules?
+- Does it alter raw KV behavior shared with plugin coprocessor or external APIs?
+- Does it change snapshot or write assumptions that must still hold across both
+  `raftkv` and `raftkv2` bridges?
+- Does it require a config-manager side effect for dynamic config?
+- Does it change resource-control integration, flow control, or quota-limiter
+  behavior?
+
+## Observability And Tests
+
+- There is heavy inline unit-test coverage across MVCC, txn commands, latches,
+  lock waiting, raw MVCC, and scheduler helpers.
+- Integration tests often belong in `components/test_storage`.
+- Hot-path metrics exist throughout scheduler, MVCC, read pools, and flow
+  control.
+
+## Common Failure Modes
+
+- callback never invoked or invoked twice
+- latch release bugs causing stuck or reordered commands
+- MVCC write/read drift across CFs
+- incorrect region error extraction from lower layers
+- dynamic config updated in memory but not applied to runtime objects
+- lock wait wake-up logic causing starvation or missed wake-ups
+
+## Reading Map And Companion Docs
+
+Suggested reading order:
+
+1. `mod.rs`
+2. `config.rs`
+3. `txn/mod.rs`
+4. `txn/scheduler.rs`
+5. `txn/commands/mod.rs`
+6. `mvcc/mod.rs`
+7. `mvcc/reader/reader.rs`
+8. `txn/store.rs`
+9. `lock_manager/mod.rs`
+10. `config_manager.rs`
+
+Companion docs:
+
+- `repo-overview.md`
+- `src/server.md`
+- `components/raftstore.md`
+- `PERFORMANCE_CRITICAL_PATH.md`
+
+## Glossary
+
+- MVCC:
+  multi-version concurrency control over default/lock/write CFs
+- Latch:
+  scheduler-side serialization primitive for conflicting commands
+- ProcessResult:
+  scheduler-execution result returned back through callbacks
+- Flow control:
+  pressure-management logic that slows or gates write-heavy activity
+
+## Related Components
+
+- `src/server/service/kv.rs` is the main caller.
+- `src/server/raftkv/mod.rs` bridges writes into raftstore.
+- `src/server/lock_manager/*` owns the live lock-manager workers and deadlock
+  service around the storage-side wait-queue contracts.
+- `components/resource_control` and `resource_metering` integrate directly with
+  scheduling and accounting.

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -854,7 +854,11 @@ impl<E: Engine> Endpoint<E> {
                 let result = {
                     tracker.on_begin_item();
 
-                    let result = handler.handle_streaming_request().await;
+                    let result = track(
+                        handler.handle_streaming_request(),
+                        tracker.poll_perf_context_tracker(),
+                    )
+                    .await;
 
                     let mut storage_stats = Statistics::default();
                     handler.collect_scan_statistics(&mut storage_stats);

--- a/src/coprocessor/tracker.rs
+++ b/src/coprocessor/tracker.rs
@@ -7,6 +7,7 @@ use engine_traits::{PerfContext, PerfContextExt, PerfContextKind};
 use kvproto::{kvrpcpb, kvrpcpb::ScanDetailV2};
 use pd_client::BucketMeta;
 use protobuf::Message;
+use resource_metering::record_rocksdb_block_read_count;
 use tikv_kv::Engine;
 use tikv_util::{
     memory::HeapSize,
@@ -167,9 +168,6 @@ impl<E: Engine> Tracker<E> {
             _ => unreachable!(),
         }
 
-        self.with_perf_context(|perf_context| {
-            perf_context.start_observe();
-        });
         self.current_stage = TrackerState::ItemBegan(now);
     }
 
@@ -181,13 +179,27 @@ impl<E: Engine> Tracker<E> {
             if let Some(storage_stats) = some_storage_stats {
                 self.total_storage_stats.add(&storage_stats);
             }
-            self.with_perf_context(|perf_context| {
-                perf_context.report_metrics(&[get_tls_tracker_token()]);
-            });
             self.current_stage = TrackerState::ItemFinished(now);
         } else {
             unreachable!()
         }
+    }
+
+    fn on_poll_begin(&mut self) {
+        self.with_perf_context(|perf_context| {
+            perf_context.start_observe();
+        });
+    }
+
+    fn on_poll_finish(&mut self) {
+        let delta = self.with_perf_context(|perf_context| {
+            perf_context.report_metrics(&[get_tls_tracker_token()])
+        });
+        record_rocksdb_block_read_count(delta.block_read_count);
+    }
+
+    pub fn poll_perf_context_tracker(&mut self) -> impl FutureTrack + '_ {
+        PollPerfContextTracker { tracker: self }
     }
 
     pub fn collect_storage_statistics(&mut self, storage_stats: Statistics) {
@@ -465,6 +477,35 @@ impl<E: Engine> Tracker<E> {
     }
 }
 
+<<<<<<< HEAD
+=======
+impl<E: Engine> FutureTrack for &mut Tracker<E> {
+    fn on_poll_begin(&mut self) {
+        self.on_begin_item();
+        Tracker::on_poll_begin(self);
+    }
+
+    fn on_poll_finish(&mut self) {
+        Tracker::on_poll_finish(self);
+        self.on_finish_item(None);
+    }
+}
+
+struct PollPerfContextTracker<'a, E: Engine> {
+    tracker: &'a mut Tracker<E>,
+}
+
+impl<E: Engine> FutureTrack for PollPerfContextTracker<'_, E> {
+    fn on_poll_begin(&mut self) {
+        self.tracker.on_poll_begin();
+    }
+
+    fn on_poll_finish(&mut self) {
+        self.tracker.on_poll_finish();
+    }
+}
+
+>>>>>>> 49e7a1179d (*: extend Top SQL resource dimensions (#19953))
 impl<E: Engine> Drop for Tracker<E> {
     /// `Tracker` may be dropped without even calling `on_begin_all_items`. For
     /// example, if get snapshot failed. So we fast-forward if some steps
@@ -533,14 +574,82 @@ impl<E: Engine> HeapSize for Tracker<E> {
 
 #[cfg(test)]
 mod tests {
-    use std::{sync::Arc, time::Duration, vec};
+    use std::{
+        future::Future,
+        pin::Pin,
+        sync::Arc,
+        task::{Context as TaskContext, Poll},
+        thread,
+        time::Duration,
+        vec,
+    };
 
+    use futures::executor::block_on;
     use kvproto::kvrpcpb;
     use pd_client::BucketMeta;
-    use tikv_kv::RocksEngine;
+    use tikv_kv::{RocksEngine, destroy_tls_engine, set_tls_engine};
+    use tracker::track;
 
     use super::{PerfLevel, ReqTag, TLS_COP_METRICS, TimeStamp, Tracker};
-    use crate::{coprocessor::ReqContextInner, storage::Statistics};
+    use crate::{
+        coprocessor::ReqContextInner,
+        storage::{Statistics, TestEngineBuilder},
+    };
+
+    struct TwoPollFuture {
+        first_poll: bool,
+    }
+
+    impl Future for TwoPollFuture {
+        type Output = ();
+
+        fn poll(mut self: Pin<&mut Self>, cx: &mut TaskContext<'_>) -> Poll<Self::Output> {
+            thread::sleep(Duration::from_millis(20));
+            if self.first_poll {
+                self.first_poll = false;
+                cx.waker().wake_by_ref();
+                Poll::Pending
+            } else {
+                Poll::Ready(())
+            }
+        }
+    }
+
+    #[test]
+    fn test_streaming_item_process_time_spans_multiple_polls() {
+        set_tls_engine(TestEngineBuilder::new().build().unwrap());
+
+        let req_ctx_inner = ReqContextInner::new(
+            kvrpcpb::Context::default(),
+            vec![],
+            Duration::from_secs(0),
+            None,
+            None,
+            TimeStamp::max(),
+            None,
+            PerfLevel::EnableCount,
+            false,
+        );
+        let mut tracker: Tracker<RocksEngine> =
+            Tracker::new(req_ctx_inner.into(), ReqTag::select, Duration::default());
+        tracker.on_scheduled();
+        tracker.on_snapshot_finished();
+        tracker.on_begin_all_items();
+        tracker.on_begin_item();
+
+        block_on(track(
+            TwoPollFuture { first_poll: true },
+            tracker.poll_perf_context_tracker(),
+        ));
+        tracker.on_finish_item(None);
+
+        assert!(tracker.item_process_time >= Duration::from_millis(35));
+        assert_eq!(tracker.total_process_time, tracker.item_process_time);
+
+        tracker.on_finish_all_items();
+        drop(tracker);
+        unsafe { destroy_tls_engine::<RocksEngine>() };
+    }
 
     #[test]
     fn test_track() {

--- a/src/storage/metrics.rs
+++ b/src/storage/metrics.rs
@@ -12,6 +12,7 @@ use pd_client::{BucketMeta, RegionWriteCfCopDetail};
 use prometheus::*;
 use prometheus_static_metric::*;
 use raftstore::store::{ReadStats, util::build_key_range};
+use resource_metering::{io_collection_config, record_rocksdb_block_read_count};
 use tikv_kv::Engine;
 use tracker::get_tls_tracker_token;
 
@@ -320,11 +321,10 @@ impl From<ServerGcKeysDetail> for GcKeysDetail {
     }
 }
 
-// Safety: It should be only called when the thread-local engine exists.
-pub unsafe fn with_perf_context<E: Engine, Fn, T>(cmd: CommandKind, f: Fn) -> T
-where
-    Fn: FnOnce() -> T,
-{
+fn with_perf_context_mut<E: Engine, T>(
+    cmd: CommandKind,
+    f: impl FnOnce(&mut dyn PerfContext) -> T,
+) -> Option<T> {
     thread_local! {
         static GET: RefCell<Option<Box<dyn PerfContext>>> = RefCell::new(None);
         static BATCH_GET: RefCell<Option<Box<dyn PerfContext>>> = RefCell::new(None);
@@ -332,10 +332,12 @@ where
         static SCAN: RefCell<Option<Box<dyn PerfContext>>> = RefCell::new(None);
         static PREWRITE: RefCell<Option<Box<dyn PerfContext>>> = RefCell::new(None);
         static ACQUIRE_PESSIMISTIC_LOCK: RefCell<Option<Box<dyn PerfContext>>> = RefCell::new(None);
+        static ACQUIRE_PESSIMISTIC_LOCK_RESUMED: RefCell<Option<Box<dyn PerfContext>>> = RefCell::new(None);
         static COMMIT: RefCell<Option<Box<dyn PerfContext>>> = RefCell::new(None);
         static CLEANUP: RefCell<Option<Box<dyn PerfContext>>> = RefCell::new(None);
         static ROLLBACK: RefCell<Option<Box<dyn PerfContext>>> = RefCell::new(None);
         static PESSIMISTIC_ROLLBACK: RefCell<Option<Box<dyn PerfContext>>> = RefCell::new(None);
+        static PESSIMISTIC_ROLLBACK_READ_PHASE: RefCell<Option<Box<dyn PerfContext>>> = RefCell::new(None);
         static TXN_HEART_BEAT: RefCell<Option<Box<dyn PerfContext>>> = RefCell::new(None);
         static CHECK_TXN_STATUS: RefCell<Option<Box<dyn PerfContext>>> = RefCell::new(None);
         static CHECK_SECONDARY_LOCKS: RefCell<Option<Box<dyn PerfContext>>> = RefCell::new(None);
@@ -344,6 +346,7 @@ where
         static RESOLVE_LOCK_LITE: RefCell<Option<Box<dyn PerfContext>>> = RefCell::new(None);
         static FLUSH: RefCell<Option<Box<dyn PerfContext>>> = RefCell::new(None);
         static BUFFER_BATCH_GET: RefCell<Option<Box<dyn PerfContext>>> = RefCell::new(None);
+        static RAW_COMPARE_AND_SWAP: RefCell<Option<Box<dyn PerfContext>>> = RefCell::new(None);
     }
     let tls_cell = match cmd {
         CommandKind::get => &GET,
@@ -353,10 +356,12 @@ where
         CommandKind::scan => &SCAN,
         CommandKind::prewrite => &PREWRITE,
         CommandKind::acquire_pessimistic_lock => &ACQUIRE_PESSIMISTIC_LOCK,
+        CommandKind::acquire_pessimistic_lock_resumed => &ACQUIRE_PESSIMISTIC_LOCK_RESUMED,
         CommandKind::commit => &COMMIT,
         CommandKind::cleanup => &CLEANUP,
         CommandKind::rollback => &ROLLBACK,
         CommandKind::pessimistic_rollback => &PESSIMISTIC_ROLLBACK,
+        CommandKind::pessimistic_rollback_read_phase => &PESSIMISTIC_ROLLBACK_READ_PHASE,
         CommandKind::txn_heart_beat => &TXN_HEART_BEAT,
         CommandKind::check_txn_status => &CHECK_TXN_STATUS,
         CommandKind::check_secondary_locks => &CHECK_SECONDARY_LOCKS,
@@ -364,7 +369,8 @@ where
         CommandKind::resolve_lock => &RESOLVE_LOCK,
         CommandKind::resolve_lock_lite => &RESOLVE_LOCK_LITE,
         CommandKind::flush => &FLUSH,
-        _ => return f(),
+        CommandKind::raw_compare_and_swap => &RAW_COMPARE_AND_SWAP,
+        _ => return None,
     };
     tls_cell.with(|c| {
         let mut c = c.borrow_mut();
@@ -374,11 +380,43 @@ where
                 PerfContextKind::Storage(cmd.get_str()),
             )) as Box<dyn PerfContext>
         });
-        perf_context.start_observe();
-        let res = f();
-        perf_context.report_metrics(&[get_tls_tracker_token()]);
-        res
+        Some(f(perf_context.as_mut()))
     })
+}
+
+fn start_perf_context<E: Engine>(cmd: CommandKind) -> bool {
+    with_perf_context_mut::<E, _>(cmd, |perf_context| perf_context.start_observe()).is_some()
+}
+
+fn finish_perf_context<E: Engine>(cmd: CommandKind) {
+    let delta = with_perf_context_mut::<E, _>(cmd, |perf_context| {
+        perf_context.report_metrics(&[get_tls_tracker_token()])
+    });
+    if let Some(delta) = delta {
+        record_rocksdb_block_read_count(delta.block_read_count);
+    }
+}
+
+// Safety: It should be only called when the thread-local engine exists.
+pub unsafe fn with_perf_context<E: Engine, Fn, T>(cmd: CommandKind, f: Fn) -> T
+where
+    Fn: FnOnce() -> T,
+{
+    // These commands were added to PerfContext only for detailed TopSQL I/O.
+    // Preserve their previous path while detailed collection is disabled.
+    if matches!(
+        cmd,
+        CommandKind::pessimistic_rollback_read_phase | CommandKind::raw_compare_and_swap
+    ) && !io_collection_config().detailed_io_collection_enabled()
+    {
+        return f();
+    }
+    if !start_perf_context::<E>(cmd) {
+        return f();
+    }
+    let res = f();
+    finish_perf_context::<E>(cmd);
+    res
 }
 
 make_static_metric! {

--- a/src/storage/txn/scheduler.rs
+++ b/src/storage/txn/scheduler.rs
@@ -49,8 +49,8 @@ use pd_client::{Feature, FeatureGate};
 use raftstore::store::TxnExt;
 use resource_control::{ResourceController, ResourceGroupManager, TaskMetadata};
 use resource_metering::{
-    FutureExt, ResourceTagFactory, record_logical_read_bytes, record_logical_write_bytes,
-    record_network_in_bytes,
+    FutureExt, ResourceTagFactory, io_collection_config, record_logical_read_bytes,
+    record_logical_write_bytes, record_network_in_bytes,
 };
 use smallvec::{SmallVec, smallvec};
 use tikv_kv::{Modify, Snapshot, SnapshotExt, WriteData, WriteEvent};
@@ -1448,8 +1448,17 @@ impl<E: Engine, L: LockManager> TxnScheduler<E, L> {
                 txn_status_cache: txn_scheduler.inner.txn_status_cache.clone(),
             };
             let begin_instant = Instant::now();
-            let res = unsafe {
-                with_perf_context::<E, _, _>(tag, || task.process_write(snapshot, context))
+            // A resumed-lock command can merge requests with different tags. TopSQL
+            // intentionally attributes the batch to the command's first context as
+            // its representative, avoiding O(batch size) PerfContext work here.
+            let observe_perf_context = tag != CommandKind::acquire_pessimistic_lock_resumed
+                || io_collection_config().detailed_io_collection_enabled();
+            let res = if observe_perf_context {
+                unsafe {
+                    with_perf_context::<E, _, _>(tag, || task.process_write(snapshot, context))
+                }
+            } else {
+                task.process_write(snapshot, context)
             };
             let cmd_process_duration = begin_instant.saturating_elapsed();
             sched_details.cmd_process_nanos = cmd_process_duration.as_nanos() as u64;

--- a/tests/integrations/resource_metering/test_dynamic_config.rs
+++ b/tests/integrations/resource_metering/test_dynamic_config.rs
@@ -3,7 +3,7 @@
 use std::{iter, thread::sleep, time::Duration};
 
 use rand::prelude::SliceRandom;
-use resource_metering::ENABLE_NETWORK_IO_COLLECTION;
+use resource_metering::io_collection_config;
 use test_util::alloc_port;
 use tikv_util::config::ReadableDuration;
 use tokio::time::Instant;
@@ -18,6 +18,7 @@ pub fn test_enable() {
         max_resource_groups: 5000,
         precision: ReadableDuration::secs(1),
         enable_network_io_collection: false,
+        enable_detailed_io_collection: false,
     });
 
     let port = alloc_port();
@@ -63,6 +64,7 @@ pub fn test_report_interval() {
         max_resource_groups: 5000,
         precision: ReadableDuration::secs(1),
         enable_network_io_collection: false,
+        enable_detailed_io_collection: false,
     });
     test_suite.start_receiver_at(port);
 
@@ -104,6 +106,7 @@ pub fn test_max_resource_groups() {
         max_resource_groups: 5000,
         precision: ReadableDuration::secs(2),
         enable_network_io_collection: false,
+        enable_detailed_io_collection: false,
     });
     test_suite.start_receiver_at(port);
 
@@ -147,6 +150,7 @@ pub fn test_precision() {
         max_resource_groups: 5000,
         precision: ReadableDuration::secs(1),
         enable_network_io_collection: false,
+        enable_detailed_io_collection: false,
     });
     test_suite.start_receiver_at(port);
 
@@ -193,14 +197,27 @@ pub fn test_enable_network_io_collection() {
         max_resource_groups: 5000,
         precision: ReadableDuration::secs(1),
         enable_network_io_collection: false,
+        enable_detailed_io_collection: false,
     });
     test_suite.start_receiver_at(port);
     // Workload
     // [req-1]
     test_suite.setup_workload(vec!["req-1"]);
 
+    test_suite.cfg_enable_detailed_io_collection("true");
+    test_suite.flush_receiver();
+    let _res = test_suite.block_receive_one();
+    assert!(!io_collection_config().detailed_io_collection_enabled());
+
     test_suite.cfg_enable_network_io_collection("true");
     test_suite.flush_receiver();
     let _res = test_suite.block_receive_one();
-    assert!(ENABLE_NETWORK_IO_COLLECTION.load(std::sync::atomic::Ordering::Relaxed));
+    let config = io_collection_config();
+    assert!(config.network_io_collection_enabled());
+    assert!(config.detailed_io_collection_enabled());
+
+    test_suite.cfg_enable_network_io_collection("false");
+    test_suite.flush_receiver();
+    let _res = test_suite.block_receive_one();
+    assert!(!io_collection_config().detailed_io_collection_enabled());
 }

--- a/tests/integrations/resource_metering/test_read_keys.rs
+++ b/tests/integrations/resource_metering/test_read_keys.rs
@@ -160,6 +160,7 @@ fn test_read_keys_coprocessor() {
         resource_metering::init_recorder(
             cfg.precision.as_millis(),
             cfg.enable_network_io_collection,
+            cfg.enable_detailed_io_collection,
         );
     let (_, data_sink_reg_handle, reporter_worker) =
         resource_metering::init_reporter(cfg, collector_reg_handle);

--- a/tests/integrations/resource_metering/test_receiver.rs
+++ b/tests/integrations/resource_metering/test_receiver.rs
@@ -16,6 +16,7 @@ pub fn test_alter_receiver_address() {
         max_resource_groups: 5000,
         precision: ReadableDuration::secs(1),
         enable_network_io_collection: false,
+        enable_detailed_io_collection: false,
     });
     test_suite.start_receiver_at(port);
 
@@ -53,6 +54,7 @@ pub fn test_receiver_blocking() {
         max_resource_groups: 5000,
         precision: ReadableDuration::secs(1),
         enable_network_io_collection: false,
+        enable_detailed_io_collection: false,
     });
     test_suite.start_receiver_at(port);
 
@@ -92,6 +94,7 @@ pub fn test_receiver_shutdown() {
         max_resource_groups: 5000,
         precision: ReadableDuration::secs(1),
         enable_network_io_collection: false,
+        enable_detailed_io_collection: false,
     });
     test_suite.start_receiver_at(port);
 

--- a/tests/integrations/resource_metering/test_suite/mod.rs
+++ b/tests/integrations/resource_metering/test_suite/mod.rs
@@ -58,6 +58,7 @@ impl TestSuite {
             resource_metering::init_recorder(
                 cfg.precision.as_millis(),
                 cfg.enable_network_io_collection,
+                cfg.enable_detailed_io_collection,
             );
         let (reporter_notifier, data_sink_reg_handle, reporter_worker) =
             resource_metering::init_reporter(cfg.clone(), collector_reg_handle);
@@ -165,6 +166,13 @@ impl TestSuite {
         let flag = flag.into();
         self.cfg_controller
             .update_config("resource-metering.enable-network-io-collection", &flag)
+            .unwrap();
+    }
+
+    pub fn cfg_enable_detailed_io_collection(&self, flag: impl Into<String>) {
+        let flag = flag.into();
+        self.cfg_controller
+            .update_config("resource-metering.enable-detailed-io-collection", &flag)
             .unwrap();
     }
 


### PR DESCRIPTION
### What is changed and how it works?\n\nIssue Number: ref #19867\n\nWhat's Changed:\\n\\n- Cherry-pick #19953 to release-8.5.\\n- Replace unresolved conflict markers left in #20047 with the intended tracker implementation.\\n- Use the kvproto release-8.5 backport from pingcap/kvproto#1524.\\n- Adapt the coprocessor future tracker to the release-8.5 interceptor layout.\\n- This PR replaces #20047 because its ti-chi-bot branch is not writable by the contributor.\\n\\n```commit-message\\n*: extend Top SQL resource dimensions\\n\\nExtend Top SQL resource dimensions with logical read, logical write, and\\nforeground RocksDB block-read deltas on release-8.5.\\n```\\n\\n### Related changes\\n\\n- [ ] PR to update `pingcap/docs`/`pingcap/docs-cn`:\\n- [ ] Need to cherry-pick to the release branch\\n\\n### Check List\\n\\nTests\\n\\n- [x] Unit test\\n- [ ] Integration test\\n- [ ] Manual test (add detailed scripts or steps below)\\n- [ ] No code\\n\\nValidation:\\n\\n- `make format`\\n- `cargo metadata --locked --no-deps --format-version=1`\\n- `cargo test -p tikv --lib test_streaming_item_process_time_spans_multiple_polls --no-default-features --features "test-engine-kv-rocksdb test-engine-raft-raft-engine openssl-vendored" --locked -- --nocapture`\\n\\nSide effects\\n\\n- [ ] Performance regression: Consumes more CPU\\n- [ ] Performance regression: Consumes more Memory\\n- [ ] Breaking backward compatibility\\n\\n### Release note\\n\\n```release-note\\nAdd RocksDB block-read counts to Top SQL resource usage records.\\n```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional detailed I/O collection for resource metering.
  * Resource metrics now include RocksDB block-read counts.
  * Added runtime configuration support for enabling network and detailed I/O collection independently.
  * Improved metric tracking for multi-poll coprocessor and storage operations.

* **Documentation**
  * Added maintenance guides covering coprocessor and storage components.

* **Bug Fixes**
  * Improved handling of empty metric records and disabled detailed I/O collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->