### PR TITLE
coprocessor: backport TiCI versioned lookup to release-8.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4404,7 +4404,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git?branch=release-8.5#07aa8c6a46fab0a4cd577119c249c9c8e718c553"
+source = "git+https://github.com/AilinKid/kvproto.git?branch=cp-fts-858-kvproto#47bcf5dc38ad704f62e3ce20b0ca7442956ed34b"
 dependencies = [
  "bytes",
  "futures 0.3.15",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -437,7 +437,7 @@ grpcio-health = { version = "0.10.4", default-features = false, features = [
   "protobuf-codec",
 ] }
 tipb = { git = "https://github.com/pingcap/tipb.git", branch = "release-8.5" }
-kvproto = { git = "https://github.com/pingcap/kvproto.git", branch = "release-8.5" }
+kvproto = { git = "https://github.com/AilinKid/kvproto.git", branch = "cp-fts-858-kvproto" }
 yatp = { git = "https://github.com/tikv/yatp.git", branch = "master" }
 tokio-timer = { git = "https://github.com/tikv/tokio", branch = "tokio-timer-hotfix" }
 tokio-executor = { git = "https://github.com/tikv/tokio", branch = "tokio-timer-hotfix" }

--- a/components/test_backup/src/lib.rs
+++ b/components/test_backup/src/lib.rs
@@ -366,6 +366,7 @@ impl TestSuite {
             is_key_only: false,
             is_scanned_range_aware: false,
             load_commit_ts: false,
+            range_versions: None,
         });
         let digest = crc64fast::Digest::new();
         while let Some(row) = block_on(scanner.next()).unwrap() {

--- a/components/tidb_query_common/src/storage/mod.rs
+++ b/components/tidb_query_common/src/storage/mod.rs
@@ -58,6 +58,15 @@ pub trait Storage: Send {
         range: PointRange,
     ) -> Result<Option<OwnedKvPairEntry>>;
 
+    /// Get a point entry at the specified read timestamp.
+    fn get_entry_at_ts(
+        &mut self,
+        is_key_only: bool,
+        load_commit_ts: bool,
+        range: PointRange,
+        ts: u64,
+    ) -> Result<Option<OwnedKvPairEntry>>;
+
     #[inline]
     fn get(&mut self, is_key_only: bool, range: PointRange) -> Result<Option<OwnedKvPair>> {
         Ok(self
@@ -94,6 +103,16 @@ impl<T: Storage + ?Sized> Storage for Box<T> {
         range: PointRange,
     ) -> Result<Option<OwnedKvPairEntry>> {
         (**self).get_entry(is_key_only, load_commit_ts, range)
+    }
+
+    fn get_entry_at_ts(
+        &mut self,
+        is_key_only: bool,
+        load_commit_ts: bool,
+        range: PointRange,
+        ts: u64,
+    ) -> Result<Option<OwnedKvPairEntry>> {
+        (**self).get_entry_at_ts(is_key_only, load_commit_ts, range, ts)
     }
 
     fn met_uncacheable_data(&self) -> Option<bool> {

--- a/components/tidb_query_common/src/storage/test_fixture.rs
+++ b/components/tidb_query_common/src/storage/test_fixture.rs
@@ -126,6 +126,25 @@ impl super::Storage for FixtureStorage {
         }
     }
 
+    fn get_entry_at_ts(
+        &mut self,
+        is_key_only: bool,
+        load_commit_ts: bool,
+        range: PointRange,
+        ts: u64,
+    ) -> Result<Option<OwnedKvPairEntry>> {
+        // For fixture tests, we don't implement MVCC. Encode the per-key ts into
+        // the key by appending `#<ts>`.
+        //
+        // This is enough to verify the per-range versions plumbing:
+        // TableScan -> ScanExecutor -> RangesScanner -> Storage::get_entry_at_ts.
+        let mut k = range.0.clone();
+        k.extend_from_slice(b"#");
+        k.extend_from_slice(ts.to_string().as_bytes());
+
+        self.get_entry(is_key_only, load_commit_ts, PointRange(k))
+    }
+
     fn collect_statistics(&mut self, _dest: &mut Self::Statistics) {}
 
     fn met_uncacheable_data(&self) -> Option<bool> {

--- a/components/tidb_query_executors/src/index_lookup_executor.rs
+++ b/components/tidb_query_executors/src/index_lookup_executor.rs
@@ -688,6 +688,7 @@ impl<S: Storage> TableTask<S> {
             // because it will be read to drain.
             false,
             primary_prefix_column_ids,
+            None,
         )
     }
 }

--- a/components/tidb_query_executors/src/index_scan_executor.rs
+++ b/components/tidb_query_executors/src/index_scan_executor.rs
@@ -156,6 +156,7 @@ impl<S: Storage, F: KvFormat> BatchIndexScanExecutor<S, F> {
             accept_point_range: unique,
             is_scanned_range_aware,
             load_commit_ts: false,
+            range_versions: None,
         })?;
         Ok(Self(wrapper))
     }

--- a/components/tidb_query_executors/src/runner.rs
+++ b/components/tidb_query_executors/src/runner.rs
@@ -249,6 +249,7 @@ pub fn build_executors<S: Storage + 'static, F: KvFormat>(
     storage: S,
     extra_storage_accessor: Option<impl RegionStorageAccessor<Storage = S> + 'static>,
     ranges: Vec<KeyRange>,
+    range_versions: Option<Vec<u64>>,
     config: Arc<EvalConfig>,
     is_scanned_range_aware: bool,
 ) -> Result<Box<dyn BatchExecutor<StorageStats = S::Statistics>>> {
@@ -283,6 +284,7 @@ pub fn build_executors<S: Storage + 'static, F: KvFormat>(
                     descriptor.get_desc(),
                     is_scanned_range_aware,
                     primary_prefix_column_ids,
+                    range_versions,
                 )?
                 .collect_summary(summary_slot_index),
             )
@@ -615,6 +617,7 @@ impl<SS: 'static> BatchExecutorsRunner<SS> {
         ranges: Vec<KeyRange>,
         storage: S,
         extra_storage_accessor: Option<impl RegionStorageAccessor<Storage = S> + 'static>,
+        range_versions: Option<Vec<u64>>,
         deadline: Deadline,
         stream_row_limit: usize,
         is_streaming: bool,
@@ -633,6 +636,7 @@ impl<SS: 'static> BatchExecutorsRunner<SS> {
             storage,
             extra_storage_accessor,
             ranges,
+            range_versions,
             config.clone(),
             is_streaming || paging_size.is_some(), /* For streaming and paging request,
                                                     * executors will continue scan from range
@@ -1292,6 +1296,7 @@ mod tests {
             vec![],
             MockStorage(Region::default(), vec![]),
             Some(MockRegionStorageAccessor::with_expect_mode()),
+            None,
             Deadline::from_now(Duration::from_secs(300)),
             1024,
             false,
@@ -1396,6 +1401,7 @@ mod tests {
                 MockStorage(Region::default(), vec![]),
                 Some(MockRegionStorageAccessor::with_expect_mode()),
                 vec![],
+                None,
                 Arc::new(cfg.clone()),
                 false,
             )

--- a/components/tidb_query_executors/src/util/mock_executor.rs
+++ b/components/tidb_query_executors/src/util/mock_executor.rs
@@ -251,6 +251,16 @@ impl Storage for MockStorage {
         unimplemented!()
     }
 
+    fn get_entry_at_ts(
+        &mut self,
+        _is_key_only: bool,
+        _load_commit_ts: bool,
+        _range: PointRange,
+        _ts: u64,
+    ) -> StorageResult<Option<OwnedKvPairEntry>> {
+        unimplemented!()
+    }
+
     fn met_uncacheable_data(&self) -> Option<bool> {
         unimplemented!()
     }

--- a/deny.toml
+++ b/deny.toml
@@ -133,4 +133,5 @@ exceptions = [
 [sources]
 unknown-git = "deny"
 unknown-registry = "deny"
+allow-git = ["https://github.com/AilinKid/kvproto.git"]
 allow-org = { github = ["tikv", "pingcap", "rust-lang"] }

--- a/src/coprocessor/checksum.rs
+++ b/src/coprocessor/checksum.rs
@@ -40,6 +40,7 @@ impl<S: Snapshot> ChecksumContext<S> {
             false,
         );
         let scanner = RangesScanner::new(RangesScannerOptions {
+            range_versions: None,
             storage: TikvStorage::new(store, false),
             ranges: ranges
                 .into_iter()

--- a/src/coprocessor/dag/mod.rs
+++ b/src/coprocessor/dag/mod.rs
@@ -34,6 +34,7 @@ where
 {
     req: DagRequest,
     ranges: Vec<KeyRange>,
+    range_versions: Option<Vec<u64>>,
     store: S,
     extra_storage_accessor: Option<R>,
     data_version: Option<u64>,
@@ -55,6 +56,7 @@ where
     pub fn new(
         req: DagRequest,
         ranges: Vec<KeyRange>,
+        range_versions: Option<Vec<u64>>,
         store: S,
         extra_storage_accessor: Option<R>,
         deadline: Deadline,
@@ -67,6 +69,7 @@ where
         DagHandlerBuilder {
             req,
             ranges,
+            range_versions,
             store,
             extra_storage_accessor,
             data_version: None,
@@ -91,6 +94,7 @@ where
         Ok(BatchDagHandler::new::<_, F>(
             self.req,
             self.ranges,
+            self.range_versions,
             self.store,
             self.extra_storage_accessor,
             self.data_version,
@@ -155,6 +159,7 @@ impl BatchDagHandler {
     pub fn new<S: Store + 'static, F: KvFormat>(
         req: DagRequest,
         ranges: Vec<KeyRange>,
+        range_versions: Option<Vec<u64>>,
         store: S,
         extra_storage_accessor: Option<impl RegionStorageAccessor<Storage = S> + 'static>,
         data_version: Option<u64>,
@@ -173,6 +178,7 @@ impl BatchDagHandler {
                 ranges,
                 TikvStorage::new(store, is_cache_enabled),
                 extra_storage_accessor,
+                range_versions,
                 deadline,
                 streaming_batch_limit,
                 is_streaming,

--- a/src/coprocessor/endpoint.rs
+++ b/src/coprocessor/endpoint.rs
@@ -30,6 +30,7 @@ use tidb_query_common::{
     error::StorageError,
     execute_stats::ExecSummary,
     storage::{FindRegionResult, RegionStorageAccessor, Result as StorageResult},
+    util::is_point,
 };
 use tikv_alloc::trace::MemoryTraceGuard;
 use tikv_kv::{ExtraRegionOverride, SnapshotExt};
@@ -227,13 +228,43 @@ impl<E: Engine> Endpoint<E> {
             "unsupported tp (failpoint)"
         )));
 
-        let (context, data, ranges, mut start_ts) = (
+        let (context, data, mut ranges, mut start_ts) = (
             req.take_context(),
             req.take_data(),
             req.take_ranges().to_vec(),
             req.get_start_ts(),
         );
-        let cache_match_version = if req.get_is_cache_enabled() {
+        // `versioned_ranges` is an extension for "versioned lookup" reads
+        // (key + per-key read ts). It intentionally bypasses txn-related
+        // checks (e.g. memory lock checks / max_ts update), so it is expected
+        // to be used only via the dedicated `VersionedKv` RPC (the normal
+        // coprocessor RPC rejects requests carrying it).
+        //
+        // Invariants:
+        // - When `versioned_ranges` is non-empty, `ranges` must be empty.
+        // - All `versioned_ranges[i].range` must be point ranges.
+        let mut range_versions = Vec::new();
+        let versioned_ranges = req.take_versioned_ranges();
+        let is_versioned_lookup = !versioned_ranges.is_empty();
+        if is_versioned_lookup {
+            if !ranges.is_empty() {
+                return Err(box_err!("versioned_ranges requires ranges to be empty"));
+            }
+            ranges = Vec::with_capacity(versioned_ranges.len());
+            range_versions = Vec::with_capacity(versioned_ranges.len());
+            for mut versioned_range in versioned_ranges.into_iter() {
+                let range = versioned_range.take_range();
+                if !is_point(&range) {
+                    return Err(box_err!(
+                        "versioned_ranges is only supported for point ranges"
+                    ));
+                }
+                ranges.push(range);
+                range_versions.push(versioned_range.get_read_ts());
+            }
+        }
+        let is_cache_enabled = req.get_is_cache_enabled() && !is_versioned_lookup;
+        let cache_match_version = if is_cache_enabled {
             Some(req.get_cache_if_match_version())
         } else {
             None
@@ -246,6 +277,13 @@ impl<E: Engine> Endpoint<E> {
         let handler_builder: RequestHandlerBuilder<E::IMSnap>;
         let req_tag: ReqTag;
         let semaphore_group: SemaphoreGroup;
+
+        if is_versioned_lookup && req.get_tp() != REQ_TYPE_DAG {
+            return Err(box_err!(
+                "versioned_ranges is only supported for DAG requests"
+            ));
+        }
+
         match req.get_tp() {
             REQ_TYPE_DAG => {
                 let mut dag = DagRequest::default();
@@ -286,11 +324,19 @@ impl<E: Engine> Endpoint<E> {
                     tracker.req_info.start_ts = start_ts;
                 });
 
-                self.check_memory_locks(&req_ctx)?;
+                if !is_versioned_lookup {
+                    self.check_memory_locks(&req_ctx)?;
+                }
 
                 let batch_row_limit = self.get_batch_row_limit(is_streaming);
                 let quota_limiter = self.quota_limiter.clone();
                 let concurrency_manager = self.concurrency_manager.clone();
+                let paging_size = req.get_paging_size();
+                let range_versions = if is_versioned_lookup {
+                    Some(range_versions)
+                } else {
+                    None
+                };
                 handler_builder = Box::new(move |snap, req_ctx| {
                     let data_version = snap.ext().get_data_version();
                     let store = SnapshotStore::new(
@@ -300,24 +346,24 @@ impl<E: Engine> Endpoint<E> {
                         !req_ctx.context.get_not_fill_cache(),
                         req_ctx.bypass_locks.clone(),
                         req_ctx.access_locks.clone(),
-                        req.get_is_cache_enabled(),
+                        is_cache_enabled,
                     );
-                    let paging_size = match req.get_paging_size() {
+                    let paging_size = match paging_size {
                         0 => None,
                         i => Some(i),
                     };
-
                     let extra_store_accessor =
                         ExtraSnapStoreAccessor::<E>::new(req_ctx.clone(), concurrency_manager);
                     dag::DagHandlerBuilder::<_, _, F>::new(
                         dag,
                         req_ctx.ranges.clone(),
+                        range_versions,
                         store,
                         extra_store_accessor,
                         req_ctx.deadline,
                         batch_row_limit,
                         is_streaming,
-                        req.get_is_cache_enabled(),
+                        is_cache_enabled,
                         paging_size,
                         quota_limiter,
                     )
@@ -754,6 +800,7 @@ impl<E: Engine> Endpoint<E> {
                 // coprocessor cache related fields are not passed in the "task" by now.
                 new_req.is_cache_enabled = false;
                 new_req.ranges = task.take_ranges();
+                new_req.versioned_ranges = task.take_versioned_ranges();
                 let new_context = new_req.mut_context();
                 new_context.set_region_id(task.get_region_id());
                 new_context.set_region_epoch(task.take_region_epoch());
@@ -1301,6 +1348,7 @@ mod tests {
         thread, vec,
     };
 
+    use api_version::ApiV1;
     use futures::executor::{block_on, block_on_stream};
     use kvproto::kvrpcpb::{IsolationLevel, LockInfo};
     use protobuf::Message;
@@ -1309,7 +1357,8 @@ mod tests {
         coprocessor::region_info_accessor::MockRegionInfoProvider,
         store::{ReadStats, WriteStats},
     };
-    use tidb_query_common::storage::Storage;
+    use tidb_query_common::{storage::Storage, util::convert_to_prefix_next};
+    use tidb_query_datatype::codec::table::encode_row_key;
     use tikv_kv::{MockEngine, MockEngineBuilder, destroy_tls_engine, set_tls_engine};
     use tikv_util::yatp_pool::CleanupMethod;
     use tipb::{Executor, Expr};
@@ -2761,6 +2810,376 @@ mod tests {
 
         let resp = block_on(copr.parse_and_handle_unary_request(req, None));
         assert_eq!(resp.get_locked().get_key(), b"key");
+    }
+
+    #[test]
+    fn test_versioned_ranges_requires_empty_ranges() {
+        let engine = TestEngineBuilder::new().build().unwrap();
+        let read_pool = ReadPool::from(build_read_pool_for_test(
+            &CoprReadPoolConfig::default_for_test(),
+            engine,
+        ));
+        let cm = ConcurrencyManager::new(1.into());
+        let copr = Endpoint::<RocksEngine>::new(
+            &Config::default(),
+            read_pool.handle(),
+            cm,
+            ResourceTagFactory::new_for_test(),
+            Arc::new(QuotaLimiter::default()),
+            None,
+        );
+
+        let mut req = coppb::Request::default();
+        req.mut_context().set_isolation_level(IsolationLevel::Si);
+        req.set_start_ts(100);
+        req.set_tp(REQ_TYPE_DAG);
+
+        let mut r1 = coppb::KeyRange::default();
+        r1.set_start(b"k1".to_vec());
+        r1.set_end(b"k2".to_vec());
+        req.mut_ranges().push(r1);
+
+        // `versioned_ranges` must keep `ranges` empty.
+        let mut r = coppb::KeyRange::default();
+        r.set_start(b"k1".to_vec());
+        r.set_end(b"k2".to_vec());
+        let mut vr = coppb::VersionedKeyRange::default();
+        vr.set_range(r);
+        vr.set_read_ts(10);
+        req.mut_versioned_ranges().push(vr);
+
+        let mut dag = DagRequest::default();
+        dag.mut_executors().push(Executor::default());
+        req.set_data(dag.write_to_bytes().unwrap());
+
+        let resp = block_on(copr.parse_and_handle_unary_request(req, None));
+        assert!(!resp.get_other_error().is_empty());
+        assert!(
+            resp.get_other_error()
+                .contains("versioned_ranges requires ranges to be empty")
+        );
+    }
+
+    #[test]
+    fn test_versioned_ranges_requires_point_ranges() {
+        let engine = TestEngineBuilder::new().build().unwrap();
+        let read_pool = ReadPool::from(build_read_pool_for_test(
+            &CoprReadPoolConfig::default_for_test(),
+            engine,
+        ));
+        let cm = ConcurrencyManager::new(1.into());
+        let copr = Endpoint::<RocksEngine>::new(
+            &Config::default(),
+            read_pool.handle(),
+            cm,
+            ResourceTagFactory::new_for_test(),
+            Arc::new(QuotaLimiter::default()),
+            None,
+        );
+
+        let mut req = coppb::Request::default();
+        req.mut_context().set_isolation_level(IsolationLevel::Si);
+        req.set_start_ts(100);
+        req.set_tp(REQ_TYPE_DAG);
+
+        let mut r = coppb::KeyRange::default();
+        r.set_start(b"a".to_vec());
+        r.set_end(b"z".to_vec());
+        let mut vr = coppb::VersionedKeyRange::default();
+        vr.set_range(r);
+        vr.set_read_ts(10);
+        req.mut_versioned_ranges().push(vr);
+
+        let mut dag = DagRequest::default();
+        dag.mut_executors().push(Executor::default());
+        req.set_data(dag.write_to_bytes().unwrap());
+
+        let resp = block_on(copr.parse_and_handle_unary_request(req, None));
+        assert!(!resp.get_other_error().is_empty());
+        assert!(
+            resp.get_other_error()
+                .contains("only supported for point ranges")
+        );
+    }
+
+    #[test]
+    fn test_versioned_ranges_requires_dag_request() {
+        let engine = TestEngineBuilder::new().build().unwrap();
+        let read_pool = ReadPool::from(build_read_pool_for_test(
+            &CoprReadPoolConfig::default_for_test(),
+            engine,
+        ));
+        let cm = ConcurrencyManager::new(1.into());
+        let copr = Endpoint::<RocksEngine>::new(
+            &Config::default(),
+            read_pool.handle(),
+            cm,
+            ResourceTagFactory::new_for_test(),
+            Arc::new(QuotaLimiter::default()),
+            None,
+        );
+
+        let mut req = coppb::Request::default();
+        req.mut_context().set_isolation_level(IsolationLevel::Si);
+        req.set_start_ts(100);
+        req.set_tp(REQ_TYPE_ANALYZE);
+
+        let mut r = coppb::KeyRange::default();
+        r.set_start(b"k1".to_vec());
+        r.set_end(b"k2".to_vec());
+        let mut vr = coppb::VersionedKeyRange::default();
+        vr.set_range(r);
+        vr.set_read_ts(10);
+        req.mut_versioned_ranges().push(vr);
+
+        let mut analyze = AnalyzeReq::default();
+        analyze.set_tp(AnalyzeType::TypeIndex);
+        req.set_data(analyze.write_to_bytes().unwrap());
+
+        let resp = block_on(copr.parse_and_handle_unary_request(req, None));
+        assert!(!resp.get_other_error().is_empty());
+        assert!(
+            resp.get_other_error()
+                .contains("only supported for DAG requests")
+        );
+    }
+
+    #[test]
+    fn test_versioned_ranges_allows_common_handle_table_scan() {
+        let engine = TestEngineBuilder::new().build().unwrap();
+        let read_pool = ReadPool::from(build_read_pool_for_test(
+            &CoprReadPoolConfig::default_for_test(),
+            engine,
+        ));
+        let cm = ConcurrencyManager::new(1.into());
+        let copr = Endpoint::<RocksEngine>::new(
+            &Config::default(),
+            read_pool.handle(),
+            cm,
+            ResourceTagFactory::new_for_test(),
+            Arc::new(QuotaLimiter::default()),
+            None,
+        );
+
+        let mut req = coppb::Request::default();
+        req.mut_context().set_isolation_level(IsolationLevel::Si);
+        req.set_start_ts(100);
+        req.set_tp(REQ_TYPE_DAG);
+
+        let mut r = coppb::KeyRange::default();
+        r.set_start(b"k1".to_vec());
+        r.set_end(b"k2".to_vec());
+        let mut vr = coppb::VersionedKeyRange::default();
+        vr.set_range(r);
+        vr.set_read_ts(10);
+        req.mut_versioned_ranges().push(vr);
+
+        let mut dag = DagRequest::default();
+        let mut scan_exec = Executor::default();
+        scan_exec.set_tp(ExecType::TypeTableScan);
+        scan_exec.mut_tbl_scan().mut_primary_column_ids().push(1);
+        dag.mut_executors().push(scan_exec);
+        req.set_data(dag.write_to_bytes().unwrap());
+
+        copr.parse_request_and_check_memory_locks_impl::<ApiV1>(req, None, false)
+            .unwrap();
+    }
+
+    #[test]
+    fn test_versioned_ranges_skip_memory_lock_check_and_max_ts_not_updated() {
+        let engine = TestEngineBuilder::new().build().unwrap();
+        let read_pool = ReadPool::from(build_read_pool_for_test(
+            &CoprReadPoolConfig::default_for_test(),
+            engine,
+        ));
+        let cm = ConcurrencyManager::new(1.into());
+
+        let point_key = encode_row_key(1, 1);
+        let key = Key::from_raw(&point_key);
+        let guard = block_on(cm.lock_key(&key));
+        guard.with_lock(|lock| {
+            *lock = Some(txn_types::Lock::new(
+                LockType::Put,
+                point_key.clone(),
+                10.into(),
+                100,
+                Some(vec![]),
+                0.into(),
+                1,
+                20.into(),
+                false,
+            ));
+        });
+
+        let copr = Endpoint::<RocksEngine>::new(
+            &Config::default(),
+            read_pool.handle(),
+            cm.clone(),
+            ResourceTagFactory::new_for_test(),
+            Arc::new(QuotaLimiter::default()),
+            None,
+        );
+
+        let table_scan_data = {
+            let mut dag = DagRequest::default();
+            let mut scan_exec = Executor::default();
+            scan_exec.set_tp(ExecType::TypeTableScan);
+            dag.mut_executors().push(scan_exec);
+            dag.write_to_bytes().unwrap()
+        };
+
+        assert_eq!(cm.max_ts(), 1.into());
+
+        // Case 1: versioned point range (point getter path).
+        let mut req = coppb::Request::default();
+        req.mut_context().set_isolation_level(IsolationLevel::Si);
+        req.set_start_ts(100);
+        req.set_tp(REQ_TYPE_DAG);
+        let mut end = point_key.clone();
+        convert_to_prefix_next(&mut end);
+        let mut key_range = coppb::KeyRange::default();
+        key_range.set_start(point_key.clone());
+        key_range.set_end(end);
+        let mut vr = coppb::VersionedKeyRange::default();
+        vr.set_range(key_range);
+        vr.set_read_ts(10);
+        req.mut_versioned_ranges().push(vr);
+        req.set_data(table_scan_data.clone());
+        let resp = block_on(copr.parse_and_handle_unary_request(req, None));
+        assert!(
+            resp.get_other_error().is_empty(),
+            "{}",
+            resp.get_other_error()
+        );
+        assert_eq!(cm.max_ts(), 1.into());
+
+        // Case 2: versioned lookup with multiple point ranges (not stale read).
+        let mut req = coppb::Request::default();
+        req.mut_context().set_isolation_level(IsolationLevel::Si);
+        req.set_start_ts(100);
+        req.set_tp(REQ_TYPE_DAG);
+
+        let key1 = encode_row_key(1, 1);
+        let mut end1 = key1.clone();
+        convert_to_prefix_next(&mut end1);
+        let mut key_range1 = coppb::KeyRange::default();
+        key_range1.set_start(key1);
+        key_range1.set_end(end1);
+        let mut vr1 = coppb::VersionedKeyRange::default();
+        vr1.set_range(key_range1);
+        vr1.set_read_ts(10);
+        req.mut_versioned_ranges().push(vr1);
+
+        let key2 = encode_row_key(1, 2);
+        let mut end2 = key2.clone();
+        convert_to_prefix_next(&mut end2);
+        let mut key_range2 = coppb::KeyRange::default();
+        key_range2.set_start(key2);
+        key_range2.set_end(end2);
+        let mut vr2 = coppb::VersionedKeyRange::default();
+        vr2.set_range(key_range2);
+        vr2.set_read_ts(20);
+        req.mut_versioned_ranges().push(vr2);
+
+        req.set_data(table_scan_data);
+        let resp = block_on(copr.parse_and_handle_unary_request(req, None));
+        assert!(
+            resp.get_other_error().is_empty(),
+            "{}",
+            resp.get_other_error()
+        );
+        assert_eq!(cm.max_ts(), 1.into());
+    }
+
+    #[test]
+    fn test_versioned_ranges_disables_cache_match_version() {
+        let engine = TestEngineBuilder::new().build().unwrap();
+        let read_pool = ReadPool::from(build_read_pool_for_test(
+            &CoprReadPoolConfig::default_for_test(),
+            engine,
+        ));
+        let cm = ConcurrencyManager::new(1.into());
+        let copr = Endpoint::<RocksEngine>::new(
+            &Config::default(),
+            read_pool.handle(),
+            cm,
+            ResourceTagFactory::new_for_test(),
+            Arc::new(QuotaLimiter::default()),
+            None,
+        );
+
+        let mut req = coppb::Request::default();
+        req.mut_context().set_isolation_level(IsolationLevel::Si);
+        req.set_start_ts(100);
+        req.set_tp(REQ_TYPE_DAG);
+
+        req.set_is_cache_enabled(true);
+        req.set_cache_if_match_version(42);
+
+        let mut end = b"key".to_vec();
+        convert_to_prefix_next(&mut end);
+        let mut key_range = coppb::KeyRange::default();
+        key_range.set_start(b"key".to_vec());
+        key_range.set_end(end);
+        let mut vr = coppb::VersionedKeyRange::default();
+        vr.set_range(key_range);
+        vr.set_read_ts(10);
+        req.mut_versioned_ranges().push(vr);
+
+        let mut dag = DagRequest::default();
+        let mut scan_exec = Executor::default();
+        scan_exec.set_tp(ExecType::TypeTableScan);
+        dag.mut_executors().push(scan_exec);
+        req.set_data(dag.write_to_bytes().unwrap());
+
+        let parsed = copr
+            .parse_request_and_check_memory_locks_impl::<ApiV1>(req, None, false)
+            .unwrap();
+        assert!(parsed.req_ctx.cache_match_version.is_none());
+    }
+
+    #[test]
+    fn test_cache_match_version_kept_for_normal_lookup() {
+        let engine = TestEngineBuilder::new().build().unwrap();
+        let read_pool = ReadPool::from(build_read_pool_for_test(
+            &CoprReadPoolConfig::default_for_test(),
+            engine,
+        ));
+        let cm = ConcurrencyManager::new(1.into());
+        let copr = Endpoint::<RocksEngine>::new(
+            &Config::default(),
+            read_pool.handle(),
+            cm,
+            ResourceTagFactory::new_for_test(),
+            Arc::new(QuotaLimiter::default()),
+            None,
+        );
+
+        let mut req = coppb::Request::default();
+        req.mut_context().set_isolation_level(IsolationLevel::Si);
+        req.set_start_ts(100);
+        req.set_tp(REQ_TYPE_DAG);
+
+        req.set_is_cache_enabled(true);
+        req.set_cache_if_match_version(42);
+
+        let mut end = b"key".to_vec();
+        convert_to_prefix_next(&mut end);
+        let mut key_range = coppb::KeyRange::default();
+        key_range.set_start(b"key".to_vec());
+        key_range.set_end(end);
+        req.mut_ranges().push(key_range);
+
+        let mut dag = DagRequest::default();
+        let mut scan_exec = Executor::default();
+        scan_exec.set_tp(ExecType::TypeTableScan);
+        dag.mut_executors().push(scan_exec);
+        req.set_data(dag.write_to_bytes().unwrap());
+
+        let parsed = copr
+            .parse_request_and_check_memory_locks_impl::<ApiV1>(req, None, false)
+            .unwrap();
+        assert_eq!(parsed.req_ctx.cache_match_version, Some(42));
     }
 
     #[test]

--- a/src/coprocessor/statistics/analyze.rs
+++ b/src/coprocessor/statistics/analyze.rs
@@ -64,6 +64,7 @@ impl<S: Snapshot, F: KvFormat> RowSampleBuilder<S, F> {
             false,
             false, // Streaming mode is not supported in Analyze request, always false here
             req.take_primary_prefix_column_ids(),
+            None,
         )?;
         Ok(Self {
             data: table_scanner,
@@ -566,6 +567,7 @@ impl<S: Snapshot, F: KvFormat> SampleBuilder<S, F> {
             false,
             false, // Streaming mode is not supported in Analyze request, always false here
             req.take_primary_prefix_column_ids(),
+            None,
         )?;
         Ok(Self {
             data: table_scanner,

--- a/src/coprocessor/statistics/analyze_context.rs
+++ b/src/coprocessor/statistics/analyze_context.rs
@@ -228,6 +228,7 @@ impl<S: Snapshot, F: KvFormat> RequestHandler for AnalyzeContext<S, F> {
                 let ranges = std::mem::take(&mut self.ranges);
                 table::check_table_ranges::<F>(&ranges)?;
                 let mut scanner = RangesScanner::<_, F>::new(RangesScannerOptions {
+                    range_versions: None,
                     storage: self.storage.take().unwrap(),
                     ranges: ranges
                         .into_iter()

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -94,7 +94,7 @@ where
 
 impl<S> GrpcBuilderFactory for BuilderFactory<S>
 where
-    S: Tikv + Send + Clone + 'static,
+    S: Tikv + VersionedKv + Send + Clone + 'static,
 {
     fn create_builder(&self, env: Arc<Environment>) -> Result<ServerBuilder> {
         let addr = SocketAddr::from_str(&self.cfg.value().addr)?;
@@ -130,6 +130,7 @@ where
         let sb = ServerBuilder::new(Arc::clone(&env))
             .channel_args(channel_args)
             .register_service(create_tikv(self.kv_service.clone()))
+            .register_service(create_versioned_kv(self.kv_service.clone()))
             .register_service(create_health(self.health_service.clone()));
         Ok(self.security_mgr.bind(sb, &ip, addr.port()))
     }

--- a/src/server/service/kv.rs
+++ b/src/server/service/kv.rs
@@ -72,6 +72,10 @@ use crate::{
 const GRPC_MSG_MAX_BATCH_SIZE: usize = 128;
 const GRPC_MSG_NOTIFY_SIZE: usize = 8;
 
+const ERR_VERSIONED_RANGES_ONLY_VERSIONED_COPR: &str =
+    "versioned_ranges is only supported by VersionedKv.VersionedCoprocessor";
+const ERR_VERSIONED_RANGES_REQUIRED_VERSIONED_COPR: &str =
+    "versioned_ranges must be non-empty for VersionedKv.VersionedCoprocessor";
 /// Service handles the RPC messages for the `Tikv` service.
 pub struct Service<E: Engine, L: LockManager, F: KvFormat> {
     cluster_id: u64,
@@ -546,6 +550,17 @@ impl<E: Engine, L: LockManager, F: KvFormat> Tikv for Service<E, L, F> {
 
     fn coprocessor(&mut self, ctx: RpcContext<'_>, req: Request, sink: UnarySink<Response>) {
         reject_if_cluster_id_mismatch!(req, self, ctx, sink);
+        if has_versioned_ranges(&req) {
+            let e = RpcStatus::with_message(
+                RpcStatusCode::INVALID_ARGUMENT,
+                ERR_VERSIONED_RANGES_ONLY_VERSIONED_COPR.into(),
+            );
+            ctx.spawn(
+                sink.fail(e)
+                    .unwrap_or_else(|e| error!("kv rpc failed"; "err" => ?e)),
+            );
+            return;
+        }
         forward_unary!(self.proxy, coprocessor, ctx, req, sink);
         let source = req.get_context().get_request_source().to_owned();
         let resource_control_ctx = req.get_context().get_resource_control_context();
@@ -692,6 +707,17 @@ impl<E: Engine, L: LockManager, F: KvFormat> Tikv for Service<E, L, F> {
         mut sink: ServerStreamingSink<Response>,
     ) {
         reject_if_cluster_id_mismatch!(req, self, ctx, sink);
+        if has_versioned_ranges(&req) {
+            let e = RpcStatus::with_message(
+                RpcStatusCode::INVALID_ARGUMENT,
+                ERR_VERSIONED_RANGES_ONLY_VERSIONED_COPR.into(),
+            );
+            ctx.spawn(
+                sink.fail(e)
+                    .unwrap_or_else(|e| error!("kv rpc failed"; "err" => ?e)),
+            );
+            return;
+        }
         let begin_instant = Instant::now();
         let resource_control_ctx = req.get_context().get_resource_control_context();
         let mut resource_group_priority = ResourcePriority::unknown;
@@ -1377,6 +1403,23 @@ fn handle_batch_commands_request<E: Engine, L: LockManager, F: KvFormat>(
                 },
                 Some(batch_commands_request::request::Cmd::Coprocessor(req)) => {
                     handle_cluster_id_mismatch!(cluster_id, req);
+                    if has_versioned_ranges(&req) {
+                        let begin_instant = Instant::now();
+                        let mut resp = Response::default();
+                        resp.set_other_error(ERR_VERSIONED_RANGES_ONLY_VERSIONED_COPR.into());
+                        let resp = future::ok(resp)
+                            .map_ok(oneof!(batch_commands_response::response::Cmd::Coprocessor));
+                        response_batch_commands_request(
+                            id,
+                            resp,
+                            tx.clone(),
+                            begin_instant,
+                            GrpcTypeKind::invalid,
+                            String::default(),
+                            ResourcePriority::unknown,
+                        );
+                        return Ok(());
+                    }
                     let resource_control_ctx = req.get_context().get_resource_control_context();
                     let mut resource_group_priority = ResourcePriority::unknown;
                     if let Some(resource_manager) = resource_manager {
@@ -1528,6 +1571,68 @@ fn handle_measures_for_batch_commands(measures: &mut MeasuredBatchResponse) {
                 .mut_time_detail_v2()
                 .set_kv_grpc_wait_time_ns(wait.as_nanos() as u64);
         }
+    }
+}
+
+impl<E: Engine, L: LockManager, F: KvFormat> VersionedKv for Service<E, L, F> {
+    fn versioned_coprocessor(
+        &mut self,
+        ctx: RpcContext<'_>,
+        req: Request,
+        sink: UnarySink<Response>,
+    ) {
+        reject_if_cluster_id_mismatch!(req, self, ctx, sink);
+        if !has_versioned_ranges(&req) {
+            let e = RpcStatus::with_message(
+                RpcStatusCode::INVALID_ARGUMENT,
+                ERR_VERSIONED_RANGES_REQUIRED_VERSIONED_COPR.into(),
+            );
+            ctx.spawn(
+                sink.fail(e)
+                    .unwrap_or_else(|e| error!("kv rpc failed"; "err" => ?e)),
+            );
+            return;
+        }
+
+        let source = req.get_context().get_request_source().to_owned();
+        let resource_control_ctx = req.get_context().get_resource_control_context();
+        let mut resource_group_priority = ResourcePriority::unknown;
+        if let Some(resource_manager) = &self.resource_manager {
+            resource_manager.consume_penalty(resource_control_ctx);
+            resource_group_priority =
+                ResourcePriority::from(resource_control_ctx.override_priority);
+        }
+
+        GRPC_RESOURCE_GROUP_COUNTER_VEC
+            .with_label_values(&[
+                resource_control_ctx.get_resource_group_name(),
+                resource_control_ctx.get_resource_group_name(),
+            ])
+            .inc();
+
+        let begin_instant = Instant::now();
+        let future = future_copr(&self.copr, Some(ctx.peer()), req);
+        let task = async move {
+            let resp = future.await?.consume();
+
+            let elapsed = begin_instant.saturating_elapsed();
+            sink.success(resp).await?;
+            GRPC_MSG_HISTOGRAM_STATIC
+                .coprocessor
+                .get(resource_group_priority)
+                .observe(elapsed.as_secs_f64());
+            record_request_source_metrics(source, elapsed);
+            ServerResult::Ok(())
+        }
+        .map_err(|e| {
+            log_net_error!(e, "kv rpc failed";
+                "request" => "versioned_coprocessor"
+            );
+            GRPC_MSG_FAIL_COUNTER.coprocessor.inc();
+        })
+        .map(|_| ());
+
+        ctx.spawn(task);
     }
 }
 
@@ -2291,6 +2396,15 @@ fn future_copr<E: Engine>(
 ) -> impl Future<Output = ServerResult<MemoryTraceGuard<Response>>> {
     let ret = copr.parse_and_handle_unary_request(req, peer);
     async move { Ok(ret.await) }
+}
+
+#[inline]
+fn has_versioned_ranges(req: &Request) -> bool {
+    !req.get_versioned_ranges().is_empty()
+        || req
+            .get_tasks()
+            .iter()
+            .any(|task| !task.get_versioned_ranges().is_empty())
 }
 
 fn future_raw_coprocessor<E: Engine, L: LockManager, F: KvFormat>(

--- a/src/storage/mvcc/reader/point_getter.rs
+++ b/src/storage/mvcc/reader/point_getter.rs
@@ -26,6 +26,9 @@ pub struct PointGetterBuilder<S: Snapshot> {
     bypass_locks: TsSet,
     access_locks: TsSet,
     check_has_newer_ts_data: bool,
+    /// If true, this getter is used by versioned lookup, which must ignore all
+    /// txn-related checks (lock checking, RcCheckTs newer-ts check).
+    is_versioned_lookup: bool,
 }
 
 impl<S: Snapshot> PointGetterBuilder<S> {
@@ -40,6 +43,7 @@ impl<S: Snapshot> PointGetterBuilder<S> {
             bypass_locks: Default::default(),
             access_locks: Default::default(),
             check_has_newer_ts_data: false,
+            is_versioned_lookup: false,
         }
     }
 
@@ -107,6 +111,17 @@ impl<S: Snapshot> PointGetterBuilder<S> {
         self
     }
 
+    /// Mark this getter as used by versioned lookup and skip all txn-related
+    /// checks (lock checking and `RcCheckTs` newer-ts check).
+    ///
+    /// Defaults to `false`.
+    #[inline]
+    #[must_use]
+    pub(crate) fn set_versioned_lookup(mut self, enabled: bool) -> Self {
+        self.is_versioned_lookup = enabled;
+        self
+    }
+
     /// Build `PointGetter` from the current configuration.
     pub fn build(self) -> Result<PointGetter<S>> {
         let write_cursor = CursorBuilder::new(&self.snapshot, CF_WRITE)
@@ -127,6 +142,7 @@ impl<S: Snapshot> PointGetterBuilder<S> {
             } else {
                 NewerTsCheckState::Unknown
             },
+            is_versioned_lookup: self.is_versioned_lookup,
 
             statistics: Statistics::default(),
 
@@ -148,6 +164,7 @@ pub struct PointGetter<S: Snapshot> {
     bypass_locks: TsSet,
     access_locks: TsSet,
     met_newer_ts_data: NewerTsCheckState,
+    is_versioned_lookup: bool,
 
     statistics: Statistics,
 
@@ -191,7 +208,7 @@ impl<S: Snapshot> PointGetter<S> {
         load_commit_ts: bool,
     ) -> Result<Option<ValueEntry>> {
         fail_point!("point_getter_get");
-        if need_check_locks(self.isolation_level) {
+        if !self.is_versioned_lookup && need_check_locks(self.isolation_level) {
             // Check locks that signal concurrent writes for `Si` or more recent writes for
             // `RcCheckTs`.
             if let Some(lock) = self.load_and_check_lock(user_key, !load_commit_ts)? {
@@ -274,8 +291,9 @@ impl<S: Snapshot> PointGetter<S> {
         let mut use_near_seek = false;
         let mut seek_key = user_key.clone();
 
-        if self.met_newer_ts_data == NewerTsCheckState::NotMetYet
-            || self.isolation_level == IsolationLevel::RcCheckTs
+        if !self.is_versioned_lookup
+            && (self.met_newer_ts_data == NewerTsCheckState::NotMetYet
+                || self.isolation_level == IsolationLevel::RcCheckTs)
         {
             seek_key = seek_key.append_ts(TimeStamp::max());
             if !self
@@ -869,6 +887,7 @@ mod tests {
             bypass_locks: Default::default(),
             access_locks: Default::default(),
             met_newer_ts_data: NewerTsCheckState::NotMetYet,
+            is_versioned_lookup: false,
             statistics: Statistics::default(),
             write_cursor,
         };
@@ -1623,5 +1642,50 @@ mod tests {
                 .unwrap()
                 .is_none()
         );
+    }
+
+    #[test]
+    fn test_versioned_lookup_skips_lock_conflict() {
+        let mut engine = new_sample_engine_2();
+        let snapshot = engine.snapshot(Default::default()).unwrap();
+
+        let mut normal = PointGetterBuilder::new(snapshot.clone(), 5.into())
+            .isolation_level(IsolationLevel::Si)
+            .build()
+            .unwrap();
+        let err = must_get_entry_err(&mut normal, b"bar", false);
+        assert!(matches!(err.0, box ErrorInner::KeyIsLocked { .. }));
+
+        let mut bypass = PointGetterBuilder::new(snapshot, 5.into())
+            .isolation_level(IsolationLevel::Si)
+            .set_versioned_lookup(true)
+            .build()
+            .unwrap();
+        must_get_entry(&mut bypass, b"bar", false, b"barval", None);
+    }
+
+    #[test]
+    fn test_versioned_lookup_skips_rc_check_ts_newer_version() {
+        let mut engine = TestEngineBuilder::new().build().unwrap();
+        let key = b"k";
+
+        must_prewrite_put(&mut engine, key, b"v20", key, 10);
+        must_commit(&mut engine, key, 10, 20);
+        must_prewrite_put(&mut engine, key, b"v40", key, 30);
+        must_commit(&mut engine, key, 30, 40);
+
+        let snapshot = engine.snapshot(Default::default()).unwrap();
+        let mut normal = PointGetterBuilder::new(snapshot.clone(), 35.into())
+            .isolation_level(IsolationLevel::RcCheckTs)
+            .build()
+            .unwrap();
+        must_get_err(&mut normal, key);
+
+        let mut bypass = PointGetterBuilder::new(snapshot, 35.into())
+            .isolation_level(IsolationLevel::RcCheckTs)
+            .set_versioned_lookup(true)
+            .build()
+            .unwrap();
+        must_get_value(&mut bypass, key, b"v20");
     }
 }

--- a/src/storage/txn/store.rs
+++ b/src/storage/txn/store.rs
@@ -15,6 +15,31 @@ use crate::storage::{
 };
 
 pub trait Store: Send {
+    /// Fetch the provided key at the specified read timestamp.
+    ///
+    /// This API is intended for special read paths that need per-key read ts
+    /// and must bypass all txn-related checks (lock checking and `RcCheckTs`
+    /// newer-ts conflicts).
+    ///
+    /// Currently this is only used by the versioned lookup coprocessor path
+    /// (the `VersionedKv` RPC carrying `versioned_ranges`), which is intended
+    /// for TiCI.
+    ///
+    /// WARNING: This method intentionally violates transactional semantics. It
+    /// may read through locks and ignore `RcCheckTs` write conflicts. Do not
+    /// use it for normal reads.
+    ///
+    /// Implementations must provide a per-key read path; this interface
+    /// intentionally bypasses transaction checks. There is **no default**
+    /// to force every `Store` to acknowledge the semantic cost.
+    fn get_entry_at_ts(
+        &self,
+        key: &Key,
+        ts: TimeStamp,
+        load_commit_ts: bool,
+        statistics: &mut Statistics,
+    ) -> Result<Option<ValueEntry>>;
+
     /// The scanner type returned by `scanner()`.
     type Scanner: Scanner;
 
@@ -346,15 +371,17 @@ impl<S: Snapshot> Store for SnapshotStore<S> {
         load_commit_ts: bool,
         statistics: &mut Statistics,
     ) -> Result<Option<ValueEntry>> {
-        let mut point_getter = PointGetterBuilder::new(self.snapshot.clone(), self.start_ts)
-            .fill_cache(self.fill_cache)
-            .isolation_level(self.isolation_level)
-            .bypass_locks(self.bypass_locks.clone())
-            .access_locks(self.access_locks.clone())
-            .build()?;
-        let v = point_getter.get_entry(key, load_commit_ts)?;
-        statistics.add(&point_getter.take_statistics());
-        Ok(v)
+        self.get_entry_internal(key, self.start_ts, load_commit_ts, false, statistics)
+    }
+
+    fn get_entry_at_ts(
+        &self,
+        key: &Key,
+        ts: TimeStamp,
+        load_commit_ts: bool,
+        statistics: &mut Statistics,
+    ) -> Result<Option<ValueEntry>> {
+        self.get_entry_internal(key, ts, load_commit_ts, true, statistics)
     }
 
     fn incremental_get_entry(
@@ -546,6 +573,27 @@ impl<S: Snapshot> SnapshotStore<S> {
     }
 
     #[inline]
+    fn get_entry_internal(
+        &self,
+        key: &Key,
+        ts: TimeStamp,
+        load_commit_ts: bool,
+        is_versioned_lookup: bool,
+        statistics: &mut Statistics,
+    ) -> Result<Option<ValueEntry>> {
+        let mut point_getter = PointGetterBuilder::new(self.snapshot.clone(), ts)
+            .fill_cache(self.fill_cache)
+            .isolation_level(self.isolation_level)
+            .bypass_locks(self.bypass_locks.clone())
+            .access_locks(self.access_locks.clone())
+            .set_versioned_lookup(is_versioned_lookup)
+            .build()?;
+        let v = point_getter.get_entry(key, load_commit_ts)?;
+        statistics.add(&point_getter.take_statistics());
+        Ok(v)
+    }
+
+    #[inline]
     pub fn is_fill_cache(&self) -> bool {
         self.fill_cache
     }
@@ -636,6 +684,17 @@ impl Store for FixtureStore {
             })),
             Some(Err(e)) => Err(e.maybe_clone().unwrap()),
         }
+    }
+
+    fn get_entry_at_ts(
+        &self,
+        key: &Key,
+        ts: TimeStamp,
+        load_commit_ts: bool,
+        statistics: &mut Statistics,
+    ) -> Result<Option<ValueEntry>> {
+        let _ = ts;
+        self.get_entry(key, load_commit_ts, statistics)
     }
 
     #[inline]

--- a/tests/benches/coprocessor_executors/integrated/util.rs
+++ b/tests/benches/coprocessor_executors/integrated/util.rs
@@ -79,6 +79,7 @@ where
                 black_box(TikvStorage::new(ToTxnStore::<T>::to_store(store), false)),
                 StubAccessor::none(),
                 black_box(ranges.to_vec()),
+                black_box(None),
                 black_box(Arc::new(EvalConfig::default())),
                 black_box(false),
             )

--- a/tests/benches/coprocessor_executors/table_scan/util.rs
+++ b/tests/benches/coprocessor_executors/table_scan/util.rs
@@ -46,6 +46,7 @@ impl<T: TxnStore + 'static> scan_bencher::ScanExecutorBuilder for BatchTableScan
             black_box(false),
             black_box(false),
             black_box(vec![]),
+            black_box(None),
         )
         .unwrap();
         // There is a step of building scanner in the first `next()` which cost time,

--- a/tests/benches/coprocessor_executors/util/mod.rs
+++ b/tests/benches/coprocessor_executors/util/mod.rs
@@ -46,6 +46,7 @@ pub fn build_dag_handler<TargetTxnStore: TxnStore + 'static>(
     tikv::coprocessor::dag::DagHandlerBuilder::<_, _, ApiV1>::new(
         black_box(dag),
         black_box(ranges.to_vec()),
+        black_box(None),
         black_box(ToTxnStore::<TargetTxnStore>::to_store(store)),
         StubAccessor::none(),
         tikv_util::deadline::Deadline::from_now(std::time::Duration::from_secs(10)),

--- a/tests/integrations/coprocessor/test_checksum.rs
+++ b/tests/integrations/coprocessor/test_checksum.rs
@@ -87,6 +87,7 @@ fn reversed_checksum_crc64_xor<E: Engine>(store: &Store<E>, range: KeyRange) -> 
         is_key_only: false,
         is_scanned_range_aware: false,
         load_commit_ts: false,
+        range_versions: None,
     });
 
     let mut checksum = 0;

--- a/tests/integrations/coprocessor/test_select.rs
+++ b/tests/integrations/coprocessor/test_select.rs
@@ -14,6 +14,7 @@ use test_coprocessor::*;
 use test_raftstore::*;
 use test_raftstore_macro::test_case;
 use test_storage::*;
+use tidb_query_common::util::convert_to_prefix_next;
 use tidb_query_datatype::{
     FieldTypeTp,
     codec::{Datum, datum, table::encode_row_key},
@@ -93,6 +94,52 @@ fn test_select() {
         assert_eq!(result_encoded, &*expected_encoded);
     }
     assert_eq!(limiter.total_read_bytes_consumed(true), total_chunk_size); // the consume_sample is called due to read bytes quota
+}
+
+#[test]
+fn test_versioned_lookup_versioned_ranges_reads_old_version() {
+    let product = ProductTable::new();
+
+    // Write an initial version.
+    let data = vec![(1, Some("name:old"), 2)];
+    let (mut store, endpoint) = init_with_data(&product, &data);
+    let ts_old = store.to_snapshot_store().get_start_ts();
+
+    // Overwrite the same row key to create a newer version.
+    store.begin();
+    store
+        .insert_into(&product)
+        .set(&product["id"], Datum::I64(1))
+        .set(&product["name"], Some("name:new".as_bytes()).into())
+        .set(&product["count"], Datum::I64(2))
+        .execute_with_ctx(Context::default());
+    store.commit();
+    let ts_new = store.to_snapshot_store().get_start_ts();
+    assert!(ts_new > ts_old);
+
+    // Point range for this row key.
+    let row_key = encode_row_key(product.table_id(), 1);
+    let mut end = row_key.clone();
+    convert_to_prefix_next(&mut end);
+    let mut key_range = kvproto::coprocessor::KeyRange::default();
+    key_range.set_start(row_key);
+    key_range.set_end(end);
+
+    // Read using per-key ts = old commit ts, should return the old row value.
+    let mut req = DagSelect::from(&product)
+        .key_ranges(vec![key_range.clone()])
+        .build();
+    req.take_ranges();
+    let mut versioned_range = kvproto::coprocessor::VersionedKeyRange::default();
+    versioned_range.set_range(key_range);
+    versioned_range.set_read_ts(ts_old.into_inner());
+    req.mut_versioned_ranges().push(versioned_range);
+
+    let mut resp = handle_select(&endpoint, req);
+    let mut spliter = DagChunkSpliter::new(resp.take_chunks().into(), 3);
+    let row = spliter.next().unwrap();
+    assert_eq!(row[1], Datum::Bytes(b"name:old".to_vec()));
+    assert!(spliter.next().is_none());
 }
 
 #[test]


### PR DESCRIPTION
### What is changed and how it works?

Issue Number: ref #19357

Backport #19302 (`28890b9736b1553a162c63373fdc052bb60c9172`) onto TiKV v8.5.8 for coordinated FTS/TiCI development builds against release-8.5.

The existing branch `3pointer:release-8.5-fts` contains one backport commit, `9d61ce63fe574fc07468fc4201bdf2238abc886e`, directly on v8.5.8. It registers `VersionedKv.VersionedCoprocessor` and supports point lookup with a separate read timestamp for each key. Validation guards restrict this path to supported DAG table scans; ordinary coprocessor behavior is preserved.

The backport adapts release test APIs and pins KVProto to `AilinKid/kvproto@47bcf5dc38ad704f62e3ce20b0ca7442956ed34b`, matching the companion TiDB and TiFlash builds.

### Related changes

- TiDB: https://github.com/pingcap/tidb/pull/71016
- TiFlash: https://github.com/pingcap/tiflash/pull/11074
- mysql-test: https://github.com/PingCAP-QE/tidb-test/pull/2778

The source is https://github.com/3pointer/tikv/tree/release-8.5-fts . GitHub requires collaborator access to open a draft directly from that fork, so the identical commit is published as `AilinKid:codex/release-8.5-fts` without rewriting history or changing authorship. Keep this PR in draft for development image builds and integration validation.

### Check List

Tests included in the backport:

- [x] Unit test
- [x] Integration test

Validation for this draft: source/target range-diff, RPC registration and dependency pins were inspected. The tests above are included, but were not run during this audit. A fresh build and end-to-end versioned lookup validation remain to be performed by CI or the development build consumers.

### Release note

```release-note
Add a versioned coprocessor point-lookup RPC for TiCI to read keys at individual timestamps.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added versioned point lookups for reads at a specified timestamp.
  * Added a dedicated versioned coprocessor endpoint for retrieving historical row values.
  * Supported versioned point-range scans, including common-handle and backward scans.

* **Bug Fixes**
  * Historical reads now bypass transactional lock and newer-version checks.
  * Added validation for unsupported or malformed versioned-range requests.

* **Tests**
  * Added coverage for historical reads, RPC behavior, validation, and scan scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->